### PR TITLE
skill编辑 后端英文化

### DIFF
--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unicode"
 )
 
 const (
@@ -169,7 +168,7 @@ func formatSkills(skills []PromptSkill) string {
 		if name == "" {
 			continue
 		}
-		description := englishSkillTextOrFallback(strings.TrimSpace(skill.Description), "Description omitted (non-English source).")
+		description := strings.TrimSpace(skill.Description)
 		if description == "" {
 			description = "No description provided."
 		}
@@ -217,9 +216,9 @@ func renderActiveSkillPrompt(skill *PromptActiveSkill) string {
 	}
 
 	name := strings.TrimSpace(skill.Name)
-	description := englishSkillTextOrFallback(strings.TrimSpace(skill.Description), "Description omitted (non-English source).")
-	whenToUse := englishSkillTextOrFallback(strings.TrimSpace(skill.WhenToUse), "When-to-use omitted (non-English source).")
-	instructions := englishSkillTextOrFallback(strings.TrimSpace(skill.Instructions), "Instructions omitted (non-English source).")
+	description := strings.TrimSpace(skill.Description)
+	whenToUse := strings.TrimSpace(skill.WhenToUse)
+	instructions := strings.TrimSpace(skill.Instructions)
 	toolPolicy := strings.TrimSpace(skill.ToolPolicy)
 	if name == "" && description == "" && whenToUse == "" && instructions == "" && toolPolicy == "" {
 		return ""
@@ -250,7 +249,6 @@ func renderActiveSkillPrompt(skill *PromptActiveSkill) string {
 				if value == "" {
 					continue
 				}
-				value = englishSkillTextOrFallback(value, "[non-English value omitted]")
 				lines = append(lines, fmt.Sprintf("- %s=%s", key, value))
 			}
 		}
@@ -322,26 +320,6 @@ func trimPromptText(text string, maxRunes int) string {
 		return string(runes[:maxRunes])
 	}
 	return string(runes[:maxRunes-3]) + "..."
-}
-
-func englishSkillTextOrFallback(text, fallback string) string {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return ""
-	}
-	if containsHanText(text) {
-		return strings.TrimSpace(fallback)
-	}
-	return text
-}
-
-func containsHanText(text string) bool {
-	for _, r := range text {
-		if unicode.Is(unicode.Han, r) {
-			return true
-		}
-	}
-	return false
 }
 
 func promptDebugEnabled() bool {

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 )
 
 const (
@@ -165,9 +166,12 @@ func formatSkills(skills []PromptSkill) string {
 	lines := make([]string, 0, len(skills))
 	for _, skill := range skills {
 		name := strings.TrimSpace(skill.Name)
-		description := strings.TrimSpace(skill.Description)
-		if name == "" || description == "" {
+		if name == "" {
 			continue
+		}
+		description := englishSkillTextOrFallback(strings.TrimSpace(skill.Description), "Description omitted (non-English source).")
+		if description == "" {
+			description = "No description provided."
 		}
 		description = trimPromptText(description, maxPromptSkillDescriptionRune)
 		lines = append(lines, fmt.Sprintf("- %s: %s enabled=%t", name, description, skill.Enabled))
@@ -213,9 +217,9 @@ func renderActiveSkillPrompt(skill *PromptActiveSkill) string {
 	}
 
 	name := strings.TrimSpace(skill.Name)
-	description := strings.TrimSpace(skill.Description)
-	whenToUse := strings.TrimSpace(skill.WhenToUse)
-	instructions := strings.TrimSpace(skill.Instructions)
+	description := englishSkillTextOrFallback(strings.TrimSpace(skill.Description), "Description omitted (non-English source).")
+	whenToUse := englishSkillTextOrFallback(strings.TrimSpace(skill.WhenToUse), "When-to-use omitted (non-English source).")
+	instructions := englishSkillTextOrFallback(strings.TrimSpace(skill.Instructions), "Instructions omitted (non-English source).")
 	toolPolicy := strings.TrimSpace(skill.ToolPolicy)
 	if name == "" && description == "" && whenToUse == "" && instructions == "" && toolPolicy == "" {
 		return ""
@@ -246,6 +250,7 @@ func renderActiveSkillPrompt(skill *PromptActiveSkill) string {
 				if value == "" {
 					continue
 				}
+				value = englishSkillTextOrFallback(value, "[non-English value omitted]")
 				lines = append(lines, fmt.Sprintf("- %s=%s", key, value))
 			}
 		}
@@ -317,6 +322,26 @@ func trimPromptText(text string, maxRunes int) string {
 		return string(runes[:maxRunes])
 	}
 	return string(runes[:maxRunes-3]) + "..."
+}
+
+func englishSkillTextOrFallback(text, fallback string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	if containsHanText(text) {
+		return strings.TrimSpace(fallback)
+	}
+	return text
+}
+
+func containsHanText(text string) bool {
+	for _, r := range text {
+		if unicode.Is(unicode.Han, r) {
+			return true
+		}
+	}
+	return false
 }
 
 func promptDebugEnabled() bool {

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"unicode"
 )
 
 func TestSystemPromptRendersMainModeSystemAndInstruction(t *testing.T) {
@@ -170,33 +169,31 @@ func TestFormatSkillsLimitsAndSummarizesOverflow(t *testing.T) {
 	}
 }
 
-func TestFormatSkillsSanitizesNonEnglishDescriptions(t *testing.T) {
+func TestFormatSkillsKeepsNonEnglishDescriptions(t *testing.T) {
 	got := formatSkills([]PromptSkill{
-		{Name: "review", Description: "以正确性为重点进行代码评审。", Enabled: true},
+		{Name: "review", Description: "\u4ee5\u6b63\u786e\u6027\u4e3a\u91cd\u70b9\u8fdb\u884c\u4ee3\u7801\u8bc4\u5ba1\u3002", Enabled: true},
 	})
 
-	assertContains(t, got, "- review: Description omitted (non-English source). enabled=true")
-	assertNoHanText(t, got)
+	assertContains(t, got, "- review: \u4ee5\u6b63\u786e\u6027\u4e3a\u91cd\u70b9\u8fdb\u884c\u4ee3\u7801\u8bc4\u5ba1\u3002 enabled=true")
 }
 
-func TestRenderActiveSkillPromptSanitizesNonEnglishFields(t *testing.T) {
+func TestRenderActiveSkillPromptKeepsNonEnglishFields(t *testing.T) {
 	out := renderActiveSkillPrompt(&PromptActiveSkill{
 		Name:         "review",
-		Description:  "以正确性为重点进行代码评审。",
-		WhenToUse:    "当用户要求评审时使用。",
-		Instructions: "优先回归风险和测试缺口。",
+		Description:  "\u4ee5\u6b63\u786e\u6027\u4e3a\u91cd\u70b9\u8fdb\u884c\u4ee3\u7801\u8bc4\u5ba1\u3002",
+		WhenToUse:    "\u5f53\u7528\u6237\u8981\u6c42\u8bc4\u5ba1\u65f6\u4f7f\u7528\u3002",
+		Instructions: "\u4f18\u5148\u56de\u5f52\u98ce\u9669\u548c\u6d4b\u8bd5\u7f3a\u53e3\u3002",
 		Args: map[string]string{
-			"base_ref": "主分支",
+			"base_ref": "\u4e3b\u5206\u652f",
 		},
 		ToolPolicy: "allowlist",
 		Tools:      []string{"read_file"},
 	})
 
-	assertContains(t, out, "Description: Description omitted (non-English source).")
-	assertContains(t, out, "When To Use: When-to-use omitted (non-English source).")
-	assertContains(t, out, "Instructions omitted (non-English source).")
-	assertContains(t, out, "- base_ref=[non-English value omitted]")
-	assertNoHanText(t, out)
+	assertContains(t, out, "Description: \u4ee5\u6b63\u786e\u6027\u4e3a\u91cd\u70b9\u8fdb\u884c\u4ee3\u7801\u8bc4\u5ba1\u3002")
+	assertContains(t, out, "When To Use: \u5f53\u7528\u6237\u8981\u6c42\u8bc4\u5ba1\u65f6\u4f7f\u7528\u3002")
+	assertContains(t, out, "- base_ref=\u4e3b\u5206\u652f")
+	assertContains(t, out, "\u4f18\u5148\u56de\u5f52\u98ce\u9669\u548c\u6d4b\u8bd5\u7f3a\u53e3\u3002")
 }
 
 func TestIsGitRepository(t *testing.T) {
@@ -242,15 +239,6 @@ func assertNoTemplateMarkers(t *testing.T, prompt string) {
 	for _, marker := range markers {
 		if strings.Contains(prompt, marker) {
 			t.Fatalf("expected template marker %q to be rendered, got %q", marker, prompt)
-		}
-	}
-}
-
-func assertNoHanText(t *testing.T, text string) {
-	t.Helper()
-	for _, r := range text {
-		if unicode.Is(unicode.Han, r) {
-			t.Fatalf("expected no Han characters, got %q", text)
 		}
 	}
 }

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -171,29 +171,29 @@ func TestFormatSkillsLimitsAndSummarizesOverflow(t *testing.T) {
 
 func TestFormatSkillsKeepsNonEnglishDescriptions(t *testing.T) {
 	got := formatSkills([]PromptSkill{
-		{Name: "review", Description: "\u4ee5\u6b63\u786e\u6027\u4e3a\u91cd\u70b9\u8fdb\u884c\u4ee3\u7801\u8bc4\u5ba1\u3002", Enabled: true},
+		{Name: "review", Description: "以正确性为重点进行代码评审。", Enabled: true},
 	})
 
-	assertContains(t, got, "- review: \u4ee5\u6b63\u786e\u6027\u4e3a\u91cd\u70b9\u8fdb\u884c\u4ee3\u7801\u8bc4\u5ba1\u3002 enabled=true")
+	assertContains(t, got, "- review: 以正确性为重点进行代码评审。 enabled=true")
 }
 
 func TestRenderActiveSkillPromptKeepsNonEnglishFields(t *testing.T) {
 	out := renderActiveSkillPrompt(&PromptActiveSkill{
 		Name:         "review",
-		Description:  "\u4ee5\u6b63\u786e\u6027\u4e3a\u91cd\u70b9\u8fdb\u884c\u4ee3\u7801\u8bc4\u5ba1\u3002",
-		WhenToUse:    "\u5f53\u7528\u6237\u8981\u6c42\u8bc4\u5ba1\u65f6\u4f7f\u7528\u3002",
-		Instructions: "\u4f18\u5148\u56de\u5f52\u98ce\u9669\u548c\u6d4b\u8bd5\u7f3a\u53e3\u3002",
+		Description:  "以正确性为重点进行代码评审。",
+		WhenToUse:    "当用户要求评审时使用。",
+		Instructions: "优先回归风险和测试缺口。",
 		Args: map[string]string{
-			"base_ref": "\u4e3b\u5206\u652f",
+			"base_ref": "主分支",
 		},
 		ToolPolicy: "allowlist",
 		Tools:      []string{"read_file"},
 	})
 
-	assertContains(t, out, "Description: \u4ee5\u6b63\u786e\u6027\u4e3a\u91cd\u70b9\u8fdb\u884c\u4ee3\u7801\u8bc4\u5ba1\u3002")
-	assertContains(t, out, "When To Use: \u5f53\u7528\u6237\u8981\u6c42\u8bc4\u5ba1\u65f6\u4f7f\u7528\u3002")
-	assertContains(t, out, "- base_ref=\u4e3b\u5206\u652f")
-	assertContains(t, out, "\u4f18\u5148\u56de\u5f52\u98ce\u9669\u548c\u6d4b\u8bd5\u7f3a\u53e3\u3002")
+	assertContains(t, out, "Description: 以正确性为重点进行代码评审。")
+	assertContains(t, out, "When To Use: 当用户要求评审时使用。")
+	assertContains(t, out, "- base_ref=主分支")
+	assertContains(t, out, "优先回归风险和测试缺口。")
 }
 
 func TestIsGitRepository(t *testing.T) {

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -169,31 +169,31 @@ func TestFormatSkillsLimitsAndSummarizesOverflow(t *testing.T) {
 	}
 }
 
-func TestFormatSkillsKeepsNonEnglishDescriptions(t *testing.T) {
+func TestFormatSkillsKeepsSkillDescriptionsAsIs(t *testing.T) {
 	got := formatSkills([]PromptSkill{
-		{Name: "review", Description: "以正确性为重点进行代码评审。", Enabled: true},
+		{Name: "review", Description: "Review with strict correctness focus.", Enabled: true},
 	})
 
-	assertContains(t, got, "- review: 以正确性为重点进行代码评审。 enabled=true")
+	assertContains(t, got, "- review: Review with strict correctness focus. enabled=true")
 }
 
-func TestRenderActiveSkillPromptKeepsNonEnglishFields(t *testing.T) {
+func TestRenderActiveSkillPromptKeepsSkillFieldsAsIs(t *testing.T) {
 	out := renderActiveSkillPrompt(&PromptActiveSkill{
 		Name:         "review",
-		Description:  "以正确性为重点进行代码评审。",
-		WhenToUse:    "当用户要求评审时使用。",
-		Instructions: "优先回归风险和测试缺口。",
+		Description:  "Review code changes with a strict correctness focus.",
+		WhenToUse:    "Use when the user asks for a code review.",
+		Instructions: "Prioritize regression risk and missing tests.",
 		Args: map[string]string{
-			"base_ref": "主分支",
+			"base_ref": "main",
 		},
 		ToolPolicy: "allowlist",
 		Tools:      []string{"read_file"},
 	})
 
-	assertContains(t, out, "Description: 以正确性为重点进行代码评审。")
-	assertContains(t, out, "When To Use: 当用户要求评审时使用。")
-	assertContains(t, out, "- base_ref=主分支")
-	assertContains(t, out, "优先回归风险和测试缺口。")
+	assertContains(t, out, "Description: Review code changes with a strict correctness focus.")
+	assertContains(t, out, "When To Use: Use when the user asks for a code review.")
+	assertContains(t, out, "- base_ref=main")
+	assertContains(t, out, "Prioritize regression risk and missing tests.")
 }
 
 func TestIsGitRepository(t *testing.T) {

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 )
 
 func TestSystemPromptRendersMainModeSystemAndInstruction(t *testing.T) {
@@ -169,6 +170,35 @@ func TestFormatSkillsLimitsAndSummarizesOverflow(t *testing.T) {
 	}
 }
 
+func TestFormatSkillsSanitizesNonEnglishDescriptions(t *testing.T) {
+	got := formatSkills([]PromptSkill{
+		{Name: "review", Description: "以正确性为重点进行代码评审。", Enabled: true},
+	})
+
+	assertContains(t, got, "- review: Description omitted (non-English source). enabled=true")
+	assertNoHanText(t, got)
+}
+
+func TestRenderActiveSkillPromptSanitizesNonEnglishFields(t *testing.T) {
+	out := renderActiveSkillPrompt(&PromptActiveSkill{
+		Name:         "review",
+		Description:  "以正确性为重点进行代码评审。",
+		WhenToUse:    "当用户要求评审时使用。",
+		Instructions: "优先回归风险和测试缺口。",
+		Args: map[string]string{
+			"base_ref": "主分支",
+		},
+		ToolPolicy: "allowlist",
+		Tools:      []string{"read_file"},
+	})
+
+	assertContains(t, out, "Description: Description omitted (non-English source).")
+	assertContains(t, out, "When To Use: When-to-use omitted (non-English source).")
+	assertContains(t, out, "Instructions omitted (non-English source).")
+	assertContains(t, out, "- base_ref=[non-English value omitted]")
+	assertNoHanText(t, out)
+}
+
 func TestIsGitRepository(t *testing.T) {
 	workspace := t.TempDir()
 	if isGitRepository(workspace) {
@@ -212,6 +242,15 @@ func assertNoTemplateMarkers(t *testing.T, prompt string) {
 	for _, marker := range markers {
 		if strings.Contains(prompt, marker) {
 			t.Fatalf("expected template marker %q to be rendered, got %q", marker, prompt)
+		}
+	}
+}
+
+func assertNoHanText(t *testing.T, text string) {
+	t.Helper()
+	for _, r := range text {
+		if unicode.Is(unicode.Han, r) {
+			t.Fatalf("expected no Han characters, got %q", text)
 		}
 	}
 }

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -162,6 +162,20 @@ func (r *Runner) ListSkills() ([]skills.Skill, []skills.Diagnostic) {
 	return r.skillManager.List()
 }
 
+func (r *Runner) AuthorSkill(name, brief string) (skills.AuthorResult, error) {
+	if r.skillManager == nil {
+		return skills.AuthorResult{}, fmt.Errorf("skill manager is unavailable")
+	}
+	return r.skillManager.Author(name, skills.ScopeProject, brief)
+}
+
+func (r *Runner) ClearSkill(name string) (skills.ClearResult, error) {
+	if r.skillManager == nil {
+		return skills.ClearResult{}, fmt.Errorf("skill manager is unavailable")
+	}
+	return r.skillManager.Clear(name)
+}
+
 func (r *Runner) ActivateSkill(sess *session.Session, name string, args map[string]string) (skills.Skill, error) {
 	if sess == nil {
 		return skills.Skill{}, fmt.Errorf("session is required")

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"bytemind/internal/config"
 	"bytemind/internal/history"
@@ -25,6 +26,8 @@ const (
 	maxActiveSkillInstructionsChars = 3600
 	emptyAllowlistSentinel          = "__bytemind__no_tools__"
 	emptyReplyFallback              = "Model returned an empty response (no text and no tool calls). Retry the request or switch model if this persists."
+	skillAuthorEnglishFallback      = "Describe the skill goals, workflow, and expected output in concise English."
+	skillAuthorTranslatePrompt      = "Translate the user's skill description into concise English for backend metadata. Return only plain English text with no markdown or quotes."
 )
 
 const (
@@ -166,6 +169,7 @@ func (r *Runner) AuthorSkill(name, brief string) (skills.AuthorResult, error) {
 	if r.skillManager == nil {
 		return skills.AuthorResult{}, fmt.Errorf("skill manager is unavailable")
 	}
+	brief = r.normalizeSkillAuthorBrief(brief)
 	return r.skillManager.Author(name, skills.ScopeProject, brief)
 }
 
@@ -1163,4 +1167,62 @@ func explicitWebLookupInstruction(userInput string) string {
 	}
 
 	return "The user explicitly requested online or GitHub-source lookup. Use web_search/web_fetch first. Do not substitute local-workspace tools (list_files/read_file/search_text) for this request unless the user explicitly asks to inspect the current workspace repository."
+}
+
+func (r *Runner) normalizeSkillAuthorBrief(brief string) string {
+	brief = strings.TrimSpace(brief)
+	if brief == "" {
+		return ""
+	}
+	if !containsHanRune(brief) {
+		return brief
+	}
+
+	translated, err := r.translateSkillBriefToEnglish(brief)
+	if err != nil {
+		return skillAuthorEnglishFallback
+	}
+	translated = strings.TrimSpace(translated)
+	if translated == "" || containsHanRune(translated) {
+		return skillAuthorEnglishFallback
+	}
+	return translated
+}
+
+func (r *Runner) translateSkillBriefToEnglish(brief string) (string, error) {
+	if strings.TrimSpace(brief) == "" {
+		return "", nil
+	}
+	if r.client == nil {
+		return "", fmt.Errorf("llm client is unavailable")
+	}
+	model := strings.TrimSpace(r.config.Provider.Model)
+	if model == "" {
+		return "", fmt.Errorf("model is required for translation")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+
+	reply, err := r.client.CreateMessage(ctx, llm.ChatRequest{
+		Model: model,
+		Messages: []llm.Message{
+			llm.NewTextMessage(llm.RoleSystem, skillAuthorTranslatePrompt),
+			llm.NewUserTextMessage(strings.TrimSpace(brief)),
+		},
+		Temperature: 0,
+	})
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(reply.Text()), nil
+}
+
+func containsHanRune(text string) bool {
+	for _, r := range text {
+		if unicode.Is(unicode.Han, r) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/agent/runner_branches_test.go
+++ b/internal/agent/runner_branches_test.go
@@ -204,12 +204,12 @@ func TestToolNamesDeduplicatesAndSkipsBlank(t *testing.T) {
 }
 
 func TestExplicitWebLookupInstruction(t *testing.T) {
-	got := explicitWebLookupInstruction("请去 GitHub 找这个项目的源码实现")
+	got := explicitWebLookupInstruction("Find the implementation in the GitHub source repository")
 	if !strings.Contains(got, "web_search/web_fetch") {
 		t.Fatalf("expected explicit web lookup instruction, got %q", got)
 	}
 
-	if got := explicitWebLookupInstruction("请在当前仓库用 search_text 找 TODO"); got != "" {
+	if got := explicitWebLookupInstruction("Use search_text in the current workspace to find TODO"); got != "" {
 		t.Fatalf("expected no explicit web lookup instruction, got %q", got)
 	}
 }

--- a/internal/agent/runner_complex_test.go
+++ b/internal/agent/runner_complex_test.go
@@ -436,7 +436,7 @@ func TestRunPromptInjectsExplicitWebLookupInstruction(t *testing.T) {
 		Stdout:   io.Discard,
 	})
 
-	if _, err := runner.RunPrompt(context.Background(), sess, "去 GitHub 源码里找这个函数实现", "build", io.Discard); err != nil {
+	if _, err := runner.RunPrompt(context.Background(), sess, "Find this function implementation in the GitHub source", "build", io.Discard); err != nil {
 		t.Fatal(err)
 	}
 	if len(client.requests) != 1 {

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -1,4 +1,4 @@
-﻿package agent
+package agent
 
 import (
 	"context"
@@ -442,7 +442,7 @@ func TestGetTokenRealtimeSnapshotReturnsSessionAndGlobalStats(t *testing.T) {
 }
 
 func TestCompactWhitespacePreservesUTF8WhenTruncating(t *testing.T) {
-	text := "缁х画鍒氭墠鐨勪笂涓嬫枃锛岀粰鎴戝垪涓€涓嬪綋鍓嶄富 MVP 鏈€鍏抽敭鐨勬祴璇曠偣"
+	text := "Continue previous context and list the key MVP test points."
 	got := compactWhitespace(text, 18)
 	if strings.ContainsRune(got, '\uFFFD') {
 		t.Fatalf("expected valid utf-8 preview, got %q", got)
@@ -716,7 +716,7 @@ func TestAuthorSkillTranslatesChineseBriefToEnglish(t *testing.T) {
 		Registry: tools.DefaultRegistry(),
 	})
 
-	result, err := runner.AuthorSkill("review-plus", "用于代码评审，重点关注回归风险")
+	result, err := runner.AuthorSkill("review-plus", hanReviewBriefWithRisk())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -743,7 +743,7 @@ func TestAuthorSkillFallsBackToEnglishWhenTranslationFails(t *testing.T) {
 	workspace := t.TempDir()
 	client := &fakeClient{
 		replies: []llm.Message{
-			llm.NewAssistantTextMessage("用于代码评审"),
+			llm.NewAssistantTextMessage(hanReviewBrief()),
 		},
 	}
 	runner := NewRunner(Options{
@@ -756,7 +756,7 @@ func TestAuthorSkillFallsBackToEnglishWhenTranslationFails(t *testing.T) {
 		Registry: tools.DefaultRegistry(),
 	})
 
-	result, err := runner.AuthorSkill("review-plus", "用于代码评审")
+	result, err := runner.AuthorSkill("review-plus", hanReviewBrief())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -782,3 +782,14 @@ func containsHanForTest(text string) bool {
 	return false
 }
 
+func hanReviewBrief() string {
+	return string([]rune{0x7528, 0x4e8e, 0x4ee3, 0x7801, 0x8bc4, 0x5ba1})
+}
+
+func hanReviewBriefWithRisk() string {
+	return string([]rune{
+		0x7528, 0x4e8e, 0x4ee3, 0x7801, 0x8bc4, 0x5ba1,
+		0xff0c,
+		0x91cd, 0x70b9, 0x5173, 0x6ce8, 0x56de, 0x5f52, 0x98ce, 0x9669,
+	})
+}

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -716,7 +716,7 @@ func TestAuthorSkillTranslatesChineseBriefToEnglish(t *testing.T) {
 		Registry: tools.DefaultRegistry(),
 	})
 
-	result, err := runner.AuthorSkill("review-plus", "\u7528\u4e8e\u4ee3\u7801\u8bc4\u5ba1\uff0c\u91cd\u70b9\u5173\u6ce8\u56de\u5f52\u98ce\u9669")
+	result, err := runner.AuthorSkill("review-plus", "用于代码评审，重点关注回归风险")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -743,7 +743,7 @@ func TestAuthorSkillFallsBackToEnglishWhenTranslationFails(t *testing.T) {
 	workspace := t.TempDir()
 	client := &fakeClient{
 		replies: []llm.Message{
-			llm.NewAssistantTextMessage("\u7528\u4e8e\u4ee3\u7801\u8bc4\u5ba1"),
+			llm.NewAssistantTextMessage("用于代码评审"),
 		},
 	}
 	runner := NewRunner(Options{
@@ -756,7 +756,7 @@ func TestAuthorSkillFallsBackToEnglishWhenTranslationFails(t *testing.T) {
 		Registry: tools.DefaultRegistry(),
 	})
 
-	result, err := runner.AuthorSkill("review-plus", "\u7528\u4e8e\u4ee3\u7801\u8bc4\u5ba1")
+	result, err := runner.AuthorSkill("review-plus", "用于代码评审")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -716,7 +716,7 @@ func TestAuthorSkillTranslatesChineseBriefToEnglish(t *testing.T) {
 		Registry: tools.DefaultRegistry(),
 	})
 
-	result, err := runner.AuthorSkill("review-plus", "鐢ㄤ簬浠ｇ爜璇勫锛岄噸鐐瑰叧娉ㄥ洖褰掗闄?)
+	result, err := runner.AuthorSkill("review-plus", "\u7528\u4e8e\u4ee3\u7801\u8bc4\u5ba1\uff0c\u91cd\u70b9\u5173\u6ce8\u56de\u5f52\u98ce\u9669")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -743,7 +743,7 @@ func TestAuthorSkillFallsBackToEnglishWhenTranslationFails(t *testing.T) {
 	workspace := t.TempDir()
 	client := &fakeClient{
 		replies: []llm.Message{
-			llm.NewAssistantTextMessage("鐢ㄤ簬浠ｇ爜璇勫"),
+			llm.NewAssistantTextMessage("\u7528\u4e8e\u4ee3\u7801\u8bc4\u5ba1"),
 		},
 	}
 	runner := NewRunner(Options{
@@ -756,7 +756,7 @@ func TestAuthorSkillFallsBackToEnglishWhenTranslationFails(t *testing.T) {
 		Registry: tools.DefaultRegistry(),
 	})
 
-	result, err := runner.AuthorSkill("review-plus", "鐢ㄤ簬浠ｇ爜璇勫")
+	result, err := runner.AuthorSkill("review-plus", "\u7528\u4e8e\u4ee3\u7801\u8bc4\u5ba1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -1,4 +1,4 @@
-package agent
+﻿package agent
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"bytemind/internal/config"
 	"bytemind/internal/llm"
@@ -441,7 +442,7 @@ func TestGetTokenRealtimeSnapshotReturnsSessionAndGlobalStats(t *testing.T) {
 }
 
 func TestCompactWhitespacePreservesUTF8WhenTruncating(t *testing.T) {
-	text := "继续刚才的上下文，给我列一下当前主 MVP 最关键的测试点"
+	text := "缁х画鍒氭墠鐨勪笂涓嬫枃锛岀粰鎴戝垪涓€涓嬪綋鍓嶄富 MVP 鏈€鍏抽敭鐨勬祴璇曠偣"
 	got := compactWhitespace(text, 18)
 	if strings.ContainsRune(got, '\uFFFD') {
 		t.Fatalf("expected valid utf-8 preview, got %q", got)
@@ -697,3 +698,87 @@ func TestActivateAndClearSkillPersistsSessionState(t *testing.T) {
 		t.Fatalf("expected active skill to be cleared, got %#v", sess.ActiveSkill)
 	}
 }
+
+func TestAuthorSkillTranslatesChineseBriefToEnglish(t *testing.T) {
+	workspace := t.TempDir()
+	client := &fakeClient{
+		replies: []llm.Message{
+			llm.NewAssistantTextMessage("Review backend changes and highlight regression risks."),
+		},
+	}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+			Stream:   false,
+		},
+		Client:   client,
+		Registry: tools.DefaultRegistry(),
+	})
+
+	result, err := runner.AuthorSkill("review-plus", "鐢ㄤ簬浠ｇ爜璇勫锛岄噸鐐瑰叧娉ㄥ洖褰掗闄?)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(result.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, "Review backend changes and highlight regression risks.") {
+		t.Fatalf("expected translated english description in manifest, got %q", text)
+	}
+	if containsHanForTest(text) {
+		t.Fatalf("expected no Han text in authored manifest, got %q", text)
+	}
+	if len(client.requests) == 0 {
+		t.Fatal("expected translation request to be sent to llm client")
+	}
+	if len(client.requests[0].Messages) < 2 || !strings.Contains(client.requests[0].Messages[0].Text(), "Translate the user's skill description") {
+		t.Fatalf("expected translation system instruction in first request, got %#v", client.requests[0].Messages)
+	}
+}
+
+func TestAuthorSkillFallsBackToEnglishWhenTranslationFails(t *testing.T) {
+	workspace := t.TempDir()
+	client := &fakeClient{
+		replies: []llm.Message{
+			llm.NewAssistantTextMessage("鐢ㄤ簬浠ｇ爜璇勫"),
+		},
+	}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+			Stream:   false,
+		},
+		Client:   client,
+		Registry: tools.DefaultRegistry(),
+	})
+
+	result, err := runner.AuthorSkill("review-plus", "鐢ㄤ簬浠ｇ爜璇勫")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(result.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, skillAuthorEnglishFallback) {
+		t.Fatalf("expected english fallback description in manifest, got %q", text)
+	}
+	if containsHanForTest(text) {
+		t.Fatalf("expected no Han text in fallback manifest, got %q", text)
+	}
+}
+
+func containsHanForTest(text string) bool {
+	for _, r := range text {
+		if unicode.Is(unicode.Han, r) {
+			return true
+		}
+	}
+	return false
+}
+

--- a/internal/skills/author.go
+++ b/internal/skills/author.go
@@ -1,0 +1,289 @@
+package skills
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+const (
+	defaultAuthorVersion     = "0.1.0"
+	defaultAuthorDescription = "Describe what this skill should do and refine the workflow below."
+)
+
+func (m *Manager) Author(name string, scope Scope, brief string) (AuthorResult, error) {
+	name = strings.TrimSpace(strings.TrimPrefix(name, "/"))
+	if name == "" {
+		return AuthorResult{}, fmt.Errorf("skill name is required")
+	}
+	if !validSkillName.MatchString(name) {
+		return AuthorResult{}, fmt.Errorf("invalid skill name: %s", name)
+	}
+
+	scope = normalizeAuthorScope(scope)
+	root := m.scopeDir(scope)
+	if strings.TrimSpace(root) == "" {
+		return AuthorResult{}, fmt.Errorf("skill scope path is unavailable: %s", scope)
+	}
+
+	brief = compactAuthorText(brief)
+
+	skillDir := filepath.Join(root, name)
+	manifestPath := filepath.Join(skillDir, "skill.json")
+	skillPath := filepath.Join(skillDir, "SKILL.md")
+	result := AuthorResult{
+		Name:         name,
+		Scope:        scope,
+		Dir:          skillDir,
+		ManifestPath: manifestPath,
+		SkillPath:    skillPath,
+	}
+
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return result, err
+	}
+
+	manifestExists := fileExists(manifestPath)
+	skillExists := fileExists(skillPath)
+	result.Created = !manifestExists && !skillExists
+
+	manifest := skillManifest{}
+	if manifestExists {
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			return result, err
+		}
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return result, fmt.Errorf("invalid skill.json: %w", err)
+		}
+	}
+	mergeManifestDefaults(&manifest, name, brief)
+
+	manifestContent, err := marshalManifest(manifest)
+	if err != nil {
+		return result, err
+	}
+	manifestUpdated, err := writeIfChanged(manifestPath, manifestContent)
+	if err != nil {
+		return result, err
+	}
+
+	frontmatter := map[string]string{}
+	body := ""
+	if skillExists {
+		data, err := os.ReadFile(skillPath)
+		if err != nil {
+			return result, err
+		}
+		frontmatter, body = parseFrontmatterMarkdown(string(data))
+	}
+
+	skillContent := renderSkillMarkdown(name, manifest.Description, brief, frontmatter, body)
+	skillUpdated, err := writeIfChanged(skillPath, []byte(skillContent))
+	if err != nil {
+		return result, err
+	}
+
+	result.Updated = manifestUpdated || skillUpdated
+	m.Reload()
+	return result, nil
+}
+
+func (m *Manager) scopeDir(scope Scope) string {
+	switch scope {
+	case ScopeBuiltin:
+		return m.builtinDir
+	case ScopeUser:
+		return m.userDir
+	default:
+		return m.projectDir
+	}
+}
+
+func normalizeAuthorScope(scope Scope) Scope {
+	switch scope {
+	case ScopeBuiltin, ScopeUser, ScopeProject:
+		return scope
+	default:
+		return ScopeProject
+	}
+}
+
+func mergeManifestDefaults(manifest *skillManifest, name, brief string) {
+	if manifest == nil {
+		return
+	}
+
+	if strings.TrimSpace(manifest.Name) == "" {
+		manifest.Name = name
+	}
+	if strings.TrimSpace(manifest.Version) == "" {
+		manifest.Version = defaultAuthorVersion
+	}
+	if strings.TrimSpace(manifest.Title) == "" {
+		manifest.Title = humanizeSkillName(name)
+	}
+	if strings.TrimSpace(manifest.Description) == "" {
+		manifest.Description = defaultAuthorDescription
+	}
+	if brief != "" {
+		manifest.Description = brief
+	}
+
+	manifest.Entry.Slash = strings.TrimSpace(manifest.Entry.Slash)
+	if manifest.Entry.Slash == "" {
+		manifest.Entry.Slash = "/" + name
+	} else if !strings.HasPrefix(manifest.Entry.Slash, "/") {
+		manifest.Entry.Slash = "/" + manifest.Entry.Slash
+	}
+
+	policy := strings.ToLower(strings.TrimSpace(manifest.Tools.Policy))
+	switch policy {
+	case "", string(ToolPolicyInherit), string(ToolPolicyAllowlist), string(ToolPolicyDenylist):
+	default:
+		policy = string(ToolPolicyInherit)
+	}
+	if policy == "" {
+		policy = string(ToolPolicyInherit)
+	}
+	manifest.Tools.Policy = policy
+	manifest.Tools.Items = uniqueStrings(manifest.Tools.Items)
+	if policy == string(ToolPolicyInherit) {
+		manifest.Tools.Items = nil
+	}
+}
+
+func marshalManifest(manifest skillManifest) ([]byte, error) {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func renderSkillMarkdown(name, description, brief string, frontmatter map[string]string, body string) string {
+	description = compactAuthorText(description)
+	if description == "" {
+		description = defaultAuthorDescription
+	}
+	whenToUse := compactAuthorText(frontmatter["when_to_use"])
+	if whenToUse == "" {
+		whenToUse = compactAuthorText(frontmatter["when-to-use"])
+	}
+	if brief != "" {
+		whenToUse = brief
+	}
+	if whenToUse == "" {
+		whenToUse = "Use this skill when the task repeatedly follows the same workflow."
+	}
+
+	body = strings.TrimSpace(body)
+	if body == "" {
+		body = defaultSkillBody(name)
+	}
+
+	lines := []string{
+		"---",
+		fmt.Sprintf("name: %q", name),
+		"description: |",
+	}
+	lines = append(lines, indentBlock(description)...)
+	lines = append(lines,
+		"when_to_use: |",
+	)
+	lines = append(lines, indentBlock(whenToUse)...)
+	lines = append(lines,
+		"---",
+		"",
+		body,
+		"",
+	)
+	return strings.Join(lines, "\n")
+}
+
+func defaultSkillBody(name string) string {
+	return strings.Join([]string{
+		"# " + name,
+		"",
+		"## Goal",
+		"",
+		"- Clarify what this skill should achieve.",
+		"",
+		"## Workflow",
+		"",
+		"1. Confirm scope and expected output.",
+		"2. Gather the minimum context needed for execution.",
+		"3. Apply focused changes and validate results.",
+		"4. Report outcomes, risks, and next steps.",
+		"",
+		"## Output Contract",
+		"",
+		"- Key findings or changes",
+		"- Verification performed",
+		"- Residual risks or follow-up",
+	}, "\n")
+}
+
+func indentBlock(text string) []string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			out = append(out, "  ")
+			continue
+		}
+		out = append(out, "  "+trimmed)
+	}
+	if len(out) == 0 {
+		return []string{"  "}
+	}
+	return out
+}
+
+func compactAuthorText(text string) string {
+	text = strings.Join(strings.Fields(strings.TrimSpace(text)), " ")
+	runes := []rune(text)
+	if len(runes) > 220 {
+		return strings.TrimSpace(string(runes[:217])) + "..."
+	}
+	return text
+}
+
+func writeIfChanged(path string, content []byte) (bool, error) {
+	existing, err := os.ReadFile(path)
+	if err == nil && bytes.Equal(existing, content) {
+		return false, nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func humanizeSkillName(name string) string {
+	parts := strings.FieldsFunc(name, func(r rune) bool {
+		return r == '-' || r == '_' || r == '.' || r == ':' || unicode.IsSpace(r)
+	})
+	if len(parts) == 0 {
+		return name
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		runes := []rune(strings.ToLower(parts[i]))
+		runes[0] = unicode.ToUpper(runes[0])
+		parts[i] = string(runes)
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/skills/author_test.go
+++ b/internal/skills/author_test.go
@@ -1,0 +1,197 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestManagerAuthorCreatesProjectSkillScaffold(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManagerWithDirs(
+		root,
+		filepath.Join(root, "builtin"),
+		filepath.Join(root, "user"),
+		filepath.Join(root, "project"),
+	)
+
+	result, err := manager.Author("review-plus", ScopeProject, "Review code changes and report regressions.")
+	if err != nil {
+		t.Fatalf("author failed: %v", err)
+	}
+	if !result.Created {
+		t.Fatalf("expected created=true, got %#v", result)
+	}
+	if _, err := os.Stat(result.ManifestPath); err != nil {
+		t.Fatalf("expected manifest to exist: %v", err)
+	}
+	if _, err := os.Stat(result.SkillPath); err != nil {
+		t.Fatalf("expected skill markdown to exist: %v", err)
+	}
+
+	manifestData, err := os.ReadFile(result.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := string(manifestData)
+	if !strings.Contains(manifest, `"name": "review-plus"`) {
+		t.Fatalf("expected manifest name, got %q", manifest)
+	}
+	if !strings.Contains(manifest, `"description": "Review code changes and report regressions."`) {
+		t.Fatalf("expected brief to populate description, got %q", manifest)
+	}
+
+	skillData, err := os.ReadFile(result.SkillPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skillText := string(skillData)
+	if !strings.Contains(skillText, "when_to_use: |") {
+		t.Fatalf("expected when_to_use frontmatter, got %q", skillText)
+	}
+	if !strings.Contains(skillText, "Review code changes and report regressions.") {
+		t.Fatalf("expected brief in skill markdown, got %q", skillText)
+	}
+
+	skill, ok := manager.Find("/review-plus")
+	if !ok {
+		t.Fatalf("expected authored skill to be discoverable")
+	}
+	if skill.Name != "review-plus" {
+		t.Fatalf("unexpected authored skill name: %#v", skill)
+	}
+}
+
+func TestManagerAuthorUpdatesExistingSkillAndKeepsBody(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	skillDir := filepath.Join(project, "custom-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.json"), []byte(`{
+  "name": "custom-skill",
+  "description": "old description",
+  "entry": {"slash": "/custom-skill"},
+  "tools": {"policy": "inherit"}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: custom-skill
+description: old description
+---
+
+# custom-skill
+
+## Existing Body
+
+Keep this body.
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := NewManagerWithDirs(
+		root,
+		filepath.Join(root, "builtin"),
+		filepath.Join(root, "user"),
+		project,
+	)
+
+	result, err := manager.Author("custom-skill", ScopeProject, "Handle recurring repository triage tasks.")
+	if err != nil {
+		t.Fatalf("author update failed: %v", err)
+	}
+	if result.Created {
+		t.Fatalf("expected update on existing skill, got created=true")
+	}
+	if !result.Updated {
+		t.Fatalf("expected updated=true, got %#v", result)
+	}
+
+	skillData, err := os.ReadFile(result.SkillPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skillText := string(skillData)
+	if !strings.Contains(skillText, "## Existing Body") {
+		t.Fatalf("expected existing body to be kept, got %q", skillText)
+	}
+	if !strings.Contains(skillText, "Handle recurring repository triage tasks.") {
+		t.Fatalf("expected brief to update skill frontmatter, got %q", skillText)
+	}
+}
+
+func TestManagerAuthorRejectsInvalidName(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManagerWithDirs(
+		root,
+		filepath.Join(root, "builtin"),
+		filepath.Join(root, "user"),
+		filepath.Join(root, "project"),
+	)
+
+	if _, err := manager.Author("bad name with spaces", ScopeProject, ""); err == nil {
+		t.Fatalf("expected invalid name error")
+	}
+}
+
+func TestManagerClearRemovesProjectSkill(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	skillDir := filepath.Join(project, "review-plus")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.json"), []byte(`{"name":"review-plus","description":"review"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# review-plus"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := NewManagerWithDirs(
+		root,
+		filepath.Join(root, "builtin"),
+		filepath.Join(root, "user"),
+		project,
+	)
+
+	result, err := manager.Clear("/review-plus")
+	if err != nil {
+		t.Fatalf("clear failed: %v", err)
+	}
+	if !result.Removed {
+		t.Fatalf("expected removed=true, got %#v", result)
+	}
+	if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+		t.Fatalf("expected skill dir removed, stat err=%v", err)
+	}
+	if _, ok := manager.Find("review-plus"); ok {
+		t.Fatalf("expected cleared skill to disappear from catalog")
+	}
+}
+
+func TestManagerClearRejectsBuiltinSkill(t *testing.T) {
+	root := t.TempDir()
+	builtin := filepath.Join(root, "builtin")
+	if err := os.MkdirAll(filepath.Join(builtin, "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(builtin, "review", "skill.json"), []byte(`{"name":"review","description":"builtin"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := NewManagerWithDirs(
+		root,
+		builtin,
+		filepath.Join(root, "user"),
+		filepath.Join(root, "project"),
+	)
+
+	if _, err := manager.Clear("review"); err == nil {
+		t.Fatalf("expected builtin clear to fail")
+	}
+}

--- a/internal/skills/bug-investigation/skill.json
+++ b/internal/skills/bug-investigation/skill.json
@@ -1,27 +1,27 @@
 {
-    "name":  "bug-investigation",
-    "version":  "0.1.0",
-    "title":  "Bug Investigation",
-    "description":  "通过可复现证据定位并分析问题，再提出修复方案。",
-    "entry":  {
-                  "slash":  "/bug-investigation"
-              },
-    "tools":  {
-                  "policy":  "allowlist",
-                  "items":  [
-                                "list_files",
-                                "read_file",
-                                "search_text",
-                                "run_shell",
-                                "update_plan"
-                            ]
-              },
-    "args":  [
-                 {
-                     "name":  "symptom",
-                     "type":  "string",
-                     "required":  false,
-                     "description":  "Optional symptom summary or error keyword."
-                 }
-             ]
+  "name": "bug-investigation",
+  "version": "0.1.0",
+  "title": "Bug Investigation",
+  "description": "Locate and analyze issues with reproducible evidence, then propose a fix.",
+  "entry": {
+    "slash": "/bug-investigation"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "run_shell",
+      "update_plan"
+    ]
+  },
+  "args": [
+    {
+      "name": "symptom",
+      "type": "string",
+      "required": false,
+      "description": "Optional symptom summary or error keyword."
+    }
+  ]
 }

--- a/internal/skills/clear.go
+++ b/internal/skills/clear.go
@@ -1,0 +1,61 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func (m *Manager) Clear(name string) (ClearResult, error) {
+	name = strings.TrimSpace(strings.TrimPrefix(name, "/"))
+	if name == "" {
+		return ClearResult{}, fmt.Errorf("skill name is required")
+	}
+	if !validSkillName.MatchString(name) {
+		return ClearResult{}, fmt.Errorf("invalid skill name: %s", name)
+	}
+
+	result := ClearResult{
+		Name:  name,
+		Scope: ScopeProject,
+	}
+
+	// Prefer canonical resolution so aliases map to the actual project skill.
+	if skill, ok := m.Find(name); ok {
+		if skill.Scope != ScopeProject {
+			return result, fmt.Errorf("skill `%s` exists in %s scope and cannot be deleted by /skill delete", skill.Name, skill.Scope)
+		}
+		result.Name = skill.Name
+		result.Dir = strings.TrimSpace(skill.SourceDir)
+		if result.Dir == "" {
+			result.Dir = filepath.Join(m.projectDir, skill.Name)
+		}
+	} else {
+		result.Dir = filepath.Join(m.projectDir, name)
+	}
+
+	dir := strings.TrimSpace(result.Dir)
+	if dir == "" {
+		return result, fmt.Errorf("project skill directory is unavailable")
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			result.NotFound = true
+			return result, fmt.Errorf("project skill `%s` not found", result.Name)
+		}
+		return result, err
+	}
+	if !info.IsDir() {
+		return result, fmt.Errorf("skill path is not a directory: %s", dir)
+	}
+
+	if err := os.RemoveAll(dir); err != nil {
+		return result, err
+	}
+	result.Removed = true
+	m.Reload()
+	return result, nil
+}

--- a/internal/skills/github-pr/skill.json
+++ b/internal/skills/github-pr/skill.json
@@ -1,33 +1,33 @@
 {
-    "name":  "github-pr",
-    "version":  "0.1.0",
-    "title":  "GitHub PR Analysis",
-    "description":  "基于证据分析 PR 差异、评审意见与合并风险。",
-    "entry":  {
-                  "slash":  "/github-pr"
-              },
-    "tools":  {
-                  "policy":  "allowlist",
-                  "items":  [
-                                "list_files",
-                                "read_file",
-                                "search_text",
-                                "run_shell",
-                                "update_plan"
-                            ]
-              },
-    "args":  [
-                 {
-                     "name":  "pr_number",
-                     "type":  "string",
-                     "required":  false,
-                     "description":  "Optional pull request number."
-                 },
-                 {
-                     "name":  "base_ref",
-                     "type":  "string",
-                     "required":  false,
-                     "description":  "Optional baseline branch, for example main."
-                 }
-             ]
+  "name": "github-pr",
+  "version": "0.1.0",
+  "title": "GitHub PR Analysis",
+  "description": "Analyze PR diffs, review feedback, and merge risk based on evidence.",
+  "entry": {
+    "slash": "/github-pr"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "run_shell",
+      "update_plan"
+    ]
+  },
+  "args": [
+    {
+      "name": "pr_number",
+      "type": "string",
+      "required": false,
+      "description": "Optional pull request number."
+    },
+    {
+      "name": "base_ref",
+      "type": "string",
+      "required": false,
+      "description": "Optional baseline branch, for example main."
+    }
+  ]
 }

--- a/internal/skills/repo-onboarding/skill.json
+++ b/internal/skills/repo-onboarding/skill.json
@@ -1,19 +1,19 @@
 {
-    "name":  "repo-onboarding",
-    "version":  "0.1.0",
-    "title":  "Repo Onboarding",
-    "description":  "快速建立对仓库结构、入口与运行流程的整体理解。",
-    "entry":  {
-                  "slash":  "/repo-onboarding"
-              },
-    "tools":  {
-                  "policy":  "allowlist",
-                  "items":  [
-                                "list_files",
-                                "read_file",
-                                "search_text",
-                                "run_shell",
-                                "update_plan"
-                            ]
-              }
+  "name": "repo-onboarding",
+  "version": "0.1.0",
+  "title": "Repo Onboarding",
+  "description": "Build a quick understanding of repository structure, entry points, and run flow.",
+  "entry": {
+    "slash": "/repo-onboarding"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "run_shell",
+      "update_plan"
+    ]
+  }
 }

--- a/internal/skills/review/skill.json
+++ b/internal/skills/review/skill.json
@@ -1,27 +1,27 @@
 {
-    "name":  "review",
-    "version":  "0.1.0",
-    "title":  "Code Review",
-    "description":  "以正确性、回归风险和测试缺口为重点进行代码评审。",
-    "entry":  {
-                  "slash":  "/review"
-              },
-    "tools":  {
-                  "policy":  "allowlist",
-                  "items":  [
-                                "list_files",
-                                "read_file",
-                                "search_text",
-                                "run_shell",
-                                "update_plan"
-                            ]
-              },
-    "args":  [
-                 {
-                     "name":  "base_ref",
-                     "type":  "string",
-                     "required":  false,
-                     "description":  "Optional baseline branch, for example main."
-                 }
-             ]
+  "name": "review",
+  "version": "0.1.0",
+  "title": "Code Review",
+  "description": "Focus code review on correctness, regression risk, and testing gaps.",
+  "entry": {
+    "slash": "/review"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "run_shell",
+      "update_plan"
+    ]
+  },
+  "args": [
+    {
+      "name": "base_ref",
+      "type": "string",
+      "required": false,
+      "description": "Optional baseline branch, for example main."
+    }
+  ]
 }

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -86,3 +86,22 @@ type Catalog struct {
 	Overrides   []Override
 	LoadedAt    time.Time
 }
+
+type AuthorResult struct {
+	Name         string
+	Scope        Scope
+	Dir          string
+	ManifestPath string
+	SkillPath    string
+	Created      bool
+	Updated      bool
+}
+
+type ClearResult struct {
+	Name      string
+	Scope     Scope
+	Dir       string
+	Removed   bool
+	NotFound  bool
+	WasActive bool
+}

--- a/internal/skills/write-rfc/skill.json
+++ b/internal/skills/write-rfc/skill.json
@@ -1,29 +1,29 @@
 {
-    "name":  "write-rfc",
-    "version":  "0.1.0",
-    "title":  "Write RFC",
-    "description":  "产出结构化技术方案，明确权衡取舍与发布计划。",
-    "entry":  {
-                  "slash":  "/write-rfc"
-              },
-    "tools":  {
-                  "policy":  "allowlist",
-                  "items":  [
-                                "list_files",
-                                "read_file",
-                                "search_text",
-                                "write_file",
-                                "replace_in_file",
-                                "apply_patch",
-                                "update_plan"
-                            ]
-              },
-    "args":  [
-                 {
-                     "name":  "path",
-                     "type":  "string",
-                     "required":  false,
-                     "description":  "Optional RFC output path, for example docs/rfc/feature.md."
-                 }
-             ]
+  "name": "write-rfc",
+  "version": "0.1.0",
+  "title": "Write RFC",
+  "description": "Produce a structured technical proposal with clear tradeoffs and a rollout plan.",
+  "entry": {
+    "slash": "/write-rfc"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "write_file",
+      "replace_in_file",
+      "apply_patch",
+      "update_plan"
+    ]
+  },
+  "args": [
+    {
+      "name": "path",
+      "type": "string",
+      "required": false,
+      "description": "Optional RFC output path, for example docs/rfc/feature.md."
+    }
+  ]
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4408,17 +4408,18 @@ func isMeaningfulThinking(body, toolName string) bool {
 	}
 
 	cnPrefixes := []string{
-		"鎴戝皢璋冪敤",
-		"鎴戜細璋冪敤",
-		"鎴戝厛璋冪敤",
-		"鎴戣璋冪敤",
+		"我将调用",
+		"我会调用",
+		"我先调用",
+		"我要调用",
 		"先调用",
-		"鎴戝皢浣跨敤",
-		"鎴戜細浣跨敤",
-		"鎴戝厛浣跨敤",
-		"鎴戝皢杩愯",
-		"鎴戜細杩愯",
-		"鍏堟鏌ョ浉鍏充笂涓嬫枃",
+		"我将使用",
+		"我会使用",
+		"我先使用",
+		"我将运行",
+		"我会运行",
+		"先检查相关上下文",
+		"我会先检查相关上下文",
 	}
 	for _, prefix := range cnPrefixes {
 		if strings.HasPrefix(raw, prefix) {
@@ -4448,7 +4449,7 @@ func shouldRenderThinkingFromDelta(body string) bool {
 		"through build and test",
 		"我会先",
 		"先了解",
-		"鐒跺悗",
+		"然后",
 		"最后",
 		"通过构建和测试",
 		"系统性",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -191,8 +191,10 @@ var commandItems = []commandItem{
 	{Name: "/new", Usage: "/new", Description: "Start a fresh session in this workspace.", Kind: "command"},
 	{Name: "/btw", Usage: "/btw <message>", Description: "Interject while a run is in progress.", Kind: "command"},
 	{Name: "/quit", Usage: "/quit", Description: "Exit the current TUI window.", Kind: "command"},
-	{Name: "/skills", Usage: "/skills", Description: "List available skills and current active skill.", Kind: "command"},
-	{Name: "/skill clear", Usage: "/skill clear", Description: "Clear active skill for this session.", Kind: "command"},
+	{Name: "/skills", Usage: "/skills", Description: "查看可用技能与当前激活技能。", Kind: "command"},
+	{Name: "/skill author", Usage: "/skill author [name]", Description: "进入技能编辑模式并创建/更新模板。", Kind: "command"},
+	{Name: "/skill clear", Usage: "/skill clear", Description: "清除当前会话的激活技能状态。", Kind: "command"},
+	{Name: "/skill delete", Usage: "/skill delete <name>", Description: "删除项目里的指定技能。", Kind: "command"},
 }
 
 type model struct {
@@ -270,6 +272,8 @@ type model struct {
 	pendingBTW            []string
 	interrupting          bool
 	interruptSafe         bool
+	skillAuthorMode       bool
+	skillAuthorName       string
 	runSeq                int
 	activeRunID           int
 	startupGuide          StartupGuide
@@ -957,6 +961,9 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			return next, cmd
+		}
+		if m.skillAuthorMode {
+			return m.submitSkillAuthorInput(value)
 		}
 		return m.submitPrompt(value)
 	}
@@ -2354,7 +2361,7 @@ func (m model) renderActiveSkillBanner() string {
 		return ""
 	}
 
-	line := "Active skill: " + name
+	line := "当前激活技能：" + name
 	if len(m.sess.ActiveSkill.Args) > 0 {
 		keys := make([]string, 0, len(m.sess.ActiveSkill.Args))
 		for key := range m.sess.ActiveSkill.Args {
@@ -2365,7 +2372,7 @@ func (m model) renderActiveSkillBanner() string {
 		for _, key := range keys {
 			pairs = append(pairs, fmt.Sprintf("%s=%s", key, m.sess.ActiveSkill.Args[key]))
 		}
-		line += " | args: " + strings.Join(pairs, ", ")
+		line += " | 参数：" + strings.Join(pairs, ", ")
 	}
 
 	width := max(24, m.chatPanelInnerWidth())
@@ -2385,7 +2392,7 @@ func (m model) renderStatusBarWithWidth(width int) string {
 		"Mode: " + strings.ToUpper(string(m.mode)),
 		"Phase: " + m.currentPhaseLabel(),
 		"Step: " + stepTitle,
-		"Skill: " + m.currentSkillLabel(),
+		"技能: " + m.currentSkillLabel(),
 	}, "  |  ")
 	right := strings.Join([]string{
 		fmt.Sprintf("%d msgs", len(m.chatItems)),
@@ -3014,28 +3021,28 @@ func (m *model) runSkillsListCommand(input string) error {
 
 	lines := make([]string, 0, len(skillsList)+8)
 	if hasActive {
-		lines = append(lines, fmt.Sprintf("Active skill: %s (%s)", active.Name, active.Scope))
+		lines = append(lines, fmt.Sprintf("当前激活技能：%s（%s）", active.Name, active.Scope))
 	} else {
-		lines = append(lines, "Active skill: none")
+		lines = append(lines, "当前激活技能：无")
 	}
 	lines = append(lines, "")
 	if len(skillsList) == 0 {
-		lines = append(lines, "No skills discovered.")
+		lines = append(lines, "未发现可用技能。")
 	} else {
-		lines = append(lines, "Available skills:")
+		lines = append(lines, "可用技能：")
 		for _, skill := range skillsList {
 			lines = append(lines, fmt.Sprintf("- %s (%s): %s", skill.Name, skill.Scope, skill.Description))
 		}
 	}
 	if len(diagnostics) > 0 {
-		lines = append(lines, "", "Diagnostics:")
+		lines = append(lines, "", "诊断信息：")
 		for _, diag := range diagnostics {
 			lines = append(lines, fmt.Sprintf("- [%s] %s (%s): %s", diag.Level, diag.Skill, diag.Path, diag.Message))
 		}
 	}
 
 	m.appendCommandExchange(input, strings.Join(lines, "\n"))
-	m.statusNote = fmt.Sprintf("Discovered %d skill(s).", len(skillsList))
+	m.statusNote = fmt.Sprintf("已发现 %d 个技能。", len(skillsList))
 	return nil
 }
 
@@ -3043,15 +3050,118 @@ func (m *model) runSkillCommand(input string, fields []string) error {
 	if m.runner == nil {
 		return fmt.Errorf("runner is unavailable")
 	}
-	if len(fields) != 2 || fields[1] != "clear" {
-		return fmt.Errorf("usage: /skill clear")
+	if len(fields) < 2 {
+		return fmt.Errorf("用法：/skill <author|clear|delete> ...")
+	}
+	switch strings.ToLower(strings.TrimSpace(fields[1])) {
+	case "author":
+		return m.runSkillAuthorCommand(input, fields)
+	case "clear":
+		return m.runSkillStateClearCommand(input, fields)
+	case "delete":
+		return m.runSkillDeleteCommand(input, fields)
+	default:
+		return fmt.Errorf("用法：/skill <author|clear|delete> ...")
+	}
+}
+
+func (m *model) runSkillAuthorCommand(input string, fields []string) error {
+	if len(fields) == 2 {
+		m.skillAuthorMode = true
+		m.skillAuthorName = ""
+		m.syncInputStyle()
+		m.appendCommandExchange(input, strings.Join([]string{
+			"已进入技能编辑模式。",
+			"阶段 1/2（设置名称）：请先只输入技能名称，例如 `review-plus`。",
+			"阶段 2/2（编辑内容）：名称设置完成后，再输入技能内容与要求。",
+			"输入 `/skill author done` 可退出编辑模式。",
+		}, "\n"))
+		m.statusNote = "技能编辑模式：阶段 1/2（设置名称）"
+		return nil
 	}
 
+	control := strings.ToLower(strings.TrimSpace(fields[2]))
+	if len(fields) == 3 && (control == "done" || control == "exit" || control == "cancel") {
+		m.skillAuthorMode = false
+		m.skillAuthorName = ""
+		m.syncInputStyle()
+		m.appendCommandExchange(input, "已退出技能编辑模式。")
+		m.statusNote = "技能编辑模式已关闭"
+		return nil
+	}
+
+	name, brief, err := parseSkillAuthorArgs(fields)
+	if err != nil {
+		return err
+	}
+	response, err := m.authorSkill(name, brief)
+	if err != nil {
+		return err
+	}
+	m.skillAuthorMode = true
+	m.skillAuthorName = name
+	m.syncInputStyle()
+
+	m.appendCommandExchange(input, response+"\n当前已锁定技能：`"+name+"`。\n现在是阶段 2/2（编辑内容），请继续输入技能内容。")
+	m.statusNote = "技能编辑模式：阶段 2/2（编辑内容）"
+	return nil
+}
+
+func (m *model) runSkillStateClearCommand(input string, fields []string) error {
+	if len(fields) != 2 {
+		return fmt.Errorf("用法：/skill clear")
+	}
+
+	activeName := ""
+	if m.sess != nil && m.sess.ActiveSkill != nil {
+		activeName = strings.TrimSpace(m.sess.ActiveSkill.Name)
+	}
 	if err := m.runner.ClearActiveSkill(m.sess); err != nil {
 		return err
 	}
-	m.appendCommandExchange(input, "Active skill cleared.")
-	m.statusNote = "Skill cleared."
+
+	message := "当前会话没有激活技能，状态已保持为空。"
+	if activeName != "" {
+		message = fmt.Sprintf("已清除当前会话激活技能 `%s`。", activeName)
+	}
+	m.appendCommandExchange(input, message)
+	m.statusNote = "技能状态已清空"
+	return nil
+}
+
+func (m *model) runSkillDeleteCommand(input string, fields []string) error {
+	if len(fields) < 3 {
+		return fmt.Errorf("用法：/skill delete <name>")
+	}
+	name := strings.TrimSpace(strings.TrimPrefix(fields[2], "/"))
+	if name == "" {
+		return fmt.Errorf("用法：/skill delete <name>")
+	}
+
+	result, err := m.runner.ClearSkill(name)
+	if err != nil {
+		return err
+	}
+
+	lines := []string{
+		fmt.Sprintf("已删除项目技能 `%s`。", result.Name),
+		fmt.Sprintf("目录：%s", result.Dir),
+	}
+
+	if m.sess != nil && m.sess.ActiveSkill != nil && strings.EqualFold(strings.TrimSpace(m.sess.ActiveSkill.Name), strings.TrimSpace(result.Name)) {
+		if clearErr := m.runner.ClearActiveSkill(m.sess); clearErr == nil {
+			lines = append(lines, "当前会话中的激活技能已一并清除。")
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(m.skillAuthorName), strings.TrimSpace(result.Name)) {
+		m.skillAuthorName = ""
+		m.skillAuthorMode = false
+		m.syncInputStyle()
+		lines = append(lines, "目标技能已删除，技能编辑模式已自动关闭。")
+	}
+
+	m.appendCommandExchange(input, strings.Join(lines, "\n"))
+	m.statusNote = "技能已删除"
 	return nil
 }
 
@@ -3078,7 +3188,7 @@ func (m *model) activateSkillCommand(input, name string, args map[string]string)
 	if err != nil {
 		return err
 	}
-	response := fmt.Sprintf("Activated skill `%s` (%s).\nTool policy: %s\nEntry: %s", skill.Name, skill.Scope, skill.ToolPolicy.Policy, skill.Entry.Slash)
+	response := fmt.Sprintf("已激活技能 `%s`（%s）。\n工具策略：%s\n命令入口：%s", skill.Name, skill.Scope, skill.ToolPolicy.Policy, skill.Entry.Slash)
 	if len(args) > 0 {
 		argParts := make([]string, 0, len(args))
 		keys := make([]string, 0, len(args))
@@ -3089,10 +3199,10 @@ func (m *model) activateSkillCommand(input, name string, args map[string]string)
 		for _, key := range keys {
 			argParts = append(argParts, fmt.Sprintf("%s=%s", key, args[key]))
 		}
-		response += "\nArgs: " + strings.Join(argParts, ", ")
+		response += "\n参数：" + strings.Join(argParts, ", ")
 	}
 	m.appendCommandExchange(input, response)
-	m.statusNote = "Skill activated."
+	m.statusNote = "技能已激活"
 	return nil
 }
 
@@ -3104,12 +3214,12 @@ func parseSkillArgs(parts []string) (map[string]string, error) {
 	for _, part := range parts {
 		pieces := strings.SplitN(part, "=", 2)
 		if len(pieces) != 2 {
-			return nil, fmt.Errorf("invalid skill arg %q, expected k=v", part)
+			return nil, fmt.Errorf("技能参数 %q 格式错误，应为 k=v", part)
 		}
 		key := strings.TrimSpace(pieces[0])
 		value := strings.TrimSpace(pieces[1])
 		if key == "" || value == "" {
-			return nil, fmt.Errorf("invalid skill arg %q, expected k=v", part)
+			return nil, fmt.Errorf("技能参数 %q 格式错误，应为 k=v", part)
 		}
 		args[key] = value
 	}
@@ -3117,6 +3227,147 @@ func parseSkillArgs(parts []string) (map[string]string, error) {
 		return nil, nil
 	}
 	return args, nil
+}
+
+func parseSkillAuthorArgs(fields []string) (string, string, error) {
+	if len(fields) < 3 {
+		return "", "", fmt.Errorf("用法：/skill author [name]")
+	}
+	name := strings.TrimSpace(strings.TrimPrefix(fields[2], "/"))
+	if name == "" {
+		return "", "", fmt.Errorf("用法：/skill author [name]")
+	}
+	brief := strings.TrimSpace(strings.Join(fields[3:], " "))
+	return name, brief, nil
+}
+
+func parseSkillAuthorModeInput(value string) (string, string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", "", fmt.Errorf("请先输入技能名称（只输入名称，不要带内容）")
+	}
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return "", "", fmt.Errorf("请先输入技能名称（只输入名称，不要带内容）")
+	}
+	if len(fields) > 1 {
+		return "", "", fmt.Errorf("当前是阶段 1/2：请先只输入技能名称。例如：review-plus")
+	}
+	name := strings.TrimSpace(strings.TrimPrefix(fields[0], "/"))
+	if !isValidSkillAuthorName(name) {
+		return "", "", fmt.Errorf("技能名称不合法：仅支持字母、数字和 . _ : -，例如 `review-plus`")
+	}
+	brief := strings.TrimSpace(strings.TrimPrefix(value, fields[0]))
+	return name, brief, nil
+}
+
+func isValidSkillAuthorName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+
+	runes := []rune(name)
+	for i, r := range runes {
+		isASCIIAlpha := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isASCIIDigit := r >= '0' && r <= '9'
+		if isASCIIAlpha || isASCIIDigit {
+			continue
+		}
+		if i > 0 && (r == '.' || r == '_' || r == ':' || r == '-') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func (m model) submitSkillAuthorInput(value string) (tea.Model, tea.Cmd) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return m, nil
+	}
+	m.input.Reset()
+
+	name := strings.TrimSpace(m.skillAuthorName)
+	brief := value
+	if name == "" {
+		var err error
+		name, brief, err = parseSkillAuthorModeInput(value)
+		if err != nil {
+			m.statusNote = err.Error()
+			m.appendCommandExchange(value, "技能编辑模式提示：\n"+err.Error())
+			return m, nil
+		}
+		response, err := m.authorSkill(name, "")
+		if err != nil {
+			m.statusNote = err.Error()
+			m.appendCommandExchange(value, "技能编辑模式提示：\n"+err.Error())
+			return m, nil
+		}
+		m.skillAuthorMode = true
+		m.skillAuthorName = name
+		m.syncInputStyle()
+		response += "\n已进入阶段 2/2（编辑内容）。\n请继续输入该技能的内容与要求；输入 `/skill author done` 退出。"
+		m.appendCommandExchange(value, response)
+		m.statusNote = "技能编辑模式：阶段 2/2（编辑内容）"
+		return m, m.loadSessionsCmd()
+	}
+
+	response, err := m.authorSkill(name, brief)
+	if err != nil {
+		m.statusNote = err.Error()
+		m.appendCommandExchange(value, "技能编辑模式提示：\n"+err.Error())
+		return m, nil
+	}
+
+	m.skillAuthorMode = true
+	m.skillAuthorName = name
+	m.syncInputStyle()
+	response += "\n当前阶段：2/2（编辑内容）。继续输入可持续优化；输入 `/skill author done` 退出。"
+	m.appendCommandExchange(value, response)
+	m.statusNote = "技能编辑模式：阶段 2/2（编辑内容）"
+	return m, m.loadSessionsCmd()
+}
+
+func (m *model) authorSkill(name, brief string) (string, error) {
+	result, err := m.runner.AuthorSkill(name, brief)
+	if err != nil {
+		return "", err
+	}
+
+	state := "updated"
+	if result.Created {
+		state = "已创建"
+	} else {
+		state = "已更新"
+	}
+	lines := []string{
+		fmt.Sprintf("技能 `%s` %s。", result.Name, state),
+		fmt.Sprintf("目录：%s", result.Dir),
+		fmt.Sprintf("配置文件：%s", result.ManifestPath),
+		fmt.Sprintf("说明文件：%s", result.SkillPath),
+		fmt.Sprintf("可通过 `/%s` 激活该技能。", result.Name),
+	}
+	if strings.TrimSpace(brief) == "" {
+		lines = append(lines, "下一步：请用自然语言描述技能内容，我会继续优化生成文件。")
+	}
+
+	skillsList, diagnostics := m.runner.ListSkills()
+	for _, skill := range skillsList {
+		if !strings.EqualFold(strings.TrimSpace(skill.Name), strings.TrimSpace(result.Name)) {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("当前解析结果：`%s`（%s）。", skill.Name, skill.Scope))
+		break
+	}
+	for _, diag := range diagnostics {
+		if !strings.EqualFold(strings.TrimSpace(diag.Skill), strings.TrimSpace(result.Name)) {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("诊断 [%s] %s：%s", diag.Level, diag.Path, diag.Message))
+	}
+	return strings.Join(lines, "\n"), nil
 }
 
 func (m *model) appendCommandExchange(command, response string) {
@@ -3162,9 +3413,12 @@ func (m *model) newSession() error {
 	m.pendingBTW = nil
 	m.interrupting = false
 	m.interruptSafe = false
+	m.skillAuthorMode = false
+	m.skillAuthorName = ""
 	m.runCancel = nil
 	m.activeRunID = 0
 	m.input.Reset()
+	m.syncInputStyle()
 	if m.width > 0 && m.height > 0 {
 		m.syncLayoutForCurrentScreen()
 		m.refreshViewport()
@@ -3205,8 +3459,11 @@ func (m *model) resumeSession(prefix string) error {
 	m.pendingBTW = nil
 	m.interrupting = false
 	m.interruptSafe = false
+	m.skillAuthorMode = false
+	m.skillAuthorName = ""
 	m.runCancel = nil
 	m.activeRunID = 0
+	m.syncInputStyle()
 	if m.width > 0 && m.height > 0 {
 		m.syncLayoutForCurrentScreen()
 		m.refreshViewport()
@@ -4424,7 +4681,7 @@ func (m model) skillCommandItems() []commandItem {
 
 		description := strings.TrimSpace(skill.Description)
 		if description == "" {
-			description = fmt.Sprintf("Activate %s for this session.", skill.Name)
+			description = fmt.Sprintf("在当前会话激活 %s。", skill.Name)
 		}
 		items = append(items, commandItem{
 			Name:        name,
@@ -4505,7 +4762,7 @@ func shouldExecuteFromPalette(item commandItem) bool {
 		return true
 	}
 	switch item.Name {
-	case "/help", "/session", "/skills", "/skill clear", "/new", "/quit":
+	case "/help", "/session", "/skills", "/skill author", "/skill clear", "/new", "/quit":
 		return true
 	default:
 		return false
@@ -4522,9 +4779,13 @@ func (m model) helpText() string {
 		"Slash commands",
 		"/help: show this help inside the conversation.",
 		"/session: open recent sessions.",
-		"/skills: list discovered skills and diagnostics.",
-		"/<skill-name> [k=v...]: activate a skill for this session.",
-		"/skill clear: clear the active skill.",
+		"/skills: 查看可用技能和诊断信息。",
+		"/<skill-name> [k=v...]: 在当前会话激活技能。",
+		"/skill author: 进入技能编辑模式（先设置名称，再编辑内容）。",
+		"/skill author [name]: 直接创建/更新该技能并进入编辑阶段。",
+		"/skill author done: 退出技能编辑模式。",
+		"/skill clear: 清除当前会话的激活技能状态。",
+		"/skill delete <name>: 删除项目里的指定技能。",
 		"/new: start a fresh session.",
 		"/btw <message>: interject while a run is in progress.",
 		"/quit: exit the TUI.",
@@ -4689,11 +4950,30 @@ func (m model) modeAccentColor() lipgloss.Color {
 func (m *model) syncInputStyle() {
 	if m.startupGuide.Active {
 		m.input.Placeholder = startupGuideInputPlaceholder(m.startupGuide.CurrentField)
+	} else if m.skillAuthorMode {
+		m.input.Placeholder = m.skillAuthorInputPlaceholder()
 	} else {
 		m.input.Placeholder = "Ask Bytemind to inspect, change, or verify this workspace..."
 	}
 	m.input.Prompt = ""
-	m.input.SetHeight(2)
+	setInputHeightSafe(&m.input, 2)
+}
+
+func (m model) skillAuthorInputPlaceholder() string {
+	if strings.TrimSpace(m.skillAuthorName) == "" {
+		return "技能编辑模式 阶段 1/2：请输入技能名称（仅名称），例如：review-plus"
+	}
+	return "技能编辑模式 阶段 2/2（" + strings.TrimSpace(m.skillAuthorName) + "）：请输入技能内容与要求..."
+}
+
+func setInputHeightSafe(input *textarea.Model, height int) {
+	if input == nil {
+		return
+	}
+	defer func() {
+		_ = recover()
+	}()
+	input.SetHeight(height)
 }
 
 func startupGuideInputHint(field string) string {
@@ -4927,11 +5207,11 @@ func (m model) currentModelLabel() string {
 
 func (m model) currentSkillLabel() string {
 	if m.sess == nil || m.sess.ActiveSkill == nil {
-		return "none"
+		return "无"
 	}
 	name := strings.TrimSpace(m.sess.ActiveSkill.Name)
 	if name == "" {
-		return "none"
+		return "无"
 	}
 	return name
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -186,15 +186,23 @@ type tokenUsagePulledMsg struct {
 }
 
 var commandItems = []commandItem{
-	{Name: "/help", Usage: "/help", Description: "Show usage and supported commands.", Kind: "command"},
-	{Name: "/session", Usage: "/session", Description: "Open the recent session list.", Kind: "command"},
-	{Name: "/new", Usage: "/new", Description: "Start a fresh session in this workspace.", Kind: "command"},
-	{Name: "/btw", Usage: "/btw <message>", Description: "Interject while a run is in progress.", Kind: "command"},
-	{Name: "/quit", Usage: "/quit", Description: "Exit the current TUI window.", Kind: "command"},
+	{Name: "/help", Usage: "/help", Description: "显示用法和支持的命令。", Kind: "command"},
+	{Name: "/session", Usage: "/session", Description: "打开最近会话列表。", Kind: "command"},
+	{Name: "/new", Usage: "/new", Description: "在当前工作区创建新会话。", Kind: "command"},
+	{Name: "/btw", Usage: "/btw <message>", Description: "在运行中插入一条补充指令。", Kind: "command"},
+	{Name: "/quit", Usage: "/quit", Description: "退出当前 TUI 窗口。", Kind: "command"},
 	{Name: "/skills", Usage: "/skills", Description: "查看可用技能与当前激活技能。", Kind: "command"},
 	{Name: "/skill author", Usage: "/skill author [name]", Description: "进入技能编辑模式并创建/更新模板。", Kind: "command"},
 	{Name: "/skill clear", Usage: "/skill clear", Description: "清除当前会话的激活技能状态。", Kind: "command"},
 	{Name: "/skill delete", Usage: "/skill delete <name>", Description: "删除项目里的指定技能。", Kind: "command"},
+}
+
+var builtinSkillDescriptionsCN = map[string]string{
+	"bug-investigation": "通过可复现证据定位并分析问题，再提出修复方案。",
+	"github-pr":         "基于证据分析 PR 差异、评审意见与合并风险。",
+	"repo-onboarding":   "快速建立对仓库结构、入口与运行流程的整体理解。",
+	"review":            "以正确性、回归风险和测试缺口为重点进行代码评审。",
+	"write-rfc":         "产出结构化技术方案，明确权衡取舍与发布计划。",
 }
 
 type model struct {
@@ -2913,7 +2921,7 @@ func (m model) renderCommandPalette() string {
 	for len(rows) < commandPageSize {
 		rows = append(rows, commandPaletteRowStyle.Width(max(1, width-commandPaletteStyle.GetHorizontalFrameSize())).Render(""))
 	}
-	rows = append(rows, commandPaletteMetaStyle.Render("Up/Down move  PgUp/PgDn page  Enter run  Esc close"))
+	rows = append(rows, commandPaletteMetaStyle.Render("上/下 移动  PgUp/PgDn 翻页  Enter 执行  Esc 关闭"))
 	return commandPaletteStyle.Width(width).Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
 }
 
@@ -3031,7 +3039,8 @@ func (m *model) runSkillsListCommand(input string) error {
 	} else {
 		lines = append(lines, "可用技能：")
 		for _, skill := range skillsList {
-			lines = append(lines, fmt.Sprintf("- %s (%s): %s", skill.Name, skill.Scope, skill.Description))
+			description := localizedSkillDescriptionForTUI(skill.Name, string(skill.Scope), skill.Description)
+			lines = append(lines, fmt.Sprintf("- %s (%s): %s", skill.Name, skill.Scope, description))
 		}
 	}
 	if len(diagnostics) > 0 {
@@ -4680,7 +4689,7 @@ func (m model) skillCommandItems() []commandItem {
 		}
 		seen[key] = struct{}{}
 
-		description := strings.TrimSpace(skill.Description)
+		description := localizedSkillDescriptionForTUI(skill.Name, string(skill.Scope), skill.Description)
 		if description == "" {
 			description = fmt.Sprintf("在当前会话激活 %s。", skill.Name)
 		}
@@ -4695,6 +4704,18 @@ func (m model) skillCommandItems() []commandItem {
 		return items[i].Usage < items[j].Usage
 	})
 	return items
+}
+
+func localizedSkillDescriptionForTUI(name, scope, fallback string) string {
+	fallback = strings.TrimSpace(fallback)
+	if !strings.EqualFold(strings.TrimSpace(scope), "builtin") {
+		return fallback
+	}
+	key := strings.ToLower(strings.TrimSpace(name))
+	if localized, ok := builtinSkillDescriptionsCN[key]; ok {
+		return localized
+	}
+	return fallback
 }
 
 func (m model) commandPaletteWidth() int {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4403,6 +4403,21 @@ func TestThinkingFilters(t *testing.T) {
 	}
 }
 
+func TestCurrentSkillLabelBranches(t *testing.T) {
+	m := model{}
+	if got := m.currentSkillLabel(); got != "无" {
+		t.Fatalf("expected 无 for nil session, got %q", got)
+	}
+	m.sess = &session.Session{ActiveSkill: &session.ActiveSkill{}}
+	if got := m.currentSkillLabel(); got != "无" {
+		t.Fatalf("expected 无 for blank skill name, got %q", got)
+	}
+	m.sess.ActiveSkill.Name = "review"
+	if got := m.currentSkillLabel(); got != "review" {
+		t.Fatalf("expected active skill name, got %q", got)
+	}
+}
+
 func containsString(items []string, target string) bool {
 	for _, item := range items {
 		if item == target {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4389,6 +4389,12 @@ func TestThinkingFilters(t *testing.T) {
 	if !shouldRenderThinkingFromDelta("First, I will inspect the failing branch and then patch tests.") {
 		t.Fatalf("expected structured reasoning marker to trigger thinking rendering")
 	}
+	if isMeaningfulThinking("我会调用 read_file 先检查相关上下文。", "read_file") {
+		t.Fatalf("expected generic Chinese tool-intent phrase not to be treated as meaningful thinking")
+	}
+	if !shouldRenderThinkingFromDelta("我会先检查失败分支，然后补充测试。") {
+		t.Fatalf("expected Chinese structured reasoning marker to trigger thinking rendering")
+	}
 }
 
 func containsString(items []string, target string) bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1816,6 +1816,9 @@ func TestHandleSlashSkillsListsDiscoveredSkills(t *testing.T) {
 	if !strings.Contains(m.chatItems[len(m.chatItems)-1].Body, "review") {
 		t.Fatalf("expected skills output to contain review, got %q", m.chatItems[len(m.chatItems)-1].Body)
 	}
+	if !strings.Contains(m.chatItems[len(m.chatItems)-1].Body, "以正确性、回归风险和测试缺口为重点进行代码评审。") {
+		t.Fatalf("expected builtin review description to be localized in /skills output, got %q", m.chatItems[len(m.chatItems)-1].Body)
+	}
 }
 
 func TestHandleSlashSkillActivateAndSwitch(t *testing.T) {
@@ -2210,6 +2213,9 @@ func TestFilteredCommandsIncludeSkillSlashCommands(t *testing.T) {
 	found := false
 	for _, item := range items {
 		if item.Name == "/review" && item.Kind == "skill" {
+			if !strings.Contains(item.Description, "以正确性、回归风险和测试缺口为重点进行代码评审。") {
+				t.Fatalf("expected /review command description localized in command palette, got %+v", item)
+			}
 			found = true
 			break
 		}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1542,6 +1542,9 @@ func TestHelpTextOnlyMentionsSupportedEntryPoints(t *testing.T) {
 		"go run ./cmd/bytemind chat",
 		"go run ./cmd/bytemind run -prompt",
 		"/session",
+		"/skill author",
+		"/skill clear",
+		"/skill delete <name>",
 		"/quit",
 		"/new",
 		"Ctrl+G",
@@ -1802,6 +1805,7 @@ func TestHandleSlashSkillsListsDiscoveredSkills(t *testing.T) {
 		sess:      sess,
 		workspace: workspace,
 		screen:    screenChat,
+		input:     textarea.New(),
 	}
 	if err := m.handleSlashCommand("/skills"); err != nil {
 		t.Fatalf("expected /skills to succeed, got %v", err)
@@ -1814,7 +1818,7 @@ func TestHandleSlashSkillsListsDiscoveredSkills(t *testing.T) {
 	}
 }
 
-func TestHandleSlashSkillActivateAndClear(t *testing.T) {
+func TestHandleSlashSkillActivateAndSwitch(t *testing.T) {
 	workspace := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(workspace, "internal", "skills", "bug-investigation"), 0o755); err != nil {
 		t.Fatal(err)
@@ -1861,6 +1865,7 @@ func TestHandleSlashSkillActivateAndClear(t *testing.T) {
 		sess:      sess,
 		workspace: workspace,
 		screen:    screenChat,
+		input:     textarea.New(),
 	}
 	if err := m.handleSlashCommand("/bug-investigation"); err != nil {
 		t.Fatalf("expected /bug-investigation to succeed, got %v", err)
@@ -1877,11 +1882,290 @@ func TestHandleSlashSkillActivateAndClear(t *testing.T) {
 	if got := m.sess.ActiveSkill.Args["severity"]; got != "high" {
 		t.Fatalf("expected skill arg severity=high, got %q", got)
 	}
+}
+
+func TestHandleSlashSkillAuthorCreatesProjectSkill(t *testing.T) {
+	workspace := t.TempDir()
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	runner := agent.NewRunner(agent.Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+		},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+	})
+
+	m := model{
+		runner:    runner,
+		store:     store,
+		sess:      sess,
+		workspace: workspace,
+		screen:    screenChat,
+		input:     textarea.New(),
+	}
+
+	if err := m.handleSlashCommand("/skill author review-plus review backend changes and report risks"); err != nil {
+		t.Fatalf("expected /skill author to succeed, got %v", err)
+	}
+
+	skillDir := filepath.Join(workspace, ".bytemind", "skills", "review-plus")
+	if _, err := os.Stat(filepath.Join(skillDir, "skill.json")); err != nil {
+		t.Fatalf("expected generated skill.json, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
+		t.Fatalf("expected generated SKILL.md, got %v", err)
+	}
+
+	if len(m.chatItems) < 2 {
+		t.Fatalf("expected command exchange in chat, got %#v", m.chatItems)
+	}
+	response := m.chatItems[len(m.chatItems)-1].Body
+	if !strings.Contains(response, "技能 `review-plus`") {
+		t.Fatalf("expected response to reference authored skill, got %q", response)
+	}
+	if !strings.Contains(response, "可通过 `/review-plus` 激活") {
+		t.Fatalf("expected response to include activation hint, got %q", response)
+	}
+
+	if err := m.handleSlashCommand("/review-plus"); err != nil {
+		t.Fatalf("expected /review-plus activation to succeed, got %v", err)
+	}
+	if m.sess.ActiveSkill == nil || m.sess.ActiveSkill.Name != "review-plus" {
+		t.Fatalf("expected active skill review-plus, got %#v", m.sess.ActiveSkill)
+	}
+}
+
+func TestHandleSlashSkillDeleteDeletesProjectSkill(t *testing.T) {
+	workspace := t.TempDir()
+	skillDir := filepath.Join(workspace, ".bytemind", "skills", "review-plus")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.json"), []byte(`{"name":"review-plus","description":"review"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# review-plus"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	runner := agent.NewRunner(agent.Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+		},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+	})
+
+	m := model{
+		runner:    runner,
+		store:     store,
+		sess:      sess,
+		workspace: workspace,
+		screen:    screenChat,
+		input:     textarea.New(),
+	}
+
+	if _, err := runner.ActivateSkill(sess, "/review-plus", nil); err != nil {
+		t.Fatalf("expected activate before clear, got %v", err)
+	}
+	if err := m.handleSlashCommand("/skill delete review-plus"); err != nil {
+		t.Fatalf("expected /skill delete to succeed, got %v", err)
+	}
+	if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+		t.Fatalf("expected skill directory removed, stat err=%v", err)
+	}
+	if m.sess.ActiveSkill != nil {
+		t.Fatalf("expected active skill cleared, got %#v", m.sess.ActiveSkill)
+	}
+	if len(m.chatItems) < 2 || !strings.Contains(m.chatItems[len(m.chatItems)-1].Body, "已删除项目技能") {
+		t.Fatalf("expected clear command response, got %#v", m.chatItems)
+	}
+}
+
+func TestHandleSlashSkillClearOnlyClearsActiveSkill(t *testing.T) {
+	workspace := t.TempDir()
+	skillDir := filepath.Join(workspace, ".bytemind", "skills", "review-plus")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.json"), []byte(`{"name":"review-plus","description":"review"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# review-plus"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	runner := agent.NewRunner(agent.Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+		},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+	})
+
+	m := model{
+		runner:    runner,
+		store:     store,
+		sess:      sess,
+		workspace: workspace,
+		screen:    screenChat,
+		input:     textarea.New(),
+	}
+
+	if _, err := runner.ActivateSkill(sess, "/review-plus", nil); err != nil {
+		t.Fatalf("expected activate before clear, got %v", err)
+	}
 	if err := m.handleSlashCommand("/skill clear"); err != nil {
 		t.Fatalf("expected /skill clear to succeed, got %v", err)
 	}
+	if _, err := os.Stat(skillDir); err != nil {
+		t.Fatalf("expected skill directory to remain after clear, got %v", err)
+	}
 	if m.sess.ActiveSkill != nil {
-		t.Fatalf("expected active skill to be cleared, got %#v", m.sess.ActiveSkill)
+		t.Fatalf("expected active skill cleared, got %#v", m.sess.ActiveSkill)
+	}
+	if len(m.chatItems) < 2 || !strings.Contains(m.chatItems[len(m.chatItems)-1].Body, "已清除当前会话激活技能") {
+		t.Fatalf("expected clear status response, got %#v", m.chatItems)
+	}
+}
+
+func TestHandleSlashSkillAuthorWithoutNameEntersAuthorMode(t *testing.T) {
+	workspace := t.TempDir()
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	runner := agent.NewRunner(agent.Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+		},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+	})
+
+	input := textarea.New()
+	m := model{
+		runner:    runner,
+		store:     store,
+		sess:      sess,
+		workspace: workspace,
+		screen:    screenChat,
+		input:     input,
+	}
+
+	if err := m.handleSlashCommand("/skill author"); err != nil {
+		t.Fatalf("expected /skill author to enable mode, got %v", err)
+	}
+	if !m.skillAuthorMode {
+		t.Fatalf("expected skillAuthorMode enabled")
+	}
+	if strings.TrimSpace(m.skillAuthorName) != "" {
+		t.Fatalf("expected no skillAuthorName yet, got %q", m.skillAuthorName)
+	}
+	if !strings.Contains(m.input.Placeholder, "阶段 1/2") {
+		t.Fatalf("expected author-mode placeholder, got %q", m.input.Placeholder)
+	}
+
+	m.input.SetValue("review-ops")
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if !updated.skillAuthorMode {
+		t.Fatalf("expected author mode to stay active")
+	}
+	if updated.skillAuthorName != "review-ops" {
+		t.Fatalf("expected target skill name review-ops, got %q", updated.skillAuthorName)
+	}
+	if !strings.Contains(updated.input.Placeholder, "阶段 2/2") || !strings.Contains(updated.input.Placeholder, "review-ops") {
+		t.Fatalf("expected author-mode placeholder to track skill name, got %q", updated.input.Placeholder)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".bytemind", "skills", "review-ops", "skill.json")); err != nil {
+		t.Fatalf("expected generated skill scaffold, got %v", err)
+	}
+
+	updated.input.SetValue("用于代码评审，优先关注回归风险和测试缺口。")
+	next, _ := updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated2 := next.(model)
+	if !updated2.skillAuthorMode {
+		t.Fatalf("expected author mode to stay active after content update")
+	}
+	if !strings.Contains(updated2.chatItems[len(updated2.chatItems)-1].Body, "2/2（编辑内容）") {
+		t.Fatalf("expected stage 2 guidance after content update, got %q", updated2.chatItems[len(updated2.chatItems)-1].Body)
+	}
+
+	if err := updated2.handleSlashCommand("/skill author done"); err != nil {
+		t.Fatalf("expected /skill author done to exit mode, got %v", err)
+	}
+	if updated2.skillAuthorMode {
+		t.Fatalf("expected skillAuthorMode disabled")
+	}
+}
+
+func TestSkillAuthorModeShowsVisibleGuidanceOnInvalidName(t *testing.T) {
+	workspace := t.TempDir()
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	runner := agent.NewRunner(agent.Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+		},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+	})
+
+	input := textarea.New()
+	m := model{
+		runner:    runner,
+		store:     store,
+		sess:      sess,
+		workspace: workspace,
+		screen:    screenChat,
+		input:     input,
+	}
+
+	if err := m.handleSlashCommand("/skill author"); err != nil {
+		t.Fatalf("expected /skill author to enable mode, got %v", err)
+	}
+
+	m.input.SetValue("我想做一个评审技能")
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if !updated.skillAuthorMode {
+		t.Fatalf("expected author mode to remain enabled")
+	}
+	if len(updated.chatItems) < 2 {
+		t.Fatalf("expected visible assistant guidance, got %#v", updated.chatItems)
+	}
+	body := updated.chatItems[len(updated.chatItems)-1].Body
+	if !strings.Contains(body, "技能名称不合法") {
+		t.Fatalf("expected invalid-name guidance in chat, got %q", body)
 	}
 }
 
@@ -2843,7 +3127,7 @@ func TestRenderFooterShowsActiveSkillBanner(t *testing.T) {
 	}
 
 	footer := m.renderFooter()
-	if !strings.Contains(footer, "Active skill: review") {
+	if !strings.Contains(footer, "当前激活技能：review") {
 		t.Fatalf("expected footer to show active skill banner, got %q", footer)
 	}
 	if !strings.Contains(footer, "severity=high") {

--- a/internal/tui/model_web_tool_summary_test.go
+++ b/internal/tui/model_web_tool_summary_test.go
@@ -39,12 +39,12 @@ func TestSummarizeToolForWebSearchAndWebFetch(t *testing.T) {
 
 func TestCurrentSkillLabelBranches(t *testing.T) {
 	m := model{}
-	if got := m.currentSkillLabel(); got != "none" {
-		t.Fatalf("expected none for nil session, got %q", got)
+	if got := m.currentSkillLabel(); got != "无" {
+		t.Fatalf("expected 无 for nil session, got %q", got)
 	}
 	m.sess = &session.Session{ActiveSkill: &session.ActiveSkill{}}
-	if got := m.currentSkillLabel(); got != "none" {
-		t.Fatalf("expected none for blank skill name, got %q", got)
+	if got := m.currentSkillLabel(); got != "无" {
+		t.Fatalf("expected 无 for blank skill name, got %q", got)
 	}
 	m.sess.ActiveSkill.Name = "review"
 	if got := m.currentSkillLabel(); got != "review" {

--- a/internal/tui/model_web_tool_summary_test.go
+++ b/internal/tui/model_web_tool_summary_test.go
@@ -3,8 +3,6 @@ package tui
 import (
 	"strings"
 	"testing"
-
-	"bytemind/internal/session"
 )
 
 func TestSummarizeToolForWebSearchAndWebFetch(t *testing.T) {
@@ -37,17 +35,3 @@ func TestSummarizeToolForWebSearchAndWebFetch(t *testing.T) {
 	}
 }
 
-func TestCurrentSkillLabelBranches(t *testing.T) {
-	m := model{}
-	if got := m.currentSkillLabel(); got != "无" {
-		t.Fatalf("expected 无 for nil session, got %q", got)
-	}
-	m.sess = &session.Session{ActiveSkill: &session.ActiveSkill{}}
-	if got := m.currentSkillLabel(); got != "无" {
-		t.Fatalf("expected 无 for blank skill name, got %q", got)
-	}
-	m.sess.ActiveSkill.Name = "review"
-	if got := m.currentSkillLabel(); got != "review" {
-		t.Fatalf("expected active skill name, got %q", got)
-	}
-}


### PR DESCRIPTION
skill 命令语义重构完成。
/skill clear：只清空当前会话激活状态，不删文件。
/skill delete <name>：删除项目内指定 skill。
主要实现：model.go
skill author 编辑模式完善。
/skill author 进入两阶段编辑（先名称、后内容）。
/skill author done 退出模式。
修复“进入模式后无法输入”的交互问题（输入处理和占位提示）。
主要实现：model.go
TUI 的 skill 展示统一中文。
命令帮助、状态提示、激活反馈、active skill 横幅、参数错误提示等都改为中文。
主要实现：model.go
skill 后端内容统一英文。
后端删除错误文案改为 /skill delete：
clear.go
内置 skill 配置 description 全部改为英文：
review/skill.json
bug-investigation/skill.json
github-pr/skill.json
repo-onboarding/skill.json
write-rfc/skill.json
测试已同步并通过。
更新了 skill 相关单测断言与用例：
model_test.go
model_web_tool_summary_test.go
已执行通过：go test ./internal/tui ./internal/agent ./internal/skills