### PR TITLE
test: add tui state-flow tests and coverage soft gates

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -34,6 +34,36 @@ jobs:
       - name: Print coverage summary
         run: go tool cover -func=coverage.out
 
+      - name: Report package coverage soft thresholds
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "## Coverage Soft Thresholds" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Package | Coverage | Suggested floor | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | ---: | ---: | --- |" >> "$GITHUB_STEP_SUMMARY"
+
+          report_pkg () {
+            pkg="$1"
+            floor="$2"
+            safe_name="${pkg//\//-}"
+            profile="${safe_name}.cover.out"
+
+            go test "$pkg" -coverprofile="$profile" >/tmp/"$safe_name".log
+            coverage=$(go tool cover -func="$profile" | awk '/^total:/ {print substr($3, 1, length($3)-1)}')
+            status="OK"
+            awk -v cov="$coverage" -v floor="$floor" 'BEGIN { exit !(cov+0 < floor+0) }' && status="Below floor (non-blocking)" || true
+
+            echo "| \`$pkg\` | ${coverage}% | ${floor}% | ${status} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "$pkg coverage: ${coverage}% (suggested floor: ${floor}%) - ${status}"
+          }
+
+          report_pkg ./cmd/bytemind 55
+          report_pkg ./internal/agent 65
+          report_pkg ./internal/tools 70
+          report_pkg ./internal/provider 75
+          report_pkg ./internal/tui 55
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -31,7 +31,37 @@ jobs:
         run: go tool cover -func=coverage.out
 
       - name: Run focused coverage checks
-        run: go test -cover ./cmd/bytemind ./internal/agent ./internal/tools ./internal/provider
+        run: go test -cover ./cmd/bytemind ./internal/agent ./internal/tools ./internal/provider ./internal/tui
+
+      - name: Report package coverage soft thresholds
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "## Coverage Soft Thresholds" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Package | Coverage | Suggested floor | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | ---: | ---: | --- |" >> "$GITHUB_STEP_SUMMARY"
+
+          report_pkg () {
+            pkg="$1"
+            floor="$2"
+            safe_name="${pkg//\//-}"
+            profile="${safe_name}.cover.out"
+
+            go test "$pkg" -coverprofile="$profile" >/tmp/"$safe_name".log
+            coverage=$(go tool cover -func="$profile" | awk '/^total:/ {print substr($3, 1, length($3)-1)}')
+            status="OK"
+            awk -v cov="$coverage" -v floor="$floor" 'BEGIN { exit !(cov+0 < floor+0) }' && status="Below floor (non-blocking)" || true
+
+            echo "| \`$pkg\` | ${coverage}% | ${floor}% | ${status} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "$pkg coverage: ${coverage}% (suggested floor: ${floor}%) - ${status}"
+          }
+
+          report_pkg ./cmd/bytemind 55
+          report_pkg ./internal/agent 65
+          report_pkg ./internal/tools 70
+          report_pkg ./internal/provider 75
+          report_pkg ./internal/tui 55
 
       - name: Upload coverage to Codecov
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"bytemind/internal/agent"
 	"bytemind/internal/config"
 	"bytemind/internal/session"
+	"bytemind/internal/tools"
 
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -899,6 +901,58 @@ func TestHandleAgentEventShowsToolProgressInChat(t *testing.T) {
 	}
 }
 
+func TestHandleAgentEventTracksRunLifecyclePhases(t *testing.T) {
+	m := model{
+		busy:         true,
+		llmConnected: true,
+		chatItems: []chatEntry{
+			{Kind: "user", Title: "You", Body: "inspect tui", Status: "final"},
+			{Kind: "assistant", Title: thinkingLabel, Body: "thinking", Status: "thinking"},
+		},
+		streamingIndex: 1,
+	}
+
+	m.handleAgentEvent(agent.Event{
+		Type:    agent.EventAssistantDelta,
+		Content: "Inspecting the TUI flow...",
+	})
+	if m.phase != "responding" || m.statusNote != "LLM is responding..." {
+		t.Fatalf("expected assistant delta to move UI into responding phase, got phase=%q note=%q", m.phase, m.statusNote)
+	}
+	if m.chatItems[1].Status != "streaming" || !strings.Contains(m.chatItems[1].Body, "Inspecting the TUI flow") {
+		t.Fatalf("expected streaming assistant card after delta, got %+v", m.chatItems[1])
+	}
+
+	m.handleAgentEvent(agent.Event{
+		Type:          agent.EventToolCallStarted,
+		ToolName:      "read_file",
+		ToolArguments: `{"path":"internal/tui/model.go","start_line":1,"end_line":5}`,
+	})
+	if m.phase != "tool" || m.statusNote != "Running tool: read_file" {
+		t.Fatalf("expected tool start to move UI into tool phase, got phase=%q note=%q", m.phase, m.statusNote)
+	}
+
+	m.handleAgentEvent(agent.Event{
+		Type:       agent.EventToolCallCompleted,
+		ToolName:   "read_file",
+		ToolResult: `{"path":"internal/tui/model.go","start_line":1,"end_line":5}`,
+	})
+	if m.phase != "thinking" {
+		t.Fatalf("expected completed tool to return UI to thinking phase, got %q", m.phase)
+	}
+	if !strings.Contains(m.statusNote, "Read internal/tui/model.go lines 1-5") {
+		t.Fatalf("expected tool result summary in status note, got %q", m.statusNote)
+	}
+
+	m.handleAgentEvent(agent.Event{
+		Type:    agent.EventRunFinished,
+		Content: "Done.",
+	})
+	if m.phase != "idle" || m.statusNote != "Run finished." {
+		t.Fatalf("expected run finished event to return UI to idle, got phase=%q note=%q", m.phase, m.statusNote)
+	}
+}
+
 func TestToolStartReplacesStreamedAssistantTurnWithStableToolIntro(t *testing.T) {
 	m := model{
 		chatItems: []chatEntry{
@@ -972,6 +1026,212 @@ func TestApprovalBannerRendersAboveInput(t *testing.T) {
 	if strings.Contains(footer, "Approval Request") {
 		t.Fatalf("did not expect old centered approval modal title in footer")
 	}
+}
+
+func TestUpdateApprovalRequestMsgSetsApprovalPhase(t *testing.T) {
+	reply := make(chan approvalDecision, 1)
+	m := model{async: make(chan tea.Msg, 1)}
+
+	got, cmd := m.Update(approvalRequestMsg{
+		Request: tools.ApprovalRequest{
+			Command: "go test ./internal/tui",
+			Reason:  "run focused tests",
+		},
+		Reply: reply,
+	})
+	updated := got.(model)
+
+	if cmd == nil {
+		t.Fatalf("expected approval request to keep waiting for async events")
+	}
+	if updated.approval == nil {
+		t.Fatalf("expected approval prompt to be stored on the model")
+	}
+	if updated.approval.Command != "go test ./internal/tui" || updated.approval.Reason != "run focused tests" {
+		t.Fatalf("expected approval prompt contents to be preserved, got %+v", updated.approval)
+	}
+	if updated.phase != "approval" || updated.statusNote != "Approval required." {
+		t.Fatalf("expected approval request to switch UI into approval state, got phase=%q note=%q", updated.phase, updated.statusNote)
+	}
+}
+
+func TestApprovalKeysTransitionStateAndSendDecision(t *testing.T) {
+	t.Run("approve", func(t *testing.T) {
+		reply := make(chan approvalDecision, 1)
+		m := model{
+			approval: &approvalPrompt{
+				Command: "go test ./internal/tui",
+				Reason:  "run focused tests",
+				Reply:   reply,
+			},
+			phase: "approval",
+		}
+
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+		updated := got.(model)
+
+		if updated.approval != nil {
+			t.Fatalf("expected approval prompt to clear after approval")
+		}
+		if updated.phase != "tool" || updated.statusNote != "Shell command approved." {
+			t.Fatalf("expected approval to move UI into tool phase, got phase=%q note=%q", updated.phase, updated.statusNote)
+		}
+
+		select {
+		case decision := <-reply:
+			if !decision.Approved {
+				t.Fatalf("expected approval decision to be true")
+			}
+		default:
+			t.Fatalf("expected approval decision to be sent")
+		}
+	})
+
+	t.Run("reject", func(t *testing.T) {
+		reply := make(chan approvalDecision, 1)
+		m := model{
+			approval: &approvalPrompt{
+				Command: "go test ./internal/tui",
+				Reason:  "run focused tests",
+				Reply:   reply,
+			},
+			phase: "approval",
+		}
+
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+		updated := got.(model)
+
+		if updated.approval != nil {
+			t.Fatalf("expected approval prompt to clear after rejection")
+		}
+		if updated.phase != "thinking" || updated.statusNote != "Shell command rejected." {
+			t.Fatalf("expected rejection to return UI to thinking phase, got phase=%q note=%q", updated.phase, updated.statusNote)
+		}
+
+		select {
+		case decision := <-reply:
+			if decision.Approved {
+				t.Fatalf("expected rejection decision to be false")
+			}
+		default:
+			t.Fatalf("expected rejection decision to be sent")
+		}
+	})
+}
+
+func TestUpdateRunFinishedMsgResetsBusyState(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := model{
+			async:          make(chan tea.Msg, 1),
+			busy:           true,
+			streamingIndex: 3,
+			statusNote:     "Running...",
+			phase:          "responding",
+			llmConnected:   true,
+		}
+
+		got, cmd := m.Update(runFinishedMsg{})
+		updated := got.(model)
+
+		if cmd == nil {
+			t.Fatalf("expected run finished to schedule follow-up async/session work")
+		}
+		if updated.busy {
+			t.Fatalf("expected run finished to clear busy state")
+		}
+		if updated.streamingIndex != -1 {
+			t.Fatalf("expected run finished to clear streaming index, got %d", updated.streamingIndex)
+		}
+		if updated.phase != "idle" || updated.statusNote != "Ready." {
+			t.Fatalf("expected successful run to return to idle, got phase=%q note=%q", updated.phase, updated.statusNote)
+		}
+		if !updated.llmConnected {
+			t.Fatalf("expected successful run to keep llmConnected=true")
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		m := model{
+			async:          make(chan tea.Msg, 1),
+			busy:           true,
+			streamingIndex: 1,
+			statusNote:     "Running...",
+			phase:          "responding",
+			llmConnected:   true,
+			chatItems: []chatEntry{
+				{Kind: "user", Title: "You", Body: "inspect repo", Status: "final"},
+				{Kind: "assistant", Title: thinkingLabel, Body: "thinking", Status: "thinking"},
+			},
+		}
+
+		got, _ := m.Update(runFinishedMsg{Err: errors.New("provider unavailable")})
+		updated := got.(model)
+
+		if updated.busy {
+			t.Fatalf("expected failed run to clear busy state")
+		}
+		if updated.phase != "error" || !strings.Contains(updated.statusNote, "provider unavailable") {
+			t.Fatalf("expected failed run to switch UI into error state, got phase=%q note=%q", updated.phase, updated.statusNote)
+		}
+		if updated.llmConnected {
+			t.Fatalf("expected failed run to mark llmConnected=false")
+		}
+		last := updated.chatItems[len(updated.chatItems)-1]
+		if last.Status != "error" || !strings.Contains(last.Body, "provider unavailable") {
+			t.Fatalf("expected latest assistant card to show failure, got %+v", last)
+		}
+	})
+}
+
+func TestUpdateSessionsLoadedMsgUpdatesAndClampsSessions(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := model{
+			sessionCursor: 3,
+			sessions: []session.Summary{
+				{ID: "old-1"},
+				{ID: "old-2"},
+				{ID: "old-3"},
+				{ID: "old-4"},
+			},
+		}
+
+		got, _ := m.Update(sessionsLoadedMsg{
+			Summaries: []session.Summary{
+				{ID: "new-1"},
+				{ID: "new-2"},
+			},
+		})
+		updated := got.(model)
+
+		if len(updated.sessions) != 2 {
+			t.Fatalf("expected sessions list to be replaced, got %d entries", len(updated.sessions))
+		}
+		if updated.sessionCursor != 1 {
+			t.Fatalf("expected session cursor to clamp to last available entry, got %d", updated.sessionCursor)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		m := model{
+			sessionCursor: 1,
+			sessions: []session.Summary{
+				{ID: "keep-1"},
+				{ID: "keep-2"},
+			},
+		}
+
+		got, _ := m.Update(sessionsLoadedMsg{
+			Err: errors.New("store unavailable"),
+		})
+		updated := got.(model)
+
+		if len(updated.sessions) != 2 || updated.sessions[0].ID != "keep-1" || updated.sessions[1].ID != "keep-2" {
+			t.Fatalf("expected session list to stay unchanged on load error, got %+v", updated.sessions)
+		}
+		if updated.sessionCursor != 1 {
+			t.Fatalf("expected session cursor to remain unchanged on load error, got %d", updated.sessionCursor)
+		}
+	})
 }
 
 func TestFormatChatBodyPreservesExplicitBlankLines(t *testing.T) {


### PR DESCRIPTION
## 概要

这个 PR 继续完善 ByteMind 的测试质量护栏，重点补强了 TUI 层关键状态流测试，并在 CI 中加入了非阻断式的 coverage 软门槛。

本次改动的目标是：在不把 coverage 立即变成硬性门禁的前提下，先提升 TUI 关键交互状态的自动化保护，并让 PR / main 流水线持续输出更清晰的覆盖率信号。

## 本次改动

### 1. 补充 TUI 关键状态流测试
在 `internal/tui/model_test.go` 中新增了针对关键 UI 状态切换的测试，主要覆盖：

- `approvalRequestMsg` 进入审批状态
- 审批通过 / 拒绝后的状态切换
- run 成功完成后的状态重置
- run 失败完成后的状态收口
- session 列表加载成功后的更新与 cursor 修正
- session 列表加载失败时保持原状态
- `assistant delta -> tool start -> tool result -> run finished` 的完整生命周期流转

### 2. 在 CI 中加入 coverage 软门槛
更新了以下 workflow：

- `.github/workflows/ci-pr.yml`
- `.github/workflows/ci-main.yml`

现在 CI 会：
- 继续执行正常的测试、`go vet` 和 `race`
- 输出整体 coverage
- 在 GitHub Actions Summary 中输出关键包的 coverage 建议线
- 即使低于建议线，也只提示 `Below floor (non-blocking)`，不会直接让 CI 失败

当前纳入软门槛提示的包包括：

- `./cmd/bytemind`
- `./internal/agent`
- `./internal/tools`
- `./internal/provider`
- `./internal/tui`

## 为什么这样做

在前一轮已经补强 `provider`、`tools`、`agent` 和 one-shot smoke 的基础上，当前最明显的后续薄弱点主要集中在 TUI 层。

因此，这一轮优先补齐用户更容易感知、也更容易在后续交互迭代中回归的 TUI 状态流测试。同时，coverage 先以“软门槛”的形式进入 CI，让团队先形成持续关注关键包覆盖情况的习惯，而不是一上来就把 coverage 设成硬性阻断条件。

## 本地验证

已本地执行：

- `go test ./internal/tui`
- `go test ./internal/tui -cover`
- `go test ./...`

## 后续计划

后续会继续推进：

- 增加更多独立的 smoke / integration 检查
- 继续补强 TUI 交互与状态展示测试
- 视团队执行情况评估哪些 coverage 软门槛适合升级为硬门槛
