### PR TITLE
feat: 新增Ctrl+F历史检索、启动配置向导与全局安装能力

### DIFF
--- a/cmd/bytemind/install.go
+++ b/cmd/bytemind/install.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"bytemind/internal/config"
+)
+
+func runInstall(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	installDir := fs.String("to", "", "Install directory. Defaults to BYTEMIND_HOME/bin (or ~/.bytemind/bin).")
+	binaryName := fs.String("name", "", "Binary name. Defaults to bytemind (bytemind.exe on Windows).")
+	addToPath := fs.Bool("add-to-path", true, "Automatically add install directory to user PATH when possible.")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if len(fs.Args()) > 0 {
+		return fmt.Errorf("install does not accept positional args: %s", strings.Join(fs.Args(), " "))
+	}
+
+	sourcePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve current executable: %w", err)
+	}
+	targetPath, err := resolveInstallTarget(*installDir, *binaryName)
+	if err != nil {
+		return err
+	}
+	if err := installBinary(sourcePath, targetPath); err != nil {
+		return err
+	}
+
+	targetDir := filepath.Dir(targetPath)
+	fmt.Fprintf(stdout, "Installed Bytemind to %s\n", targetPath)
+	if pathContainsDir(os.Getenv("PATH"), targetDir) {
+		fmt.Fprintln(stdout, "PATH already includes this directory in this terminal. You can now run: bytemind")
+		return nil
+	}
+	if *addToPath {
+		changed, err := addInstallDirToUserPath(targetDir)
+		if err == nil {
+			if changed {
+				fmt.Fprintln(stdout, "Added install directory to user PATH.")
+				fmt.Fprintln(stdout, "Open a new terminal, then run: bytemind")
+			} else {
+				fmt.Fprintln(stdout, "Install directory already exists in user PATH.")
+			}
+			return nil
+		}
+		fmt.Fprintf(stdout, "Automatic PATH update failed: %v\n", err)
+	}
+
+	fmt.Fprintf(stdout, "Add this directory to PATH to run Bytemind from anywhere:\n%s\n", targetDir)
+	printPathHint(stdout, targetDir)
+	return nil
+}
+
+func resolveInstallTarget(dirValue, nameValue string) (string, error) {
+	dir := strings.TrimSpace(dirValue)
+	if dir == "" {
+		home, err := config.ResolveHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dir = filepath.Join(home, "bin")
+	} else {
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return "", err
+		}
+		dir = abs
+	}
+
+	name := strings.TrimSpace(nameValue)
+	if name == "" {
+		name = defaultBinaryName(runtime.GOOS)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return "", errors.New("install -name must be a file name, not a path")
+	}
+
+	return filepath.Join(dir, name), nil
+}
+
+func defaultBinaryName(goos string) string {
+	if strings.EqualFold(goos, "windows") {
+		return "bytemind.exe"
+	}
+	return "bytemind"
+}
+
+func installBinary(sourcePath, targetPath string) error {
+	sourcePath = strings.TrimSpace(sourcePath)
+	targetPath = strings.TrimSpace(targetPath)
+	if sourcePath == "" || targetPath == "" {
+		return errors.New("source and target path are required")
+	}
+
+	sourceInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		return err
+	}
+	if sourceInfo.IsDir() {
+		return fmt.Errorf("source executable is a directory: %s", sourcePath)
+	}
+
+	targetDir := filepath.Dir(targetPath)
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return err
+	}
+
+	sourceFile, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	tempPath := targetPath + ".tmp"
+	_ = os.Remove(tempPath)
+	targetFile, err := os.OpenFile(tempPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, sourceInfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	copyOK := false
+	defer func() {
+		if !copyOK {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := io.Copy(targetFile, sourceFile); err != nil {
+		_ = targetFile.Close()
+		return err
+	}
+	if err := targetFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tempPath, sourceInfo.Mode()); err != nil && runtime.GOOS != "windows" {
+		return err
+	}
+
+	if err := os.Remove(targetPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.Rename(tempPath, targetPath); err != nil {
+		return err
+	}
+	copyOK = true
+	return nil
+}
+
+func addInstallDirToUserPath(targetDir string) (bool, error) {
+	targetDir = strings.TrimSpace(targetDir)
+	if targetDir == "" {
+		return false, errors.New("install directory is empty")
+	}
+	if runtime.GOOS != "windows" {
+		return false, errors.New("automatic PATH update is currently supported on Windows only")
+	}
+	return addToWindowsUserPath(targetDir)
+}
+
+var windowsUserPathGetter = func() (string, error) {
+	cmd := exec.Command("powershell", "-NoProfile", "-Command", "[Environment]::GetEnvironmentVariable('Path','User')")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("read user PATH via PowerShell: %w (%s)", err, strings.TrimSpace(string(output)))
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+var windowsUserPathSetter = func(newPath string) error {
+	cmd := exec.Command("powershell", "-NoProfile", "-Command", "[Environment]::SetEnvironmentVariable('Path', $env:BYTEMIND_USER_PATH, 'User')")
+	cmd.Env = append(os.Environ(), "BYTEMIND_USER_PATH="+newPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("write user PATH via PowerShell: %w (%s)", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func addToWindowsUserPath(targetDir string) (bool, error) {
+	currentUserPath, err := windowsUserPathGetter()
+	if err != nil {
+		return false, err
+	}
+	nextUserPath, changed := appendPathEntry(currentUserPath, targetDir, true)
+	if !changed {
+		return false, nil
+	}
+	if err := windowsUserPathSetter(nextUserPath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func pathContainsDir(pathEnv, targetDir string) bool {
+	return pathContainsDirForOS(pathEnv, targetDir, runtime.GOOS == "windows")
+}
+
+func appendPathEntry(pathEnv, targetDir string, windows bool) (string, bool) {
+	target := strings.TrimSpace(strings.Trim(targetDir, `"`))
+	if target == "" {
+		return pathEnv, false
+	}
+	if pathContainsDirForOS(pathEnv, target, windows) {
+		return pathEnv, false
+	}
+	if strings.TrimSpace(pathEnv) == "" {
+		return target, true
+	}
+	sep := string(os.PathListSeparator)
+	if windows {
+		sep = ";"
+	}
+	cleanBase := strings.TrimRight(pathEnv, sep+" ")
+	if cleanBase == "" {
+		return target, true
+	}
+	return cleanBase + sep + target, true
+}
+
+func pathContainsDirForOS(pathEnv, targetDir string, windows bool) bool {
+	target := normalizePathEntry(targetDir, windows)
+	if target == "" {
+		return false
+	}
+	for _, item := range splitPathListForOS(pathEnv, windows) {
+		if normalizePathEntry(item, windows) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func splitPathListForOS(pathEnv string, windows bool) []string {
+	if windows {
+		return strings.Split(pathEnv, ";")
+	}
+	return filepath.SplitList(pathEnv)
+}
+
+func normalizePathEntry(value string, windows bool) string {
+	value = strings.TrimSpace(strings.Trim(value, `"`))
+	if value == "" {
+		return ""
+	}
+	if windows {
+		value = strings.ReplaceAll(value, `\`, `/`)
+		value = filepath.Clean(value)
+		return strings.ToLower(value)
+	}
+	return filepath.Clean(value)
+}
+
+func printPathHint(w io.Writer, targetDir string) {
+	if runtime.GOOS == "windows" {
+		fmt.Fprintln(w, "PowerShell (current terminal):")
+		fmt.Fprintf(w, "$env:Path = \"%s;\" + $env:Path\n", targetDir)
+		fmt.Fprintln(w, "PowerShell (persist for future terminals):")
+		fmt.Fprintf(w, "$userPath = [Environment]::GetEnvironmentVariable('Path','User'); if ($userPath -notlike '*%s*') { [Environment]::SetEnvironmentVariable('Path', $userPath + ';%s', 'User') }\n", targetDir, targetDir)
+		return
+	}
+	fmt.Fprintln(w, "Shell (current terminal):")
+	fmt.Fprintf(w, "export PATH=\"%s:$PATH\"\n", targetDir)
+	fmt.Fprintln(w, "Persist in your shell profile (~/.bashrc, ~/.zshrc, etc.).")
+}

--- a/cmd/bytemind/install_test.go
+++ b/cmd/bytemind/install_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultBinaryName(t *testing.T) {
+	if got := defaultBinaryName("windows"); got != "bytemind.exe" {
+		t.Fatalf("expected windows binary name with .exe, got %q", got)
+	}
+	if got := defaultBinaryName("linux"); got != "bytemind" {
+		t.Fatalf("expected non-windows binary name without extension, got %q", got)
+	}
+}
+
+func TestResolveInstallTargetUsesBytemindHomeByDefault(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".bytemind-home")
+	t.Setenv("BYTEMIND_HOME", home)
+
+	target, err := resolveInstallTarget("", "custom-bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, "bin", "custom-bin")
+	if !samePath(target, want) {
+		t.Fatalf("expected target %q, got %q", want, target)
+	}
+}
+
+func TestResolveInstallTargetRejectsNamePath(t *testing.T) {
+	_, err := resolveInstallTarget("", "nested/bytemind")
+	if err == nil {
+		t.Fatal("expected install target resolution to reject path-like name")
+	}
+}
+
+func TestInstallBinaryCopiesExecutableFile(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.exe")
+	content := []byte("binary-content")
+	if err := os.WriteFile(source, content, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "bin", "bytemind.exe")
+	if err := installBinary(source, target); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("expected target content %q, got %q", string(content), string(got))
+	}
+}
+
+func TestPathContainsDirForOS(t *testing.T) {
+	pathEnv := strings.Join([]string{"C:/Tools", "C:/Users/Wheat/.bytemind/bin"}, ";")
+	if !pathContainsDirForOS(pathEnv, `c:\users\wheat\.bytemind\bin`, true) {
+		t.Fatal("expected windows path lookup to be case-insensitive and slash-insensitive")
+	}
+	if pathContainsDirForOS(pathEnv, `C:\missing`, true) {
+		t.Fatal("did not expect missing path entry")
+	}
+}
+
+func TestAppendPathEntryAvoidsDuplicates(t *testing.T) {
+	current := strings.Join([]string{`C:\Tools`, `C:\Users\wheat\.bytemind\bin`}, ";")
+	next, changed := appendPathEntry(current, `c:\users\wheat\.bytemind\bin`, true)
+	if changed {
+		t.Fatalf("expected duplicate path to be ignored, got changed=true next=%q", next)
+	}
+	if next != current {
+		t.Fatalf("expected unchanged path, got %q", next)
+	}
+}
+
+func TestAppendPathEntryAddsMissingEntry(t *testing.T) {
+	current := `C:\Tools`
+	next, changed := appendPathEntry(current, `C:\Users\wheat\.bytemind\bin`, true)
+	if !changed {
+		t.Fatal("expected missing path entry to be appended")
+	}
+	if !strings.Contains(next, `C:\Users\wheat\.bytemind\bin`) {
+		t.Fatalf("expected appended path entry, got %q", next)
+	}
+}
+
+func TestAddToWindowsUserPathUsesGetterAndSetter(t *testing.T) {
+	originalGetter := windowsUserPathGetter
+	originalSetter := windowsUserPathSetter
+	t.Cleanup(func() {
+		windowsUserPathGetter = originalGetter
+		windowsUserPathSetter = originalSetter
+	})
+
+	windowsUserPathGetter = func() (string, error) {
+		return `C:\Tools`, nil
+	}
+	captured := ""
+	windowsUserPathSetter = func(newPath string) error {
+		captured = newPath
+		return nil
+	}
+
+	changed, err := addToWindowsUserPath(`C:\Users\wheat\.bytemind\bin`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected user path to change")
+	}
+	if !strings.Contains(captured, `C:\Users\wheat\.bytemind\bin`) {
+		t.Fatalf("expected setter to receive appended path, got %q", captured)
+	}
+}
+
+func samePath(a, b string) bool {
+	return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
+}

--- a/cmd/bytemind/main.go
+++ b/cmd/bytemind/main.go
@@ -62,6 +62,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return runTUI(args[1:], stdin, stdout, stderr)
 	case "run":
 		return runOneShot(args[1:], stdin, stdout, stderr)
+	case "install":
+		return runInstall(args[1:], stdout, stderr)
 	case "help", "-h", "--help":
 		printUsage(stdout)
 		return nil
@@ -111,6 +113,14 @@ func promptPrefix() string {
 }
 
 func bootstrap(configPath, modelOverride, sessionID, streamOverride, workspaceOverride string, maxIterationsOverride int, stdin io.Reader, stdout io.Writer) (*agent.Runner, *session.Store, *session.Session, error) {
+	return bootstrapWithOptions(configPath, modelOverride, sessionID, streamOverride, workspaceOverride, maxIterationsOverride, stdin, stdout, true)
+}
+
+func bootstrapForTUI(configPath, modelOverride, sessionID, streamOverride, workspaceOverride string, maxIterationsOverride int, stdin io.Reader, stdout io.Writer) (*agent.Runner, *session.Store, *session.Session, error) {
+	return bootstrapWithOptions(configPath, modelOverride, sessionID, streamOverride, workspaceOverride, maxIterationsOverride, stdin, stdout, false)
+}
+
+func bootstrapWithOptions(configPath, modelOverride, sessionID, streamOverride, workspaceOverride string, maxIterationsOverride int, stdin io.Reader, stdout io.Writer, requireAPIKey bool) (*agent.Runner, *session.Store, *session.Session, error) {
 	workspace, err := resolveWorkspace(workspaceOverride)
 	if err != nil {
 		return nil, nil, nil, err
@@ -143,7 +153,7 @@ func bootstrap(configPath, modelOverride, sessionID, streamOverride, workspaceOv
 	}
 
 	apiKey := cfg.Provider.ResolveAPIKey()
-	if apiKey == "" {
+	if requireAPIKey && apiKey == "" {
 		return nil, nil, nil, errors.New("missing API key; configure provider.api_key in the config file")
 	}
 
@@ -381,9 +391,11 @@ func sameWorkspace(a, b string) bool {
 }
 
 func printUsage(w io.Writer) {
-	fmt.Fprintln(w, "go run ./cmd/bytemind chat [-config path] [-model name] [-session id] [-stream true|false] [-workspace path] [-max-iterations n]")
-	fmt.Fprintln(w, "go run ./cmd/bytemind tui [-config path] [-model name] [-session id] [-stream true|false] [-workspace path] [-max-iterations n]")
-	fmt.Fprintln(w, "go run ./cmd/bytemind run -prompt \"task\" [-config path] [-model name] [-session id] [-stream true|false] [-max-iterations n]")
+	fmt.Fprintln(w, "bytemind chat [-config path] [-model name] [-session id] [-stream true|false] [-workspace path] [-max-iterations n]")
+	fmt.Fprintln(w, "bytemind tui [-config path] [-model name] [-session id] [-stream true|false] [-workspace path] [-max-iterations n]")
+	fmt.Fprintln(w, "bytemind run -prompt \"task\" [-config path] [-model name] [-session id] [-stream true|false] [-max-iterations n]")
+	fmt.Fprintln(w, "bytemind install [-to dir] [-name binary-name]")
+	fmt.Fprintln(w, "tip: first time use `go run ./cmd/bytemind install`, then add install dir to PATH")
 }
 
 func printCommandSuggestions(w io.Writer, input string, suggestions []string) {

--- a/cmd/bytemind/main_test.go
+++ b/cmd/bytemind/main_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"bytemind/internal/config"
+	"bytemind/internal/provider"
 	"bytemind/internal/session"
 )
 
@@ -20,6 +22,14 @@ func TestCompleteSlashCommand(t *testing.T) {
 	}
 	if completed != "/help" {
 		t.Fatalf("expected /help, got %q", completed)
+	}
+}
+
+func TestPrintUsageIncludesInstallCommand(t *testing.T) {
+	var out bytes.Buffer
+	printUsage(&out)
+	if !strings.Contains(out.String(), "bytemind install") {
+		t.Fatalf("expected usage to mention install command, got %q", out.String())
 	}
 }
 
@@ -455,6 +465,59 @@ func TestBootstrapRejectsMissingAPIKey(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "missing API key") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBootstrapForTUIAllowsMissingAPIKey(t *testing.T) {
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	t.Setenv("BYTEMIND_API_KEY", "")
+	writeTestConfig(t, workspace, map[string]any{
+		"provider": map[string]any{
+			"type":     "openai-compatible",
+			"base_url": "https://api.openai.com/v1",
+			"model":    "gpt-5.4-mini",
+		},
+		"stream": false,
+	})
+
+	runner, store, sess, err := bootstrapForTUI("", "", "", "", "", 0, strings.NewReader(""), &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("expected bootstrapForTUI to continue without api key, got %v", err)
+	}
+	if runner == nil || store == nil || sess == nil {
+		t.Fatal("expected bootstrapForTUI to return runner, store, and session")
+	}
+}
+
+func TestBuildStartupGuideIncludesReasonAndPath(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := config.Config{
+		Provider: config.ProviderConfig{
+			APIKeyEnv: "BYTEMIND_API_KEY",
+		},
+	}
+	guide := buildStartupGuide(cfg, provider.Availability{
+		Ready:  false,
+		Reason: "API key unauthorized",
+		Detail: "provider error 401",
+	}, workspace, "")
+
+	if !guide.Active {
+		t.Fatal("expected active startup guide")
+	}
+	if !strings.Contains(guide.Status, "guide you through provider") {
+		t.Fatalf("unexpected guide status: %q", guide.Status)
+	}
+	if guide.CurrentField != "type" {
+		t.Fatalf("expected startup guide to begin at provider step, got %q", guide.CurrentField)
+	}
+	if len(guide.Lines) == 0 {
+		t.Fatal("expected guide lines")
+	}
+	joined := strings.Join(guide.Lines, "\n")
+	if !strings.Contains(joined, "Paste your API key") {
+		t.Fatalf("expected key input hint, got %q", joined)
 	}
 }
 

--- a/cmd/bytemind/tui.go
+++ b/cmd/bytemind/tui.go
@@ -1,12 +1,21 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"bytemind/internal/assets"
+	"bytemind/internal/agent"
 	"bytemind/internal/config"
+	"bytemind/internal/provider"
+	"bytemind/internal/session"
 	"bytemind/internal/tui"
 )
 
@@ -27,31 +36,43 @@ func runTUI(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return err
 	}
 
-	app, store, sess, err := bootstrap(*configPath, *model, *sessionID, *streamOverride, *workspaceOverride, *maxIterations, stdin, stdout)
-	if err != nil {
-		return err
-	}
-
 	workspace, err := resolveWorkspace(*workspaceOverride)
 	if err != nil {
 		return err
 	}
+
 	cfg, err := config.Load(workspace, *configPath)
 	if err != nil {
 		return err
 	}
-	if *model != "" {
-		cfg.Provider.Model = *model
+	if err := applyRuntimeOverrides(&cfg, *model, *streamOverride, *maxIterations); err != nil {
+		return err
 	}
-	if *streamOverride != "" {
-		parsed, err := strconv.ParseBool(*streamOverride)
-		if err != nil {
-			return err
-		}
-		cfg.Stream = parsed
+
+	interactive := isInteractiveStdin(stdin)
+	check := provider.Availability{Ready: true}
+	if interactive {
+		check = provider.CheckAvailability(context.Background(), cfg.Provider)
 	}
-	if *maxIterations > 0 {
-		cfg.MaxIterations = *maxIterations
+
+	guide := tui.StartupGuide{}
+	if !check.Ready {
+		guide = buildStartupGuide(cfg, check, workspace, *configPath)
+	}
+
+	var app *agent.Runner
+	var store *session.Store
+	var sess *session.Session
+	if guide.Active && interactive {
+		app, store, sess, err = bootstrapForTUI(*configPath, *model, *sessionID, *streamOverride, *workspaceOverride, *maxIterations, stdin, stdout)
+	} else {
+		app, store, sess, err = bootstrap(*configPath, *model, *sessionID, *streamOverride, *workspaceOverride, *maxIterations, stdin, stdout)
+	}
+	if err != nil {
+		return err
+	}
+	if app == nil || store == nil || sess == nil {
+		return errors.New("internal error: bootstrap returned nil runtime")
 	}
 	home, err := config.EnsureHomeLayout()
 	if err != nil {
@@ -62,6 +83,7 @@ func runTUI(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return err
 	}
 
+<<<<<<< HEAD
 	return runTUIProgram(tui.Options{
 		Runner:     app,
 		Store:      store,
@@ -69,5 +91,128 @@ func runTUI(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		ImageStore: imageStore,
 		Config:     cfg,
 		Workspace:  sess.Workspace,
+=======
+	return tui.Run(tui.Options{
+		Runner:       app,
+		Store:        store,
+		Session:      sess,
+		Config:       cfg,
+		Workspace:    sess.Workspace,
+		StartupGuide: guide,
+>>>>>>> 122d737 (feat: 新增Ctrl+F历史检索、启动配置向导与全局安装能力)
 	})
+}
+
+func applyRuntimeOverrides(cfg *config.Config, modelOverride, streamOverride string, maxIterations int) error {
+	if modelOverride != "" {
+		cfg.Provider.Model = modelOverride
+	}
+	if streamOverride != "" {
+		parsed, err := strconv.ParseBool(streamOverride)
+		if err != nil {
+			return fmt.Errorf("invalid -stream value: %w", err)
+		}
+		cfg.Stream = parsed
+	}
+	if maxIterations > 0 {
+		cfg.MaxIterations = maxIterations
+	}
+	return nil
+}
+
+func isInteractiveStdin(stdin io.Reader) bool {
+	file, ok := stdin.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
+func buildStartupGuide(cfg config.Config, check provider.Availability, workspace, explicitConfigPath string) tui.StartupGuide {
+	path := configPathHint(workspace, explicitConfigPath)
+	envName := strings.TrimSpace(cfg.Provider.APIKeyEnv)
+	if envName == "" {
+		envName = "BYTEMIND_API_KEY"
+	}
+	lines := []string{
+		"Paste your API key in the input box below and press Enter.",
+		"Bytemind will verify it and save it automatically.",
+		"Default OpenAI setup only needs API key.",
+		"For other providers, set provider.base_url and provider.model too.",
+		"Optional: model=<name>  base_url=<url>  provider=<openai-compatible|anthropic>",
+		"You can still use /help and /quit commands.",
+		"Env fallback: " + envName,
+	}
+	if path != "" {
+		lines = append(lines, "Config file: "+path)
+	}
+	lines = append(lines, "Issue: "+startupIssueHint(check))
+
+	return tui.StartupGuide{
+		Active:       true,
+		Title:        "Let's finish setup",
+		Status:       "Bytemind will guide you through provider, base_url, model, and API key.",
+		Lines:        lines,
+		ConfigPath:   path,
+		CurrentField: "type",
+	}
+}
+
+func startupIssueHint(check provider.Availability) string {
+	reason := strings.ToLower(strings.TrimSpace(check.Reason))
+	switch {
+	case strings.Contains(reason, "missing api key"):
+		return "No API key is configured yet."
+	case strings.Contains(reason, "unauthorized"):
+		return "The API key was rejected by the provider."
+	case strings.Contains(reason, "failed to reach"):
+		return "Cannot reach provider endpoint. Check proxy or network."
+	case strings.Contains(reason, "not found"):
+		return "Provider endpoint path looks incorrect."
+	default:
+		if strings.TrimSpace(check.Reason) == "" {
+			return "Provider check failed."
+		}
+		return compactLine(check.Reason, 120)
+	}
+}
+
+func configPathHint(workspace, explicit string) string {
+	if strings.TrimSpace(explicit) != "" {
+		if abs, err := filepath.Abs(explicit); err == nil {
+			return abs
+		}
+		return explicit
+	}
+
+	candidates := []string{
+		filepath.Join(workspace, "config.json"),
+		filepath.Join(workspace, ".bytemind", "config.json"),
+		filepath.Join(workspace, "bytemind.config.json"),
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	home, err := config.ResolveHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, "config.json")
+}
+
+func compactLine(raw string, limit int) string {
+	raw = strings.TrimSpace(strings.ReplaceAll(raw, "\n", " "))
+	if len(raw) <= limit {
+		return raw
+	}
+	if limit <= 3 {
+		return raw[:limit]
+	}
+	return raw[:limit-3] + "..."
 }

--- a/cmd/bytemind/tui.go
+++ b/cmd/bytemind/tui.go
@@ -83,23 +83,14 @@ func runTUI(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return err
 	}
 
-<<<<<<< HEAD
 	return runTUIProgram(tui.Options{
-		Runner:     app,
-		Store:      store,
-		Session:    sess,
-		ImageStore: imageStore,
-		Config:     cfg,
-		Workspace:  sess.Workspace,
-=======
-	return tui.Run(tui.Options{
 		Runner:       app,
 		Store:        store,
 		Session:      sess,
+		ImageStore:   imageStore,
 		Config:       cfg,
 		Workspace:    sess.Workspace,
 		StartupGuide: guide,
->>>>>>> 122d737 (feat: 新增Ctrl+F历史检索、启动配置向导与全局安装能力)
 	})
 }
 

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"bytemind/internal/config"
+	"bytemind/internal/history"
 	"bytemind/internal/llm"
 	planpkg "bytemind/internal/plan"
 	"bytemind/internal/session"
@@ -156,6 +157,11 @@ func (r *Runner) GetActiveSkill(sess *session.Session) (skills.Skill, bool) {
 		return skills.Skill{}, false
 	}
 	return r.skillManager.Find(sess.ActiveSkill.Name)
+func (r *Runner) UpdateProvider(providerCfg config.ProviderConfig, client llm.Client) {
+	r.config.Provider = providerCfg
+	if client != nil {
+		r.client = client
+	}
 }
 
 func (r *Runner) RunPrompt(ctx context.Context, sess *session.Session, userInput, mode string, out io.Writer) (string, error) {
@@ -204,6 +210,7 @@ func (r *Runner) RunPromptWithInput(ctx context.Context, sess *session.Session, 
 	if err := r.store.Save(sess); err != nil {
 		return "", err
 	}
+	_ = history.AppendPrompt(r.workspace, sess.ID, userInput, time.Now().UTC())
 	r.emit(Event{
 		Type:      EventRunStarted,
 		SessionID: sess.ID,

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -157,6 +157,8 @@ func (r *Runner) GetActiveSkill(sess *session.Session) (skills.Skill, bool) {
 		return skills.Skill{}, false
 	}
 	return r.skillManager.Find(sess.ActiveSkill.Name)
+}
+
 func (r *Runner) UpdateProvider(providerCfg config.ProviderConfig, client llm.Client) {
 	r.config.Provider = providerCfg
 	if client != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -260,7 +260,10 @@ func normalize(cfg *Config) error {
 		return errors.New("provider.base_url is required")
 	}
 	if strings.TrimSpace(cfg.Provider.Model) == "" {
-		return errors.New("provider.model is required")
+		cfg.Provider.Model = defaultModel(cfg.Provider.Type)
+		if strings.TrimSpace(cfg.Provider.Model) == "" {
+			return errors.New("provider.model is required")
+		}
 	}
 	if cfg.Provider.APIKeyEnv == "" {
 		cfg.Provider.APIKeyEnv = "BYTEMIND_API_KEY"
@@ -364,5 +367,14 @@ func defaultBaseURL(providerType string) string {
 		return "https://api.anthropic.com"
 	default:
 		return "https://api.openai.com/v1"
+	}
+}
+
+func defaultModel(providerType string) string {
+	switch normalizeProviderType(providerType) {
+	case "openai-compatible", "openai", "":
+		return "GPT-5.4"
+	default:
+		return ""
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -137,6 +137,29 @@ func TestLoadAcceptsLegacySessionDirField(t *testing.T) {
 	}
 }
 
+func TestLoadDefaultsOpenAIModelWhenMissing(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", t.TempDir())
+	if err := writeConfig(filepath.Join(workspace, "config.json"), map[string]any{
+		"provider": map[string]any{
+			"type":     "openai-compatible",
+			"base_url": "https://api.deepseek.com",
+			"model":    "",
+			"api_key":  "test-key",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(workspace, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider.Model != "GPT-5.4" {
+		t.Fatalf("expected default model GPT-5.4, got %q", cfg.Provider.Model)
+	}
+}
+
 func TestLoadRejectsUnsupportedProviderType(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("BYTEMIND_HOME", t.TempDir())
@@ -233,6 +256,121 @@ func TestEnsureHomeLayoutCreatesStandardDirectories(t *testing.T) {
 	}
 	if strings.TrimSpace(cfg.Provider.Model) == "" {
 		t.Fatalf("expected default provider model to be present")
+	}
+}
+
+func TestUpsertProviderAPIKeyUpdatesExistingConfig(t *testing.T) {
+	workspace := t.TempDir()
+	configPath := filepath.Join(workspace, "config.json")
+	if err := os.WriteFile(configPath, []byte(`{
+  "provider": {
+    "type": "openai-compatible",
+    "base_url": "https://api.openai.com/v1",
+    "model": "GPT-5.4",
+    "api_key": "old-key",
+    "api_key_env": "BYTEMIND_API_KEY"
+  },
+  "custom": "keep-me"
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writtenPath, err := UpsertProviderAPIKey(configPath, "new-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if writtenPath == "" {
+		t.Fatal("expected written path")
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	providerDoc, ok := doc["provider"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected provider object, got %#v", doc["provider"])
+	}
+	if providerDoc["api_key"] != "new-key" {
+		t.Fatalf("expected api_key to be updated, got %#v", providerDoc["api_key"])
+	}
+	if doc["custom"] != "keep-me" {
+		t.Fatalf("expected custom field to be preserved, got %#v", doc["custom"])
+	}
+}
+
+func TestUpsertProviderAPIKeyCreatesConfigWhenMissing(t *testing.T) {
+	workspace := t.TempDir()
+	configPath := filepath.Join(workspace, "nested", "config.json")
+
+	writtenPath, err := UpsertProviderAPIKey(configPath, "new-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Clean(writtenPath) != filepath.Clean(configPath) {
+		t.Fatalf("expected written path %q, got %q", configPath, writtenPath)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider.ResolveAPIKey() != "new-key" {
+		t.Fatalf("expected api key to be written, got %q", cfg.Provider.ResolveAPIKey())
+	}
+	if cfg.Provider.Model == "" || cfg.Provider.BaseURL == "" {
+		t.Fatalf("expected defaults to be present, got %#v", cfg.Provider)
+	}
+}
+
+func TestUpsertProviderFieldUpdatesModelAndBaseURL(t *testing.T) {
+	workspace := t.TempDir()
+	configPath := filepath.Join(workspace, "config.json")
+	if err := os.WriteFile(configPath, []byte(`{
+  "provider": {
+    "type": "openai-compatible",
+    "base_url": "https://api.openai.com/v1",
+    "model": "GPT-5.4",
+    "api_key": "test-key"
+  }
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := UpsertProviderField(configPath, "model", "deepseek-chat"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UpsertProviderField(configPath, "base_url", "https://api.deepseek.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(workspace, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider.Model != "deepseek-chat" {
+		t.Fatalf("expected updated model, got %q", cfg.Provider.Model)
+	}
+	if cfg.Provider.BaseURL != "https://api.deepseek.com" {
+		t.Fatalf("expected updated base url, got %q", cfg.Provider.BaseURL)
+	}
+}
+
+func TestUpsertProviderFieldRejectsUnsupportedField(t *testing.T) {
+	_, err := UpsertProviderField(filepath.Join(t.TempDir(), "config.json"), "foo", "bar")
+	if err == nil {
+		t.Fatal("expected unsupported field error")
+	}
+	if !strings.Contains(err.Error(), "unsupported provider field") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/config/update.go
+++ b/internal/config/update.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func UpsertProviderAPIKey(configPath, apiKey string) (string, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return "", errors.New("api key is empty")
+	}
+	return upsertProviderValues(configPath, map[string]string{
+		"api_key": apiKey,
+	})
+}
+
+func UpsertProviderField(configPath, field, value string) (string, error) {
+	field = strings.ToLower(strings.TrimSpace(field))
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", errors.New("provider field value is empty")
+	}
+	switch field {
+	case "type", "base_url", "model", "api_key", "api_key_env":
+	default:
+		return "", fmt.Errorf("unsupported provider field: %s", field)
+	}
+	return upsertProviderValues(configPath, map[string]string{
+		field: value,
+	})
+}
+
+func upsertProviderValues(configPath string, values map[string]string) (string, error) {
+	path, err := resolveWritableConfigPath(configPath)
+	if err != nil {
+		return "", err
+	}
+
+	raw, err := loadConfigDocument(path)
+	if err != nil {
+		return "", err
+	}
+
+	providerSection, ok := raw["provider"].(map[string]any)
+	if !ok || providerSection == nil {
+		providerSection = map[string]any{}
+	}
+	for field, value := range values {
+		if strings.TrimSpace(field) == "" {
+			continue
+		}
+		providerSection[field] = strings.TrimSpace(value)
+	}
+	if strings.TrimSpace(asString(providerSection["api_key_env"])) == "" {
+		providerSection["api_key_env"] = "BYTEMIND_API_KEY"
+	}
+	if strings.TrimSpace(asString(providerSection["type"])) == "" {
+		providerSection["type"] = "openai-compatible"
+	}
+	if strings.TrimSpace(asString(providerSection["base_url"])) == "" {
+		providerSection["base_url"] = "https://api.openai.com/v1"
+	}
+	if strings.TrimSpace(asString(providerSection["model"])) == "" {
+		providerSection["model"] = "GPT-5.4"
+	}
+	raw["provider"] = providerSection
+
+	if _, ok := raw["approval_policy"]; !ok {
+		raw["approval_policy"] = "on-request"
+	}
+	if _, ok := raw["max_iterations"]; !ok {
+		raw["max_iterations"] = 32
+	}
+	if _, ok := raw["stream"]; !ok {
+		raw["stream"] = true
+	}
+
+	if err := writeConfigDocument(path, raw); err != nil {
+		return "", err
+	}
+
+	return path, nil
+}
+
+func loadConfigDocument(path string) (map[string]any, error) {
+	raw := map[string]any{}
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if strings.TrimSpace(string(data)) != "" {
+			if err := json.Unmarshal(data, &raw); err != nil {
+				return nil, err
+			}
+		}
+		return raw, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return raw, nil
+	}
+	return nil, err
+}
+
+func writeConfigDocument(path string, raw map[string]any) error {
+	encoded, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, encoded, 0o644)
+}
+
+func resolveWritableConfigPath(explicit string) (string, error) {
+	if strings.TrimSpace(explicit) != "" {
+		return filepath.Abs(explicit)
+	}
+
+	home, err := EnsureHomeLayout()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "config.json"), nil
+}
+
+func asString(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	default:
+		return ""
+	}
+}

--- a/internal/history/store.go
+++ b/internal/history/store.go
@@ -1,0 +1,145 @@
+package history
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"bytemind/internal/config"
+)
+
+const (
+	defaultRecentLimit  = 5000
+	promptHistoryFile   = "prompt_history.jsonl"
+	scannerMaxLineBytes = 1024 * 1024
+)
+
+type PromptEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Workspace string    `json:"workspace"`
+	SessionID string    `json:"session_id"`
+	Prompt    string    `json:"prompt"`
+}
+
+var appendMu sync.Mutex
+
+func AppendPrompt(workspace, sessionID, prompt string, at time.Time) error {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	} else {
+		at = at.UTC()
+	}
+
+	path, err := historyFilePath()
+	if err != nil {
+		return err
+	}
+
+	entry := PromptEntry{
+		Timestamp: at,
+		Workspace: strings.TrimSpace(workspace),
+		SessionID: strings.TrimSpace(sessionID),
+		Prompt:    prompt,
+	}
+	payload, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+
+	appendMu.Lock()
+	defer appendMu.Unlock()
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(append(payload, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func LoadRecentPrompts(limit int) ([]PromptEntry, error) {
+	if limit <= 0 {
+		limit = defaultRecentLimit
+	}
+
+	path, err := historyFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	entries := make([]PromptEntry, 0, minInt(limit, 256))
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), scannerMaxLineBytes)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var entry PromptEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		entry.Prompt = strings.TrimSpace(entry.Prompt)
+		if entry.Prompt == "" {
+			continue
+		}
+		if entry.Timestamp.IsZero() {
+			entry.Timestamp = time.Now().UTC()
+		} else {
+			entry.Timestamp = entry.Timestamp.UTC()
+		}
+
+		entries = append(entries, entry)
+		if len(entries) > limit {
+			copy(entries, entries[len(entries)-limit:])
+			entries = entries[:limit]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}
+
+func historyFilePath() (string, error) {
+	home, err := config.ResolveHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	cacheDir := filepath.Join(home, "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(cacheDir, promptHistoryFile), nil
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/history/store_test.go
+++ b/internal/history/store_test.go
@@ -1,0 +1,81 @@
+package history
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestAppendPromptAndLoadRecentPrompts(t *testing.T) {
+	t.Setenv("BYTEMIND_HOME", t.TempDir())
+
+	now := time.Date(2026, 4, 5, 10, 0, 0, 0, time.UTC)
+	if err := AppendPrompt("/repo", "sess-1", "first prompt", now); err != nil {
+		t.Fatalf("append first prompt: %v", err)
+	}
+	if err := AppendPrompt("/repo", "sess-2", "second prompt", now.Add(time.Second)); err != nil {
+		t.Fatalf("append second prompt: %v", err)
+	}
+
+	entries, err := LoadRecentPrompts(10)
+	if err != nil {
+		t.Fatalf("load prompts: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Prompt != "first prompt" || entries[1].Prompt != "second prompt" {
+		t.Fatalf("unexpected prompts: %#v", entries)
+	}
+	if entries[0].SessionID != "sess-1" || entries[1].SessionID != "sess-2" {
+		t.Fatalf("unexpected session ids: %#v", entries)
+	}
+}
+
+func TestLoadRecentPromptsRespectsLimit(t *testing.T) {
+	t.Setenv("BYTEMIND_HOME", t.TempDir())
+
+	for i, text := range []string{"a", "b", "c"} {
+		if err := AppendPrompt("/repo", "sess", text, time.Unix(int64(i), 0)); err != nil {
+			t.Fatalf("append %q: %v", text, err)
+		}
+	}
+
+	entries, err := LoadRecentPrompts(2)
+	if err != nil {
+		t.Fatalf("load prompts: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Prompt != "b" || entries[1].Prompt != "c" {
+		t.Fatalf("expected most recent prompts [b c], got %#v", entries)
+	}
+}
+
+func TestLoadRecentPromptsSkipsCorruptedLines(t *testing.T) {
+	t.Setenv("BYTEMIND_HOME", t.TempDir())
+
+	path, err := historyFilePath()
+	if err != nil {
+		t.Fatalf("history path: %v", err)
+	}
+
+	content := []byte("{bad json}\n" +
+		"{\"prompt\":\"\",\"session_id\":\"s\"}\n" +
+		"{\"prompt\":\"ok\",\"session_id\":\"s\",\"timestamp\":\"2026-04-05T10:00:00Z\"}\n")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	entries, err := LoadRecentPrompts(10)
+	if err != nil {
+		t.Fatalf("load prompts: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 valid entry, got %d", len(entries))
+	}
+	if entries[0].Prompt != "ok" {
+		t.Fatalf("expected prompt ok, got %#v", entries[0])
+	}
+}

--- a/internal/provider/preflight.go
+++ b/internal/provider/preflight.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"bytemind/internal/config"
+)
+
+const (
+	preflightTimeout = 8 * time.Second
+	maxErrorBodySize = 4 * 1024
+)
+
+type Availability struct {
+	Ready  bool
+	Reason string
+	Detail string
+}
+
+func CheckAvailability(ctx context.Context, cfg config.ProviderConfig) Availability {
+	apiKey := strings.TrimSpace(cfg.ResolveAPIKey())
+	if apiKey == "" {
+		return Availability{
+			Ready:  false,
+			Reason: "missing API key",
+			Detail: "No API key was found in provider.api_key or provider.api_key_env.",
+		}
+	}
+
+	endpoint, headers := preflightRequest(cfg, apiKey)
+	if strings.TrimSpace(endpoint) == "" {
+		return Availability{
+			Ready:  false,
+			Reason: "provider configuration is incomplete",
+			Detail: "Provider base_url is empty.",
+		}
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, preflightTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return Availability{
+			Ready:  false,
+			Reason: "failed to build provider check request",
+			Detail: err.Error(),
+		}
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := (&http.Client{Timeout: preflightTimeout}).Do(req)
+	if err != nil {
+		return Availability{
+			Ready:  false,
+			Reason: "failed to reach provider endpoint",
+			Detail: err.Error(),
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return Availability{Ready: true}
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		detail = fmt.Sprintf("provider returned HTTP %d", resp.StatusCode)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return Availability{
+			Ready:  false,
+			Reason: "API key unauthorized",
+			Detail: detail,
+		}
+	case http.StatusNotFound:
+		return Availability{
+			Ready:  false,
+			Reason: "provider endpoint not found",
+			Detail: detail,
+		}
+	default:
+		return Availability{
+			Ready:  false,
+			Reason: fmt.Sprintf("provider check failed (HTTP %d)", resp.StatusCode),
+			Detail: detail,
+		}
+	}
+}
+
+func preflightRequest(cfg config.ProviderConfig, apiKey string) (string, map[string]string) {
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	providerType := strings.ToLower(strings.TrimSpace(cfg.Type))
+
+	switch providerType {
+	case "anthropic":
+		version := strings.TrimSpace(cfg.AnthropicVersion)
+		if version == "" {
+			version = "2023-06-01"
+		}
+		return baseURL + "/v1/models", map[string]string{
+			"x-api-key":         apiKey,
+			"anthropic-version": version,
+		}
+	default:
+		return baseURL + "/models", map[string]string{
+			"Authorization": "Bearer " + apiKey,
+		}
+	}
+}

--- a/internal/provider/preflight_test.go
+++ b/internal/provider/preflight_test.go
@@ -1,0 +1,108 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"bytemind/internal/config"
+)
+
+func TestCheckAvailabilityReturnsMissingKey(t *testing.T) {
+	result := CheckAvailability(context.Background(), config.ProviderConfig{
+		Type:    "openai-compatible",
+		BaseURL: "https://api.openai.com/v1",
+		Model:   "gpt-5.4",
+		APIKey:  "",
+	})
+
+	if result.Ready {
+		t.Fatal("expected unavailable result when api key is missing")
+	}
+	if !strings.Contains(result.Reason, "missing API key") {
+		t.Fatalf("unexpected reason: %q", result.Reason)
+	}
+}
+
+func TestCheckAvailabilityReturnsReadyOnSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			http.Error(w, "bad auth", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	result := CheckAvailability(context.Background(), config.ProviderConfig{
+		Type:    "openai-compatible",
+		BaseURL: server.URL,
+		Model:   "gpt-5.4",
+		APIKey:  "test-key",
+	})
+
+	if !result.Ready {
+		t.Fatalf("expected ready=true, got %+v", result)
+	}
+}
+
+func TestCheckAvailabilityReturnsUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_api_key"}`))
+	}))
+	defer server.Close()
+
+	result := CheckAvailability(context.Background(), config.ProviderConfig{
+		Type:    "openai-compatible",
+		BaseURL: server.URL,
+		Model:   "gpt-5.4",
+		APIKey:  "bad-key",
+	})
+
+	if result.Ready {
+		t.Fatal("expected unavailable result for unauthorized key")
+	}
+	if !strings.Contains(result.Reason, "unauthorized") {
+		t.Fatalf("unexpected reason: %q", result.Reason)
+	}
+	if !strings.Contains(result.Detail, "invalid_api_key") {
+		t.Fatalf("unexpected detail: %q", result.Detail)
+	}
+}
+
+func TestCheckAvailabilityUsesAnthropicHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("x-api-key"); got != "anth-key" {
+			http.Error(w, "bad key", http.StatusUnauthorized)
+			return
+		}
+		if got := r.Header.Get("anthropic-version"); got != "2023-06-01" {
+			http.Error(w, "bad version", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	result := CheckAvailability(context.Background(), config.ProviderConfig{
+		Type:    "anthropic",
+		BaseURL: server.URL,
+		Model:   "claude",
+		APIKey:  "anth-key",
+	})
+
+	if !result.Ready {
+		t.Fatalf("expected ready=true, got %+v", result)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -10,15 +10,10 @@ import (
 )
 
 type Options struct {
-	Runner     *agent.Runner
-	Store      *session.Store
-	Session    *session.Session
-	ImageStore assets.ImageStore
-	Config     config.Config
-	Workspace  string
 	Runner       *agent.Runner
 	Store        *session.Store
 	Session      *session.Session
+	ImageStore   assets.ImageStore
 	Config       config.Config
 	Workspace    string
 	StartupGuide StartupGuide

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -16,6 +16,21 @@ type Options struct {
 	ImageStore assets.ImageStore
 	Config     config.Config
 	Workspace  string
+	Runner       *agent.Runner
+	Store        *session.Store
+	Session      *session.Session
+	Config       config.Config
+	Workspace    string
+	StartupGuide StartupGuide
+}
+
+type StartupGuide struct {
+	Active       bool
+	Title        string
+	Status       string
+	Lines        []string
+	ConfigPath   string
+	CurrentField string
 }
 
 func Run(opts Options) error {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,8 +16,10 @@ import (
 	"bytemind/internal/assets"
 	"bytemind/internal/config"
 	"bytemind/internal/llm"
+	"bytemind/internal/history"
 	"bytemind/internal/mention"
 	planpkg "bytemind/internal/plan"
+	"bytemind/internal/provider"
 	"bytemind/internal/session"
 	"bytemind/internal/tools"
 
@@ -30,17 +32,20 @@ import (
 )
 
 const (
-	defaultSessionLimit = 8
-	scrollStep          = 3
-	commandPageSize     = 3
-	mentionPageSize     = 5
-	maxPendingBTW       = 5
-	pasteSubmitGuard    = 400 * time.Millisecond
-	assistantLabel      = "Bytemind"
-	thinkingLabel       = "Bytemind"
-	chatTitleLabel      = "Bytemind Chat"
-	tuiTitleLabel       = "Bytemind TUI"
-	footerHintText      = "tab agents | / commands | Ctrl+L sessions | Ctrl+C quit"
+	defaultSessionLimit   = 8
+	scrollStep            = 3
+	commandPageSize       = 3
+	mentionPageSize       = 5
+	maxPendingBTW         = 5
+	promptSearchPageSize  = 5
+	promptSearchLoadLimit = 50000
+	promptSearchResultCap = 200
+	pasteSubmitGuard      = 400 * time.Millisecond
+	assistantLabel        = "Bytemind"
+	thinkingLabel         = "Bytemind"
+	chatTitleLabel        = "Bytemind Chat"
+	tuiTitleLabel         = "Bytemind TUI"
+	footerHintText        = "tab agents | / commands | Ctrl+F history | Ctrl+L sessions | Ctrl+C quit"
 )
 
 type screenKind string
@@ -56,6 +61,27 @@ const (
 	modeBuild agentMode = "build"
 	modePlan  agentMode = "plan"
 )
+
+type promptSearchMode string
+
+const (
+	promptSearchModeQuick promptSearchMode = "quick"
+	promptSearchModePanel promptSearchMode = "panel"
+)
+
+const (
+	startupFieldType    = "type"
+	startupFieldBaseURL = "base_url"
+	startupFieldModel   = "model"
+	startupFieldAPIKey  = "api_key"
+)
+
+var startupFieldOrder = []string{
+	startupFieldType,
+	startupFieldBaseURL,
+	startupFieldModel,
+	startupFieldAPIKey,
+}
 
 type chatEntry struct {
 	Kind   string
@@ -150,47 +176,56 @@ type model struct {
 	input    textarea.Model
 	spinner  spinner.Model
 
-	chatItems          []chatEntry
-	toolRuns           []toolRun
-	plan               planpkg.State
-	sessions           []session.Summary
-	sessionLimit       int
-	sessionCursor      int
-	commandCursor      int
-	mentionCursor      int
-	screen             screenKind
-	mode               agentMode
-	sessionsOpen       bool
-	helpOpen           bool
-	commandOpen        bool
-	mentionOpen        bool
-	busy               bool
-	streamingIndex     int
-	statusNote         string
-	phase              string
-	llmConnected       bool
-	approval           *approvalPrompt
-	mentionQuery       string
-	mentionToken       mention.Token
-	mentionResults     []mention.Candidate
-	mentionIndex       *mention.WorkspaceFileIndex
-	mentionRecent      map[string]int
-	mentionSeq         int
-	inputImageRefs     map[int]llm.AssetID
-	inputImageMentions map[string]llm.AssetID
-	orphanedImages     map[llm.AssetID]time.Time
-	nextImageID        int
-	clipboard          clipboardImageReader
-	lastPasteAt        time.Time
-	lastInputAt        time.Time
-	inputBurstSize     int
-	chatAutoFollow     bool
-	runCancel      context.CancelFunc
-	pendingBTW     []string
-	interrupting   bool
-	interruptSafe  bool
-	runSeq         int
-	activeRunID    int
+	chatItems             []chatEntry
+	toolRuns              []toolRun
+	plan                  planpkg.State
+	sessions              []session.Summary
+	sessionLimit          int
+	sessionCursor         int
+	commandCursor         int
+	mentionCursor         int
+	screen                screenKind
+	mode                  agentMode
+	sessionsOpen          bool
+	helpOpen              bool
+	commandOpen           bool
+	mentionOpen           bool
+	promptSearchOpen      bool
+	busy                  bool
+	streamingIndex        int
+	statusNote            string
+	phase                 string
+	llmConnected          bool
+	approval              *approvalPrompt
+	mentionQuery          string
+	mentionToken          mention.Token
+	mentionResults        []mention.Candidate
+	mentionIndex          *mention.WorkspaceFileIndex
+	mentionRecent         map[string]int
+	mentionSeq            int
+	promptHistoryLoaded   bool
+	promptHistoryEntries  []history.PromptEntry
+	promptSearchMode      promptSearchMode
+	promptSearchQuery     string
+	promptSearchMatches   []history.PromptEntry
+	promptSearchCursor    int
+	promptSearchBaseInput string
+	inputImageRefs        map[int]llm.AssetID
+	inputImageMentions    map[string]llm.AssetID
+	orphanedImages        map[llm.AssetID]time.Time
+	nextImageID           int
+	clipboard             clipboardImageReader
+	lastPasteAt           time.Time
+	lastInputAt           time.Time
+	inputBurstSize        int
+	chatAutoFollow        bool
+	runCancel             context.CancelFunc
+	pendingBTW            []string
+	interrupting          bool
+	interruptSafe         bool
+	runSeq                int
+	activeRunID           int
+	startupGuide          StartupGuide
 }
 
 func newModel(opts Options) model {
@@ -262,6 +297,13 @@ func newModel(opts Options) model {
 		orphanedImages:     make(map[llm.AssetID]time.Time, 8),
 		nextImageID:        nextSessionImageID(opts.Session),
 		clipboard:          defaultClipboardImageReader{},
+		startupGuide:   opts.StartupGuide,
+	}
+	if opts.StartupGuide.Active {
+		m.statusNote = opts.StartupGuide.Status
+		m.llmConnected = false
+		m.phase = "error"
+		m.initializeStartupGuide()
 	}
 	m.ensureSessionImageAssets()
 	m.syncInputStyle()
@@ -382,7 +424,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
-	if m.helpOpen || m.commandOpen || m.mentionOpen || m.approval != nil {
+	if m.helpOpen || m.commandOpen || m.mentionOpen || m.promptSearchOpen || m.approval != nil {
 		return m, nil
 	}
 	if m.screen != screenChat && m.screen != screenLanding {
@@ -511,7 +553,13 @@ func (m model) mouseOverChatInput(y int) bool {
 	if m.approval != nil {
 		inputTop += lipgloss.Height(m.renderApprovalBanner())
 	}
-	if m.commandOpen {
+	if m.startupGuide.Active {
+		inputTop += lipgloss.Height(m.renderStartupGuidePanel())
+	} else if m.promptSearchOpen {
+		inputTop += lipgloss.Height(m.renderPromptSearchPalette())
+	} else if m.mentionOpen {
+		inputTop += lipgloss.Height(m.renderMentionPalette())
+	} else if m.commandOpen {
 		inputTop += lipgloss.Height(m.renderCommandPalette())
 	}
 	inputBottom := inputTop + max(1, inputHeight) - 1
@@ -532,6 +580,16 @@ func (m model) mouseOverLandingInput(y int) bool {
 	}, "\n")))
 	titleHeight := 0
 	subtitleHeight := 0
+	overlayHeight := 0
+	if m.startupGuide.Active {
+		overlayHeight = lipgloss.Height(m.renderStartupGuidePanel()) + 1
+	} else if m.promptSearchOpen {
+		overlayHeight = lipgloss.Height(m.renderPromptSearchPalette()) + 1
+	} else if m.mentionOpen {
+		overlayHeight = lipgloss.Height(m.renderMentionPalette()) + 1
+	} else if m.commandOpen {
+		overlayHeight = lipgloss.Height(m.renderCommandPalette()) + 1
+	}
 	inputHeight := lipgloss.Height(
 		landingInputStyle.Copy().
 			BorderForeground(m.modeAccentColor()).
@@ -539,9 +597,9 @@ func (m model) mouseOverLandingInput(y int) bool {
 			Render(m.input.View()),
 	)
 	hintHeight := lipgloss.Height(mutedStyle.Render(footerHintText))
-	contentHeight := logoHeight + 1 + titleHeight + subtitleHeight + 1 + inputHeight + 1 + hintHeight
+	contentHeight := logoHeight + 1 + titleHeight + subtitleHeight + 1 + overlayHeight + inputHeight + 1 + hintHeight
 	contentTop := max(0, (m.height-contentHeight)/2)
-	inputTop := contentTop + logoHeight + 1 + titleHeight + subtitleHeight + 1
+	inputTop := contentTop + logoHeight + 1 + titleHeight + subtitleHeight + 1 + overlayHeight
 	inputBottom := inputTop + max(1, inputHeight) - 1
 	return y >= inputTop && y <= inputBottom
 }
@@ -556,6 +614,13 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.runCancel()
 		}
 		return m, tea.Quit
+	}
+
+	if m.promptSearchOpen {
+		return m.handlePromptSearchKey(msg)
+	}
+
+	switch msg.String() {
 	case "tab":
 		if m.commandOpen || m.mentionOpen || m.sessionsOpen || m.helpOpen || m.approval != nil {
 			break
@@ -566,6 +631,12 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.approval == nil {
 			m.helpOpen = !m.helpOpen
 		}
+		return m, nil
+	case "ctrl+f":
+		if m.approval != nil || m.helpOpen || m.sessionsOpen || m.commandOpen || m.mentionOpen {
+			return m, nil
+		}
+		m.openPromptSearch(promptSearchModeQuick)
 		return m, nil
 	}
 
@@ -678,7 +749,15 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		}
-		value := strings.TrimSpace(m.input.Value())
+		rawValue := m.input.Value()
+		value := strings.TrimSpace(rawValue)
+		if m.startupGuide.Active && !strings.HasPrefix(value, "/") {
+			if err := m.handleStartupGuideSubmission(rawValue); err != nil {
+				m.statusNote = err.Error()
+			}
+			m.screen = screenLanding
+			return m, nil
+		}
 		if value == "" {
 			return m, nil
 		}
@@ -1009,6 +1088,121 @@ func (m *model) openCommandPalette() {
 	m.syncInputOverlays()
 }
 
+func (m *model) openPromptSearch(mode promptSearchMode) {
+	m.ensurePromptHistoryLoaded()
+	m.promptSearchMode = mode
+	m.promptSearchBaseInput = m.input.Value()
+	m.promptSearchQuery = ""
+	m.promptSearchCursor = 0
+	m.promptSearchOpen = true
+	m.commandOpen = false
+	m.closeMentionPalette()
+	m.refreshPromptSearchMatches()
+	if len(m.promptSearchMatches) == 0 {
+		if mode == promptSearchModePanel {
+			m.statusNote = "History panel opened. No matching prompts."
+		} else {
+			m.statusNote = "No matching prompts."
+		}
+	} else {
+		if mode == promptSearchModePanel {
+			m.statusNote = fmt.Sprintf("History panel ready (%d matches).", len(m.promptSearchMatches))
+		} else {
+			m.statusNote = fmt.Sprintf("Prompt history ready (%d matches).", len(m.promptSearchMatches))
+		}
+	}
+}
+
+func (m *model) closePromptSearch(restoreInput bool) {
+	if restoreInput {
+		m.setInputValue(m.promptSearchBaseInput)
+	}
+	m.promptSearchOpen = false
+	m.promptSearchMode = ""
+	m.promptSearchQuery = ""
+	m.promptSearchMatches = nil
+	m.promptSearchCursor = 0
+	m.promptSearchBaseInput = ""
+	m.syncInputOverlays()
+}
+
+func (m *model) ensurePromptHistoryLoaded() {
+	if m.promptHistoryLoaded {
+		return
+	}
+	entries, err := history.LoadRecentPrompts(promptSearchLoadLimit)
+	if err != nil {
+		m.promptHistoryEntries = nil
+		m.promptHistoryLoaded = true
+		m.statusNote = "Prompt history unavailable: " + compact(err.Error(), 72)
+		return
+	}
+	m.promptHistoryEntries = entries
+	m.promptHistoryLoaded = true
+}
+
+func (m *model) refreshPromptSearchMatches() {
+	tokens, workspaceFilter, sessionFilter := parsePromptSearchQuery(m.promptSearchQuery)
+	limit := promptSearchResultCap
+	if m.promptSearchMode == promptSearchModePanel {
+		limit = promptSearchLoadLimit
+	}
+	matches := make([]history.PromptEntry, 0, min(len(m.promptHistoryEntries), limit))
+	for i := len(m.promptHistoryEntries) - 1; i >= 0; i-- {
+		entry := m.promptHistoryEntries[i]
+		prompt := strings.TrimSpace(entry.Prompt)
+		if prompt == "" {
+			continue
+		}
+		workspaceValue := strings.ToLower(strings.TrimSpace(entry.Workspace))
+		if workspaceFilter != "" && !strings.Contains(workspaceValue, workspaceFilter) {
+			continue
+		}
+		sessionValue := strings.ToLower(strings.TrimSpace(entry.SessionID))
+		if sessionFilter != "" && !strings.Contains(sessionValue, sessionFilter) {
+			continue
+		}
+		promptLower := strings.ToLower(prompt)
+		if !matchAllTokens(promptLower, tokens) {
+			continue
+		}
+		matches = append(matches, entry)
+		if len(matches) >= limit {
+			break
+		}
+	}
+
+	m.promptSearchMatches = matches
+	if len(matches) == 0 {
+		m.promptSearchCursor = 0
+		return
+	}
+	m.promptSearchCursor = clamp(m.promptSearchCursor, 0, len(matches)-1)
+}
+
+func (m *model) stepPromptSearch(delta int) {
+	if len(m.promptSearchMatches) == 0 {
+		return
+	}
+	next := m.promptSearchCursor + delta
+	if next < 0 {
+		next = 0
+	}
+	if next >= len(m.promptSearchMatches) {
+		next = len(m.promptSearchMatches) - 1
+	}
+	m.promptSearchCursor = next
+}
+
+func (m *model) trimPromptSearchQuery() {
+	if m.promptSearchQuery == "" {
+		return
+	}
+	runes := []rune(m.promptSearchQuery)
+	m.promptSearchQuery = string(runes[:len(runes)-1])
+	m.refreshPromptSearchMatches()
+}
+
 func (m *model) toggleMode() {
 	if m.mode == modeBuild {
 		m.mode = modePlan
@@ -1140,6 +1334,22 @@ func (m model) submitPrompt(value string) (tea.Model, tea.Cmd) {
 
 	m.input.Reset()
 	m.screen = screenChat
+	if m.promptHistoryLoaded {
+		entry := history.PromptEntry{
+			Timestamp: time.Now().UTC(),
+			Workspace: strings.TrimSpace(m.workspace),
+			Prompt:    strings.TrimSpace(displayText),
+		}
+		if m.sess != nil {
+			entry.SessionID = m.sess.ID
+		}
+		if entry.Prompt != "" {
+			m.promptHistoryEntries = append(m.promptHistoryEntries, entry)
+			if len(m.promptHistoryEntries) > promptSearchLoadLimit {
+				m.promptHistoryEntries = m.promptHistoryEntries[len(m.promptHistoryEntries)-promptSearchLoadLimit:]
+			}
+		}
+	}
 	m.appendChat(chatEntry{
 		Kind:   "user",
 		Title:  "You",
@@ -1594,7 +1804,11 @@ func (m model) renderLanding() string {
 		Width(m.landingInputShellWidth()).
 		Render(m.input.View())
 	parts := []string{logo, "", m.renderModeTabs(), ""}
-	if m.mentionOpen {
+	if m.startupGuide.Active {
+		parts = append(parts, m.renderStartupGuidePanel(), "")
+	} else if m.promptSearchOpen {
+		parts = append(parts, m.renderPromptSearchPalette(), "")
+	} else if m.mentionOpen {
 		parts = append(parts, m.renderMentionPalette(), "")
 	} else if m.commandOpen {
 		parts = append(parts, m.renderCommandPalette(), "")
@@ -1612,7 +1826,11 @@ func (m model) renderFooter() string {
 	if m.approval != nil {
 		parts = append(parts, m.renderApprovalBanner())
 	}
-	if m.mentionOpen {
+	if m.startupGuide.Active {
+		parts = append(parts, m.renderStartupGuidePanel())
+	} else if m.promptSearchOpen {
+		parts = append(parts, m.renderPromptSearchPalette())
+	} else if m.mentionOpen {
 		parts = append(parts, m.renderMentionPalette())
 	} else if m.commandOpen {
 		parts = append(parts, m.renderCommandPalette())
@@ -1770,6 +1988,457 @@ func (m model) renderTopInfoLine(left, right string, width int) string {
 	}
 	gap := width - leftW - rightW
 	return left + strings.Repeat(" ", max(2, gap)) + right
+}
+
+func (m model) renderPromptSearchPalette() string {
+	width := m.commandPaletteWidth()
+	items := m.promptSearchMatches
+	modeLabel := "search"
+	if m.promptSearchMode == promptSearchModePanel {
+		modeLabel = "panel"
+	}
+	if len(items) == 0 {
+		query := strings.TrimSpace(m.promptSearchQuery)
+		if query == "" {
+			query = "(all)"
+		}
+		content := []string{
+			commandPaletteMetaStyle.Render("Prompt history " + modeLabel),
+			commandPaletteMetaStyle.Render("query: " + query + "  (filters: ws:<kw> sid:<kw>)"),
+			commandPaletteMetaStyle.Render("No matching prompts."),
+			commandPaletteMetaStyle.Render("Type to filter  PgUp/PgDn page  Enter apply  Esc close"),
+		}
+		return commandPaletteStyle.Width(width).Render(lipgloss.JoinVertical(lipgloss.Left, content...))
+	}
+
+	selected, _ := m.selectedPromptSearchEntry()
+	rowWidth := max(1, width-commandPaletteStyle.GetHorizontalFrameSize())
+	rows := make([]string, 0, promptSearchPageSize+3)
+	for _, item := range m.visiblePromptSearchEntriesPage() {
+		rowStyle := commandPaletteRowStyle
+		textStyle := commandPaletteDescStyle
+		if item.Timestamp.Equal(selected.Timestamp) && item.SessionID == selected.SessionID && item.Prompt == selected.Prompt {
+			rowStyle = commandPaletteSelectedRowStyle
+			textStyle = commandPaletteSelectedDescStyle
+		}
+		workspaceName := filepath.Base(strings.TrimSpace(item.Workspace))
+		if workspaceName == "" || workspaceName == "." {
+			workspaceName = strings.TrimSpace(item.Workspace)
+		}
+		if workspaceName == "" {
+			workspaceName = "-"
+		}
+		meta := fmt.Sprintf("%s  ws:%s  sid:%s", item.Timestamp.Local().Format("01-02 15:04"), compact(workspaceName, 16), compact(item.SessionID, 12))
+		rowText := compact(strings.TrimSpace(item.Prompt), max(12, rowWidth-2))
+		rows = append(rows, rowStyle.Width(rowWidth).Render(textStyle.Render(rowText)))
+		rows = append(rows, rowStyle.Width(rowWidth).Render(commandPaletteMetaStyle.Render(compact(meta, max(12, rowWidth-2)))))
+	}
+	for len(rows) < promptSearchPageSize*2 {
+		rows = append(rows, commandPaletteRowStyle.Width(rowWidth).Render(""))
+	}
+
+	query := strings.TrimSpace(m.promptSearchQuery)
+	if query == "" {
+		query = "(all)"
+	}
+	meta := fmt.Sprintf("%s  query:%s  |  ws:<kw> sid:<kw>  PgUp/PgDn page  Ctrl+F next  Ctrl+S prev  Enter apply  Esc close", modeLabel, compact(query, 24))
+	rows = append(rows, commandPaletteMetaStyle.Render(meta))
+	return commandPaletteStyle.Width(width).Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+}
+
+func (m model) renderStartupGuidePanel() string {
+	width := max(24, m.commandPaletteWidth())
+	title := strings.TrimSpace(m.startupGuide.Title)
+	if title == "" {
+		title = "Provider setup required"
+	}
+	status := strings.TrimSpace(m.startupGuide.Status)
+	if status == "" {
+		status = "AI provider is not available."
+	}
+
+	innerWidth := max(20, width-commandPaletteStyle.GetHorizontalFrameSize())
+	content := make([]string, 0, 2+len(m.startupGuide.Lines))
+	content = append(content, accentStyle.Render(title))
+	content = append(content, commandPaletteMetaStyle.Width(innerWidth).Render(status))
+	for _, line := range m.startupGuide.Lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		content = append(content, commandPaletteMetaStyle.Width(innerWidth).Render(line))
+	}
+	content = append(content, commandPaletteMetaStyle.Width(innerWidth).Render(startupGuideInputHint(m.startupGuide.CurrentField)))
+
+	return commandPaletteStyle.Width(width).Render(lipgloss.JoinVertical(lipgloss.Left, content...))
+}
+
+func (m *model) handleStartupGuideSubmission(rawInput string) error {
+	rawInput = strings.TrimSpace(rawInput)
+
+	field := strings.TrimSpace(m.startupGuide.CurrentField)
+	if !isStartupGuideField(field) {
+		field = startupFieldType
+	}
+	if explicitField, explicitValue, ok := parseStartupConfigInput(rawInput); ok {
+		field = explicitField
+		rawInput = explicitValue
+	}
+
+	switch field {
+	case startupFieldType, startupFieldBaseURL, startupFieldModel:
+		value, err := m.resolveStartupFieldValue(field, rawInput)
+		if err != nil {
+			return err
+		}
+		if err := m.applyStartupConfigField(field, value); err != nil {
+			return err
+		}
+		next := startupNextField(field)
+		if next == "" {
+			next = startupFieldAPIKey
+		}
+		m.setStartupGuideStep(next, "")
+		m.input.Reset()
+		return nil
+	case startupFieldAPIKey:
+		return m.verifyAndFinalizeStartupAPIKey(rawInput)
+	default:
+		return fmt.Errorf("unsupported setup field: %s", field)
+	}
+}
+
+func (m *model) verifyAndFinalizeStartupAPIKey(rawInput string) error {
+	apiKey := sanitizeAPIKeyInput(rawInput)
+	if apiKey == "" {
+		return fmt.Errorf("please paste a non-empty API key")
+	}
+
+	checkCfg := m.cfg.Provider
+	checkCfg.APIKey = apiKey
+	check := provider.CheckAvailability(context.Background(), checkCfg)
+	if !check.Ready {
+		m.llmConnected = false
+		m.phase = "error"
+		m.setStartupGuideStep(startupFieldAPIKey, startupGuideIssueHint(check))
+		return nil
+	}
+
+	writtenPath, saveErr := config.UpsertProviderAPIKey(m.startupGuide.ConfigPath, apiKey)
+
+	if envName := strings.TrimSpace(checkCfg.APIKeyEnv); envName != "" {
+		_ = os.Setenv(envName, apiKey)
+	} else {
+		_ = os.Setenv("BYTEMIND_API_KEY", apiKey)
+	}
+
+	client, err := provider.NewClient(checkCfg)
+	if err != nil {
+		return err
+	}
+	if m.runner != nil {
+		m.runner.UpdateProvider(checkCfg, client)
+	}
+	m.cfg.Provider = checkCfg
+	m.startupGuide.Active = false
+	m.statusNote = "Provider configured and verified. You can start chatting."
+	m.llmConnected = true
+	m.phase = "idle"
+	if saveErr != nil {
+		m.statusNote = "Provider verified, but config save failed: " + compact(saveErr.Error(), 80)
+	} else if strings.TrimSpace(writtenPath) != "" {
+		m.statusNote = "Provider configured and verified. Saved to " + compact(writtenPath, 48)
+	}
+	m.syncInputStyle()
+	m.input.Reset()
+	return nil
+}
+
+func (m *model) applyStartupConfigField(field, value string) error {
+	field = strings.TrimSpace(field)
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("%s cannot be empty", field)
+	}
+	persistValue := value
+
+	switch field {
+	case "model":
+		m.cfg.Provider.Model = value
+	case "base_url":
+		m.cfg.Provider.BaseURL = value
+	case "type":
+		normalized, ok := normalizeStartupProviderType(value)
+		if !ok {
+			return fmt.Errorf("provider must be openai-compatible or anthropic")
+		}
+		m.cfg.Provider.Type = normalized
+		persistValue = normalized
+	default:
+		return fmt.Errorf("unsupported setup field: %s", field)
+	}
+
+	writtenPath, err := config.UpsertProviderField(m.startupGuide.ConfigPath, field, persistValue)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(writtenPath) != "" {
+		m.startupGuide.ConfigPath = writtenPath
+	}
+	return nil
+}
+
+func parseStartupConfigInput(raw string) (field, value string, ok bool) {
+	trimmed := strings.TrimSpace(raw)
+	lower := strings.ToLower(trimmed)
+	if lower == "" {
+		return "", "", false
+	}
+
+	parse := func(alias, normalized string) (string, string, bool) {
+		for _, sep := range []string{"=", ":"} {
+			prefix := alias + sep
+			if strings.HasPrefix(lower, prefix) {
+				val := strings.TrimSpace(trimmed[len(prefix):])
+				return normalized, val, true
+			}
+		}
+		return "", "", false
+	}
+
+	for _, candidate := range []struct {
+		alias      string
+		normalized string
+	}{
+		{alias: "model", normalized: "model"},
+		{alias: "base_url", normalized: "base_url"},
+		{alias: "baseurl", normalized: "base_url"},
+		{alias: "base-url", normalized: "base_url"},
+		{alias: "provider", normalized: "type"},
+		{alias: "type", normalized: "type"},
+		{alias: "provider_type", normalized: "type"},
+		{alias: "api_key", normalized: "api_key"},
+		{alias: "apikey", normalized: "api_key"},
+		{alias: "key", normalized: "api_key"},
+	} {
+		if field, value, ok := parse(candidate.alias, candidate.normalized); ok {
+			return field, value, true
+		}
+	}
+
+	return "", "", false
+}
+
+func sanitizeAPIKeyInput(raw string) string {
+	value := strings.TrimSpace(raw)
+	value = strings.Trim(value, "\"'")
+	lower := strings.ToLower(value)
+	if strings.HasPrefix(lower, "authorization: bearer ") {
+		value = strings.TrimSpace(value[len("authorization: bearer "):])
+	}
+	if strings.HasPrefix(lower, "bearer ") {
+		value = strings.TrimSpace(value[len("bearer "):])
+	}
+	return strings.TrimSpace(value)
+}
+
+func normalizeStartupProviderType(value string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "openai-compatible", "openai_compatible", "openai":
+		return "openai-compatible", true
+	case "anthropic":
+		return "anthropic", true
+	default:
+		return "", false
+	}
+}
+
+func isStartupGuideField(field string) bool {
+	switch field {
+	case startupFieldType, startupFieldBaseURL, startupFieldModel, startupFieldAPIKey:
+		return true
+	default:
+		return false
+	}
+}
+
+func startupNextField(current string) string {
+	for i, field := range startupFieldOrder {
+		if field == current {
+			if i+1 >= len(startupFieldOrder) {
+				return ""
+			}
+			return startupFieldOrder[i+1]
+		}
+	}
+	return startupFieldType
+}
+
+func startupFieldStep(field string) (int, int) {
+	for i, item := range startupFieldOrder {
+		if item == field {
+			return i + 1, len(startupFieldOrder)
+		}
+	}
+	return 1, len(startupFieldOrder)
+}
+
+func startupFieldName(field string) string {
+	switch field {
+	case startupFieldType:
+		return "provider"
+	case startupFieldBaseURL:
+		return "base_url"
+	case startupFieldModel:
+		return "model"
+	case startupFieldAPIKey:
+		return "api_key"
+	default:
+		return field
+	}
+}
+
+func startupProviderDefaultBaseURL(providerType string) string {
+	switch strings.ToLower(strings.TrimSpace(providerType)) {
+	case "anthropic":
+		return "https://api.anthropic.com"
+	default:
+		return "https://api.openai.com/v1"
+	}
+}
+
+func startupProviderDefaultModel(providerType string) string {
+	switch strings.ToLower(strings.TrimSpace(providerType)) {
+	case "anthropic":
+		return ""
+	default:
+		return "GPT-5.4"
+	}
+}
+
+func (m model) startupCurrentValue(field string) string {
+	switch field {
+	case startupFieldType:
+		return strings.TrimSpace(m.cfg.Provider.Type)
+	case startupFieldBaseURL:
+		return strings.TrimSpace(m.cfg.Provider.BaseURL)
+	case startupFieldModel:
+		return strings.TrimSpace(m.cfg.Provider.Model)
+	default:
+		return ""
+	}
+}
+
+func (m *model) resolveStartupFieldValue(field, rawInput string) (string, error) {
+	value := strings.TrimSpace(rawInput)
+	if value != "" {
+		return value, nil
+	}
+
+	current := m.startupCurrentValue(field)
+	if current != "" {
+		return current, nil
+	}
+
+	switch field {
+	case startupFieldType:
+		return "openai-compatible", nil
+	case startupFieldBaseURL:
+		return startupProviderDefaultBaseURL(m.cfg.Provider.Type), nil
+	case startupFieldModel:
+		if fallback := startupProviderDefaultModel(m.cfg.Provider.Type); fallback != "" {
+			return fallback, nil
+		}
+		return "", fmt.Errorf("please enter model name for provider %s", strings.TrimSpace(m.cfg.Provider.Type))
+	default:
+		return "", fmt.Errorf("%s cannot be empty", startupFieldName(field))
+	}
+}
+
+func (m *model) initializeStartupGuide() {
+	field := strings.TrimSpace(m.startupGuide.CurrentField)
+	if !isStartupGuideField(field) {
+		field = startupFieldType
+	}
+	m.setStartupGuideStep(field, "")
+}
+
+func (m *model) setStartupGuideStep(field, issue string) {
+	if !isStartupGuideField(field) {
+		field = startupFieldType
+	}
+	step, total := startupFieldStep(field)
+	fieldName := startupFieldName(field)
+	if strings.TrimSpace(issue) == "" {
+		m.startupGuide.Status = fmt.Sprintf("Step %d/%d: set %s.", step, total, fieldName)
+	} else {
+		m.startupGuide.Status = fmt.Sprintf("Step %d/%d: set %s. %s", step, total, fieldName, issue)
+	}
+	m.statusNote = m.startupGuide.Status
+	m.startupGuide.CurrentField = field
+	m.startupGuide.Lines = startupGuideStepLines(field, m.cfg, m.startupGuide.ConfigPath, issue)
+	m.syncInputStyle()
+}
+
+func startupGuideStepLines(field string, cfg config.Config, configPath, issue string) []string {
+	lines := make([]string, 0, 8)
+	switch field {
+	case startupFieldType:
+		lines = append(lines, "Enter provider: openai-compatible or anthropic.")
+	case startupFieldBaseURL:
+		lines = append(lines, "Enter provider base_url.")
+		lines = append(lines, "Example: https://api.deepseek.com")
+	case startupFieldModel:
+		lines = append(lines, "Enter model name.")
+		lines = append(lines, "Example: deepseek-chat or GPT-5.4")
+	case startupFieldAPIKey:
+		lines = append(lines, "Paste API key and press Enter.")
+		lines = append(lines, "Bytemind will verify it automatically.")
+	}
+
+	switch field {
+	case startupFieldType, startupFieldBaseURL, startupFieldModel:
+		current := ""
+		switch field {
+		case startupFieldType:
+			current = strings.TrimSpace(cfg.Provider.Type)
+		case startupFieldBaseURL:
+			current = strings.TrimSpace(cfg.Provider.BaseURL)
+		case startupFieldModel:
+			current = strings.TrimSpace(cfg.Provider.Model)
+		}
+		if current == "" {
+			lines = append(lines, "Press Enter to use default.")
+		} else {
+			lines = append(lines, "Press Enter to keep current: "+current)
+		}
+	}
+	if strings.TrimSpace(issue) != "" {
+		lines = append(lines, "Issue: "+issue)
+	}
+	if strings.TrimSpace(configPath) != "" {
+		lines = append(lines, "Config file: "+configPath)
+	}
+	return lines
+}
+
+func startupGuideIssueHint(check provider.Availability) string {
+	reason := strings.ToLower(strings.TrimSpace(check.Reason))
+	switch {
+	case strings.Contains(reason, "missing api key"):
+		return "No API key is configured yet."
+	case strings.Contains(reason, "unauthorized"):
+		return "The API key was rejected by the provider."
+	case strings.Contains(reason, "failed to reach"):
+		return "Cannot reach provider endpoint. Check proxy or network."
+	case strings.Contains(reason, "not found"):
+		return "Provider endpoint path looks incorrect."
+	default:
+		if strings.TrimSpace(check.Reason) == "" {
+			return "Provider check failed."
+		}
+		return compact(strings.TrimSpace(check.Reason), 90)
+	}
 }
 
 func (m model) renderCommandPalette() string {
@@ -2857,9 +3526,72 @@ func (m *model) syncCommandPalette() {
 }
 
 func (m *model) syncInputOverlays() {
+	if m.startupGuide.Active || m.promptSearchOpen {
+		return
+	}
 	m.syncCommandPalette()
 	m.syncMentionPalette()
 	m.syncInputImageRefs(m.input.Value())
+}
+
+func (m model) handlePromptSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case isPageUpKey(msg):
+		m.stepPromptSearch(-promptSearchPageSize)
+		return m, nil
+	case isPageDownKey(msg):
+		m.stepPromptSearch(promptSearchPageSize)
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "esc":
+		m.closePromptSearch(true)
+		m.statusNote = "Prompt search canceled."
+		return m, nil
+	case "enter":
+		selected, ok := m.selectedPromptSearchEntry()
+		if ok {
+			m.setInputValue(selected.Prompt)
+			m.closePromptSearch(false)
+			m.statusNote = "Prompt restored from history."
+			return m, nil
+		}
+		m.closePromptSearch(true)
+		m.statusNote = "No prompt selected."
+		return m, nil
+	case "ctrl+f", "down", "j":
+		m.stepPromptSearch(1)
+		return m, nil
+	case "ctrl+s", "up", "k":
+		m.stepPromptSearch(-1)
+		return m, nil
+	case "home":
+		m.stepPromptSearch(-len(m.promptSearchMatches))
+		return m, nil
+	case "end":
+		m.stepPromptSearch(len(m.promptSearchMatches))
+		return m, nil
+	case "backspace", "ctrl+h":
+		m.trimPromptSearchQuery()
+		return m, nil
+	}
+
+	switch msg.Type {
+	case tea.KeyBackspace:
+		m.trimPromptSearchQuery()
+		return m, nil
+	case tea.KeySpace:
+		m.promptSearchQuery += " "
+		m.refreshPromptSearchMatches()
+		return m, nil
+	case tea.KeyRunes:
+		m.promptSearchQuery += string(msg.Runes)
+		m.refreshPromptSearchMatches()
+		return m, nil
+	default:
+		return m, nil
+	}
 }
 
 func (m *model) syncMentionPalette() {
@@ -3043,6 +3775,24 @@ func (m model) visibleMentionItemsPage() []mention.Candidate {
 	return m.mentionResults[start:end]
 }
 
+func (m model) selectedPromptSearchEntry() (history.PromptEntry, bool) {
+	if len(m.promptSearchMatches) == 0 {
+		return history.PromptEntry{}, false
+	}
+	index := clamp(m.promptSearchCursor, 0, len(m.promptSearchMatches)-1)
+	return m.promptSearchMatches[index], true
+}
+
+func (m model) visiblePromptSearchEntriesPage() []history.PromptEntry {
+	if len(m.promptSearchMatches) == 0 {
+		return nil
+	}
+	cursor := clamp(m.promptSearchCursor, 0, len(m.promptSearchMatches)-1)
+	start := (cursor / promptSearchPageSize) * promptSearchPageSize
+	end := min(len(m.promptSearchMatches), start+promptSearchPageSize)
+	return m.promptSearchMatches[start:end]
+}
+
 func (m *model) setInputValue(value string) {
 	m.input.SetValue(value)
 	m.input.CursorEnd()
@@ -3081,9 +3831,11 @@ func (m model) helpText() string {
 		"Tab toggles between Build and Plan modes.",
 		"Plan mode keeps the plan panel visible and focused on structured steps.",
 		"Use Ctrl+G to open or close the help panel.",
+		"Use Ctrl+F to search prompt history and restore previous input.",
+		"If provider setup is required, paste an API key in the input and press Enter.",
 		"After restoring a session with a saved plan, type 'continue execution' to resume it.",
 		"Approval requests appear above the input area when a shell command needs confirmation.",
-		"The footer keeps only the essential shortcuts: tab agents, / commands, Ctrl+L sessions, Ctrl+C quit.",
+		"The footer keeps only the essential shortcuts: tab agents, / commands, Ctrl+F history, Ctrl+L sessions, Ctrl+C quit.",
 	}, "\n")
 }
 func visibleCommandItems(group string) []commandItem {
@@ -3158,6 +3910,46 @@ func matchesCommandItem(item commandItem, query string) bool {
 		strings.HasPrefix(usage, query)
 }
 
+func matchAllTokens(text string, tokens []string) bool {
+	if len(tokens) == 0 {
+		return true
+	}
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		if !strings.Contains(text, token) {
+			return false
+		}
+	}
+	return true
+}
+
+func parsePromptSearchQuery(raw string) (tokens []string, workspaceFilter, sessionFilter string) {
+	fields := strings.Fields(strings.ToLower(strings.TrimSpace(raw)))
+	tokens = make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(field, "ws:"):
+			workspaceFilter = strings.TrimSpace(strings.TrimPrefix(field, "ws:"))
+		case strings.HasPrefix(field, "workspace:"):
+			workspaceFilter = strings.TrimSpace(strings.TrimPrefix(field, "workspace:"))
+		case strings.HasPrefix(field, "sid:"):
+			sessionFilter = strings.TrimSpace(strings.TrimPrefix(field, "sid:"))
+		case strings.HasPrefix(field, "session:"):
+			sessionFilter = strings.TrimSpace(strings.TrimPrefix(field, "session:"))
+		default:
+			tokens = append(tokens, field)
+		}
+	}
+	return tokens, workspaceFilter, sessionFilter
+}
+
 func (m model) chatPanelWidth() int {
 	return max(20, m.width)
 }
@@ -3193,9 +3985,43 @@ func (m model) modeAccentColor() lipgloss.Color {
 }
 
 func (m *model) syncInputStyle() {
-	m.input.Placeholder = "Ask Bytemind to inspect, change, or verify this workspace..."
+	if m.startupGuide.Active {
+		m.input.Placeholder = startupGuideInputPlaceholder(m.startupGuide.CurrentField)
+	} else {
+		m.input.Placeholder = "Ask Bytemind to inspect, change, or verify this workspace..."
+	}
 	m.input.Prompt = ""
 	m.input.SetHeight(2)
+}
+
+func startupGuideInputHint(field string) string {
+	switch strings.TrimSpace(field) {
+	case startupFieldType:
+		return "Enter provider and press Enter."
+	case startupFieldBaseURL:
+		return "Enter base_url and press Enter."
+	case startupFieldModel:
+		return "Enter model and press Enter."
+	case startupFieldAPIKey:
+		return "Paste API key and press Enter to verify."
+	default:
+		return "Input value then press Enter."
+	}
+}
+
+func startupGuideInputPlaceholder(field string) string {
+	switch strings.TrimSpace(field) {
+	case startupFieldType:
+		return "Step 1/4: provider (openai-compatible or anthropic)"
+	case startupFieldBaseURL:
+		return "Step 2/4: base_url (example: https://api.deepseek.com)"
+	case startupFieldModel:
+		return "Step 3/4: model (example: deepseek-chat)"
+	case startupFieldAPIKey:
+		return "Step 4/4: paste API key and press Enter..."
+	default:
+		return "Complete setup and press Enter..."
+	}
 }
 
 func resolveSessionID(summaries []session.Summary, prefix string) (string, error) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +14,7 @@ import (
 	"bytemind/internal/agent"
 	"bytemind/internal/config"
 	"bytemind/internal/llm"
+	"bytemind/internal/history"
 	"bytemind/internal/mention"
 	planpkg "bytemind/internal/plan"
 	"bytemind/internal/session"
@@ -278,6 +281,444 @@ func TestTabTogglesBetweenBuildAndPlanModes(t *testing.T) {
 	updated = got.(model)
 	if updated.mode != modeBuild {
 		t.Fatalf("expected second tab to switch back to build mode, got %q", updated.mode)
+	}
+}
+
+func TestCtrlFOpensPromptSearchAndFiltersEntries(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	m := model{
+		input:               input,
+		promptHistoryLoaded: true,
+		promptHistoryEntries: []history.PromptEntry{
+			{Prompt: "fix tui layout spacing"},
+			{Prompt: "add model test case"},
+			{Prompt: "review runner error handling"},
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlF})
+	opened := got.(model)
+	if !opened.promptSearchOpen {
+		t.Fatalf("expected ctrl+f to open prompt search")
+	}
+	if len(opened.promptSearchMatches) != 3 {
+		t.Fatalf("expected 3 prompt matches, got %d", len(opened.promptSearchMatches))
+	}
+
+	got, _ = opened.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("test")})
+	filtered := got.(model)
+	if filtered.promptSearchQuery != "test" {
+		t.Fatalf("expected query to become test, got %q", filtered.promptSearchQuery)
+	}
+	if len(filtered.promptSearchMatches) != 1 {
+		t.Fatalf("expected one filtered prompt, got %d", len(filtered.promptSearchMatches))
+	}
+	if !strings.Contains(filtered.promptSearchMatches[0].Prompt, "test case") {
+		t.Fatalf("unexpected filtered prompt: %+v", filtered.promptSearchMatches[0])
+	}
+}
+
+func TestCtrlFWhilePromptSearchOpenMovesSelection(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	m := model{
+		input:               input,
+		promptHistoryLoaded: true,
+		promptHistoryEntries: []history.PromptEntry{
+			{Prompt: "first prompt"},
+			{Prompt: "second prompt"},
+			{Prompt: "third prompt"},
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlF})
+	opened := got.(model)
+	if opened.promptSearchCursor != 0 {
+		t.Fatalf("expected initial cursor 0, got %d", opened.promptSearchCursor)
+	}
+
+	got, _ = opened.handleKey(tea.KeyMsg{Type: tea.KeyCtrlF})
+	moved := got.(model)
+	if moved.promptSearchCursor != 1 {
+		t.Fatalf("expected ctrl+f to move cursor to 1, got %d", moved.promptSearchCursor)
+	}
+}
+
+func TestPromptSearchEnterRestoresSelectedPrompt(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("draft")
+	m := model{
+		input:               input,
+		promptHistoryLoaded: true,
+		promptHistoryEntries: []history.PromptEntry{
+			{Prompt: "first prompt"},
+			{Prompt: "second prompt"},
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlF})
+	opened := got.(model)
+	got, _ = opened.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	down := got.(model)
+
+	got, _ = down.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	applied := got.(model)
+	if applied.promptSearchOpen {
+		t.Fatalf("expected prompt search to close after enter")
+	}
+	if applied.input.Value() != "first prompt" {
+		t.Fatalf("expected selected prompt to be restored, got %q", applied.input.Value())
+	}
+}
+
+func TestPromptSearchEscRestoresOriginalInput(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("work in progress")
+	m := model{
+		input:               input,
+		promptHistoryLoaded: true,
+		promptHistoryEntries: []history.PromptEntry{
+			{Prompt: "old prompt"},
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlF})
+	opened := got.(model)
+	got, _ = opened.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("old")})
+	filtered := got.(model)
+	got, _ = filtered.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	closed := got.(model)
+
+	if closed.promptSearchOpen {
+		t.Fatalf("expected prompt search to close on esc")
+	}
+	if closed.input.Value() != "work in progress" {
+		t.Fatalf("expected original input to be restored, got %q", closed.input.Value())
+	}
+}
+
+func TestCtrlHDoesNotOpenPromptSearch(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	m := model{
+		input:               input,
+		promptHistoryLoaded: true,
+		promptHistoryEntries: []history.PromptEntry{
+			{Prompt: "first prompt"},
+			{Prompt: "second prompt"},
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlH})
+	updated := got.(model)
+	if updated.promptSearchOpen {
+		t.Fatalf("expected ctrl+h to have no prompt search binding")
+	}
+}
+
+func TestPromptSearchQuerySupportsWorkspaceAndSessionFilters(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	m := model{
+		input:               input,
+		promptHistoryLoaded: true,
+		promptHistoryEntries: []history.PromptEntry{
+			{Prompt: "fix test", Workspace: "repo-a", SessionID: "sess-alpha"},
+			{Prompt: "fix test", Workspace: "repo-b", SessionID: "sess-beta"},
+			{Prompt: "add docs", Workspace: "repo-a", SessionID: "sess-alpha"},
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlF})
+	opened := got.(model)
+	got, _ = opened.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("fix ws:repo-a sid:alpha")})
+	filtered := got.(model)
+
+	if len(filtered.promptSearchMatches) != 1 {
+		t.Fatalf("expected one filtered match, got %d", len(filtered.promptSearchMatches))
+	}
+	match := filtered.promptSearchMatches[0]
+	if match.Workspace != "repo-a" || match.SessionID != "sess-alpha" {
+		t.Fatalf("unexpected filtered match: %+v", match)
+	}
+}
+
+func TestPromptSearchPanelSupportsPageNavigation(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	entries := make([]history.PromptEntry, 0, 12)
+	for i := 0; i < 12; i++ {
+		entries = append(entries, history.PromptEntry{Prompt: "prompt " + string(rune('a'+i))})
+	}
+	m := model{
+		input:                input,
+		promptHistoryLoaded:  true,
+		promptHistoryEntries: entries,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlF})
+	opened := got.(model)
+	if opened.promptSearchCursor != 0 {
+		t.Fatalf("expected cursor at 0, got %d", opened.promptSearchCursor)
+	}
+
+	got, _ = opened.handleKey(tea.KeyMsg{Type: tea.KeyPgDown})
+	paged := got.(model)
+	if paged.promptSearchCursor != promptSearchPageSize {
+		t.Fatalf("expected pgdown to move cursor to %d, got %d", promptSearchPageSize, paged.promptSearchCursor)
+	}
+
+	got, _ = paged.handleKey(tea.KeyMsg{Type: tea.KeyPgUp})
+	back := got.(model)
+	if back.promptSearchCursor != 0 {
+		t.Fatalf("expected pgup to move cursor back to 0, got %d", back.promptSearchCursor)
+	}
+}
+
+func TestStartupGuideSequentialFlowAdvancesAndClearsInput(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{
+  "provider": {
+    "type": "openai-compatible",
+    "base_url": "https://api.openai.com/v1",
+    "model": "gpt-5.4"
+  }
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("openai-compatible")
+	m := model{
+		input: input,
+		cfg: config.Config{
+			Provider: config.ProviderConfig{
+				Type:  "openai-compatible",
+				Model: "gpt-5.4",
+			},
+		},
+		startupGuide: StartupGuide{
+			Active:       true,
+			Status:       "Bytemind needs a working API key before chat can start.",
+			ConfigPath:   configPath,
+			CurrentField: startupFieldType,
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+	if !updated.startupGuide.Active {
+		t.Fatalf("expected startup guide to remain active before api key")
+	}
+	if updated.startupGuide.CurrentField != startupFieldBaseURL {
+		t.Fatalf("expected next step base_url, got %q", updated.startupGuide.CurrentField)
+	}
+	if updated.input.Value() != "" {
+		t.Fatalf("expected input to be cleared after step submit, got %q", updated.input.Value())
+	}
+
+	updated.input.SetValue("https://api.deepseek.com")
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if updated.cfg.Provider.BaseURL != "https://api.deepseek.com" {
+		t.Fatalf("expected base_url update, got %q", updated.cfg.Provider.BaseURL)
+	}
+	if updated.startupGuide.CurrentField != startupFieldModel {
+		t.Fatalf("expected next step model, got %q", updated.startupGuide.CurrentField)
+	}
+	if updated.input.Value() != "" {
+		t.Fatalf("expected input to be cleared after base_url submit, got %q", updated.input.Value())
+	}
+
+	updated.input.SetValue("deepseek-chat")
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if updated.cfg.Provider.Model != "deepseek-chat" {
+		t.Fatalf("expected model update, got %q", updated.cfg.Provider.Model)
+	}
+	if updated.startupGuide.CurrentField != startupFieldAPIKey {
+		t.Fatalf("expected next step api_key, got %q", updated.startupGuide.CurrentField)
+	}
+	if updated.input.Value() != "" {
+		t.Fatalf("expected input to be cleared after model submit, got %q", updated.input.Value())
+	}
+}
+
+func TestStartupGuideAcceptsValidKeyAndDisablesGuide(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"provider":{"type":"openai-compatible","base_url":"`+server.URL+`","model":"gpt-5.4"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("test-key")
+	m := model{
+		input: input,
+		cfg: config.Config{
+			Provider: config.ProviderConfig{
+				Type:      "openai-compatible",
+				BaseURL:   server.URL,
+				Model:     "gpt-5.4",
+				APIKeyEnv: "BYTEMIND_API_KEY",
+			},
+		},
+		startupGuide: StartupGuide{
+			Active:       true,
+			Status:       "Bytemind needs a working API key before chat can start.",
+			ConfigPath:   configPath,
+			CurrentField: startupFieldAPIKey,
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+	if updated.startupGuide.Active {
+		t.Fatalf("expected startup guide to be disabled after valid key")
+	}
+	if !strings.Contains(updated.statusNote, "Provider configured and verified") {
+		t.Fatalf("unexpected status after setup: %q", updated.statusNote)
+	}
+
+	written, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(written), `"api_key": "test-key"`) {
+		t.Fatalf("expected config file to store api key, got %q", string(written))
+	}
+}
+
+func TestStartupGuideSupportsModelAndBaseURLInput(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{
+  "provider": {
+    "type": "openai-compatible",
+    "base_url": "https://api.openai.com/v1",
+    "model": "gpt-5.4"
+  }
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("model=deepseek-chat")
+	m := model{
+		input: input,
+		cfg: config.Config{
+			Provider: config.ProviderConfig{
+				Type:      "openai-compatible",
+				BaseURL:   "https://api.openai.com/v1",
+				Model:     "gpt-5.4",
+				APIKeyEnv: "BYTEMIND_API_KEY",
+			},
+		},
+		startupGuide: StartupGuide{
+			Active:       true,
+			Status:       "Bytemind needs a working API key before chat can start.",
+			ConfigPath:   configPath,
+			CurrentField: startupFieldType,
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+	if !updated.startupGuide.Active {
+		t.Fatalf("expected startup guide to remain active before key verification")
+	}
+	if updated.cfg.Provider.Model != "deepseek-chat" {
+		t.Fatalf("expected model to update in memory, got %q", updated.cfg.Provider.Model)
+	}
+	if updated.startupGuide.CurrentField != startupFieldAPIKey {
+		t.Fatalf("expected explicit model input to move to api_key step, got %q", updated.startupGuide.CurrentField)
+	}
+	if updated.input.Value() != "" {
+		t.Fatalf("expected input to be cleared after model update, got %q", updated.input.Value())
+	}
+
+	updated.input.SetValue("base_url=https://api.deepseek.com")
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if updated.cfg.Provider.BaseURL != "https://api.deepseek.com" {
+		t.Fatalf("expected base url to update in memory, got %q", updated.cfg.Provider.BaseURL)
+	}
+	if updated.startupGuide.CurrentField != startupFieldModel {
+		t.Fatalf("expected explicit base_url input to move to model step, got %q", updated.startupGuide.CurrentField)
+	}
+	if updated.input.Value() != "" {
+		t.Fatalf("expected input to be cleared after base_url update, got %q", updated.input.Value())
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"model": "deepseek-chat"`) {
+		t.Fatalf("expected model to be persisted, got %q", string(raw))
+	}
+	if !strings.Contains(string(raw), `"base_url": "https://api.deepseek.com"`) {
+		t.Fatalf("expected base_url to be persisted, got %q", string(raw))
+	}
+}
+
+func TestStartupGuideStillAllowsSlashCommands(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("/help")
+	m := model{
+		input: input,
+		startupGuide: StartupGuide{
+			Active: true,
+			Status: "Startup check failed: API key unauthorized",
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+	if !strings.Contains(updated.statusNote, "Help opened") {
+		t.Fatalf("expected /help to execute under startup guide, got status %q", updated.statusNote)
+	}
+}
+
+func TestRenderStartupGuidePanelInFooter(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	input.SetWidth(40)
+	input.SetHeight(3)
+	m := model{
+		input: input,
+		width: 100,
+		startupGuide: StartupGuide{
+			Active: true,
+			Title:  "AI provider not ready",
+			Status: "Startup check failed: missing API key",
+			Lines:  []string{"1) Add API key"},
+		},
+	}
+
+	footer := m.renderFooter()
+	for _, want := range []string{"AI provider not ready", "missing API key", "Add API key"} {
+		if !strings.Contains(footer, want) {
+			t.Fatalf("expected footer to contain %q", want)
+		}
 	}
 }
 
@@ -809,6 +1250,26 @@ func TestSyncInputStyleUsesSingleLineSearchField(t *testing.T) {
 	}
 	if m.input.Placeholder != "Ask Bytemind to inspect, change, or verify this workspace..." {
 		t.Fatalf("unexpected placeholder: %q", m.input.Placeholder)
+	}
+}
+
+func TestSyncInputStyleShowsStartupStepPlaceholder(t *testing.T) {
+	input := textarea.New()
+	m := model{
+		input: input,
+		startupGuide: StartupGuide{
+			Active:       true,
+			CurrentField: startupFieldModel,
+		},
+	}
+
+	m.syncInputStyle()
+
+	if !strings.Contains(m.input.Placeholder, "Step 3/4") {
+		t.Fatalf("expected startup step placeholder, got %q", m.input.Placeholder)
+	}
+	if !strings.Contains(m.input.Placeholder, "model") {
+		t.Fatalf("expected startup model placeholder, got %q", m.input.Placeholder)
 	}
 }
 


### PR DESCRIPTION
## 背景
本 PR 聚焦 Bytemind 终端体验增强，补齐三项核心能力：
1. `Ctrl+F` 历史提示词检索与回填
2. 启动时新用户配置引导（Provider 不可用时进入分步向导）
3. 全局安装与任意目录启动（`bytemind install`）

## 变更内容

### 1) Ctrl+F 历史检索
- 新增 prompt history 检索面板（关键词过滤 + `ws:`/`sid:` 过滤）
- 支持上下移动、翻页、回填输入、取消恢复原输入
- Footer 与帮助文案同步更新为 `Ctrl+F history`

### 2) 新用户配置引导（Startup Guide）
- 启动时 preflight 检测 provider 可用性
- 不可用时进入 TUI 引导，按步骤配置：
  - `type -> base_url -> model -> api_key`
- 每步提交后清空输入并提示下一步
- API key 自动清洗（Bearer 前缀）并在线验证
- 验证成功后写回配置并热更新运行时 provider

### 3) 全局启动能力
- 新增命令：`bytemind install`
- 支持参数：`-to`、`-name`、`-add-to-path`
- 默认安装到 `~/.bytemind/bin`
- Windows 下自动更新用户 PATH（去重），重开终端后可直接运行 `bytemind`

## 主要影响文件
- `cmd/bytemind/main.go`
- `cmd/bytemind/tui.go`
- `cmd/bytemind/install.go`
- `internal/tui/model.go`
- `internal/config/update.go`
- `internal/provider/preflight.go`
- `internal/history/store.go`
- 以及对应测试文件