### PR TITLE
add coding skill framework with session activation and TUI slash commands

### DIFF
--- a/docs/prompt-architecture.md
+++ b/docs/prompt-architecture.md
@@ -7,7 +7,8 @@ Keep prompt assembly simple, testable, and close to OpenCode's runtime layering 
 1. main system prompt text
 2. mode prompt (`build` or `plan`)
 3. runtime context block (environment + skills + tools)
-4. repository instruction block (`AGENTS.md`)
+4. optional active skill block
+5. repository instruction block (`AGENTS.md`)
 
 ## Prompt Files
 
@@ -16,6 +17,7 @@ Prompt assets live under `internal/agent/prompts/`:
 - `system_prompt.md`
 - `mode/build.md`
 - `mode/plan.md`
+- `block-active-skill.md`
 
 ## Assembly Order
 
@@ -24,7 +26,8 @@ Prompt assets live under `internal/agent/prompts/`:
 1. `system_prompt.md`
 2. `mode/{build|plan}.md`
 3. `renderSystemBlock(...)`
-4. `renderInstructionBlock(...)`
+4. `renderActiveSkillPrompt(...)` (only when a session skill is active)
+5. `renderInstructionBlock(...)`
 
 Only non-empty blocks are included.
 
@@ -35,6 +38,7 @@ Only non-empty blocks are included.
 - `workspace`, `approval_policy`, `model`, `mode`, `platform`, `now`
 - `skills` list
 - `tools` list
+- `active_skill` (name/description/args/tool-policy/instructions)
 - `instruction` text loaded from workspace root `AGENTS.md`
 
 ## Mode Selection
@@ -49,7 +53,7 @@ Only non-empty blocks are included.
 
 The previous prompt design had additional blocks (`repo rules`, `skills summary`, `output contract`, and injected plan state) that were mostly unwired at runtime. That created complexity without behavior gain.
 
-The current architecture keeps only blocks that are always meaningful and actively wired.
+The current architecture keeps blocks that are always meaningful in runtime, while still supporting session-level active skill guidance.
 
 ## OpenCode Alignment Notes
 
@@ -58,6 +62,7 @@ This architecture keeps the same high-level layering intent as OpenCode:
 - stable base prompt text
 - runtime mode influence
 - generated environment/tool context
+- optional focused instruction block (active skill)
 - instruction file injection
 
 ByteMind intentionally remains provider-agnostic and does not use provider-specific prompt forks.

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -20,10 +20,23 @@ var buildModePromptSource string
 //go:embed prompts/mode/plan.md
 var planModePromptSource string
 
+//go:embed prompts/block-active-skill.md
+var activeSkillPromptSource string
+
 type PromptSkill struct {
 	Name        string
 	Description string
 	Enabled     bool
+}
+
+type PromptActiveSkill struct {
+	Name         string
+	Description  string
+	WhenToUse    string
+	Instructions string
+	Args         map[string]string
+	ToolPolicy   string
+	Tools        []string
 }
 
 type PromptInput struct {
@@ -35,6 +48,7 @@ type PromptInput struct {
 	Now            time.Time
 	Skills         []PromptSkill
 	Tools          []string
+	ActiveSkill    *PromptActiveSkill
 	Instruction    string
 }
 
@@ -43,6 +57,7 @@ func systemPrompt(input PromptInput) string {
 		strings.TrimSpace(mainPromptSource),
 		strings.TrimSpace(modePrompt(input.Mode)),
 		renderSystemBlock(input),
+		renderActiveSkillPrompt(input.ActiveSkill),
 		renderInstructionBlock(input.Instruction),
 	}
 	return strings.Join(filterPromptParts(parts), "\n\n")
@@ -179,6 +194,76 @@ func formatTools(tools []string) string {
 	}
 	sort.Strings(lines)
 	return strings.Join(lines, "\n")
+}
+
+func renderActiveSkillPrompt(skill *PromptActiveSkill) string {
+	if skill == nil {
+		return ""
+	}
+
+	name := strings.TrimSpace(skill.Name)
+	description := strings.TrimSpace(skill.Description)
+	whenToUse := strings.TrimSpace(skill.WhenToUse)
+	instructions := strings.TrimSpace(skill.Instructions)
+	toolPolicy := strings.TrimSpace(skill.ToolPolicy)
+	if name == "" && description == "" && whenToUse == "" && instructions == "" && toolPolicy == "" {
+		return ""
+	}
+
+	lines := make([]string, 0, 16)
+	if name != "" {
+		lines = append(lines, "Name: "+name)
+	}
+	if description != "" {
+		lines = append(lines, "Description: "+description)
+	}
+	if whenToUse != "" {
+		lines = append(lines, "When To Use: "+whenToUse)
+	}
+	if len(skill.Args) > 0 {
+		keys := make([]string, 0, len(skill.Args))
+		for key := range skill.Args {
+			if strings.TrimSpace(key) != "" {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+		if len(keys) > 0 {
+			lines = append(lines, "Args:")
+			for _, key := range keys {
+				value := strings.TrimSpace(skill.Args[key])
+				if value == "" {
+					continue
+				}
+				lines = append(lines, fmt.Sprintf("- %s=%s", key, value))
+			}
+		}
+	}
+	if toolPolicy != "" {
+		lines = append(lines, "Tool Policy: "+toolPolicy)
+	}
+	if len(skill.Tools) > 0 {
+		tools := make([]string, 0, len(skill.Tools))
+		for _, tool := range skill.Tools {
+			tool = strings.TrimSpace(tool)
+			if tool != "" {
+				tools = append(tools, tool)
+			}
+		}
+		if len(tools) > 0 {
+			sort.Strings(tools)
+			lines = append(lines, "Tool Items: "+strings.Join(tools, ", "))
+		}
+	}
+	if instructions != "" {
+		lines = append(lines, "", "Instructions:", instructions)
+	}
+
+	if len(lines) == 0 {
+		return ""
+	}
+
+	return strings.ReplaceAll(strings.TrimSpace(activeSkillPromptSource), "{{ACTIVE_SKILL_BLOCK}}", strings.Join(lines, "\n"))
 }
 
 func renderInstructionBlock(instruction string) string {

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -25,7 +25,18 @@ func TestSystemPromptRendersMainModeSystemAndInstruction(t *testing.T) {
 		Skills: []PromptSkill{
 			{Name: "review", Description: "Review code changes for regressions.", Enabled: true},
 		},
-		Tools:       []string{"read_file", "list_files", "read_file"},
+		Tools: []string{"read_file", "list_files", "read_file"},
+		ActiveSkill: &PromptActiveSkill{
+			Name:         "review",
+			Description:  "Review code changes with correctness focus.",
+			WhenToUse:    "When user asks for review.",
+			Instructions: "Prioritize regressions and missing tests.",
+			Args: map[string]string{
+				"base_ref": "main",
+			},
+			ToolPolicy: "allowlist",
+			Tools:      []string{"read_file", "search_text"},
+		},
 		Instruction: loadAGENTSInstruction(workspace),
 	})
 
@@ -44,12 +55,15 @@ func TestSystemPromptRendersMainModeSystemAndInstruction(t *testing.T) {
 	assertContains(t, prompt, "[Available Tools]")
 	assertContains(t, prompt, "- list_files")
 	assertContains(t, prompt, "- read_file")
+	assertContains(t, prompt, "[Active Skill]")
+	assertContains(t, prompt, "Tool Policy: allowlist")
 	assertContains(t, prompt, "[Instructions]")
 	assertContains(t, prompt, "Instructions from:")
 	assertContains(t, prompt, "Use rg for search before broad shell scans.")
+	assertNoTemplateMarkers(t, prompt)
 }
 
-func TestSystemPromptOmitsInstructionWhenEmpty(t *testing.T) {
+func TestSystemPromptOmitsOptionalBlocksWhenEmpty(t *testing.T) {
 	prompt := systemPrompt(PromptInput{
 		Workspace:      "/tmp/workspace",
 		ApprovalPolicy: "never",
@@ -67,6 +81,10 @@ func TestSystemPromptOmitsInstructionWhenEmpty(t *testing.T) {
 	if strings.Contains(prompt, "[Instructions]") {
 		t.Fatalf("did not expect instruction block in prompt: %q", prompt)
 	}
+	if strings.Contains(prompt, "[Active Skill]") {
+		t.Fatalf("did not expect active skill block in prompt: %q", prompt)
+	}
+	assertNoTemplateMarkers(t, prompt)
 }
 
 func TestModePromptDefaultsToBuild(t *testing.T) {
@@ -163,5 +181,17 @@ func assertContains(t *testing.T, prompt, needle string) {
 	t.Helper()
 	if !strings.Contains(prompt, needle) {
 		t.Fatalf("expected %q in prompt, got %q", needle, prompt)
+	}
+}
+
+func assertNoTemplateMarkers(t *testing.T, prompt string) {
+	t.Helper()
+	markers := []string{
+		"{{ACTIVE_SKILL_BLOCK}}",
+	}
+	for _, marker := range markers {
+		if strings.Contains(prompt, marker) {
+			t.Fatalf("expected template marker %q to be rendered, got %q", marker, prompt)
+		}
 	}
 }

--- a/internal/agent/prompts/block-active-skill.md
+++ b/internal/agent/prompts/block-active-skill.md
@@ -1,0 +1,8 @@
+[Active Skill]
+{{ACTIVE_SKILL_BLOCK}}
+
+Skill handling:
+- The active skill is user-selected and applies for the current session unless cleared.
+- Follow the active skill workflow and output contract when relevant.
+- Do not exceed workspace or tool permission boundaries.
+

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -7,15 +7,22 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 
 	"bytemind/internal/config"
 	"bytemind/internal/llm"
 	planpkg "bytemind/internal/plan"
 	"bytemind/internal/session"
+	"bytemind/internal/skills"
 	"bytemind/internal/tools"
 )
 
 const repeatedToolSequenceThreshold = 3
+const (
+	maxActiveSkillDescriptionChars  = 320
+	maxActiveSkillInstructionsChars = 3600
+	emptyAllowlistSentinel          = "__bytemind__no_tools__"
+)
 
 const (
 	ansiReset   = "\x1b[0m"
@@ -29,40 +36,47 @@ const (
 )
 
 type Options struct {
-	Workspace string
-	Config    config.Config
-	Client    llm.Client
-	Store     *session.Store
-	Registry  *tools.Registry
-	Observer  Observer
-	Approval  tools.ApprovalHandler
-	Stdin     io.Reader
-	Stdout    io.Writer
+	Workspace    string
+	Config       config.Config
+	Client       llm.Client
+	Store        *session.Store
+	Registry     *tools.Registry
+	SkillManager *skills.Manager
+	Observer     Observer
+	Approval     tools.ApprovalHandler
+	Stdin        io.Reader
+	Stdout       io.Writer
 }
 
 type Runner struct {
-	workspace string
-	config    config.Config
-	client    llm.Client
-	store     *session.Store
-	registry  *tools.Registry
-	observer  Observer
-	approval  tools.ApprovalHandler
-	stdin     io.Reader
-	stdout    io.Writer
+	workspace    string
+	config       config.Config
+	client       llm.Client
+	store        *session.Store
+	registry     *tools.Registry
+	skillManager *skills.Manager
+	observer     Observer
+	approval     tools.ApprovalHandler
+	stdin        io.Reader
+	stdout       io.Writer
 }
 
 func NewRunner(opts Options) *Runner {
+	manager := opts.SkillManager
+	if manager == nil {
+		manager = skills.NewManager(opts.Workspace)
+	}
 	return &Runner{
-		workspace: opts.Workspace,
-		config:    opts.Config,
-		client:    opts.Client,
-		store:     opts.Store,
-		registry:  opts.Registry,
-		observer:  opts.Observer,
-		approval:  opts.Approval,
-		stdin:     opts.Stdin,
-		stdout:    opts.Stdout,
+		workspace:    opts.Workspace,
+		config:       opts.Config,
+		client:       opts.Client,
+		store:        opts.Store,
+		registry:     opts.Registry,
+		skillManager: manager,
+		observer:     opts.Observer,
+		approval:     opts.Approval,
+		stdin:        opts.Stdin,
+		stdout:       opts.Stdout,
 	}
 }
 
@@ -72,6 +86,69 @@ func (r *Runner) SetObserver(observer Observer) {
 
 func (r *Runner) SetApprovalHandler(handler tools.ApprovalHandler) {
 	r.approval = handler
+}
+
+func (r *Runner) ListSkills() ([]skills.Skill, []skills.Diagnostic) {
+	if r.skillManager == nil {
+		return nil, nil
+	}
+	return r.skillManager.List()
+}
+
+func (r *Runner) ActivateSkill(sess *session.Session, name string, args map[string]string) (skills.Skill, error) {
+	if sess == nil {
+		return skills.Skill{}, fmt.Errorf("session is required")
+	}
+	if r.skillManager == nil {
+		return skills.Skill{}, fmt.Errorf("skill manager is unavailable")
+	}
+	skill, ok := r.skillManager.Find(name)
+	if !ok {
+		return skills.Skill{}, fmt.Errorf("skill not found: %s", strings.TrimSpace(name))
+	}
+
+	normalizedArgs := normalizeSkillArgs(args)
+	for _, arg := range skill.Args {
+		if _, exists := normalizedArgs[arg.Name]; !exists && strings.TrimSpace(arg.Default) != "" {
+			normalizedArgs[arg.Name] = strings.TrimSpace(arg.Default)
+		}
+		if arg.Required && strings.TrimSpace(normalizedArgs[arg.Name]) == "" {
+			return skills.Skill{}, fmt.Errorf("missing required skill arg: %s", arg.Name)
+		}
+	}
+	if len(normalizedArgs) == 0 {
+		normalizedArgs = nil
+	}
+
+	sess.ActiveSkill = &session.ActiveSkill{
+		Name:        skill.Name,
+		Args:        normalizedArgs,
+		ActivatedAt: time.Now().UTC(),
+	}
+	if r.store != nil {
+		if err := r.store.Save(sess); err != nil {
+			return skills.Skill{}, err
+		}
+	}
+	return skill, nil
+}
+
+func (r *Runner) ClearActiveSkill(sess *session.Session) error {
+	if sess == nil {
+		return fmt.Errorf("session is required")
+	}
+	sess.ActiveSkill = nil
+	if r.store != nil {
+		return r.store.Save(sess)
+	}
+	return nil
+}
+
+func (r *Runner) GetActiveSkill(sess *session.Session) (skills.Skill, bool) {
+	if sess == nil || sess.ActiveSkill == nil || r.skillManager == nil {
+		return skills.Skill{}, false
+	}
+	return r.skillManager.Find(sess.ActiveSkill.Name)
 }
 
 func (r *Runner) RunPrompt(ctx context.Context, sess *session.Session, userInput, mode string, out io.Writer) (string, error) {
@@ -105,6 +182,11 @@ func (r *Runner) RunPrompt(ctx context.Context, sess *session.Session, userInput
 		UserInput: userInput,
 	})
 
+	activeSkill := r.resolveActiveSkill(sess)
+	allowedTools, deniedTools := policySets(activeSkill)
+	allowedToolNames := sortedToolNames(allowedTools)
+	deniedToolNames := sortedToolNames(deniedTools)
+
 	lastToolSequenceSignature := ""
 	repeatedToolSequenceCount := 0
 	executedToolNames := make([]string, 0, 16)
@@ -121,6 +203,7 @@ func (r *Runner) RunPrompt(ctx context.Context, sess *session.Session, userInput
 				Model:          r.config.Provider.Model,
 				Mode:           mode,
 				Tools:          availableTools,
+				ActiveSkill:    promptActiveSkill(activeSkill),
 				Instruction:    instructionText,
 			}),
 		})
@@ -129,7 +212,7 @@ func (r *Runner) RunPrompt(ctx context.Context, sess *session.Session, userInput
 		request := llm.ChatRequest{
 			Model:       r.config.Provider.Model,
 			Messages:    messages,
-			Tools:       r.registry.DefinitionsForMode(runMode),
+			Tools:       r.registry.DefinitionsForModeWithFilters(runMode, allowedToolNames, deniedToolNames),
 			Temperature: 0.2,
 		}
 
@@ -220,6 +303,8 @@ func (r *Runner) RunPrompt(ctx context.Context, sess *session.Session, userInput
 				Mode:           runMode,
 				Stdin:          r.stdin,
 				Stdout:         r.stdout,
+				AllowedTools:   allowedTools,
+				DeniedTools:    deniedTools,
 			})
 			if execErr != nil {
 				result = marshalToolResult(map[string]any{
@@ -579,6 +664,140 @@ func compactWhitespace(text string, limit int) string {
 		return string(runes[:limit])
 	}
 	return string(runes[:limit-3]) + "..."
+}
+
+type activeSkillRuntime struct {
+	Skill skills.Skill
+	Args  map[string]string
+}
+
+func (r *Runner) resolveActiveSkill(sess *session.Session) *activeSkillRuntime {
+	if sess == nil || sess.ActiveSkill == nil || r.skillManager == nil {
+		return nil
+	}
+
+	skill, ok := r.skillManager.Find(sess.ActiveSkill.Name)
+	if !ok {
+		sess.ActiveSkill = nil
+		if r.store != nil {
+			_ = r.store.Save(sess)
+		}
+		return nil
+	}
+
+	return &activeSkillRuntime{
+		Skill: skill,
+		Args:  normalizeSkillArgs(sess.ActiveSkill.Args),
+	}
+}
+
+func policySets(active *activeSkillRuntime) (map[string]struct{}, map[string]struct{}) {
+	if active == nil {
+		return nil, nil
+	}
+	items := active.Skill.ToolPolicy.Items
+	switch active.Skill.ToolPolicy.Policy {
+	case skills.ToolPolicyAllowlist:
+		if len(items) == 0 {
+			return map[string]struct{}{emptyAllowlistSentinel: {}}, nil
+		}
+		allow := toToolSet(items)
+		if allow == nil {
+			return map[string]struct{}{emptyAllowlistSentinel: {}}, nil
+		}
+		return allow, nil
+	case skills.ToolPolicyDenylist:
+		return nil, toToolSet(items)
+	default:
+		return nil, nil
+	}
+}
+
+func toToolSet(items []string) map[string]struct{} {
+	if len(items) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		set[item] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
+}
+
+func sortedToolNames(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(set))
+	for name := range set {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func promptActiveSkill(active *activeSkillRuntime) *PromptActiveSkill {
+	if active == nil {
+		return nil
+	}
+
+	instruction := strings.TrimSpace(active.Skill.Instruction)
+	if instruction != "" {
+		instruction = trimTextWithEllipsis(instruction, maxActiveSkillInstructionsChars)
+	}
+	description := trimTextWithEllipsis(strings.TrimSpace(active.Skill.Description), maxActiveSkillDescriptionChars)
+	whenToUse := trimTextWithEllipsis(strings.TrimSpace(active.Skill.WhenToUse), maxActiveSkillDescriptionChars)
+
+	return &PromptActiveSkill{
+		Name:         active.Skill.Name,
+		Description:  description,
+		WhenToUse:    whenToUse,
+		Instructions: instruction,
+		Args:         normalizeSkillArgs(active.Args),
+		ToolPolicy:   string(active.Skill.ToolPolicy.Policy),
+		Tools:        append([]string(nil), active.Skill.ToolPolicy.Items...),
+	}
+}
+
+func trimTextWithEllipsis(text string, maxRunes int) string {
+	text = strings.TrimSpace(text)
+	if maxRunes <= 0 || text == "" {
+		return text
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	if maxRunes <= 3 {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-3]) + "..."
+}
+
+func normalizeSkillArgs(args map[string]string) map[string]string {
+	if len(args) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(args))
+	for key, value := range args {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		result[key] = value
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 func (r *Runner) emit(event Event) {

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -3,6 +3,10 @@ package agent
 import (
 	"context"
 	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -13,11 +17,13 @@ import (
 )
 
 type fakeClient struct {
-	replies []llm.Message
-	index   int
+	replies  []llm.Message
+	requests []llm.ChatRequest
+	index    int
 }
 
 func (f *fakeClient) CreateMessage(ctx context.Context, req llm.ChatRequest) (llm.Message, error) {
+	f.requests = append(f.requests, req)
 	if len(f.replies) == 0 {
 		return llm.Message{}, nil
 	}
@@ -250,5 +256,201 @@ func TestCompactWhitespacePreservesUTF8WhenTruncating(t *testing.T) {
 	}
 	if !strings.HasSuffix(got, "...") {
 		t.Fatalf("expected truncated preview to end with ellipsis, got %q", got)
+	}
+}
+
+func TestRunPromptAppliesActiveSkillToolAllowlist(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, "internal", "skills", "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "internal", "skills", "review", "skill.json"), []byte(`{
+  "name":"review",
+  "description":"Review changes",
+  "tools":{"policy":"allowlist","items":["read_file","search_text","list_files"]}
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "internal", "skills", "review", "SKILL.md"), []byte("# review\nCheck correctness."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	sess.ActiveSkill = &session.ActiveSkill{Name: "review"}
+
+	client := &fakeClient{replies: []llm.Message{{
+		Role:    "assistant",
+		Content: "reviewed",
+	}}}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 2,
+			Stream:        false,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "review this", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "reviewed" {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+	if len(client.requests) == 0 {
+		t.Fatal("expected at least one request")
+	}
+	names := make([]string, 0, len(client.requests[0].Tools))
+	for _, def := range client.requests[0].Tools {
+		names = append(names, def.Function.Name)
+	}
+	sort.Strings(names)
+	want := []string{"list_files", "read_file", "search_text"}
+	if !slices.Equal(names, want) {
+		t.Fatalf("unexpected tool list after allowlist filter: got=%v want=%v", names, want)
+	}
+}
+
+func TestRunPromptBlocksToolCallOutsideActiveSkillPolicy(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, "internal", "skills", "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "internal", "skills", "review", "skill.json"), []byte(`{
+  "name":"review",
+  "description":"Review changes",
+  "tools":{"policy":"allowlist","items":["read_file","search_text"]}
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	sess.ActiveSkill = &session.ActiveSkill{Name: "review"}
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role: "assistant",
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "write_file",
+					Arguments: `{"path":"x.txt","content":"x"}`,
+				},
+			}},
+		},
+		{
+			Role:    "assistant",
+			Content: "recovered",
+		},
+	}}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 4,
+			Stream:        false,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "review this", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "recovered" {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+	if len(sess.Messages) < 3 {
+		t.Fatalf("expected tool result message, got %#v", sess.Messages)
+	}
+	toolMsg := sess.Messages[2]
+	if toolMsg.Role != "tool" || !strings.Contains(toolMsg.Content, "active skill policy") {
+		t.Fatalf("expected policy rejection in tool message, got %#v", toolMsg)
+	}
+}
+
+func TestActivateAndClearSkillPersistsSessionState(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, "internal", "skills", "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "internal", "skills", "review", "skill.json"), []byte(`{
+  "name":"review",
+  "description":"Review changes",
+  "tools":{"policy":"allowlist","items":["read_file","search_text"]},
+  "args":[{"name":"base_ref","required":true,"type":"string"}]
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	if err := store.Save(sess); err != nil {
+		t.Fatal(err)
+	}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 2,
+			Stream:        false,
+		},
+		Client:   &fakeClient{},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	if _, err := runner.ActivateSkill(sess, "review", nil); err == nil {
+		t.Fatal("expected missing required args to fail")
+	}
+	skill, err := runner.ActivateSkill(sess, "review", map[string]string{"base_ref": "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if skill.Name != "review" {
+		t.Fatalf("unexpected activated skill: %#v", skill)
+	}
+	if sess.ActiveSkill == nil || sess.ActiveSkill.Name != "review" {
+		t.Fatalf("expected session active skill to be set, got %#v", sess.ActiveSkill)
+	}
+
+	loaded, err := store.Load(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.ActiveSkill == nil || loaded.ActiveSkill.Args["base_ref"] != "main" {
+		t.Fatalf("expected persisted active skill args, got %#v", loaded.ActiveSkill)
+	}
+
+	if err := runner.ClearActiveSkill(sess); err != nil {
+		t.Fatal(err)
+	}
+	if sess.ActiveSkill != nil {
+		t.Fatalf("expected active skill to be cleared, got %#v", sess.ActiveSkill)
 	}
 }

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -24,14 +24,21 @@ const (
 	schemaVersion     = 1
 )
 
+type ActiveSkill struct {
+	Name        string            `json:"name"`
+	Args        map[string]string `json:"args,omitempty"`
+	ActivatedAt time.Time         `json:"activated_at,omitempty"`
+}
+
 type Session struct {
-	ID        string            `json:"id"`
-	Workspace string            `json:"workspace"`
-	CreatedAt time.Time         `json:"created_at"`
-	UpdatedAt time.Time         `json:"updated_at"`
-	Messages  []llm.Message     `json:"messages"`
-	Mode      planpkg.AgentMode `json:"mode,omitempty"`
-	Plan      planpkg.State     `json:"plan,omitempty"`
+	ID          string            `json:"id"`
+	Workspace   string            `json:"workspace"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+	Messages    []llm.Message     `json:"messages"`
+	Mode        planpkg.AgentMode `json:"mode,omitempty"`
+	Plan        planpkg.State     `json:"plan,omitempty"`
+	ActiveSkill *ActiveSkill      `json:"active_skill,omitempty"`
 }
 
 type sessionRecord struct {
@@ -91,6 +98,7 @@ func (s *Store) Save(session *Session) error {
 		session.Mode = planpkg.ModeBuild
 	}
 	session.Plan = planpkg.NormalizeState(session.Plan)
+	session.ActiveSkill = normalizeActiveSkill(session.ActiveSkill)
 	if len(session.Plan.Steps) > 0 {
 		session.Plan.UpdatedAt = session.UpdatedAt
 	}
@@ -275,8 +283,38 @@ func normalizeLoadedSession(sess *Session, path string) {
 		sess.Mode = planpkg.ModeBuild
 	}
 	sess.Plan = planpkg.NormalizeState(sess.Plan)
+	sess.ActiveSkill = normalizeActiveSkill(sess.ActiveSkill)
 	if len(sess.Plan.Steps) > 0 && sess.Plan.UpdatedAt.IsZero() {
 		sess.Plan.UpdatedAt = sess.UpdatedAt
+	}
+}
+
+func normalizeActiveSkill(raw *ActiveSkill) *ActiveSkill {
+	if raw == nil {
+		return nil
+	}
+	name := strings.TrimSpace(raw.Name)
+	if name == "" {
+		return nil
+	}
+
+	args := make(map[string]string, len(raw.Args))
+	for key, value := range raw.Args {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		args[key] = value
+	}
+	if len(args) == 0 {
+		args = nil
+	}
+
+	return &ActiveSkill{
+		Name:        name,
+		Args:        args,
+		ActivatedAt: raw.ActivatedAt,
 	}
 }
 

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -212,6 +212,40 @@ func TestStoreSaveReplacesExistingSessionFile(t *testing.T) {
 	}
 }
 
+func TestStorePersistsActiveSkill(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sess := New(`E:\\repo`)
+	sess.ActiveSkill = &ActiveSkill{
+		Name: "review",
+		Args: map[string]string{
+			"base_ref": "main",
+		},
+		ActivatedAt: time.Date(2026, 4, 3, 10, 20, 0, 0, time.UTC),
+	}
+	if err := store.Save(sess); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := store.Load(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.ActiveSkill == nil {
+		t.Fatal("expected active skill to be persisted")
+	}
+	if loaded.ActiveSkill.Name != "review" {
+		t.Fatalf("unexpected active skill name: %#v", loaded.ActiveSkill)
+	}
+	if loaded.ActiveSkill.Args["base_ref"] != "main" {
+		t.Fatalf("unexpected active skill args: %#v", loaded.ActiveSkill.Args)
+	}
+}
+
 func TestStoreIgnoresLegacyJSONFiles(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewStore(dir)

--- a/internal/skills/bug-investigation/SKILL.md
+++ b/internal/skills/bug-investigation/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: bug-investigation
+description: |
+  以复现和证据为中心定位问题，不先入为主下结论。
+when_to_use: 用户反馈 bug、测试失败、线上异常排查。
+---
+
+# bug-investigation
+
+## Workflow
+
+1. 明确症状、期望行为、实际行为。
+2. 给出可执行的最小复现路径。
+3. 记录证据（日志、调用链、代码位置、命令结果）。
+4. 输出根因假设，并标明置信度。
+5. 提供最小修复方案和验证步骤。
+
+## Output Contract
+
+- Symptom Summary
+- Reproduction Steps
+- Evidence
+- Root Cause Hypothesis
+- Fix & Verification Plan
+

--- a/internal/skills/bug-investigation/skill.json
+++ b/internal/skills/bug-investigation/skill.json
@@ -1,0 +1,28 @@
+{
+  "name": "bug-investigation",
+  "version": "0.1.0",
+  "title": "Bug Investigation",
+  "description": "面向故障定位，强调复现路径、证据链和最小修复方案。",
+  "entry": {
+    "slash": "/bug-investigation"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "run_shell",
+      "update_plan"
+    ]
+  },
+  "args": [
+    {
+      "name": "symptom",
+      "type": "string",
+      "required": false,
+      "description": "故障症状或报错关键字"
+    }
+  ]
+}
+

--- a/internal/skills/frontmatter.go
+++ b/internal/skills/frontmatter.go
@@ -1,0 +1,82 @@
+package skills
+
+import "strings"
+
+func parseFrontmatterMarkdown(content string) (map[string]string, string) {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+
+	if !strings.HasPrefix(content, "---\n") {
+		return map[string]string{}, strings.TrimSpace(content)
+	}
+
+	rest := strings.TrimPrefix(content, "---\n")
+	sep := "\n---\n"
+	idx := strings.Index(rest, sep)
+	if idx < 0 {
+		return map[string]string{}, strings.TrimSpace(content)
+	}
+
+	frontmatter := rest[:idx]
+	body := strings.TrimSpace(rest[idx+len(sep):])
+	return parseFrontmatterFields(frontmatter), body
+}
+
+func parseFrontmatterFields(raw string) map[string]string {
+	fields := map[string]string{}
+	lines := strings.Split(raw, "\n")
+
+	var multiKey string
+	var multi []string
+	flushMulti := func() {
+		if multiKey == "" {
+			return
+		}
+		fields[multiKey] = strings.TrimSpace(strings.Join(multi, "\n"))
+		multiKey = ""
+		multi = nil
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if multiKey != "" {
+			if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") || trimmed == "" {
+				multi = append(multi, strings.TrimSpace(line))
+				continue
+			}
+			flushMulti()
+		}
+
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		value := strings.TrimSpace(parts[1])
+		if key == "" {
+			continue
+		}
+		if value == "|" || value == ">" {
+			multiKey = key
+			multi = multi[:0]
+			continue
+		}
+		fields[key] = trimOuterQuotes(value)
+	}
+
+	flushMulti()
+	return fields
+}
+
+func trimOuterQuotes(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+	if (strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"")) || (strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) {
+		return value[1 : len(value)-1]
+	}
+	return value
+}

--- a/internal/skills/github-pr/SKILL.md
+++ b/internal/skills/github-pr/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: github-pr
+description: |
+  面向 PR 评审上下文，优先梳理 diff、评论和潜在回归风险。
+when_to_use: 用户要求分析 PR、处理 review comments、评估合并风险。
+---
+
+# github-pr
+
+## Workflow
+
+1. 明确比较基线（base ref / feature ref）。
+2. 汇总主要改动文件与模块。
+3. 标注风险点（行为变化、边界条件、兼容性）。
+4. 汇总 review comments 对应的处理建议。
+5. 给出合并前验证清单。
+
+## Output Contract
+
+- Diff Summary
+- Key Risks
+- Review Comment Response Plan
+- Pre-merge Verification Checklist
+

--- a/internal/skills/github-pr/skill.json
+++ b/internal/skills/github-pr/skill.json
@@ -1,0 +1,34 @@
+{
+  "name": "github-pr",
+  "version": "0.1.0",
+  "title": "GitHub PR Analysis",
+  "description": "分析 PR 变更、review 评论和 CI 风险（优先使用本地 git 证据）。",
+  "entry": {
+    "slash": "/github-pr"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "run_shell",
+      "update_plan"
+    ]
+  },
+  "args": [
+    {
+      "name": "pr_number",
+      "type": "string",
+      "required": false,
+      "description": "可选 PR 编号"
+    },
+    {
+      "name": "base_ref",
+      "type": "string",
+      "required": false,
+      "description": "对比分支，默认 main"
+    }
+  ]
+}
+

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -1,0 +1,516 @@
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+var validSkillName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]*$`)
+
+type Manager struct {
+	mu sync.RWMutex
+
+	workspace  string
+	builtinDir string
+	userDir    string
+	projectDir string
+
+	catalog Catalog
+	lookup  map[string]string
+}
+
+func NewManager(workspace string) *Manager {
+	home, _ := os.UserHomeDir()
+	return NewManagerWithDirs(
+		workspace,
+		filepath.Join(workspace, "internal", "skills"),
+		filepath.Join(home, ".bytemind", "skills"),
+		filepath.Join(workspace, ".bytemind", "skills"),
+	)
+}
+
+func NewManagerWithDirs(workspace, builtinDir, userDir, projectDir string) *Manager {
+	return &Manager{
+		workspace:  workspace,
+		builtinDir: builtinDir,
+		userDir:    userDir,
+		projectDir: projectDir,
+		lookup:     map[string]string{},
+	}
+}
+
+func (m *Manager) Reload() Catalog {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scopes := []struct {
+		scope Scope
+		dir   string
+	}{
+		{scope: ScopeBuiltin, dir: m.builtinDir},
+		{scope: ScopeUser, dir: m.userDir},
+		{scope: ScopeProject, dir: m.projectDir},
+	}
+
+	loaded := map[string]Skill{}
+	diags := make([]Diagnostic, 0, 8)
+	overrides := make([]Override, 0, 4)
+
+	for _, item := range scopes {
+		skills, skillDiags := loadSkillsFromScope(item.scope, item.dir)
+		diags = append(diags, skillDiags...)
+		for _, skill := range skills {
+			prev, exists := loaded[skill.Name]
+			if exists {
+				overrides = append(overrides, Override{
+					Name:       skill.Name,
+					Winner:     skill.Scope,
+					Loser:      prev.Scope,
+					WinnerPath: skill.SourceDir,
+					LoserPath:  prev.SourceDir,
+				})
+			}
+			loaded[skill.Name] = skill
+		}
+	}
+
+	names := make([]string, 0, len(loaded))
+	for name := range loaded {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	skills := make([]Skill, 0, len(names))
+	lookup := make(map[string]string, len(names)*4)
+	for _, name := range names {
+		skill := loaded[name]
+		skills = append(skills, skill)
+		for _, alias := range skill.Aliases {
+			normalized := normalizeAlias(alias)
+			if normalized == "" {
+				continue
+			}
+			if _, exists := lookup[normalized]; !exists {
+				lookup[normalized] = skill.Name
+			}
+		}
+		normalizedName := normalizeAlias(skill.Name)
+		if normalizedName != "" {
+			lookup[normalizedName] = skill.Name
+		}
+	}
+
+	m.lookup = lookup
+	m.catalog = Catalog{
+		Skills:      skills,
+		Diagnostics: diags,
+		Overrides:   overrides,
+		LoadedAt:    time.Now().UTC(),
+	}
+	return cloneCatalog(m.catalog)
+}
+
+func (m *Manager) List() ([]Skill, []Diagnostic) {
+	catalog := m.Reload()
+	return catalog.Skills, catalog.Diagnostics
+}
+
+func (m *Manager) Find(name string) (Skill, bool) {
+	m.mu.RLock()
+	lookup := cloneLookup(m.lookup)
+	m.mu.RUnlock()
+	if len(lookup) == 0 {
+		m.Reload()
+		m.mu.RLock()
+		lookup = cloneLookup(m.lookup)
+		m.mu.RUnlock()
+	}
+
+	normalized := normalizeAlias(name)
+	if normalized == "" {
+		return Skill{}, false
+	}
+	canonical, ok := lookup[normalized]
+	if !ok {
+		return Skill{}, false
+	}
+
+	catalog := m.Reload()
+	for _, skill := range catalog.Skills {
+		if skill.Name == canonical {
+			return skill, true
+		}
+	}
+	return Skill{}, false
+}
+
+func (m *Manager) Workspace() string {
+	return m.workspace
+}
+
+type skillManifest struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Scope       string `json:"scope"`
+	Entry       Entry  `json:"entry"`
+	Prompts     []struct {
+		ID   string `json:"id"`
+		Path string `json:"path"`
+	} `json:"prompts"`
+	Resources []struct {
+		ID       string `json:"id"`
+		URI      string `json:"uri"`
+		Optional bool   `json:"optional"`
+	} `json:"resources"`
+	Tools struct {
+		Policy string   `json:"policy"`
+		Items  []string `json:"items"`
+	} `json:"tools"`
+	Args []struct {
+		Name        string `json:"name"`
+		Type        string `json:"type"`
+		Required    bool   `json:"required"`
+		Description string `json:"description"`
+		Default     string `json:"default"`
+	} `json:"args"`
+}
+
+func loadSkillsFromScope(scope Scope, root string) ([]Skill, []Diagnostic) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, []Diagnostic{{
+			Scope:   scope,
+			Path:    root,
+			Level:   "warn",
+			Message: err.Error(),
+		}}
+	}
+
+	skills := make([]Skill, 0, len(entries))
+	diags := make([]Diagnostic, 0, 4)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillDir := filepath.Join(root, entry.Name())
+		skill, ok, skillDiags := loadSkillFromDir(scope, skillDir, entry.Name())
+		diags = append(diags, skillDiags...)
+		if ok {
+			skills = append(skills, skill)
+		}
+	}
+	return skills, diags
+}
+
+func loadSkillFromDir(scope Scope, skillDir, dirName string) (Skill, bool, []Diagnostic) {
+	manifestPath := filepath.Join(skillDir, "skill.json")
+	skillPath := filepath.Join(skillDir, "SKILL.md")
+
+	hasManifest := fileExists(manifestPath)
+	hasSkill := fileExists(skillPath)
+	if !hasManifest && !hasSkill {
+		return Skill{}, false, nil
+	}
+
+	var manifest skillManifest
+	diags := make([]Diagnostic, 0, 2)
+	if hasManifest {
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			return Skill{}, false, []Diagnostic{{
+				Scope:   scope,
+				Path:    manifestPath,
+				Skill:   dirName,
+				Level:   "error",
+				Message: fmt.Sprintf("failed to read skill.json: %v", err),
+			}}
+		}
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return Skill{}, false, []Diagnostic{{
+				Scope:   scope,
+				Path:    manifestPath,
+				Skill:   dirName,
+				Level:   "error",
+				Message: fmt.Sprintf("invalid skill.json: %v", err),
+			}}
+		}
+	}
+
+	frontmatter := map[string]string{}
+	body := ""
+	if hasSkill {
+		data, err := os.ReadFile(skillPath)
+		if err != nil {
+			diags = append(diags, Diagnostic{
+				Scope:   scope,
+				Path:    skillPath,
+				Skill:   dirName,
+				Level:   "error",
+				Message: fmt.Sprintf("failed to read SKILL.md: %v", err),
+			})
+			hasSkill = false
+		} else {
+			frontmatter, body = parseFrontmatterMarkdown(string(data))
+		}
+	}
+
+	name := strings.TrimSpace(manifest.Name)
+	if name == "" {
+		name = strings.TrimSpace(frontmatter["name"])
+	}
+	if name == "" {
+		name = dirName
+	}
+	if !validSkillName.MatchString(name) {
+		diags = append(diags, Diagnostic{
+			Scope:   scope,
+			Path:    skillDir,
+			Skill:   name,
+			Level:   "error",
+			Message: "invalid skill name",
+		})
+		return Skill{}, false, diags
+	}
+
+	description := strings.TrimSpace(manifest.Description)
+	if description == "" {
+		description = strings.TrimSpace(frontmatter["description"])
+	}
+	if description == "" {
+		description = extractDescription(body)
+	}
+	if description == "" {
+		description = "No description provided."
+	}
+
+	title := strings.TrimSpace(manifest.Title)
+	if title == "" {
+		title = name
+	}
+
+	whenToUse := strings.TrimSpace(frontmatter["when_to_use"])
+	if whenToUse == "" {
+		whenToUse = strings.TrimSpace(frontmatter["when-to-use"])
+	}
+
+	entry := manifest.Entry
+	if strings.TrimSpace(entry.Slash) == "" {
+		entry.Slash = "/" + name
+	} else if !strings.HasPrefix(entry.Slash, "/") {
+		entry.Slash = "/" + strings.TrimSpace(entry.Slash)
+	}
+
+	toolPolicy, policyDiag := buildToolPolicy(manifest.Tools.Policy, manifest.Tools.Items, frontmatter)
+	if policyDiag != nil {
+		policyDiag.Scope = scope
+		policyDiag.Path = skillDir
+		policyDiag.Skill = name
+		diags = append(diags, *policyDiag)
+	}
+
+	prompts := make([]PromptRef, 0, len(manifest.Prompts))
+	for _, prompt := range manifest.Prompts {
+		prompts = append(prompts, PromptRef{
+			ID:   strings.TrimSpace(prompt.ID),
+			Path: strings.TrimSpace(prompt.Path),
+		})
+	}
+	resources := make([]ResourceRef, 0, len(manifest.Resources))
+	for _, resource := range manifest.Resources {
+		resources = append(resources, ResourceRef{
+			ID:       strings.TrimSpace(resource.ID),
+			URI:      strings.TrimSpace(resource.URI),
+			Optional: resource.Optional,
+		})
+	}
+	args := make([]Arg, 0, len(manifest.Args))
+	for _, arg := range manifest.Args {
+		if strings.TrimSpace(arg.Name) == "" {
+			continue
+		}
+		args = append(args, Arg{
+			Name:        strings.TrimSpace(arg.Name),
+			Type:        strings.TrimSpace(arg.Type),
+			Required:    arg.Required,
+			Description: strings.TrimSpace(arg.Description),
+			Default:     strings.TrimSpace(arg.Default),
+		})
+	}
+
+	aliases := uniqueStrings([]string{
+		name,
+		dirName,
+		entry.Slash,
+		strings.TrimPrefix(entry.Slash, "/"),
+	})
+
+	skill := Skill{
+		Name:         name,
+		Version:      strings.TrimSpace(manifest.Version),
+		Title:        title,
+		Description:  description,
+		WhenToUse:    whenToUse,
+		Scope:        scope,
+		SourceDir:    skillDir,
+		Instruction:  strings.TrimSpace(body),
+		Entry:        entry,
+		Prompts:      prompts,
+		Resources:    resources,
+		ToolPolicy:   toolPolicy,
+		Args:         args,
+		Aliases:      aliases,
+		DiscoveredAt: time.Now().UTC(),
+	}
+	if !hasSkill {
+		skill.Instruction = ""
+	}
+	return skill, true, diags
+}
+
+func buildToolPolicy(policy string, items []string, frontmatter map[string]string) (ToolPolicy, *Diagnostic) {
+	policy = strings.TrimSpace(strings.ToLower(policy))
+	if policy == "" {
+		if allowed := parseToolList(frontmatter["allowed-tools"]); len(allowed) > 0 {
+			return ToolPolicy{
+				Policy: ToolPolicyAllowlist,
+				Items:  allowed,
+			}, nil
+		}
+		return ToolPolicy{Policy: ToolPolicyInherit}, nil
+	}
+
+	switch ToolPolicyMode(policy) {
+	case ToolPolicyInherit, ToolPolicyAllowlist, ToolPolicyDenylist:
+		return ToolPolicy{
+			Policy: ToolPolicyMode(policy),
+			Items:  uniqueStrings(items),
+		}, nil
+	default:
+		return ToolPolicy{Policy: ToolPolicyInherit}, &Diagnostic{
+			Level:   "warn",
+			Message: "invalid tool policy, fallback to inherit",
+		}
+	}
+}
+
+func parseToolList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	raw = strings.TrimPrefix(raw, "[")
+	raw = strings.TrimSuffix(raw, "]")
+	parts := strings.Split(raw, ",")
+	list := make([]string, 0, len(parts))
+	for _, part := range parts {
+		item := strings.TrimSpace(part)
+		item = trimOuterQuotes(item)
+		if item != "" {
+			list = append(list, item)
+		}
+	}
+	return uniqueStrings(list)
+}
+
+func extractDescription(body string) string {
+	if strings.TrimSpace(body) == "" {
+		return ""
+	}
+	lines := strings.Split(body, "\n")
+	candidate := make([]string, 0, 3)
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			if len(candidate) > 0 {
+				break
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		candidate = append(candidate, trimmed)
+		if len(candidate) >= 2 {
+			break
+		}
+	}
+	if len(candidate) == 0 {
+		return ""
+	}
+	desc := strings.TrimSpace(strings.Join(candidate, " "))
+	runes := []rune(desc)
+	if len(runes) > 220 {
+		return strings.TrimSpace(string(runes[:217])) + "..."
+	}
+	return desc
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func uniqueStrings(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func normalizeAlias(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	raw = strings.TrimPrefix(raw, "/")
+	return raw
+}
+
+func cloneLookup(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneCatalog(in Catalog) Catalog {
+	skills := make([]Skill, len(in.Skills))
+	copy(skills, in.Skills)
+	diags := make([]Diagnostic, len(in.Diagnostics))
+	copy(diags, in.Diagnostics)
+	overrides := make([]Override, len(in.Overrides))
+	copy(overrides, in.Overrides)
+	return Catalog{
+		Skills:      skills,
+		Diagnostics: diags,
+		Overrides:   overrides,
+		LoadedAt:    in.LoadedAt,
+	}
+}

--- a/internal/skills/manager_test.go
+++ b/internal/skills/manager_test.go
@@ -1,0 +1,118 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestManagerLoadsAndResolvesSkillsByAlias(t *testing.T) {
+	root := t.TempDir()
+	builtin := filepath.Join(root, "builtin")
+	if err := os.MkdirAll(filepath.Join(builtin, "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(builtin, "review", "SKILL.md"), []byte(`---
+name: review
+description: |
+  Review code changes with correctness and risk focus.
+allowed-tools: "list_files,read_file,search_text,run_shell"
+---
+# /review
+
+Use this skill when the user asks for a code review.
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := NewManagerWithDirs(root, builtin, filepath.Join(root, "user"), filepath.Join(root, "project"))
+	catalog := manager.Reload()
+	if len(catalog.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(catalog.Skills))
+	}
+	if catalog.Skills[0].ToolPolicy.Policy != ToolPolicyAllowlist {
+		t.Fatalf("expected frontmatter allowed-tools to build allowlist policy, got %q", catalog.Skills[0].ToolPolicy.Policy)
+	}
+	if len(catalog.Skills[0].ToolPolicy.Items) != 4 {
+		t.Fatalf("expected 4 allowlist tools, got %#v", catalog.Skills[0].ToolPolicy.Items)
+	}
+
+	for _, alias := range []string{"review", "/review"} {
+		skill, ok := manager.Find(alias)
+		if !ok {
+			t.Fatalf("expected alias %q to resolve", alias)
+		}
+		if skill.Name != "review" {
+			t.Fatalf("expected canonical skill name review, got %q", skill.Name)
+		}
+	}
+}
+
+func TestManagerAppliesScopePriority(t *testing.T) {
+	root := t.TempDir()
+	builtin := filepath.Join(root, "builtin")
+	user := filepath.Join(root, "user")
+	project := filepath.Join(root, "project")
+	for _, dir := range []string{
+		filepath.Join(builtin, "review"),
+		filepath.Join(user, "review"),
+		filepath.Join(project, "review"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(builtin, "review", "skill.json"), []byte(`{"name":"review","description":"builtin"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(user, "review", "skill.json"), []byte(`{"name":"review","description":"user"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "review", "skill.json"), []byte(`{"name":"review","description":"project"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := NewManagerWithDirs(root, builtin, user, project)
+	skill, ok := manager.Find("review")
+	if !ok {
+		t.Fatal("expected review skill to resolve")
+	}
+	if skill.Description != "project" {
+		t.Fatalf("expected project scope to win, got %q", skill.Description)
+	}
+
+	catalog := manager.Reload()
+	if len(catalog.Overrides) == 0 {
+		t.Fatalf("expected override diagnostics, got none")
+	}
+}
+
+func TestManagerKeepsWorkingWhenManifestIsInvalid(t *testing.T) {
+	root := t.TempDir()
+	builtin := filepath.Join(root, "builtin")
+	if err := os.MkdirAll(filepath.Join(builtin, "bad"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(builtin, "bad", "skill.json"), []byte(`{"name":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(builtin, "good"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(builtin, "good", "skill.json"), []byte(`{"name":"good","description":"ok"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := NewManagerWithDirs(root, builtin, filepath.Join(root, "user"), filepath.Join(root, "project"))
+	catalog := manager.Reload()
+	if len(catalog.Skills) != 1 || catalog.Skills[0].Name != "good" {
+		t.Fatalf("expected valid skill to remain available, got %#v", catalog.Skills)
+	}
+	if len(catalog.Diagnostics) == 0 {
+		t.Fatalf("expected diagnostics for invalid skill.json")
+	}
+	if !strings.Contains(strings.ToLower(catalog.Diagnostics[0].Message), "invalid skill.json") {
+		t.Fatalf("unexpected diagnostic: %#v", catalog.Diagnostics[0])
+	}
+}

--- a/internal/skills/repo-onboarding/SKILL.md
+++ b/internal/skills/repo-onboarding/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: repo-onboarding
+description: |
+  快速建立仓库认知：结构、入口、构建链路、关键模块与约束。
+when_to_use: 首次接手仓库、跨团队交接、排查前的上下文建立。
+---
+
+# repo-onboarding
+
+## Workflow
+
+1. 先给出目录级地图（顶层、核心模块、测试目录）。
+2. 确认启动与构建命令，以及依赖管理方式。
+3. 给出关键执行路径（入口 -> 主要模块 -> 输出/副作用）。
+4. 最后列出后续深入建议（读哪些文件、跑哪些命令）。
+
+## Output Contract
+
+- Repo Map
+- Build/Test Entry
+- Core Runtime Flow
+- Next Read/Run Checklist
+

--- a/internal/skills/repo-onboarding/skill.json
+++ b/internal/skills/repo-onboarding/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "repo-onboarding",
+  "version": "0.1.0",
+  "title": "Repo Onboarding",
+  "description": "快速梳理仓库结构、入口、构建方式和关键模块。",
+  "entry": {
+    "slash": "/repo-onboarding"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "run_shell",
+      "update_plan"
+    ]
+  }
+}
+

--- a/internal/skills/review/SKILL.md
+++ b/internal/skills/review/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: review
+description: |
+  对当前代码改动做审查，聚焦正确性、回归风险和测试缺口。
+when_to_use: 用户要求 code review、pre-merge review、风险评估时。
+---
+
+# review
+
+## Workflow
+
+1. 明确审查范围（分支、目录、文件）。
+2. 先看行为变化，再看实现细节。
+3. 按严重级别输出问题，必须包含定位信息。
+4. 单独列出测试缺口和未验证假设。
+
+## Must Check
+
+- correctness 与边界条件
+- 潜在回归与兼容性
+- 错误处理与异常路径
+- 测试覆盖是否匹配变更
+
+## Output Contract
+
+- Findings: 严重度排序，给出文件与原因
+- Risks: 非阻断但需要关注的点
+- Verification: 已执行与建议执行的验证
+

--- a/internal/skills/review/skill.json
+++ b/internal/skills/review/skill.json
@@ -1,0 +1,28 @@
+{
+  "name": "review",
+  "version": "0.1.0",
+  "title": "Code Review",
+  "description": "面向代码审查任务，优先关注 correctness、风险与测试缺口。",
+  "entry": {
+    "slash": "/review"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "run_shell",
+      "update_plan"
+    ]
+  },
+  "args": [
+    {
+      "name": "base_ref",
+      "type": "string",
+      "required": false,
+      "description": "可选的对比分支，例如 main"
+    }
+  ]
+}
+

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -1,0 +1,88 @@
+package skills
+
+import "time"
+
+type Scope string
+
+const (
+	ScopeBuiltin Scope = "builtin"
+	ScopeUser    Scope = "user"
+	ScopeProject Scope = "project"
+)
+
+type ToolPolicyMode string
+
+const (
+	ToolPolicyInherit   ToolPolicyMode = "inherit"
+	ToolPolicyAllowlist ToolPolicyMode = "allowlist"
+	ToolPolicyDenylist  ToolPolicyMode = "denylist"
+)
+
+type Entry struct {
+	Slash string `json:"slash"`
+}
+
+type PromptRef struct {
+	ID   string `json:"id"`
+	Path string `json:"path"`
+}
+
+type ResourceRef struct {
+	ID       string `json:"id"`
+	URI      string `json:"uri"`
+	Optional bool   `json:"optional"`
+}
+
+type ToolPolicy struct {
+	Policy ToolPolicyMode `json:"policy"`
+	Items  []string       `json:"items"`
+}
+
+type Arg struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Required    bool   `json:"required"`
+	Description string `json:"description"`
+	Default     string `json:"default"`
+}
+
+type Skill struct {
+	Name         string
+	Version      string
+	Title        string
+	Description  string
+	WhenToUse    string
+	Scope        Scope
+	SourceDir    string
+	Instruction  string
+	Entry        Entry
+	Prompts      []PromptRef
+	Resources    []ResourceRef
+	ToolPolicy   ToolPolicy
+	Args         []Arg
+	Aliases      []string
+	DiscoveredAt time.Time
+}
+
+type Diagnostic struct {
+	Scope   Scope
+	Path    string
+	Skill   string
+	Level   string
+	Message string
+}
+
+type Override struct {
+	Name       string
+	Winner     Scope
+	Loser      Scope
+	WinnerPath string
+	LoserPath  string
+}
+
+type Catalog struct {
+	Skills      []Skill
+	Diagnostics []Diagnostic
+	Overrides   []Override
+	LoadedAt    time.Time
+}

--- a/internal/skills/write-rfc/SKILL.md
+++ b/internal/skills/write-rfc/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: write-rfc
+description: |
+  产出可评审的技术方案文档，强调决策依据和落地路径。
+when_to_use: 用户要求设计方案、技术选型、改造计划或评审稿。
+---
+
+# write-rfc
+
+## Required Sections
+
+1. Context & Problem
+2. Goals / Non-Goals
+3. Candidate Options
+4. Trade-offs
+5. Proposed Design
+6. Rollout Plan
+7. Verification Plan
+8. Risks & Mitigations
+
+## Rules
+
+- 假设必须显式标注。
+- 风险必须可验证，不写空泛条目。
+- 结论必须能映射到后续执行步骤。
+

--- a/internal/skills/write-rfc/skill.json
+++ b/internal/skills/write-rfc/skill.json
@@ -1,0 +1,30 @@
+{
+  "name": "write-rfc",
+  "version": "0.1.0",
+  "title": "Write RFC",
+  "description": "输出结构化设计文档，明确 trade-off、风险与 rollout 计划。",
+  "entry": {
+    "slash": "/write-rfc"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "write_file",
+      "replace_in_file",
+      "apply_patch",
+      "update_plan"
+    ]
+  },
+  "args": [
+    {
+      "name": "path",
+      "type": "string",
+      "required": false,
+      "description": "RFC 输出路径，例如 docs/rfc/xxx.md"
+    }
+  ]
+}
+

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"bytemind/internal/llm"
 	planpkg "bytemind/internal/plan"
@@ -20,6 +21,8 @@ type ExecutionContext struct {
 	Mode           planpkg.AgentMode
 	Stdin          io.Reader
 	Stdout         io.Writer
+	AllowedTools   map[string]struct{}
+	DeniedTools    map[string]struct{}
 }
 
 type Tool interface {
@@ -53,9 +56,24 @@ func (r *Registry) Definitions() []llm.ToolDefinition {
 }
 
 func (r *Registry) DefinitionsForMode(mode planpkg.AgentMode) []llm.ToolDefinition {
+	return r.DefinitionsForModeWithFilters(mode, nil, nil)
+}
+
+func (r *Registry) DefinitionsForModeWithFilters(mode planpkg.AgentMode, allowlist, denylist []string) []llm.ToolDefinition {
+	allowSet := toNameSet(allowlist)
+	denySet := toNameSet(denylist)
+
 	names := make([]string, 0, len(r.tools))
 	for name := range r.tools {
 		if toolAllowedInMode(mode, name) {
+			if len(allowSet) > 0 {
+				if _, ok := allowSet[name]; !ok {
+					continue
+				}
+			}
+			if _, blocked := denySet[name]; blocked {
+				continue
+			}
 			names = append(names, name)
 		}
 	}
@@ -80,6 +98,9 @@ func (r *Registry) ExecuteForMode(ctx context.Context, mode planpkg.AgentMode, n
 	if !toolAllowedInMode(mode, name) {
 		return "", fmt.Errorf("tool %q is unavailable in %s mode", name, mode)
 	}
+	if !toolAllowedByPolicy(name, execCtx) {
+		return "", fmt.Errorf("tool %q is unavailable by active skill policy", name)
+	}
 	if rawArgs == "" {
 		rawArgs = "{}"
 	}
@@ -87,6 +108,38 @@ func (r *Registry) ExecuteForMode(ctx context.Context, mode planpkg.AgentMode, n
 		execCtx.Mode = mode
 	}
 	return tool.Run(ctx, json.RawMessage(rawArgs), execCtx)
+}
+
+func toNameSet(items []string) map[string]struct{} {
+	if len(items) == 0 {
+		return nil
+	}
+	result := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		result[item] = struct{}{}
+	}
+	return result
+}
+
+func toolAllowedByPolicy(name string, execCtx *ExecutionContext) bool {
+	if execCtx == nil {
+		return true
+	}
+	if len(execCtx.AllowedTools) > 0 {
+		if _, ok := execCtx.AllowedTools[name]; !ok {
+			return false
+		}
+	}
+	if len(execCtx.DeniedTools) > 0 {
+		if _, blocked := execCtx.DeniedTools[name]; blocked {
+			return false
+		}
+	}
+	return true
 }
 
 func toolAllowedInMode(mode planpkg.AgentMode, name string) bool {

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -80,3 +80,35 @@ func TestRegistryExecuteDefaultsEmptyArgsToJSONObject(t *testing.T) {
 		t.Fatalf("expected empty args to default to {}, got %q", tool.lastRaw)
 	}
 }
+
+func TestDefinitionsForModeWithFiltersRestrictsTools(t *testing.T) {
+	registry := DefaultRegistry()
+	defs := registry.DefinitionsForModeWithFilters("build", []string{"read_file", "search_text"}, []string{"search_text"})
+
+	names := make([]string, 0, len(defs))
+	for _, def := range defs {
+		names = append(names, def.Function.Name)
+	}
+	want := []string{"read_file"}
+	if !slices.Equal(names, want) {
+		t.Fatalf("unexpected filtered tools: got=%v want=%v", names, want)
+	}
+}
+
+func TestRegistryExecuteRespectsActiveSkillPolicy(t *testing.T) {
+	tool := &recordingTool{name: "fake_tool", result: `{"ok":true}`}
+	registry := &Registry{tools: map[string]Tool{}}
+	registry.Add(tool)
+
+	_, err := registry.ExecuteForMode(context.Background(), "build", "fake_tool", `{}`, &ExecutionContext{
+		AllowedTools: map[string]struct{}{
+			"read_file": {},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected active skill policy to block disallowed tool")
+	}
+	if !strings.Contains(err.Error(), "active skill policy") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -111,6 +112,8 @@ var commandItems = []commandItem{
 	{Name: "/session", Usage: "/session", Description: "Open the recent session list.", Kind: "command"},
 	{Name: "/new", Usage: "/new", Description: "Start a fresh session in this workspace.", Kind: "command"},
 	{Name: "/quit", Usage: "/quit", Description: "Exit the current TUI window.", Kind: "command"},
+	{Name: "/skills", Usage: "/skills", Description: "List available skills and current active skill.", Kind: "command"},
+	{Name: "/skill clear", Usage: "/skill clear", Description: "Clear active skill for this session.", Kind: "command"},
 }
 
 type model struct {
@@ -665,12 +668,12 @@ func (m model) handleCommandPaletteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc":
 		m.closeCommandPalette()
 		return m, nil
-	case "up", "k":
+	case "up":
 		if len(items) > 0 {
 			m.commandCursor = max(0, m.commandCursor-1)
 		}
 		return m, nil
-	case "down", "j":
+	case "down":
 		if len(items) > 0 {
 			m.commandCursor = min(len(items)-1, m.commandCursor+1)
 		}
@@ -1295,6 +1298,9 @@ func (m model) renderFooter() string {
 	} else if m.commandOpen {
 		parts = append(parts, m.renderCommandPalette())
 	}
+	if banner := m.renderActiveSkillBanner(); banner != "" {
+		parts = append(parts, banner)
+	}
 	parts = append(parts, inputBorder, m.renderFooterInfoLine())
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
@@ -1381,6 +1387,33 @@ func (m model) renderApprovalBanner() string {
 	return approvalBannerStyle.Width(width).Render(strings.Join(lines, "\n"))
 }
 
+func (m model) renderActiveSkillBanner() string {
+	if m.sess == nil || m.sess.ActiveSkill == nil {
+		return ""
+	}
+	name := strings.TrimSpace(m.sess.ActiveSkill.Name)
+	if name == "" {
+		return ""
+	}
+
+	line := "Active skill: " + name
+	if len(m.sess.ActiveSkill.Args) > 0 {
+		keys := make([]string, 0, len(m.sess.ActiveSkill.Args))
+		for key := range m.sess.ActiveSkill.Args {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		pairs := make([]string, 0, len(keys))
+		for _, key := range keys {
+			pairs = append(pairs, fmt.Sprintf("%s=%s", key, m.sess.ActiveSkill.Args[key]))
+		}
+		line += " | args: " + strings.Join(pairs, ", ")
+	}
+
+	width := max(24, m.chatPanelInnerWidth())
+	return activeSkillBannerStyle.Width(width).Render(accentStyle.Render(line))
+}
+
 func (m model) renderStatusBar() string {
 	width := max(24, m.chatPanelInnerWidth())
 	stepTitle := currentOrNextStepTitle(m.plan)
@@ -1391,6 +1424,7 @@ func (m model) renderStatusBar() string {
 		"Mode: " + strings.ToUpper(string(m.mode)),
 		"Phase: " + m.currentPhaseLabel(),
 		"Step: " + stepTitle,
+		"Skill: " + m.currentSkillLabel(),
 	}, "  |  ")
 	right := strings.Join([]string{
 		fmt.Sprintf("%d msgs", len(m.chatItems)),
@@ -1531,10 +1565,14 @@ func (m *model) handleSlashCommand(input string) error {
 		m.sessionsOpen = true
 		m.statusNote = "Opened recent sessions."
 		return nil
+	case "/skills":
+		return m.runSkillsListCommand(input)
+	case "/skill":
+		return m.runSkillCommand(input, fields)
 	case "/new":
 		return m.newSession()
 	default:
-		return fmt.Errorf("unknown command: %s", fields[0])
+		return m.runDirectSkillCommand(input, fields)
 	}
 }
 
@@ -1545,6 +1583,138 @@ func (m model) executeCommand(input string) (tea.Model, tea.Cmd, error) {
 	m.refreshViewport()
 	return m, m.loadSessionsCmd(), nil
 }
+
+func (m *model) runSkillsListCommand(input string) error {
+	if m.runner == nil {
+		return fmt.Errorf("runner is unavailable")
+	}
+	skillsList, diagnostics := m.runner.ListSkills()
+	active, hasActive := m.runner.GetActiveSkill(m.sess)
+
+	lines := make([]string, 0, len(skillsList)+8)
+	if hasActive {
+		lines = append(lines, fmt.Sprintf("Active skill: %s (%s)", active.Name, active.Scope))
+	} else {
+		lines = append(lines, "Active skill: none")
+	}
+	lines = append(lines, "")
+	if len(skillsList) == 0 {
+		lines = append(lines, "No skills discovered.")
+	} else {
+		lines = append(lines, "Available skills:")
+		for _, skill := range skillsList {
+			lines = append(lines, fmt.Sprintf("- %s (%s): %s", skill.Name, skill.Scope, skill.Description))
+		}
+	}
+	if len(diagnostics) > 0 {
+		lines = append(lines, "", "Diagnostics:")
+		for _, diag := range diagnostics {
+			lines = append(lines, fmt.Sprintf("- [%s] %s (%s): %s", diag.Level, diag.Skill, diag.Path, diag.Message))
+		}
+	}
+
+	m.appendCommandExchange(input, strings.Join(lines, "\n"))
+	m.statusNote = fmt.Sprintf("Discovered %d skill(s).", len(skillsList))
+	return nil
+}
+
+func (m *model) runSkillCommand(input string, fields []string) error {
+	if m.runner == nil {
+		return fmt.Errorf("runner is unavailable")
+	}
+	if len(fields) != 2 || fields[1] != "clear" {
+		return fmt.Errorf("usage: /skill clear")
+	}
+
+	if err := m.runner.ClearActiveSkill(m.sess); err != nil {
+		return err
+	}
+	m.appendCommandExchange(input, "Active skill cleared.")
+	m.statusNote = "Skill cleared."
+	return nil
+}
+
+func (m *model) runDirectSkillCommand(input string, fields []string) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	name := strings.TrimSpace(fields[0])
+	if !strings.HasPrefix(name, "/") || !m.isKnownSkillCommand(name) {
+		return fmt.Errorf("unknown command: %s", fields[0])
+	}
+	args, err := parseSkillArgs(fields[1:])
+	if err != nil {
+		return err
+	}
+	return m.activateSkillCommand(input, name, args)
+}
+
+func (m *model) activateSkillCommand(input, name string, args map[string]string) error {
+	if m.runner == nil {
+		return fmt.Errorf("runner is unavailable")
+	}
+	skill, err := m.runner.ActivateSkill(m.sess, name, args)
+	if err != nil {
+		return err
+	}
+	response := fmt.Sprintf("Activated skill `%s` (%s).\nTool policy: %s\nEntry: %s", skill.Name, skill.Scope, skill.ToolPolicy.Policy, skill.Entry.Slash)
+	if len(args) > 0 {
+		argParts := make([]string, 0, len(args))
+		keys := make([]string, 0, len(args))
+		for key := range args {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			argParts = append(argParts, fmt.Sprintf("%s=%s", key, args[key]))
+		}
+		response += "\nArgs: " + strings.Join(argParts, ", ")
+	}
+	m.appendCommandExchange(input, response)
+	m.statusNote = "Skill activated."
+	return nil
+}
+
+func parseSkillArgs(parts []string) (map[string]string, error) {
+	if len(parts) == 0 {
+		return nil, nil
+	}
+	args := make(map[string]string, len(parts))
+	for _, part := range parts {
+		pieces := strings.SplitN(part, "=", 2)
+		if len(pieces) != 2 {
+			return nil, fmt.Errorf("invalid skill arg %q, expected k=v", part)
+		}
+		key := strings.TrimSpace(pieces[0])
+		value := strings.TrimSpace(pieces[1])
+		if key == "" || value == "" {
+			return nil, fmt.Errorf("invalid skill arg %q, expected k=v", part)
+		}
+		args[key] = value
+	}
+	if len(args) == 0 {
+		return nil, nil
+	}
+	return args, nil
+}
+
+func (m *model) appendCommandExchange(command, response string) {
+	m.screen = screenChat
+	m.appendChat(chatEntry{
+		Kind:   "user",
+		Title:  "You",
+		Meta:   formatUserMeta(m.currentModelLabel(), time.Now()),
+		Body:   command,
+		Status: "final",
+	})
+	m.appendChat(chatEntry{
+		Kind:   "assistant",
+		Title:  assistantLabel,
+		Body:   response,
+		Status: "final",
+	})
+}
+
 func (m *model) newSession() error {
 	next := session.New(m.workspace)
 	if err := m.store.Save(next); err != nil {
@@ -2344,7 +2514,7 @@ func (m model) hasRecentMention(path string) bool {
 func (m model) filteredCommands() []commandItem {
 	value := strings.TrimSpace(m.input.Value())
 	query := commandFilterQuery(value, "")
-	items := visibleCommandItems("")
+	items := m.commandPaletteItems()
 	if query == "" {
 		return items
 	}
@@ -2356,6 +2526,76 @@ func (m model) filteredCommands() []commandItem {
 		}
 	}
 	return result
+}
+
+func (m model) commandPaletteItems() []commandItem {
+	base := visibleCommandItems("")
+	skillItems := m.skillCommandItems()
+	if len(skillItems) == 0 {
+		return base
+	}
+
+	items := make([]commandItem, 0, len(base)+len(skillItems))
+	seen := make(map[string]struct{}, len(base)+len(skillItems))
+	items = append(items, base...)
+	for _, item := range base {
+		seen[strings.ToLower(strings.TrimSpace(item.Usage))] = struct{}{}
+	}
+	for _, item := range skillItems {
+		key := strings.ToLower(strings.TrimSpace(item.Usage))
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		items = append(items, item)
+	}
+	return items
+}
+
+func (m model) skillCommandItems() []commandItem {
+	if m.runner == nil {
+		return nil
+	}
+	skillsList, _ := m.runner.ListSkills()
+	if len(skillsList) == 0 {
+		return nil
+	}
+
+	items := make([]commandItem, 0, len(skillsList))
+	seen := make(map[string]struct{}, len(skillsList))
+	for _, skill := range skillsList {
+		name := strings.TrimSpace(skill.Entry.Slash)
+		if name == "" {
+			name = "/" + strings.TrimSpace(skill.Name)
+		}
+		if name == "" {
+			continue
+		}
+		if !strings.HasPrefix(name, "/") {
+			name = "/" + name
+		}
+		name = "/" + strings.TrimLeft(strings.TrimSpace(name), "/")
+		key := strings.ToLower(name)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		description := strings.TrimSpace(skill.Description)
+		if description == "" {
+			description = fmt.Sprintf("Activate %s for this session.", skill.Name)
+		}
+		items = append(items, commandItem{
+			Name:        name,
+			Usage:       name,
+			Description: description,
+			Kind:        "skill",
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Usage < items[j].Usage
+	})
+	return items
 }
 
 func (m model) commandPaletteWidth() int {
@@ -2402,8 +2642,11 @@ func (m *model) setInputValue(value string) {
 }
 
 func shouldExecuteFromPalette(item commandItem) bool {
+	if item.Kind == "skill" {
+		return true
+	}
 	switch item.Name {
-	case "/help", "/session", "/new", "/quit":
+	case "/help", "/session", "/skills", "/skill clear", "/new", "/quit":
 		return true
 	default:
 		return false
@@ -2420,6 +2663,9 @@ func (m model) helpText() string {
 		"Slash commands",
 		"/help: show this help inside the conversation.",
 		"/session: open recent sessions.",
+		"/skills: list discovered skills and diagnostics.",
+		"/<skill-name> [k=v...]: activate a skill for this session.",
+		"/skill clear: clear the active skill.",
 		"/new: start a fresh session.",
 		"/quit: exit the TUI.",
 		"",
@@ -2446,6 +2692,37 @@ func visibleCommandItems(group string) []commandItem {
 		}
 	}
 	return items
+}
+
+func (m model) isKnownSkillCommand(command string) bool {
+	if m.runner == nil {
+		return false
+	}
+	normalized := normalizeSkillCommand(command)
+	if normalized == "" {
+		return false
+	}
+	skillsList, _ := m.runner.ListSkills()
+	for _, skill := range skillsList {
+		if normalizeSkillCommand(skill.Name) == normalized {
+			return true
+		}
+		if normalizeSkillCommand(skill.Entry.Slash) == normalized {
+			return true
+		}
+		for _, alias := range skill.Aliases {
+			if normalizeSkillCommand(alias) == normalized {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalizeSkillCommand(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.TrimLeft(name, "/")
+	return strings.TrimSpace(name)
 }
 
 func commandFilterQuery(value, group string) string {
@@ -2630,6 +2907,17 @@ func (m model) currentModelLabel() string {
 		return model
 	}
 	return "-"
+}
+
+func (m model) currentSkillLabel() string {
+	if m.sess == nil || m.sess.ActiveSkill == nil {
+		return "none"
+	}
+	name := strings.TrimSpace(m.sess.ActiveSkill.Name)
+	if name == "" {
+		return "none"
+	}
+	return name
 }
 
 func preparePlanForContinuation(state planpkg.State) (planpkg.State, error) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -592,6 +594,8 @@ func TestHelpTextOnlyMentionsSupportedEntryPoints(t *testing.T) {
 		"aicoding chat",
 		"aicoding run",
 		"/plan",
+		"/skill use",
+		"/skill show",
 	} {
 		if strings.Contains(text, unwanted) {
 			t.Fatalf("help text should not mention %q", unwanted)
@@ -805,6 +809,154 @@ func TestHandleSlashSessionOpensSessionsModal(t *testing.T) {
 	}
 	if !m.sessionsOpen {
 		t.Fatalf("expected /session to open sessions modal")
+	}
+}
+
+func TestHandleSlashSkillsListsDiscoveredSkills(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, "internal", "skills", "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "internal", "skills", "review", "skill.json"), []byte(`{
+  "name":"review",
+  "description":"review skill"
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	runner := agent.NewRunner(agent.Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+		},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+	})
+
+	m := model{
+		runner:    runner,
+		store:     store,
+		sess:      sess,
+		workspace: workspace,
+		screen:    screenChat,
+	}
+	if err := m.handleSlashCommand("/skills"); err != nil {
+		t.Fatalf("expected /skills to succeed, got %v", err)
+	}
+	if len(m.chatItems) < 2 {
+		t.Fatalf("expected /skills command exchange in chat, got %#v", m.chatItems)
+	}
+	if !strings.Contains(m.chatItems[len(m.chatItems)-1].Body, "review") {
+		t.Fatalf("expected skills output to contain review, got %q", m.chatItems[len(m.chatItems)-1].Body)
+	}
+}
+
+func TestHandleSlashSkillActivateAndClear(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, "internal", "skills", "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "internal", "skills", "review", "skill.json"), []byte(`{
+  "name":"review",
+  "description":"review skill",
+  "tools":{"policy":"allowlist","items":["read_file"]}
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	if err := store.Save(sess); err != nil {
+		t.Fatal(err)
+	}
+	runner := agent.NewRunner(agent.Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+		},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+	})
+
+	m := model{
+		runner:    runner,
+		store:     store,
+		sess:      sess,
+		workspace: workspace,
+		screen:    screenChat,
+	}
+	if err := m.handleSlashCommand("/review severity=high"); err != nil {
+		t.Fatalf("expected /review to succeed, got %v", err)
+	}
+	if m.sess.ActiveSkill == nil || m.sess.ActiveSkill.Name != "review" {
+		t.Fatalf("expected active skill to be set, got %#v", m.sess.ActiveSkill)
+	}
+	if got := m.sess.ActiveSkill.Args["severity"]; got != "high" {
+		t.Fatalf("expected skill arg severity=high, got %q", got)
+	}
+	if err := m.handleSlashCommand("/skill clear"); err != nil {
+		t.Fatalf("expected /skill clear to succeed, got %v", err)
+	}
+	if m.sess.ActiveSkill != nil {
+		t.Fatalf("expected active skill to be cleared, got %#v", m.sess.ActiveSkill)
+	}
+}
+
+func TestFilteredCommandsIncludeSkillSlashCommands(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, "internal", "skills", "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "internal", "skills", "review", "skill.json"), []byte(`{
+  "name":"review",
+  "description":"review skill",
+  "entry":{"slash":"/review"}
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	runner := agent.NewRunner(agent.Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+		},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+	})
+
+	input := textarea.New()
+	input.SetValue("/re")
+	m := model{
+		runner:    runner,
+		store:     store,
+		sess:      sess,
+		workspace: workspace,
+		input:     input,
+	}
+
+	items := m.filteredCommands()
+	found := false
+	for _, item := range items {
+		if item.Name == "/review" && item.Kind == "skill" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected /review skill command in filtered commands, got %+v", items)
 	}
 }
 
@@ -1195,6 +1347,35 @@ func TestRenderMentionPaletteShowsTruncatedMeta(t *testing.T) {
 	}
 }
 
+func TestCommandPaletteAllowsTypingJKWhenOpen(t *testing.T) {
+	input := textarea.New()
+	input.SetValue("/")
+	m := model{
+		screen:        screenChat,
+		commandOpen:   true,
+		commandCursor: 1,
+		input:         input,
+	}
+
+	afterK, _ := m.handleCommandPaletteKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	kModel := afterK.(model)
+	if kModel.input.Value() != "/k" {
+		t.Fatalf("expected k to be inserted into slash input, got %q", kModel.input.Value())
+	}
+	if kModel.commandCursor != 1 {
+		t.Fatalf("expected k not to move command cursor, got %d", kModel.commandCursor)
+	}
+
+	afterJ, _ := kModel.handleCommandPaletteKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	jModel := afterJ.(model)
+	if jModel.input.Value() != "/kj" {
+		t.Fatalf("expected j to be inserted into slash input, got %q", jModel.input.Value())
+	}
+	if jModel.commandCursor != 1 {
+		t.Fatalf("expected j not to move command cursor, got %d", jModel.commandCursor)
+	}
+}
+
 func TestRenderCommandPaletteDoesNotCorruptChineseDescriptions(t *testing.T) {
 	input := textarea.New()
 	input.SetValue("/")
@@ -1530,6 +1711,28 @@ func TestApprovalBannerRendersAboveInput(t *testing.T) {
 	}
 	if strings.Contains(footer, "Approval Request") {
 		t.Fatalf("did not expect old centered approval modal title in footer")
+	}
+}
+
+func TestRenderFooterShowsActiveSkillBanner(t *testing.T) {
+	input := textarea.New()
+	m := model{
+		width: 120,
+		input: input,
+		sess: &session.Session{
+			ActiveSkill: &session.ActiveSkill{
+				Name: "review",
+				Args: map[string]string{"severity": "high"},
+			},
+		},
+	}
+
+	footer := m.renderFooter()
+	if !strings.Contains(footer, "Active skill: review") {
+		t.Fatalf("expected footer to show active skill banner, got %q", footer)
+	}
+	if !strings.Contains(footer, "severity=high") {
+		t.Fatalf("expected footer to show active skill args, got %q", footer)
 	}
 }
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -107,6 +107,12 @@ var (
 				Background(lipgloss.Color("#17140D")).
 				Padding(0, 1)
 
+	activeSkillBannerStyle = lipgloss.NewStyle().
+				BorderStyle(lipgloss.NormalBorder()).
+				BorderForeground(colorAccent).
+				Background(lipgloss.Color("#0F1A28")).
+				Padding(0, 1)
+
 	statusBarStyle = lipgloss.NewStyle().
 			Foreground(colorMuted).
 			Faint(true)


### PR DESCRIPTION
## 主要改动
- 新增 `internal/skills` 模块：
  - Skill 类型定义、frontmatter 解析、manifest 加载、别名解析、作用域覆盖（builtin/user/project）与诊断输出。
- Runner 接入 Skill 生命周期：
  - 支持 `ListSkills` / `ActivateSkill` / `ClearActiveSkill` / `GetActiveSkill`。
  - 在运行时解析 active skill，并应用工具策略（allowlist/denylist）。
- Prompt 扩展 active skill block：
  - 新增 `internal/agent/prompts/block-active-skill.md`。
  - 在 system prompt 中注入当前 active skill 的名称、描述、参数、工具策略和指令内容。
- Tool Registry 增强策略约束：
  - 增加按策略过滤工具定义与执行期校验，防止绕过 active skill 策略。
- Session 持久化 active skill：
  - `Session` 新增 `active_skill`（name/args/activated_at）并支持规范化读写。
- TUI Skill 交互升级：
  - 保留 `/skills`、`/skill clear`。
  - 支持直接 `/<skill-name> 激活 skill（如 `/review`）。
  - 输入区上方显示当前 active skill。
  - 修复 `/` 命令面板下 `j/k` 输入冲突（可正常输入，不再误触发导航）。
- 新增内置 coding skills：
  - `review`
  - `repo-onboarding`
  - `bug-investigation`
  - `write-rfc`
  - `github-pr`

## 兼容性
- 旧会话未包含 `active_skill` 时保持兼容（按空 skill 处理）。
- `/skill use` 与 `/skill show` 不再作为主入口，统一为顶级 `/<skill-name>` + `/skill clear`。