### PR TITLE
test: fix cross-platform CI failures

### DIFF
--- a/cmd/bytemind/main_test.go
+++ b/cmd/bytemind/main_test.go
@@ -100,13 +100,14 @@ func TestHandleSlashCommandResumesSessionWithinWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	current := session.New(`E:\\repo`)
+	workspace := t.TempDir()
+	current := session.New(workspace)
 	current.ID = "current"
 	if err := store.Save(current); err != nil {
 		t.Fatal(err)
 	}
 
-	resumed := session.New(`E:\\repo\\.`)
+	resumed := session.New(filepath.Join(workspace, "."))
 	resumed.ID = "resume-me"
 	if err := store.Save(resumed); err != nil {
 		t.Fatal(err)
@@ -129,7 +130,8 @@ func TestHandleSlashCommandResumesSessionWithinWorkspace(t *testing.T) {
 }
 
 func TestSameWorkspaceNormalizesPaths(t *testing.T) {
-	if !sameWorkspace(`E:\\Repo`, `E:\\Repo\\.`) {
+	workspace := t.TempDir()
+	if !sameWorkspace(workspace, filepath.Join(workspace, ".")) {
 		t.Fatal("expected normalized paths to match")
 	}
 }

--- a/internal/tools/run_shell.go
+++ b/internal/tools/run_shell.go
@@ -141,7 +141,7 @@ func promptForApproval(command, reason string, execCtx *ExecutionContext) error 
 			return err
 		}
 		if !approved {
-			return errors.New("shell command not approved")
+			return errors.New("shell command was not run because approval was denied")
 		}
 		return nil
 	}

--- a/internal/tools/run_shell_test.go
+++ b/internal/tools/run_shell_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"bytes"
 	"context"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -155,7 +156,11 @@ func TestRequireApprovalReturnsClearDenialMessage(t *testing.T) {
 
 func TestRunShellToolReturnsTimeoutError(t *testing.T) {
 	tool := RunShellTool{}
-	_, err := tool.Run(context.Background(), []byte(`{"command":"Start-Sleep -Seconds 2","timeout_seconds":1}`), &ExecutionContext{
+	command := "sleep 2"
+	if runtime.GOOS == "windows" {
+		command = "Start-Sleep -Seconds 2"
+	}
+	_, err := tool.Run(context.Background(), []byte(`{"command":"`+command+`","timeout_seconds":1}`), &ExecutionContext{
 		Workspace:      t.TempDir(),
 		ApprovalPolicy: "never",
 		Stdin:          strings.NewReader(""),


### PR DESCRIPTION
## 背景

上一轮测试补强合并后，GitHub Actions 中的 `go test ./...` 出现失败。

排查后发现，问题主要来自跨平台差异，而不是主逻辑错误：
- 部分测试用例将 Windows 路径写死，导致在 Linux CI 环境下断言失败
- shell timeout 测试使用了 PowerShell 命令，导致在非 Windows 环境下不稳定
- shell 审批回调分支的拒绝文案回退成了旧版本

## 本次修改

### 1. 修复 workspace 相关测试的跨平台问题
更新：
- `cmd/bytemind/main_test.go`

调整为使用临时目录和 `filepath.Join(...)`，避免写死 Windows 路径，使以下测试在不同平台上都能成立：
- `TestHandleSlashCommandResumesSessionWithinWorkspace`
- `TestSameWorkspaceNormalizesPaths`

### 2. 修复 shell timeout 测试的跨平台问题
更新：
- `internal/tools/run_shell_test.go`

根据运行平台选择命令：
- Windows 使用 `Start-Sleep -Seconds 2`
- 其他平台使用 `sleep 2`

从而保证 `TestRunShellToolReturnsTimeoutError` 在 CI 环境下稳定通过。

### 3. 恢复更清晰的审批拒绝错误文案
更新：
- `internal/tools/run_shell.go`

将审批回调分支中的错误文案统一为：
- `shell command was not run because approval was denied`

以保持和交互式审批路径一致。

## 验证

本地已执行：

```powershell
$env:GOCACHE='E:\code\bytemind\.gocache'
go test ./...
