### PR TITLE
refactor(tui): 对齐界面展示与已实现功能

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -23,8 +23,6 @@ import (
 
 const (
 	defaultSessionLimit = 8
-	sidebarWidthMin     = 32
-	sidebarWidthMax     = 44
 )
 
 type screenKind string
@@ -96,7 +94,7 @@ var commandItems = []commandItem{
 	{Name: "/plan done", Usage: "/plan done <index>", Description: "把指定步骤标记为已完成。"},
 	{Name: "/plan pending", Usage: "/plan pending <index>", Description: "把指定步骤重新标记为待处理。"},
 	{Name: "/plan clear", Usage: "/plan clear", Description: "清空当前会话中的任务计划。"},
-	{Name: "/exit", Usage: "/exit", Description: "退出当前 TUI 界面。"},
+	{Name: "/quit", Usage: "/quit", Description: "退出当前 TUI 界面。"},
 }
 
 type model struct {
@@ -246,11 +244,27 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+	case tea.MouseMsg:
+		return m.handleMouse(msg)
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
 
 	return m, nil
+}
+
+func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if m.screen != screenChat || m.sessionsOpen || m.helpOpen || m.commandOpen || m.approval != nil {
+		return m, nil
+	}
+	switch msg.Button {
+	case tea.MouseButtonWheelUp, tea.MouseButtonWheelDown, tea.MouseButtonWheelLeft, tea.MouseButtonWheelRight:
+		var cmd tea.Cmd
+		m.viewport, cmd = m.viewport.Update(msg)
+		return m, cmd
+	default:
+		return m, nil
+	}
 }
 
 func (m model) View() string {
@@ -413,6 +427,12 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "pgdown":
 		m.viewport.PageDown()
 		return m, nil
+	case "ctrl+up":
+		m.viewport.LineUp(1)
+		return m, nil
+	case "ctrl+down":
+		m.viewport.LineDown(1)
+		return m, nil
 	case "home":
 		m.viewport.GotoTop()
 		return m, nil
@@ -430,7 +450,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if value == "" {
 			return m, nil
 		}
-		if value == "/exit" || value == "/quit" {
+		if value == "/quit" {
 			return m, tea.Quit
 		}
 		if strings.HasPrefix(value, "/") {
@@ -718,7 +738,7 @@ func (m model) renderHeader() string {
 }
 
 func (m model) renderFooter() string {
-	hint := mutedStyle.Render("Type / for commands  -  Enter send  -  Ctrl+N new session  -  Ctrl+L sessions  -  Ctrl+C quit")
+	hint := mutedStyle.Render("Type / for commands  -  ? help  -  Ctrl+Up/Down scroll  -  Enter send  -  Ctrl+N new session  -  Ctrl+L sessions  -  Ctrl+C quit")
 	inputBorder := m.inputBorderStyle().
 		Width(m.chatPanelInnerWidth()).
 		Render(m.input.View())
@@ -811,6 +831,9 @@ func (m *model) handleSlashCommand(input string) error {
 		m.statusNote = "已在聊天区显示帮助说明。"
 		return nil
 	case "/session":
+		m.screen = screenChat
+		m.appendChat(chatEntry{Kind: "user", Title: "You", Body: input, Status: "final"})
+		m.appendChat(chatEntry{Kind: "assistant", Title: "AICoding", Body: m.sessionText(), Status: "final"})
 		m.statusNote = fmt.Sprintf("session %s in %s", m.sess.ID, m.sess.Workspace)
 		return nil
 	case "/sessions":
@@ -840,6 +863,9 @@ func (m *model) handleSlashCommand(input string) error {
 func (m *model) handlePlanCommand(input string) error {
 	fields := strings.Fields(input)
 	if len(fields) == 1 {
+		m.screen = screenChat
+		m.appendChat(chatEntry{Kind: "user", Title: "You", Body: input, Status: "final"})
+		m.appendChat(chatEntry{Kind: "assistant", Title: "AICoding", Body: m.planText(), Status: "final"})
 		if len(m.plan) == 0 {
 			m.statusNote = "No active plan."
 		} else {
@@ -1232,10 +1258,10 @@ func shouldExecuteFromPalette(item commandItem) bool {
 func (m model) helpText() string {
 	return strings.Join([]string{
 		"进入方式",
-		"先执行 `scripts\\install.ps1` 安装一次，之后就可以直接在终端输入 `aicoding chat` 启动。",
-		"`aicoding chat` 会先进入带大 Logo 的启动页。",
+		"在仓库根目录运行 `go run ./cmd/bytemind chat` 即可启动。",
+		"`go run ./cmd/bytemind chat` 会先进入带大 Logo 的启动页。",
 		"在启动页输入内容并按 Enter 后，会进入正式聊天界面。",
-		"`aicoding run -prompt \"...\"` 仍然保留为一次性执行模式。",
+		"`go run ./cmd/bytemind run -prompt \"...\"` 可用于一次性执行模式。",
 		"",
 		"斜杠命令",
 		"/help: 查看帮助说明。",
@@ -1250,16 +1276,13 @@ func (m model) helpText() string {
 		"/plan done <index>: 将步骤标记为已完成。",
 		"/plan pending <index>: 将步骤重新标记为待处理。",
 		"/plan clear: 清空当前计划。",
-		"/exit 或 /quit: 退出 TUI。",
+		"/quit: 退出 TUI。",
 		"",
 		"当前界面",
 		"启动页是一个居中的 Logo 加输入框。",
 		"主界面只显示用户消息和助手回复，不把聊天内容塞到旁边区域。",
 		"顶部状态栏会显示工作区、provider、model、审批策略和当前状态。",
 		"如果需要 shell 审批，会以弹窗方式暂停等待确认。",
-		"",
-		"当前版本还没实现",
-		"/clear、/model、/undo、/compact、diff 审阅、git 回滚、token 用量显示、Markdown 高亮渲染。",
 	}, "\n")
 }
 
@@ -1391,6 +1414,29 @@ func copyPlan(plan []session.PlanItem) []session.PlanItem {
 	cloned := make([]session.PlanItem, len(plan))
 	copy(cloned, plan)
 	return cloned
+}
+
+func (m model) sessionText() string {
+	if m.sess == nil {
+		return "No active session."
+	}
+	return strings.Join([]string{
+		fmt.Sprintf("Session ID: %s", m.sess.ID),
+		fmt.Sprintf("Workspace: %s", m.sess.Workspace),
+		fmt.Sprintf("Updated: %s", m.sess.UpdatedAt.Local().Format("2006-01-02 15:04:05")),
+		fmt.Sprintf("Messages: %d", len(m.sess.Messages)),
+	}, "\n")
+}
+
+func (m model) planText() string {
+	if len(m.plan) == 0 {
+		return "No active plan."
+	}
+	lines := []string{fmt.Sprintf("Current plan (%d step(s)):", len(m.plan))}
+	for i, item := range m.plan {
+		lines = append(lines, fmt.Sprintf("%d. [%s] %s", i+1, item.Status, item.Step))
+	}
+	return strings.Join(lines, "\n")
 }
 
 func statusGlyph(status string) string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,0 +1,142 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"bytemind/internal/session"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestHandleMouseScrollsViewport(t *testing.T) {
+	m := model{
+		screen: screenChat,
+		viewport: func() (vp viewport.Model) {
+			vp = viewport.New(40, 5)
+			vp.SetContent(strings.Join([]string{
+				"1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+			}, "\n"))
+			return vp
+		}(),
+	}
+
+	got, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress})
+	updated := got.(model)
+	if updated.viewport.YOffset == 0 {
+		t.Fatalf("expected viewport to scroll down, got offset %d", updated.viewport.YOffset)
+	}
+}
+
+func TestHelpTextOnlyMentionsSupportedEntryPoints(t *testing.T) {
+	text := model{}.helpText()
+
+	for _, unwanted := range []string{
+		"scripts\\install.ps1",
+		"aicoding chat",
+		"aicoding run",
+		"当前版本还没实现",
+	} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("help text should not mention %q", unwanted)
+		}
+	}
+
+	for _, wanted := range []string{
+		"go run ./cmd/bytemind chat",
+		"go run ./cmd/bytemind run -prompt",
+		"/quit",
+	} {
+		if !strings.Contains(text, wanted) {
+			t.Fatalf("help text should mention %q", wanted)
+		}
+	}
+}
+
+func TestRenderFooterDoesNotAdvertiseHistory(t *testing.T) {
+	input := textarea.New()
+	m := model{
+		width: 120,
+		input: input,
+	}
+
+	footer := m.renderFooter()
+	if strings.Contains(footer, "Up/Down history") {
+		t.Fatalf("footer should not advertise history navigation")
+	}
+	if !strings.Contains(footer, "? help") {
+		t.Fatalf("footer should advertise help shortcut")
+	}
+}
+
+func TestCommandPaletteListsQuitCommand(t *testing.T) {
+	found := false
+	for _, item := range commandItems {
+		if item.Name == "/quit" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected command palette to include /quit")
+	}
+}
+
+func TestCommandPaletteDoesNotListExitAlias(t *testing.T) {
+	for _, item := range commandItems {
+		if item.Name == "/exit" {
+			t.Fatalf("did not expect command palette to include /exit")
+		}
+	}
+}
+
+func TestSessionTextShowsSessionDetails(t *testing.T) {
+	sess := session.New("E:\\bytemind")
+
+	m := model{sess: sess}
+	text := m.sessionText()
+
+	for _, want := range []string{"Session ID:", "Workspace:", "Updated:", "Messages:"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected session text to contain %q", want)
+		}
+	}
+}
+
+func TestPlanTextShowsSavedPlanItems(t *testing.T) {
+	m := model{
+		plan: []session.PlanItem{
+			{Step: "Inspect current TUI behavior", Status: "completed"},
+			{Step: "Align visible features with code", Status: "in_progress"},
+		},
+	}
+
+	text := m.planText()
+	for _, want := range []string{
+		"Current plan (2 step(s)):",
+		"1. [completed] Inspect current TUI behavior",
+		"2. [in_progress] Align visible features with code",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected plan text to contain %q", want)
+		}
+	}
+}
+
+func TestHelpTextDoesNotMentionSidebar(t *testing.T) {
+	text := model{}.helpText()
+	if strings.Contains(text, "右侧状态栏") {
+		t.Fatalf("help text should not mention sidebar")
+	}
+	if !strings.Contains(text, "主界面只显示用户消息和助手回复") {
+		t.Fatalf("help text should describe the actual single-panel chat layout")
+	}
+	if strings.Contains(text, "/exit") {
+		t.Fatalf("help text should not mention /exit")
+	}
+	if !strings.Contains(text, "/quit: 退出 TUI。") {
+		t.Fatalf("help text should mention /quit as the only exit command")
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -3,7 +3,6 @@ package tui
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	colorBg      = lipgloss.Color("#0F172A")
 	colorPanel   = lipgloss.Color("#111827")
 	colorBorder  = lipgloss.Color("#243244")
 	colorAccent  = lipgloss.Color("#5EEAD4")
@@ -62,15 +61,6 @@ var (
 				BorderForeground(colorAccent).
 				Padding(0, 1).
 				Background(colorPanel)
-
-	sidebarStyle = lipgloss.NewStyle().
-			Background(colorBg).
-			BorderStyle(lipgloss.RoundedBorder()).
-			BorderForeground(colorBorder).
-			Padding(0, 1)
-
-	sectionStyle = lipgloss.NewStyle().
-			MarginBottom(1)
 
 	sectionTitleStyle = lipgloss.NewStyle().
 				Bold(true).


### PR DESCRIPTION
## 变更说明
这次主要收敛了 TUI 里“界面显示”和“代码真实能力”的一致性。

调整内容：
- 去掉重复的退出命令 `/exit`，只保留 `/quit`
- 移除之前多出来的右侧栏，回到当前产品真实支持的界面形态
- 清理帮助文案和 `/` 命令面板中的不准确信息
- 补全 `/session`、`/plan` 的可见输出，让它们真正可查看
- 增加对应测试，避免后续再次出现展示和实现不一致

## 验证方式
- `go test ./internal/tui`
