### PR TITLE
refactor(tui): polish landing layout and chat visuals

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -395,13 +395,14 @@ func (m model) mouseOverLandingInput(y int) bool {
 		return false
 	}
 	logoHeight := lipgloss.Height(landingLogoStyle.Render(strings.Join([]string{
-		"   ___       __        __  ___ _           __",
-		"  / _ )__ __/ /____   /  |/  (_)__  ___ _/ /",
-		" / _  / // / __/ -_) / /|_/ / / _ \\/ _ `/ _ \\",
-		"/____/\\_, /\\__/\\__/ /_/  /_/_/_//_/\\_,_/_.__/",
-		"     /___/",
+		"    ____        __                      _           __",
+		"   / __ )__  __/ /____  ____ ___  ____(_)___  ____/ /",
+		"  / __  / / / / __/ _ \\/ __ `__ \\/ __/ / __ \\/ __  / ",
+		" / /_/ / /_/ / /_/  __/ / / / / / /_/ / / / / /_/ /  ",
+		"/_____/\\__, /\\__/\\___/_/ /_/ /_/\\__/_/_/ /_/\\__,_/   ",
+		"      /____/                                          ",
 	}, "\n")))
-	titleHeight := lipgloss.Height(landingTitleStyle.Render(chatTitleLabel))
+	titleHeight := 0
 	subtitleHeight := 0
 	inputHeight := lipgloss.Height(
 		landingInputStyle.Copy().
@@ -1044,18 +1045,18 @@ func (m model) renderMainPanel() string {
 
 func (m model) renderLanding() string {
 	logo := landingLogoStyle.Render(strings.Join([]string{
-		"   ___       __        __  ___ _           __",
-		"  / _ )__ __/ /____   /  |/  (_)__  ___ _/ /",
-		" / _  / // / __/ -_) / /|_/ / / _ \\/ _ `/ _ \\",
-		"/____/\\_, /\\__/\\__/ /_/  /_/_/_//_/\\_,_/_.__/",
-		"     /___/",
+		"    ____        __                      _           __",
+		"   / __ )__  __/ /____  ____ ___  ____(_)___  ____/ /",
+		"  / __  / / / / __/ _ \\/ __ `__ \\/ __/ / __ \\/ __  / ",
+		" / /_/ / /_/ / /_/  __/ / / / / / /_/ / / / / /_/ /  ",
+		"/_____/\\__, /\\__/\\___/_/ /_/ /_/\\__/_/_/ /_/\\__,_/   ",
+		"      /____/                                          ",
 	}, "\n"))
-	title := landingTitleStyle.Render(chatTitleLabel)
 	inputBox := landingInputStyle.Copy().
 		BorderForeground(m.modeAccentColor()).
 		Width(m.landingInputShellWidth()).
 		Render(m.input.View())
-	parts := []string{logo, "", title, "", m.renderModeTabs(), ""}
+	parts := []string{logo, "", m.renderModeTabs(), ""}
 	if m.commandOpen {
 		parts = append(parts, m.renderCommandPalette(), "")
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -690,7 +690,7 @@ func TestLandingViewRendersCommandPaletteAboveInput(t *testing.T) {
 	m.syncCommandPalette()
 
 	view := m.View()
-	if !strings.Contains(view, "Bytemind Chat") {
+	if !strings.Contains(view, "Build") || !strings.Contains(view, "Plan") {
 		t.Fatalf("expected landing view to remain visible, got %q", view)
 	}
 	if !strings.Contains(view, "/help") {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -25,7 +25,8 @@ var (
 
 	landingLogoStyle = lipgloss.NewStyle().
 				Foreground(colorAccent).
-				Bold(true)
+				Bold(true).
+				Align(lipgloss.Center)
 
 	landingTitleStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#E2E8F0")).


### PR DESCRIPTION
## 变更说明
本次继续优化 TUI 界面的交互与视觉表现，主要聚焦在启动页、输入区、模式切换以及聊天消息呈现。

主要调整包括：
- 优化启动页 logo 与间距布局
- 支持 Build / Plan 模式的 UI 切换，并通过 Tab 切换
- Plan 模式下输入框边框使用紫色高亮
- 输入框高度提升，并支持 Ctrl+J 插入换行
- 优化聊天消息视觉层级，仅保留用户消息左侧高亮线
- 调整消息块背景、间距与模式提示样式，使界面更简洁统一

## 验证方式
- `go test ./internal/tui`
