### PR TITLE
refactor(tui): improve chat interaction and command experience

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -28,7 +28,7 @@ const (
 	commandPageSize     = 3
 	pasteSubmitGuard    = 400 * time.Millisecond
 	assistantLabel      = "Bytemind"
-	thinkingLabel       = "Bytemind thinking"
+	thinkingLabel       = "Bytemind"
 	chatTitleLabel      = "Bytemind Chat"
 	tuiTitleLabel       = "Bytemind TUI"
 )
@@ -819,12 +819,7 @@ func (m *model) finalizeAssistantTurnForTool(toolName string) {
 	if m.streamingIndex >= 0 && m.streamingIndex < len(m.chatItems) {
 		item := &m.chatItems[m.streamingIndex]
 		if item.Kind == "assistant" {
-			if item.Status == "pending" ||
-				item.Body == m.thinkingText() ||
-				strings.TrimSpace(item.Body) == "" ||
-				(item.Status == "thinking" && strings.EqualFold(strings.TrimSpace(item.Body), "thinking")) {
-				item.Body = assistantToolIntro(toolName)
-			}
+			item.Body = assistantToolIntro(toolName)
 			item.Title = thinkingLabel
 			item.Status = "thinking"
 			m.streamingIndex = -1
@@ -1679,6 +1674,25 @@ func summarizeArgs(raw string) string {
 		return "default arguments"
 	}
 	return compact(raw, 88)
+}
+
+func legacyAssistantToolIntro(toolName string) string {
+	if strings.TrimSpace(toolName) == "" {
+		return "我先查看一下相关内容。"
+	}
+	return fmt.Sprintf("我先调用 `%s` 看一下相关内容。", toolName)
+}
+
+func legacyAssistantToolFollowUp(toolName, summary, status string) string {
+	if strings.TrimSpace(summary) == "" {
+		return "我拿到工具结果了，继续整理一下。"
+	}
+	switch status {
+	case "error", "warn":
+		return fmt.Sprintf("`%s` 已返回结果，我先根据这个情况继续判断。", toolName)
+	default:
+		return fmt.Sprintf("`%s` 已经执行完了，我继续往下整理。", toolName)
+	}
 }
 
 func assistantToolIntro(toolName string) string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -802,7 +802,7 @@ func TestHandleAgentEventShowsToolProgressInChat(t *testing.T) {
 	}
 }
 
-func TestToolStartKeepsStreamedAssistantTurn(t *testing.T) {
+func TestToolStartReplacesStreamedAssistantTurnWithStableToolIntro(t *testing.T) {
 	m := model{
 		chatItems: []chatEntry{
 			{Kind: "user", Title: "You", Body: "what project is this", Status: "final"},
@@ -820,8 +820,8 @@ func TestToolStartKeepsStreamedAssistantTurn(t *testing.T) {
 	if len(m.chatItems) != 3 {
 		t.Fatalf("expected tool start to append only tool call after streamed assistant turn, got %d items", len(m.chatItems))
 	}
-	if m.chatItems[1].Body != "let me inspect the repo structure first" || m.chatItems[1].Status != "thinking" || m.chatItems[1].Title != thinkingLabel {
-		t.Fatalf("expected streamed assistant turn to be preserved and finalized, got %+v", m.chatItems[1])
+	if m.chatItems[1].Body != "我先调用 `list_files` 看一下相关内容。" || m.chatItems[1].Status != "thinking" || m.chatItems[1].Title != thinkingLabel {
+		t.Fatalf("expected streamed assistant turn to be replaced with stable tool intro, got %+v", m.chatItems[1])
 	}
 	if !strings.Contains(m.chatItems[2].Title, "Tool Call | list_files") {
 		t.Fatalf("expected tool call entry, got %+v", m.chatItems[2])


### PR DESCRIPTION
- 支持在启动页通过 Ctrl+L 查看历史会话
- 修正工具调用前过程消息文案不稳定、语序混乱的问题
- 补齐鼠标支持入口与相关依赖
- 增加 demo module 配置文件，完善本地演示环境

## 验证方式
- `go test ./internal/tui`
- `go test ./internal/tui ./internal/session`