### PR TITLE
refactor: prompt, change provider and session part

### DIFF
--- a/docs/prompt-architecture.md
+++ b/docs/prompt-architecture.md
@@ -31,6 +31,8 @@ The prompt files live under `internal/agent/prompts/`.
   - Planning-first mode instructions with a required final answer structure.
 - `block-environment.md`
   - Runtime context such as workspace, provider, model, date, approval policy, and iteration budget.
+- `block-session.md`
+  - Optional compressed continuity summary for resumed or ongoing sessions.
 - `block-plan.md`
   - Current structured plan, rendered from session state when present.
 - `block-repo-rules.md`
@@ -39,6 +41,12 @@ The prompt files live under `internal/agent/prompts/`.
   - Optional skill summary block.
 - `block-output-contract.md`
   - Optional structured output constraint block.
+- `provider-openai.md`
+  - Lightweight overlay for GPT/Codex and OpenAI-compatible model families.
+- `provider-anthropic.md`
+  - Lightweight overlay for Claude-family models.
+- `provider-gemini.md`
+  - Lightweight overlay for Gemini-family models.
 
 ## Assembly Model
 
@@ -49,10 +57,12 @@ Current assembly order:
 1. `core.md`
 2. mode block
 3. environment block
-4. optional plan block
-5. optional repo rules block
-6. optional skills summary block
-7. optional output contract block
+4. optional provider overlay block
+5. optional session block
+6. optional plan block
+7. optional repo rules block
+8. optional skills summary block
+9. optional output contract block
 
 The final prompt is produced by concatenating only the non-empty blocks with blank lines between them.
 
@@ -66,6 +76,7 @@ The current runner passes these fields into `PromptInput`:
 - model
 - max iterations
 - mode
+- session summary
 - session plan
 
 This means the following blocks are fully wired today:
@@ -74,7 +85,9 @@ This means the following blocks are fully wired today:
 - `mode-build.md`
 - `mode-plan.md`
 - `block-environment.md`
+- `block-session.md` when prior session messages exist
 - `block-plan.md` when `session.Plan` is non-empty
+- provider overlay block when the provider or model family matches OpenAI, Anthropic, or Gemini heuristics
 
 The following blocks are implemented in the prompt assembler but are currently optional and unused unless future runtime code supplies data:
 
@@ -109,7 +122,7 @@ Planned natural extensions:
 - repo rule discovery
   - fill `RepoRulesSummary` from AGENTS-like files or config instructions
 - session summary
-  - add a new optional `block-session.md`
+  - improve the current heuristic summary or replace it with compaction output
 - skills registry
   - fill `Skills` with name, description, and enabled state
 - structured output
@@ -124,27 +137,35 @@ This first version deliberately does not yet implement:
 - path-scoped lazy rules
 - full skill loading
 - MCP summary injection
-- session memory summaries
-- provider-specific deep prompt forks
+- session memory compaction
+- provider-specific deep prompt forks beyond lightweight overlays
 
 Those should be added only when the corresponding runtime systems exist.
 
 ## Provider Handling
 
-This version does not keep separate provider prompt files.
+This version still avoids large provider-specific prompt forks, but it now supports lightweight provider/model overlays.
 
 Reason:
 
-- the current ByteMind runtime exposes one tool surface and one execution model to all providers
-- the previous provider split did not create a meaningful behavioral difference
-- keeping two files with near-identical content adds maintenance cost without improving outcomes
+- the shared execution model still belongs in `core.md`
+- model families do show small but real behavioral differences in tool discipline and planning style
+- a thin overlay preserves those differences without copying the whole prompt three or four times
 
-For now, provider information is still exposed in the runtime context block:
+For now, provider information is exposed in the runtime context block:
 
 - `provider_type`
 - `model`
 
-If a real provider-specific behavior gap appears later, it should be introduced as a real block with real rules, not as cosmetic duplication.
+The prompt assembler then selects at most one lightweight overlay:
+
+- `provider-openai.md`
+- `provider-anthropic.md`
+- `provider-gemini.md`
+
+The selection is heuristic and based on `provider_type` plus model-family detection.
+
+If a larger provider-specific behavior gap appears later, it should become a real new block or execution-path difference, not a cosmetic full-prompt fork.
 
 ## Plan Handling
 

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -22,6 +22,9 @@ var planModePromptSource string
 //go:embed prompts/block-environment.md
 var environmentPromptSource string
 
+//go:embed prompts/block-session.md
+var sessionPromptSource string
+
 //go:embed prompts/block-plan.md
 var planPromptSource string
 
@@ -33,6 +36,15 @@ var skillsPromptSource string
 
 //go:embed prompts/block-output-contract.md
 var outputContractPromptSource string
+
+//go:embed prompts/provider-openai.md
+var openAIProviderPromptSource string
+
+//go:embed prompts/provider-anthropic.md
+var anthropicProviderPromptSource string
+
+//go:embed prompts/provider-gemini.md
+var geminiProviderPromptSource string
 
 type PromptSkill struct {
 	Name        string
@@ -49,6 +61,7 @@ type PromptInput struct {
 	Mode             string
 	Platform         string
 	Now              time.Time
+	SessionSummary   string
 	Plan             []session.PlanItem
 	RepoRulesSummary string
 	Skills           []PromptSkill
@@ -60,6 +73,8 @@ func systemPrompt(input PromptInput) string {
 		strings.TrimSpace(corePromptSource),
 		strings.TrimSpace(modePrompt(input.Mode)),
 		renderEnvironmentPrompt(input),
+		renderProviderPrompt(input.ProviderType, input.Model),
+		renderSessionPrompt(input.SessionSummary),
 		renderPlanPrompt(input.Plan),
 		renderRepoRulesPrompt(input.RepoRulesSummary),
 		renderSkillsPrompt(input.Skills),
@@ -141,6 +156,14 @@ func renderPlanPrompt(plan []session.PlanItem) string {
 	return strings.ReplaceAll(strings.TrimSpace(planPromptSource), "{{PLAN_ITEMS}}", strings.Join(lines, "\n"))
 }
 
+func renderSessionPrompt(summary string) string {
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return ""
+	}
+	return strings.ReplaceAll(strings.TrimSpace(sessionPromptSource), "{{SESSION_SUMMARY}}", summary)
+}
+
 func renderRepoRulesPrompt(summary string) string {
 	summary = strings.TrimSpace(summary)
 	if summary == "" {
@@ -176,6 +199,39 @@ func renderOutputContractPrompt(contract string) string {
 		return ""
 	}
 	return strings.ReplaceAll(strings.TrimSpace(outputContractPromptSource), "{{OUTPUT_CONTRACT}}", contract)
+}
+
+func renderProviderPrompt(providerType, model string) string {
+	switch promptModelFamily(providerType, model) {
+	case "anthropic":
+		return strings.TrimSpace(anthropicProviderPromptSource)
+	case "gemini":
+		return strings.TrimSpace(geminiProviderPromptSource)
+	case "openai":
+		return strings.TrimSpace(openAIProviderPromptSource)
+	default:
+		return ""
+	}
+}
+
+func promptModelFamily(providerType, model string) string {
+	providerType = strings.ToLower(strings.TrimSpace(providerType))
+	model = strings.ToLower(strings.TrimSpace(model))
+
+	switch {
+	case providerType == "anthropic", strings.Contains(model, "claude"):
+		return "anthropic"
+	case providerType == "gemini", strings.Contains(model, "gemini"):
+		return "gemini"
+	case providerType == "openai", providerType == "openai-compatible":
+		return "openai"
+	case strings.Contains(model, "gpt"), strings.Contains(model, "codex"):
+		return "openai"
+	case strings.HasPrefix(model, "o1"), strings.HasPrefix(model, "o3"), strings.HasPrefix(model, "o4"):
+		return "openai"
+	default:
+		return ""
+	}
 }
 
 func filterPromptParts(parts []string) []string {

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -18,6 +18,7 @@ func TestSystemPromptRendersConfiguredBlocks(t *testing.T) {
 		Mode:           "build",
 		Platform:       "linux/amd64",
 		Now:            time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC),
+		SessionSummary: "- prior_messages: 6\n- last_user_request: tighten plan/build behavior",
 		Plan: []session.PlanItem{
 			{Step: "Inspect relevant files", Status: "completed"},
 			{Step: "Rewrite prompt architecture", Status: "in_progress"},
@@ -37,11 +38,15 @@ func TestSystemPromptRendersConfiguredBlocks(t *testing.T) {
 	assertContains(t, prompt, "gpt-5.4-mini")
 	assertContains(t, prompt, "linux/amd64")
 	assertContains(t, prompt, "2026-03-31")
+	assertContains(t, prompt, "[Session Context]")
+	assertContains(t, prompt, "tighten plan/build behavior")
 	assertContains(t, prompt, "- [completed] Inspect relevant files")
 	assertContains(t, prompt, "- [in_progress] Rewrite prompt architecture")
 	assertContains(t, prompt, "[Current Execution Plan]")
 	assertContains(t, prompt, "[Repo Rules]")
 	assertContains(t, prompt, "[Available Skills]")
+	assertContains(t, prompt, "[Provider Overlay]")
+	assertContains(t, prompt, "openai-family")
 	assertContains(t, prompt, "[Output Contract]")
 
 	assertNoTemplateMarkers(t, prompt)
@@ -66,8 +71,13 @@ func TestSystemPromptOmitsOptionalBlocksWhenEmpty(t *testing.T) {
 	assertContains(t, prompt, "Risks")
 	assertContains(t, prompt, "Verification")
 	assertContains(t, prompt, "Next Action")
+	assertContains(t, prompt, "[Provider Overlay]")
+	assertContains(t, prompt, "anthropic-family")
 	if strings.Contains(prompt, "[Current Plan]") {
 		t.Fatalf("did not expect plan block in prompt: %q", prompt)
+	}
+	if strings.Contains(prompt, "[Session Context]") {
+		t.Fatalf("did not expect session block in prompt: %q", prompt)
 	}
 	if strings.Contains(prompt, "[Repo Rules]") {
 		t.Fatalf("did not expect repo rules block in prompt: %q", prompt)
@@ -78,6 +88,22 @@ func TestSystemPromptOmitsOptionalBlocksWhenEmpty(t *testing.T) {
 	if strings.Contains(prompt, "[Output Contract]") {
 		t.Fatalf("did not expect output contract block in prompt: %q", prompt)
 	}
+}
+
+func TestSystemPromptUsesGeminiOverlayForGeminiModelFamily(t *testing.T) {
+	prompt := systemPrompt(PromptInput{
+		Workspace:      "/tmp/workspace",
+		ApprovalPolicy: "never",
+		ProviderType:   "openai-compatible",
+		Model:          "gemini-2.5-pro",
+		MaxIterations:  8,
+		Mode:           "build",
+		Platform:       "linux/amd64",
+		Now:            time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC),
+	})
+
+	assertContains(t, prompt, "[Provider Overlay]")
+	assertContains(t, prompt, "gemini-family")
 }
 
 func assertContains(t *testing.T, prompt, needle string) {
@@ -92,6 +118,7 @@ func assertNoTemplateMarkers(t *testing.T, prompt string) {
 	markers := []string{
 		"{{WORKSPACE}}",
 		"{{APPROVAL_POLICY}}",
+		"{{SESSION_SUMMARY}}",
 		"{{PLAN_ITEMS}}",
 		"{{REPO_RULES_SUMMARY}}",
 		"{{SKILLS_SUMMARY}}",

--- a/internal/agent/prompts/block-session.md
+++ b/internal/agent/prompts/block-session.md
@@ -1,0 +1,7 @@
+[Session Context]
+{{SESSION_SUMMARY}}
+
+Guidance:
+- Treat this as compressed continuity context for the ongoing session.
+- The conversation messages below remain authoritative for exact wording and details.
+- Preserve unfinished work unless the user clearly redirects the task.

--- a/internal/agent/prompts/provider-anthropic.md
+++ b/internal/agent/prompts/provider-anthropic.md
@@ -1,0 +1,7 @@
+[Provider Overlay]
+anthropic-family
+
+Model-specific guidance:
+- Keep tool preambles short and factual; do not mix speculative prose with unfinished work.
+- Before changing direction or splitting work, make the active plan explicit with update_plan.
+- Prefer clear incremental tool sequences over vague all-at-once intent.

--- a/internal/agent/prompts/provider-gemini.md
+++ b/internal/agent/prompts/provider-gemini.md
@@ -1,0 +1,7 @@
+[Provider Overlay]
+gemini-family
+
+Model-specific guidance:
+- Use precise file paths, explicit scope, and concrete next actions instead of implicit references.
+- Prefer conservative, easy-to-verify steps when touching code or shell commands.
+- When a change depends on repository evidence, read or search first and cite that evidence in the answer.

--- a/internal/agent/prompts/provider-openai.md
+++ b/internal/agent/prompts/provider-openai.md
@@ -1,0 +1,7 @@
+[Provider Overlay]
+openai-family
+
+Model-specific guidance:
+- Prefer concise, direct reasoning and concrete tool use over long preambles.
+- When several repository reads are needed, batch the smallest sensible set of tool calls.
+- Keep tool arguments strict and complete so follow-up repair turns are not wasted.

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -73,6 +73,8 @@ func (r *Runner) SetApprovalHandler(handler tools.ApprovalHandler) {
 }
 
 func (r *Runner) RunPrompt(ctx context.Context, sess *session.Session, userInput string, out io.Writer) (string, error) {
+	priorMessages := append([]llm.Message(nil), sess.Messages...)
+
 	sess.Messages = append(sess.Messages, llm.Message{
 		Role:    "user",
 		Content: userInput,
@@ -101,6 +103,7 @@ func (r *Runner) RunPrompt(ctx context.Context, sess *session.Session, userInput
 				Model:          r.config.Provider.Model,
 				MaxIterations:  r.config.MaxIterations,
 				Mode:           "build",
+				SessionSummary: summarizeSessionContext(priorMessages),
 				Plan:           append([]session.PlanItem(nil), sess.Plan...),
 			}),
 		})

--- a/internal/agent/session_summary.go
+++ b/internal/agent/session_summary.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"bytemind/internal/llm"
+)
+
+const sessionSummaryTextLimit = 160
+
+func summarizeSessionContext(messages []llm.Message) string {
+	if len(messages) == 0 {
+		return ""
+	}
+
+	lines := []string{
+		fmt.Sprintf("- prior_messages: %d", len(messages)),
+	}
+
+	if text := summarizeRecentUserMessage(messages); text != "" {
+		lines = append(lines, "- last_user_request: "+text)
+	}
+	if text := summarizeRecentAssistantMessage(messages); text != "" {
+		lines = append(lines, "- last_assistant_outcome: "+text)
+	}
+	if names := summarizeRecentToolActivity(messages); len(names) > 0 {
+		lines = append(lines, "- recent_tool_activity: "+strings.Join(names, ", "))
+	}
+
+	if len(lines) == 1 {
+		return ""
+	}
+	return strings.Join(lines, "\n")
+}
+
+func summarizeRecentUserMessage(messages []llm.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role != "user" {
+			continue
+		}
+		if text := compactSummary(messages[i].Content, sessionSummaryTextLimit); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func summarizeRecentAssistantMessage(messages []llm.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role != "assistant" {
+			continue
+		}
+		if text := compactSummary(messages[i].Content, sessionSummaryTextLimit); text != "" {
+			return text
+		}
+		if len(messages[i].ToolCalls) > 0 {
+			return "requested tools: " + strings.Join(uniqueToolCallNames(messages[i].ToolCalls), ", ")
+		}
+	}
+	return ""
+}
+
+func summarizeRecentToolActivity(messages []llm.Message) []string {
+	names := make([]string, 0, 4)
+	for _, message := range messages {
+		if message.Role != "assistant" || len(message.ToolCalls) == 0 {
+			continue
+		}
+		for _, call := range message.ToolCalls {
+			if strings.TrimSpace(call.Function.Name) == "" {
+				continue
+			}
+			names = append(names, call.Function.Name)
+		}
+	}
+	return recentToolNames(names, 4)
+}
+
+func compactSummary(text string, limit int) string {
+	text = strings.Join(strings.Fields(strings.TrimSpace(text)), " ")
+	runes := []rune(text)
+	if limit <= 0 || len(runes) <= limit {
+		return text
+	}
+	if limit <= 3 {
+		return string(runes[:limit])
+	}
+	return string(runes[:limit-3]) + "..."
+}

--- a/internal/agent/session_summary_test.go
+++ b/internal/agent/session_summary_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"bytemind/internal/llm"
+)
+
+func TestSummarizeSessionContextEmptyWhenNoPriorMessages(t *testing.T) {
+	if got := summarizeSessionContext(nil); got != "" {
+		t.Fatalf("expected empty summary, got %q", got)
+	}
+}
+
+func TestSummarizeSessionContextIncludesRecentUserAssistantAndTools(t *testing.T) {
+	got := summarizeSessionContext([]llm.Message{
+		{Role: "user", Content: "Inspect prompt architecture and suggest improvements."},
+		{
+			Role:    "assistant",
+			Content: "I found the mode wiring is still fixed to build and the prompt blocks are optional.",
+			ToolCalls: []llm.ToolCall{
+				{Function: llm.ToolFunctionCall{Name: "read_file"}},
+				{Function: llm.ToolFunctionCall{Name: "update_plan"}},
+			},
+		},
+	})
+
+	for _, want := range []string{
+		"- prior_messages: 2",
+		"- last_user_request: Inspect prompt architecture and suggest improvements.",
+		"- last_assistant_outcome: I found the mode wiring is still fixed to build and the prompt blocks are optional.",
+		"- recent_tool_activity: read_file, update_plan",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in summary, got %q", want, got)
+		}
+	}
+}
+
+func TestSummarizeSessionContextFallsBackToToolSummary(t *testing.T) {
+	got := summarizeSessionContext([]llm.Message{
+		{Role: "user", Content: "Continue."},
+		{
+			Role: "assistant",
+			ToolCalls: []llm.ToolCall{
+				{Function: llm.ToolFunctionCall{Name: "search_text"}},
+				{Function: llm.ToolFunctionCall{Name: "read_file"}},
+			},
+		},
+	})
+
+	if !strings.Contains(got, "- last_assistant_outcome: requested tools: search_text, read_file") {
+		t.Fatalf("expected tool fallback in summary, got %q", got)
+	}
+}


### PR DESCRIPTION
**补充session / provider prompt，plan mode部分未动**

  架构对比                                                                                                                                 
  | 维度 | 改之前 | 改之后 |                                                                                                               
  | --- | --- | --- |                                                                                                                      
  | Prompt 结构 | core + mode + environment + optional plan/rules/skills/output | core + mode + environment + provider overlay + session + optional plan/rules/skills/output |                                                                                                      
  | Session 上下文 | 没有单独 block，只靠完整 message history | 有 block-session.md，注入压缩后的 continuity summary |                     
  | Provider 差异 | 只在 environment 里暴露 provider_type/model，无额外行为差异 | 新增轻量 overlay，按 OpenAI/Anthropic/Gemini 家族补充差异  规则 |                                                    | Provider 维护方式 | 单一 prompt，无分层 | 仍保留共享 core，只把差异做成薄 overlay |
  | Session 实现方式 | 无 summary 字段，无 runner 注入 | runner 基于 prior messages 生成 last_user_request / last_assistant_outcome /
  