### PR TITLE
fix(tui): stabilize long-paste marker compression and chunk handling

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -1,0 +1,304 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"bytemind/internal/llm"
+	"bytemind/internal/session"
+)
+
+const (
+	autoCompactThresholdRatio    = 95
+	maxCompactionSummaryRunes    = 4000
+	maxCompactionTranscriptRunes = 48000
+	maxCompactionMessageRunes    = 1200
+)
+
+const compactionSystemPrompt = `You are a conversation compaction assistant for a coding agent.
+Create a concise continuation summary for the next model call.
+Preserve only durable, execution-relevant facts:
+- user goal and scope
+- decisions and constraints
+- completed work and remaining tasks
+- key file paths / commands / errors
+- unresolved questions
+
+Rules:
+- Do not invent facts.
+- Remove repetitive chatter and low-signal tool noise.
+- Keep the summary compact and actionable.`
+
+func (r *Runner) compactThresholdTokens() int {
+	quota := r.config.TokenQuota
+	if quota < 1 {
+		quota = 5000
+	}
+	threshold := quota * autoCompactThresholdRatio / 100
+	if threshold < 1 {
+		return 1
+	}
+	return threshold
+}
+
+func (r *Runner) maybeAutoCompactSession(ctx context.Context, sess *session.Session, promptTokens, requestTokens int) (bool, error) {
+	threshold := r.compactThresholdTokens()
+	if promptTokens >= threshold {
+		return false, fmt.Errorf("prompt too long (%d estimated tokens) for current context budget (%d). Try a shorter prompt or split it", promptTokens, threshold)
+	}
+	if requestTokens <= threshold {
+		return false, nil
+	}
+	_, changed, err := r.compactSession(ctx, sess, true, "auto")
+	if err != nil {
+		return false, err
+	}
+	return changed, nil
+}
+
+func (r *Runner) CompactSession(ctx context.Context, sess *session.Session) (string, bool, error) {
+	return r.compactSession(ctx, sess, false, "manual")
+}
+
+func (r *Runner) compactSession(ctx context.Context, sess *session.Session, keepLatestUser bool, reason string) (string, bool, error) {
+	if sess == nil {
+		return "", false, fmt.Errorf("session is required")
+	}
+	if r.client == nil {
+		return "", false, fmt.Errorf("llm client is unavailable")
+	}
+	if len(sess.Messages) < 2 {
+		return "", false, nil
+	}
+
+	messages := cloneMessages(sess.Messages)
+	latestUserIndex := -1
+	if keepLatestUser {
+		for i := len(messages) - 1; i >= 0; i-- {
+			if isHumanUserMessage(messages[i]) {
+				latestUserIndex = i
+				break
+			}
+		}
+	}
+
+	history := make([]llm.Message, 0, len(messages))
+	var preserved llm.Message
+	for i, message := range messages {
+		if i == latestUserIndex {
+			preserved = message
+			continue
+		}
+		history = append(history, message)
+	}
+	if len(history) == 0 {
+		return "", false, nil
+	}
+
+	summary, err := r.requestCompactionSummary(ctx, history)
+	if err != nil {
+		return "", false, err
+	}
+	summary = strings.TrimSpace(truncateRunes(summary, maxCompactionSummaryRunes))
+	if summary == "" {
+		return "", false, fmt.Errorf("compaction returned empty summary")
+	}
+
+	summaryMessage := llm.NewAssistantTextMessage("Context summary:\n" + summary)
+	summaryMessage.Meta = llm.MessageMeta{
+		"compaction": map[string]any{
+			"reason":               strings.TrimSpace(reason),
+			"created_at":           time.Now().UTC().Format(time.RFC3339),
+			"message_count_before": len(messages),
+		},
+	}
+
+	updated := []llm.Message{summaryMessage}
+	if latestUserIndex >= 0 {
+		preserved.Normalize()
+		updated = append(updated, preserved)
+	}
+	for i := range updated {
+		if err := llm.ValidateMessage(updated[i]); err != nil {
+			return "", false, fmt.Errorf("invalid compacted message at %d: %w", i, err)
+		}
+	}
+
+	sess.Messages = updated
+	if r.store != nil {
+		if err := r.store.Save(sess); err != nil {
+			return "", false, err
+		}
+	}
+	return summary, true, nil
+}
+
+func (r *Runner) requestCompactionSummary(ctx context.Context, history []llm.Message) (string, error) {
+	transcript := buildCompactionTranscript(history, maxCompactionTranscriptRunes)
+	if strings.TrimSpace(transcript) == "" {
+		return "", fmt.Errorf("compaction transcript is empty")
+	}
+
+	firstGoal := firstUserGoal(history)
+	if strings.TrimSpace(firstGoal) == "" {
+		firstGoal = "(unknown)"
+	}
+
+	prompt := strings.TrimSpace(strings.Join([]string{
+		"First user goal:",
+		firstGoal,
+		"",
+		"Conversation transcript:",
+		transcript,
+		"",
+		"Return only the compact continuation summary.",
+	}, "\n"))
+
+	request := llm.ChatRequest{
+		Model:       r.config.Provider.Model,
+		Temperature: 0,
+		Messages: []llm.Message{
+			llm.NewTextMessage(llm.RoleSystem, compactionSystemPrompt),
+			llm.NewUserTextMessage(prompt),
+		},
+	}
+
+	reply, err := r.client.CreateMessage(ctx, request)
+	if err != nil {
+		return "", err
+	}
+	reply.Normalize()
+	return strings.TrimSpace(reply.Text()), nil
+}
+
+func buildCompactionTranscript(messages []llm.Message, limit int) string {
+	if len(messages) == 0 || limit <= 0 {
+		return ""
+	}
+
+	lines := make([]string, 0, len(messages))
+	used := 0
+	for i := range messages {
+		line := formatCompactionMessage(i+1, messages[i])
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lineRunes := utf8.RuneCountInString(line)
+		separatorRunes := 0
+		if len(lines) > 0 {
+			separatorRunes = 2
+		}
+		if used+separatorRunes+lineRunes > limit {
+			remaining := limit - used - separatorRunes
+			if remaining > 32 {
+				lines = append(lines, truncateRunes(line, remaining))
+			}
+			lines = append(lines, "[...older details omitted...]")
+			break
+		}
+		lines = append(lines, line)
+		used += separatorRunes + lineRunes
+	}
+
+	return strings.Join(lines, "\n\n")
+}
+
+func formatCompactionMessage(index int, message llm.Message) string {
+	message.Normalize()
+	snippets := make([]string, 0, len(message.Parts))
+	for _, part := range message.Parts {
+		switch part.Type {
+		case llm.PartText:
+			if part.Text != nil {
+				snippets = append(snippets, compactForCompaction(part.Text.Value))
+			}
+		case llm.PartThinking:
+			if part.Thinking != nil {
+				snippets = append(snippets, "thinking: "+compactForCompaction(part.Thinking.Value))
+			}
+		case llm.PartToolUse:
+			if part.ToolUse != nil {
+				name := strings.TrimSpace(part.ToolUse.Name)
+				args := compactForCompaction(part.ToolUse.Arguments)
+				snippets = append(snippets, fmt.Sprintf("tool_use %s %s", name, args))
+			}
+		case llm.PartToolResult:
+			if part.ToolResult != nil {
+				snippets = append(snippets, "tool_result "+compactForCompaction(part.ToolResult.Content))
+			}
+		case llm.PartImageRef:
+			if part.Image != nil {
+				snippets = append(snippets, "image_ref "+strings.TrimSpace(string(part.Image.AssetID)))
+			}
+		}
+	}
+	if len(snippets) == 0 {
+		return ""
+	}
+
+	text := truncateRunes(strings.Join(snippets, " | "), maxCompactionMessageRunes)
+	return fmt.Sprintf("%03d %s: %s", index, strings.TrimSpace(string(message.Role)), text)
+}
+
+func compactForCompaction(value string) string {
+	value = strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+	return truncateRunes(value, maxCompactionMessageRunes)
+}
+
+func firstUserGoal(messages []llm.Message) string {
+	for i := range messages {
+		if !isHumanUserMessage(messages[i]) {
+			continue
+		}
+		text := strings.TrimSpace(messages[i].Text())
+		if text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func isHumanUserMessage(message llm.Message) bool {
+	message.Normalize()
+	if message.Role != llm.RoleUser {
+		return false
+	}
+	hasHumanPart := false
+	for _, part := range message.Parts {
+		switch part.Type {
+		case llm.PartText, llm.PartImageRef:
+			hasHumanPart = true
+		}
+	}
+	return hasHumanPart
+}
+
+func cloneMessages(messages []llm.Message) []llm.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	cloned := make([]llm.Message, len(messages))
+	copy(cloned, messages)
+	return cloned
+}
+
+func truncateRunes(value string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	if limit <= 3 {
+		return string(runes[:limit])
+	}
+	return string(runes[:limit-3]) + "..."
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -290,8 +290,9 @@ func (r *Runner) RunPromptWithInput(ctx context.Context, sess *session.Session, 
 	availableTools := toolNames(r.registry.DefinitionsForMode(runMode))
 	instructionText := loadAGENTSInstruction(r.workspace)
 	webLookupInstruction := explicitWebLookupInstruction(userInput)
+	promptTokens := int(tokenusage.ApproximateRequestTokens([]llm.Message{userMessage}))
 
-	for step := 0; step < r.config.MaxIterations; step++ {
+	buildTurnMessages := func() ([]llm.Message, error) {
 		messages := make([]llm.Message, 0, len(sess.Messages)+2)
 		systemMessage := llm.NewTextMessage(llm.RoleSystem, systemPrompt(PromptInput{
 			Workspace:      r.workspace,
@@ -304,17 +305,41 @@ func (r *Runner) RunPromptWithInput(ctx context.Context, sess *session.Session, 
 			Instruction:    instructionText,
 		}))
 		if err := llm.ValidateMessage(systemMessage); err != nil {
-			return "", err
+			return nil, err
 		}
 		messages = append(messages, systemMessage)
 		if webLookupInstruction != "" {
 			webLookupMessage := llm.NewTextMessage(llm.RoleSystem, webLookupInstruction)
 			if err := llm.ValidateMessage(webLookupMessage); err != nil {
-				return "", err
+				return nil, err
 			}
 			messages = append(messages, webLookupMessage)
 		}
 		messages = append(messages, sess.Messages...)
+		return messages, nil
+	}
+
+	for step := 0; step < r.config.MaxIterations; step++ {
+		messages, err := buildTurnMessages()
+		if err != nil {
+			return "", err
+		}
+		if step == 0 {
+			requestTokens := int(tokenusage.ApproximateRequestTokens(messages))
+			compacted, compactErr := r.maybeAutoCompactSession(ctx, sess, promptTokens, requestTokens)
+			if compactErr != nil {
+				return "", compactErr
+			}
+			if compacted {
+				if out != nil {
+					fmt.Fprintf(out, "%scontext compacted to fit long-history budget%s\n", ansiDim, ansiReset)
+				}
+				messages, err = buildTurnMessages()
+				if err != nil {
+					return "", err
+				}
+			}
+		}
 
 		filteredTools := r.registry.DefinitionsForModeWithFilters(runMode, allowedToolNames, deniedToolNames)
 		caps := llm.DefaultModelCapabilities.Resolve(r.config.Provider.Model)

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -197,6 +197,137 @@ func TestRunPromptCompletesMinimalToolLoop(t *testing.T) {
 	}
 }
 
+func TestRunPromptAutoCompactsLongHistory(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	for i := 0; i < 8; i++ {
+		sess.Messages = append(sess.Messages,
+			llm.NewUserTextMessage(strings.Repeat("history user segment ", 30)),
+			llm.NewAssistantTextMessage(strings.Repeat("history assistant segment ", 30)),
+		)
+	}
+	if err := store.Save(sess); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &fakeClient{
+		replies: []llm.Message{
+			{Role: llm.RoleAssistant, Content: "Goal: keep working\nDecisions: use go tests\nPending: continue implementation"},
+			{Role: llm.RoleAssistant, Content: "done"},
+		},
+	}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 2,
+			Stream:        false,
+			TokenQuota:    220,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "continue implementation", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "done" {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+	if len(client.requests) != 2 {
+		t.Fatalf("expected one compaction request + one turn request, got %d", len(client.requests))
+	}
+	if len(client.requests[0].Tools) != 0 {
+		t.Fatalf("expected compaction request to disable tools, got %#v", client.requests[0].Tools)
+	}
+	if len(client.requests[0].Messages) < 2 || client.requests[0].Messages[0].Role != llm.RoleSystem {
+		t.Fatalf("expected compaction request with system prompt, got %#v", client.requests[0].Messages)
+	}
+	if !strings.Contains(strings.ToLower(client.requests[0].Messages[0].Text()), "compaction") {
+		t.Fatalf("expected compaction system prompt, got %q", client.requests[0].Messages[0].Text())
+	}
+	if len(sess.Messages) != 3 {
+		t.Fatalf("expected compacted session to keep summary + latest user + final assistant, got %#v", sess.Messages)
+	}
+	if sess.Messages[0].Role != llm.RoleAssistant || !strings.Contains(sess.Messages[0].Text(), "Goal: keep working") {
+		t.Fatalf("expected first message to be compaction summary, got %#v", sess.Messages[0])
+	}
+	if sess.Messages[1].Role != llm.RoleUser || strings.TrimSpace(sess.Messages[1].Text()) != "continue implementation" {
+		t.Fatalf("expected latest user message to be preserved, got %#v", sess.Messages[1])
+	}
+}
+
+func TestCompactSessionManualRewritesHistory(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	sess.Messages = append(sess.Messages,
+		llm.NewUserTextMessage("first ask"),
+		llm.NewAssistantTextMessage("first answer"),
+		llm.NewUserTextMessage("second ask"),
+		llm.NewAssistantTextMessage("second answer"),
+	)
+	if err := store.Save(sess); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &fakeClient{
+		replies: []llm.Message{
+			{Role: llm.RoleAssistant, Content: "Goal: first ask\nCompleted: first answer\nPending: second ask"},
+		},
+	}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 2,
+			Stream:        false,
+			TokenQuota:    5000,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	summary, changed, err := runner.CompactSession(context.Background(), sess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatalf("expected compaction to change session state")
+	}
+	if strings.TrimSpace(summary) == "" {
+		t.Fatalf("expected non-empty compaction summary")
+	}
+	if len(sess.Messages) != 1 {
+		t.Fatalf("expected compacted session to keep one summary message, got %#v", sess.Messages)
+	}
+	if sess.Messages[0].Role != llm.RoleAssistant {
+		t.Fatalf("expected compacted summary role assistant, got %#v", sess.Messages[0])
+	}
+	if !strings.Contains(sess.Messages[0].Text(), "Goal: first ask") {
+		t.Fatalf("expected summary content to be persisted, got %#v", sess.Messages[0])
+	}
+	if len(client.requests) != 1 {
+		t.Fatalf("expected one compaction request, got %d", len(client.requests))
+	}
+}
+
 func TestRunPromptEncodesToolExecutionErrorsAndContinues(t *testing.T) {
 	workspace := t.TempDir()
 	store, err := session.NewStore(t.TempDir())

--- a/internal/tui/input_images.go
+++ b/internal/tui/input_images.go
@@ -599,13 +599,17 @@ func (m *model) buildPromptInput(raw string) (agent.RunPromptInput, string, erro
 		return agent.RunPromptInput{}, "", fmt.Errorf("prompt is empty")
 	}
 	m.syncInputImageRefs(raw)
+	resolvedRaw, err := m.resolvePastedLineReference(raw)
+	if err != nil {
+		return agent.RunPromptInput{}, "", err
+	}
 
-	placeholderMatches := imagePlaceholderPattern.FindAllStringSubmatchIndex(raw, -1)
-	mentionMatches := extractMentionImageSpans(raw, m.inputImageMentions)
+	placeholderMatches := imagePlaceholderPattern.FindAllStringSubmatchIndex(resolvedRaw, -1)
+	mentionMatches := extractMentionImageSpans(resolvedRaw, m.inputImageMentions)
 	if len(placeholderMatches) == 0 && len(mentionMatches) == 0 {
 		assets := m.hydrateHistoricalRequestAssets(nil)
 		return agent.RunPromptInput{
-			UserMessage: llm.NewUserTextMessage(raw),
+			UserMessage: llm.NewUserTextMessage(resolvedRaw),
 			Assets:      assets,
 			DisplayText: raw,
 		}, raw, nil
@@ -677,7 +681,7 @@ func (m *model) buildPromptInput(raw string) (agent.RunPromptInput, string, erro
 
 	last := 0
 	for _, span := range filtered {
-		appendTextPart(raw[last:span.Start])
+		appendTextPart(resolvedRaw[last:span.Start])
 		if m.imageStore == nil || strings.TrimSpace(string(span.AssetID)) == "" {
 			appendTextPart(span.Fallback)
 			last = span.End
@@ -693,10 +697,10 @@ func (m *model) buildPromptInput(raw string) (agent.RunPromptInput, string, erro
 		parts = append(parts, llm.Part{Type: llm.PartImageRef, Image: &llm.ImagePartRef{AssetID: span.AssetID}})
 		last = span.End
 	}
-	appendTextPart(raw[last:])
+	appendTextPart(resolvedRaw[last:])
 
 	if len(parts) == 0 {
-		parts = append(parts, llm.Part{Type: llm.PartText, Text: &llm.TextPart{Value: raw}})
+		parts = append(parts, llm.Part{Type: llm.PartText, Text: &llm.TextPart{Value: resolvedRaw}})
 	}
 
 	userMessage := llm.Message{Role: llm.RoleUser, Parts: parts}

--- a/internal/tui/input_paste.go
+++ b/internal/tui/input_paste.go
@@ -1,0 +1,689 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mattn/go-runewidth"
+)
+
+const (
+	pastedContentMetaKey        = "pasted_contents"
+	maxStoredPastedContents     = 10
+	longPasteLineThreshold      = 10
+	longPasteCharThreshold      = 500
+	pasteQuickCharThreshold     = 80
+	flattenedPasteCharThreshold = 180
+	pasteBurstCharThreshold     = 120
+	pasteBurstWindow            = 80 * time.Millisecond
+	pasteContinuationWindow     = 900 * time.Millisecond
+	maxSinglePastedCharLength   = 200000
+	pasteSoftWrapWidth          = 72
+)
+
+var pastedRefPattern = regexp.MustCompile(`\[(?:Paste|Pasted)(?:\s+#(\d+))?(?:\s+~(\d+)\s+lines)?(?:\s+line(\d+)(?:~line(\d+))?)?\]`)
+var compressedPasteMarkerPattern = regexp.MustCompile(`^\[(?:Paste|Pasted)\s+#\d+\s+~\d+\s+lines\]$`)
+var compressedPasteMarkerPrefixPattern = regexp.MustCompile(`^\[(?:Paste|Pasted)\s+#\d+\s+~\d+\s+lines\]`)
+var compressedPasteMarkerChainPrefixPattern = regexp.MustCompile(`^(?:(?:\[(?:Paste|Pasted)\s+#\d+\s+~\d+\s+lines\])\s*)+`)
+var compressedPasteMarkerAnyPattern = regexp.MustCompile(`\[(?:Paste|Pasted)\s+#\d+\s+~\d+\s+lines\]`)
+var compressedPasteMarkerDetailsPattern = regexp.MustCompile(`\[(?:Paste|Pasted)\s+#(\d+)\s+~(\d+)\s+lines\]`)
+
+const (
+	pasteRefGroupID        = 2
+	pasteRefGroupLineCount = 4
+	pasteRefGroupLineStart = 6
+	pasteRefGroupLineEnd   = 8
+)
+
+type pastedContent struct {
+	ID      string    `json:"id"`
+	Content string    `json:"content"`
+	Lines   int       `json:"lines"`
+	Time    time.Time `json:"time"`
+	Preview string    `json:"preview"`
+}
+
+type persistedPastedContents struct {
+	Version  int                      `json:"version"`
+	NextID   int                      `json:"next_id"`
+	Order    []string                 `json:"order"`
+	Contents map[string]pastedContent `json:"contents"`
+}
+
+func normalizeNewlines(input string) string {
+	input = strings.ReplaceAll(input, "\r\n", "\n")
+	input = strings.ReplaceAll(input, "\r", "\n")
+	return input
+}
+
+func (m *model) ensurePastedContentState() {
+	if m == nil || m.pastedStateLoaded {
+		return
+	}
+	if m.pastedContents == nil {
+		m.pastedContents = make(map[string]pastedContent, maxStoredPastedContents)
+	}
+	if m.pastedOrder == nil {
+		m.pastedOrder = make([]string, 0, maxStoredPastedContents)
+	}
+	if m.nextPasteID <= 0 {
+		m.nextPasteID = 1
+	}
+	m.pastedStateLoaded = true
+
+	if m.sess == nil || m.sess.Conversation.Meta == nil {
+		return
+	}
+	raw, ok := m.sess.Conversation.Meta[pastedContentMetaKey]
+	if !ok || raw == nil {
+		return
+	}
+	blob, err := json.Marshal(raw)
+	if err != nil {
+		return
+	}
+	var persisted persistedPastedContents
+	if err := json.Unmarshal(blob, &persisted); err != nil {
+		return
+	}
+	if len(persisted.Contents) == 0 {
+		return
+	}
+
+	m.pastedContents = make(map[string]pastedContent, len(persisted.Contents))
+	for id, content := range persisted.Contents {
+		id = strings.TrimSpace(id)
+		if id == "" || strings.TrimSpace(content.Content) == "" {
+			continue
+		}
+		content.ID = id
+		m.pastedContents[id] = content
+	}
+
+	order := make([]string, 0, len(persisted.Order))
+	seen := make(map[string]struct{}, len(persisted.Order))
+	for _, id := range persisted.Order {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := m.pastedContents[id]; !ok {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		order = append(order, id)
+	}
+	if len(order) < len(m.pastedContents) {
+		missing := make([]string, 0, len(m.pastedContents)-len(order))
+		for id := range m.pastedContents {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			missing = append(missing, id)
+		}
+		sort.Strings(missing)
+		order = append(order, missing...)
+	}
+	m.pastedOrder = order
+
+	m.nextPasteID = persisted.NextID
+	if m.nextPasteID <= 0 {
+		m.nextPasteID = 1
+	}
+	for _, id := range m.pastedOrder {
+		if n, err := strconv.Atoi(id); err == nil && n >= m.nextPasteID {
+			m.nextPasteID = n + 1
+		}
+	}
+}
+
+func (m *model) persistPastedContentState() error {
+	if m == nil || m.sess == nil {
+		return nil
+	}
+	if m.sess.Conversation.Meta == nil {
+		m.sess.Conversation.Meta = make(map[string]any, 4)
+	}
+	payload := persistedPastedContents{
+		Version:  1,
+		NextID:   m.nextPasteID,
+		Order:    append([]string(nil), m.pastedOrder...),
+		Contents: m.pastedContents,
+	}
+	m.sess.Conversation.Meta[pastedContentMetaKey] = payload
+	if m.store != nil {
+		return m.store.Save(m.sess)
+	}
+	return nil
+}
+
+func (m *model) isLongPastedText(input string) bool {
+	normalized := normalizeNewlines(input)
+	trimmed := strings.TrimSpace(normalized)
+	if trimmed == "" {
+		return false
+	}
+	if isLikelyPathInput(trimmed) {
+		return false
+	}
+
+	lines := strings.Split(normalized, "\n")
+	lineCount := len(lines)
+	newlineCount := strings.Count(normalized, "\n")
+
+	if lineCount > longPasteLineThreshold || len(normalized) > longPasteCharThreshold {
+		return true
+	}
+
+	if lineCount <= 2 && len(normalized) >= flattenedPasteCharThreshold {
+		return true
+	}
+
+	if newlineCount >= 3 && len(normalized) >= pasteQuickCharThreshold {
+		return true
+	}
+
+	return false
+}
+
+func isCtrlVSource(source string) bool {
+	source = strings.ToLower(strings.TrimSpace(source))
+	return source == "ctrl+v" || source == "ctrl+shift+v"
+}
+
+func isPasteLikeSource(source string) bool {
+	source = strings.ToLower(strings.TrimSpace(source))
+	return isCtrlVSource(source) || strings.Contains(source, "paste")
+}
+
+func (m *model) shouldCompressPastedText(input, source string) bool {
+	if m == nil {
+		return false
+	}
+	trimmed := strings.TrimSpace(input)
+	if isLikelyPathInput(trimmed) || len(extractImagePathsFromChunk(input, m.workspace)) > 0 || len(extractInlineImagePathSpans(input)) > 0 {
+		return false
+	}
+	if m.isLongPastedText(input) {
+		return true
+	}
+	if trimmed == "" || len(trimmed) < pasteQuickCharThreshold {
+		return false
+	}
+	if isPasteLikeSource(source) {
+		return true
+	}
+	if !m.lastPasteAt.IsZero() && time.Since(m.lastPasteAt) <= 2*pasteSubmitGuard {
+		return true
+	}
+	if isSplitPasteContinuation(input, source, m.lastPasteAt) {
+		return true
+	}
+	if !m.lastInputAt.IsZero() && time.Since(m.lastInputAt) <= pasteBurstWindow && m.inputBurstSize >= pasteBurstCharThreshold {
+		return true
+	}
+	return m.inputBurstSize >= pasteBurstCharThreshold
+}
+
+func isLikelyPathInput(value string) bool {
+	if strings.TrimSpace(value) == "" {
+		return false
+	}
+	if len(value) >= 3 && value[1] == ':' && (value[2] == '\\' || value[2] == '/') {
+		return true
+	}
+	if strings.HasPrefix(value, `\\`) || strings.HasPrefix(value, `/`) || strings.HasPrefix(value, `./`) || strings.HasPrefix(value, `../`) {
+		return true
+	}
+	separatorCount := strings.Count(value, `\`) + strings.Count(value, `/`)
+	if separatorCount >= 3 && !strings.Contains(value, "\n") {
+		return true
+	}
+	return false
+}
+
+func (m *model) storePastedContent(content pastedContent) error {
+	if m == nil {
+		return nil
+	}
+	m.ensurePastedContentState()
+	if strings.TrimSpace(content.ID) == "" {
+		return fmt.Errorf("invalid pasted content id")
+	}
+	if len(content.Content) > maxSinglePastedCharLength {
+		return fmt.Errorf("pasted content too large (%d chars), please attach a file instead", len(content.Content))
+	}
+	if _, exists := m.pastedContents[content.ID]; exists {
+		m.pastedContents[content.ID] = content
+		return m.persistPastedContentState()
+	}
+	m.pastedContents[content.ID] = content
+	m.pastedOrder = append(m.pastedOrder, content.ID)
+	if len(m.pastedOrder) > maxStoredPastedContents {
+		drop := len(m.pastedOrder) - maxStoredPastedContents
+		for i := 0; i < drop; i++ {
+			oldest := m.pastedOrder[i]
+			delete(m.pastedContents, oldest)
+		}
+		m.pastedOrder = append([]string(nil), m.pastedOrder[drop:]...)
+	}
+	return m.persistPastedContentState()
+}
+
+func (m *model) compressPastedText(input string) (string, pastedContent, error) {
+	m.ensurePastedContentState()
+	normalized := normalizeNewlines(input)
+	lines := strings.Split(normalized, "\n")
+	lineCount := countPastedDisplayLines(normalized)
+	id := strconv.Itoa(m.nextPasteID)
+	m.nextPasteID++
+	now := time.Now().UTC()
+
+	preview := ""
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		preview = line
+		break
+	}
+	if preview == "" {
+		preview = "(empty)"
+	}
+	if len(preview) > 80 {
+		preview = preview[:80] + "..."
+	}
+
+	content := pastedContent{
+		ID:      id,
+		Content: normalized,
+		Lines:   lineCount,
+		Time:    now,
+		Preview: preview,
+	}
+	if err := m.storePastedContent(content); err != nil {
+		return "", pastedContent{}, err
+	}
+	m.lastCompressedPasteAt = now
+	return fmt.Sprintf("[Paste #%s ~%d lines]", id, lineCount), content, nil
+}
+
+func countPastedDisplayLines(content string) int {
+	normalized := normalizeNewlines(content)
+	physicalLines := strings.Split(normalized, "\n")
+	if len(physicalLines) > 1 {
+		return len(physicalLines)
+	}
+
+	single := strings.TrimSpace(normalized)
+	if single == "" {
+		return 1
+	}
+	width := runewidth.StringWidth(single)
+	if width <= 0 {
+		return 1
+	}
+	estimated := (width + pasteSoftWrapWidth - 1) / pasteSoftWrapWidth
+	if estimated < 1 {
+		return 1
+	}
+	return estimated
+}
+
+func (m *model) applyLongPastedTextPipeline(before, after, source string) (string, string) {
+	if m == nil {
+		return after, ""
+	}
+	class, prefix, inserted, suffix := classifyInputMutation(before, after, source)
+	_, beforeHasMarkerChain := extractLeadingCompressedMarker(before)
+	if chain, ok := extractLeadingCompressedMarker(before); ok {
+		afterTrimmed := strings.TrimSpace(after)
+		if strings.HasPrefix(afterTrimmed, chain) {
+			rawTail := strings.TrimPrefix(afterTrimmed, chain)
+			tail := strings.TrimSpace(rawTail)
+			if tail != "" && !compressedPasteMarkerPattern.MatchString(tail) && !compressedPasteMarkerChainPrefixPattern.MatchString(tail) {
+				safeTail := len(extractImagePathsFromChunk(tail, m.workspace)) == 0 &&
+					len(extractInlineImagePathSpans(tail)) == 0
+				// Some terminals split one clipboard paste into multiple non-paste rune bursts.
+				// Merge those bursts into the latest marker to avoid leaking trailing raw text.
+				if safeTail && shouldMergeIntoLatestMarker(source, m.lastCompressedPasteAt) {
+					merged, ok, err := m.mergeTailIntoLatestMarker(chain, rawTail)
+					if err != nil {
+						return after, err.Error()
+					}
+					if ok {
+						return merged, ""
+					}
+				}
+				if safeTail && m.isLongPastedText(tail) {
+					marker, content, err := m.compressPastedText(tail)
+					if err != nil {
+						return after, err.Error()
+					}
+					updated := strings.TrimSpace(chain) + marker
+					note := fmt.Sprintf("Detected another pasted block and compressed it as %s (%d lines).",
+						marker, content.Lines)
+					return updated, note
+				}
+				// Keep tail as-is so split paste chunks can accumulate and then
+				// compress into the next marker once they cross thresholds.
+				return after, ""
+			}
+		}
+	}
+	if class == inputMutationPasteFilled {
+		candidate := strings.ReplaceAll(inserted, ctrlVMarkerRune, "")
+		if m.isLongPastedText(candidate) {
+			if !beforeHasMarkerChain && strings.TrimSpace(before) != "" && isSplitPasteContinuation(before, source, m.lastPasteAt) {
+				// Looks like the same clipboard paste still streaming in chunks.
+				// Defer compression so we can fold the whole paste into one marker.
+				candidate = ""
+			}
+		}
+		if strings.TrimSpace(candidate) != "" && m.isLongPastedText(candidate) {
+			marker, content, err := m.compressPastedText(candidate)
+			if err != nil {
+				return after, err.Error()
+			}
+			updated := after[:prefix] + marker + after[len(after)-suffix:]
+			note := fmt.Sprintf("Long pasted text (%d lines) compressed as %s. Use [Paste #%s], [Paste #%s line10], or [Paste #%s line10~line20].",
+				content.Lines, marker, content.ID, content.ID, content.ID)
+			return updated, note
+		}
+	}
+	if strings.Contains(after, "[Paste #") || strings.Contains(after, "[Pasted #") {
+		return after, ""
+	}
+	if !m.isLongPastedText(after) {
+		return after, ""
+	}
+	marker, content, err := m.compressPastedText(after)
+	if err != nil {
+		return after, err.Error()
+	}
+	note := fmt.Sprintf("Long pasted text (%d lines) compressed as %s. Use [Paste #%s], [Paste #%s line10], or [Paste #%s line10~line20].",
+		content.Lines, marker, content.ID, content.ID, content.ID)
+	return marker, note
+}
+
+func countCompressedMarkers(value string) int {
+	if strings.TrimSpace(value) == "" {
+		return 0
+	}
+	return len(compressedPasteMarkerAnyPattern.FindAllString(value, -1))
+}
+
+func shouldMergeIntoLatestMarker(source string, lastCompressedAt time.Time) bool {
+	if isPasteLikeSource(source) {
+		return false
+	}
+	if lastCompressedAt.IsZero() {
+		return false
+	}
+	return time.Since(lastCompressedAt) <= 300*time.Millisecond
+}
+
+func (m *model) mergeTailIntoLatestMarker(chain, tail string) (string, bool, error) {
+	if m == nil {
+		return chain, false, nil
+	}
+	rawTail := normalizeNewlines(tail)
+	if strings.TrimSpace(rawTail) == "" {
+		return chain, false, nil
+	}
+
+	loc := latestCompressedMarkerInChain(chain)
+	if !loc.ok {
+		return chain, false, nil
+	}
+	content, ok := m.findPastedContent(loc.id)
+	if !ok {
+		return chain, false, nil
+	}
+
+	if strings.TrimSpace(content.Content) == "" {
+		content.Content = rawTail
+	} else {
+		content.Content = content.Content + rawTail
+	}
+	content.Content = normalizeNewlines(content.Content)
+	content.Lines = len(strings.Split(content.Content, "\n"))
+	content.Time = time.Now().UTC()
+
+	if err := m.storePastedContent(content); err != nil {
+		return chain, false, err
+	}
+	m.lastCompressedPasteAt = time.Now().UTC()
+
+	updatedMarker := fmt.Sprintf("[Paste #%s ~%d lines]", content.ID, content.Lines)
+	updatedChain := chain[:loc.start] + updatedMarker + chain[loc.end:]
+	return strings.TrimSpace(updatedChain), true, nil
+}
+
+type compressedMarkerLoc struct {
+	id    string
+	start int
+	end   int
+	ok    bool
+}
+
+func latestCompressedMarkerInChain(chain string) compressedMarkerLoc {
+	matches := compressedPasteMarkerDetailsPattern.FindAllStringSubmatchIndex(chain, -1)
+	if len(matches) == 0 {
+		return compressedMarkerLoc{}
+	}
+	last := matches[len(matches)-1]
+	if len(last) < 4 {
+		return compressedMarkerLoc{}
+	}
+	idStart, idEnd := last[2], last[3]
+	if idStart < 0 || idEnd < 0 || idStart >= idEnd || idEnd > len(chain) {
+		return compressedMarkerLoc{}
+	}
+	return compressedMarkerLoc{
+		id:    chain[idStart:idEnd],
+		start: last[0],
+		end:   last[1],
+		ok:    true,
+	}
+}
+
+func shouldHoldCompressedMarker(before, after, source string, lastPasteAt time.Time, burst int) bool {
+	before = strings.TrimSpace(before)
+	after = strings.TrimSpace(after)
+	marker, ok := extractLeadingCompressedMarker(before)
+	if !ok {
+		return false
+	}
+	if len(after) <= len(marker) || !strings.HasPrefix(after, marker) {
+		return false
+	}
+	tail := strings.TrimSpace(strings.TrimPrefix(after, marker))
+	if tail == "" {
+		return false
+	}
+	if compressedPasteMarkerPattern.MatchString(tail) || compressedPasteMarkerChainPrefixPattern.MatchString(tail) {
+		return false
+	}
+	// If a compressed marker is followed by a sizeable tail, this is almost
+	// always a continuation chunk of the same clipboard paste.
+	if len(tail) >= 24 || strings.Contains(tail, "\n") {
+		return true
+	}
+	if isPasteLikeSource(source) || burst >= 8 {
+		return true
+	}
+	if !lastPasteAt.IsZero() && time.Since(lastPasteAt) <= pasteContinuationWindow {
+		return true
+	}
+	return false
+}
+
+func extractLeadingCompressedMarker(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	marker := compressedPasteMarkerChainPrefixPattern.FindString(value)
+	if marker == "" {
+		return "", false
+	}
+	marker = strings.TrimSpace(marker)
+	if !strings.HasPrefix(value, marker) {
+		return "", false
+	}
+	return marker, true
+}
+
+func isSplitPasteContinuation(input, source string, lastPasteAt time.Time) bool {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" || isLikelyPathInput(trimmed) {
+		return false
+	}
+	if !isPasteLikeSource(source) {
+		return false
+	}
+	if strings.Contains(trimmed, "[Paste #") || strings.Contains(trimmed, "[Pasted #") {
+		return false
+	}
+	if !lastPasteAt.IsZero() && time.Since(lastPasteAt) <= pasteContinuationWindow {
+		return true
+	}
+	return strings.Contains(trimmed, "\n") || len(trimmed) >= pasteQuickCharThreshold
+}
+
+func (m *model) resolvePastedLineReference(input string) (string, error) {
+	if m == nil || (!strings.Contains(input, "[Paste") && !strings.Contains(input, "[Pasted")) {
+		return input, nil
+	}
+	m.ensurePastedContentState()
+	if len(m.pastedOrder) == 0 {
+		return input, nil
+	}
+
+	matches := pastedRefPattern.FindAllStringSubmatchIndex(input, -1)
+	if len(matches) == 0 {
+		return input, nil
+	}
+
+	var out strings.Builder
+	last := 0
+	for _, idx := range matches {
+		start, end := idx[0], idx[1]
+		out.WriteString(input[last:start])
+
+		full := input[start:end]
+		pasteID := submatchString(input, idx, pasteRefGroupID)
+		lineCount := submatchString(input, idx, pasteRefGroupLineCount)
+		startLineStr := submatchString(input, idx, pasteRefGroupLineStart)
+		endLineStr := submatchString(input, idx, pasteRefGroupLineEnd)
+
+		if strings.TrimSpace(startLineStr) == "" && strings.TrimSpace(lineCount) != "" {
+			content, ok := m.findPastedContent(pasteID)
+			if !ok {
+				out.WriteString(full)
+			} else {
+				out.WriteString("```\n")
+				out.WriteString(content.Content)
+				out.WriteString("\n```")
+			}
+		} else if strings.TrimSpace(startLineStr) == "" {
+			content, ok := m.findPastedContent(pasteID)
+			if !ok {
+				out.WriteString(full)
+			} else {
+				out.WriteString("```\n")
+				out.WriteString(content.Content)
+				out.WriteString("\n```")
+			}
+		} else {
+			content, err := m.resolvePastedSelection(pasteID, startLineStr, endLineStr)
+			if err != nil {
+				out.WriteString(full)
+			} else {
+				out.WriteString("```\n")
+				out.WriteString(content)
+				out.WriteString("\n```")
+			}
+		}
+		last = end
+	}
+	out.WriteString(input[last:])
+	return out.String(), nil
+}
+
+func (m *model) resolvePastedSelection(pasteID, startLineStr, endLineStr string) (string, error) {
+	content, ok := m.findPastedContent(pasteID)
+	if !ok {
+		return "", fmt.Errorf("pasted reference not found")
+	}
+	if strings.TrimSpace(startLineStr) == "" {
+		return content.Content, nil
+	}
+	startLine, err := strconv.Atoi(startLineStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid start line")
+	}
+	endLine := startLine
+	if strings.TrimSpace(endLineStr) != "" {
+		if v, err := strconv.Atoi(endLineStr); err == nil {
+			endLine = v
+		}
+	}
+	return extractLineRange(content.Content, startLine, endLine), nil
+}
+
+func (m *model) findPastedContent(pasteID string) (pastedContent, bool) {
+	m.ensurePastedContentState()
+	if strings.TrimSpace(pasteID) == "" {
+		if len(m.pastedOrder) == 0 {
+			return pastedContent{}, false
+		}
+		latestID := m.pastedOrder[len(m.pastedOrder)-1]
+		content, ok := m.pastedContents[latestID]
+		return content, ok
+	}
+	content, ok := m.pastedContents[strings.TrimSpace(pasteID)]
+	return content, ok
+}
+
+func extractLineRange(content string, startLine, endLine int) string {
+	normalized := normalizeNewlines(content)
+	lines := strings.Split(normalized, "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+	if startLine <= 0 {
+		startLine = 1
+	}
+	if endLine <= 0 {
+		endLine = startLine
+	}
+	if startLine > len(lines) {
+		startLine = len(lines)
+	}
+	if endLine > len(lines) {
+		endLine = len(lines)
+	}
+	if endLine < startLine {
+		endLine = startLine
+	}
+	return strings.Join(lines[startLine-1:endLine], "\n")
+}
+
+func submatchString(input string, indexes []int, groupOffset int) string {
+	if len(indexes) <= groupOffset+1 {
+		return ""
+	}
+	start, end := indexes[groupOffset], indexes[groupOffset+1]
+	if start < 0 || end < 0 || start > end || end > len(input) {
+		return ""
+	}
+	return input[start:end]
+}

--- a/internal/tui/input_paste_test.go
+++ b/internal/tui/input_paste_test.go
@@ -1,0 +1,642 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApplyLongPastedTextPipelineCompressesCodePaste(t *testing.T) {
+	m := newImagePipelineModel(t)
+
+	longPaste := strings.Join([]string{
+		"func demo() {",
+		"    line1()",
+		"    line2()",
+		"    line3()",
+		"    line4()",
+		"    line5()",
+		"    line6()",
+		"    line7()",
+		"    line8()",
+		"    line9()",
+		"    line10()",
+		"}",
+	}, "\n")
+
+	m.handleInputMutation("", longPaste, "ctrl+v")
+	got := m.input.Value()
+	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`)
+	if !re.MatchString(got) {
+		t.Fatalf("expected compressed pasted marker, got %q", got)
+	}
+	if !strings.Contains(m.statusNote, "Long pasted text") {
+		t.Fatalf("expected compression status note, got %q", m.statusNote)
+	}
+	if len(m.pastedContents) != 1 {
+		t.Fatalf("expected one stored pasted content, got %d", len(m.pastedContents))
+	}
+}
+
+func TestApplyLongPastedTextPipelineCompressesSplitPasteChunks(t *testing.T) {
+	m := newImagePipelineModel(t)
+	chunk1 := strings.Join([]string{
+		"func demo() {",
+		"    line1()",
+		"    line2()",
+		"    line3()",
+		"    line4()",
+		"    line5()",
+	}, "\n")
+	chunk2 := strings.Join([]string{
+		"    line6()",
+		"    line7()",
+		"    line8()",
+		"    line9()",
+		"    line10()",
+		"}",
+	}, "\n")
+
+	m.input.SetValue(chunk1)
+	m.handleInputMutation("", chunk1, "paste")
+	if got := m.input.Value(); got != chunk1 {
+		t.Fatalf("expected first chunk to remain literal until paste is complete, got %q", got)
+	}
+
+	before := m.input.Value()
+	after := before + "\n" + chunk2
+	m.input.SetValue(after)
+	m.handleInputMutation(before, after, "paste")
+
+	got := m.input.Value()
+	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`)
+	if !re.MatchString(got) {
+		t.Fatalf("expected split paste to compress into marker, got %q", got)
+	}
+	if len(m.pastedContents) != 1 {
+		t.Fatalf("expected one stored pasted content after split paste, got %d", len(m.pastedContents))
+	}
+}
+
+func TestApplyLongPastedTextPipelineDoesNotCompressEarlyForShortInitialPasteChunk(t *testing.T) {
+	m := newImagePipelineModel(t)
+	chunk1 := strings.Join([]string{
+		"# Long Paste Test Block (20 lines)",
+		"func processRecords(records []string) []string {",
+	}, "\n")
+	chunk2 := strings.Join([]string{
+		"    cleaned := make([]string, 0, len(records))",
+		"    for _, r := range records {",
+		"        v := strings.TrimSpace(r)",
+		"        if v == \"\" {",
+		"            continue",
+		"        }",
+		"        v = strings.ToLower(v)",
+		"        cleaned = append(cleaned, v)",
+		"    }",
+		"    sort.Strings(cleaned)",
+		"    return cleaned",
+		"}",
+		"func main() {",
+		"    input := []string{\"  Alpha  \", \"\", \"Beta\", \"  GAMMA  \", \"delta\", \"  epsilon  \"}",
+		"    output := processRecords(input)",
+		"    fmt.Println(\"normalized:\", output)",
+		"}",
+	}, "\n")
+
+	m.input.SetValue(chunk1)
+	m.handleInputMutation("", chunk1, "paste")
+	if got := m.input.Value(); got != chunk1 {
+		t.Fatalf("expected first short chunk to stay literal, got %q", got)
+	}
+
+	before := m.input.Value()
+	after := before + "\n" + chunk2
+	m.input.SetValue(after)
+	m.handleInputMutation(before, after, "paste")
+
+	got := m.input.Value()
+	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`)
+	if !re.MatchString(got) {
+		t.Fatalf("expected whole paste to compress as one marker, got %q", got)
+	}
+	if len(m.pastedOrder) != 1 {
+		t.Fatalf("expected exactly one stored marker for one long paste, got %d", len(m.pastedOrder))
+	}
+}
+
+func TestApplyLongPastedTextPipelineCompressesBurstTypedPasteFallback(t *testing.T) {
+	m := newImagePipelineModel(t)
+	longPaste := strings.Join([]string{
+		"func demo() {",
+		"    line1()",
+		"    line2()",
+		"    line3()",
+		"    line4()",
+		"    line5()",
+		"    line6()",
+		"    line7()",
+		"    line8()",
+		"    line9()",
+		"    line10()",
+		"}",
+	}, "\n")
+
+	before := ""
+	for _, r := range longPaste {
+		after := before + string(r)
+		m.input.SetValue(after)
+		m.handleInputMutation(before, after, "rune")
+		before = m.input.Value()
+		if strings.HasPrefix(before, "[Paste #") {
+			break
+		}
+	}
+	if !strings.HasPrefix(m.input.Value(), "[Paste #") {
+		t.Fatalf("expected burst fallback compression, got %q", m.input.Value())
+	}
+}
+
+func TestApplyLongPastedTextPipelineCompressesTailAfterMarkerIntoNewMarker(t *testing.T) {
+	m := newImagePipelineModel(t)
+	longPaste := strings.Join([]string{
+		"segment-01", "segment-02", "segment-03", "segment-04", "segment-05", "segment-06",
+		"segment-07", "segment-08", "segment-09", "segment-10", "segment-11",
+	}, "\n")
+
+	m.handleInputMutation("", longPaste, "paste")
+	marker := m.input.Value()
+	if !strings.HasPrefix(marker, "[Paste #") {
+		t.Fatalf("expected initial compression marker, got %q", marker)
+	}
+
+	before := marker
+	after := marker + "\nextra-01\nextra-02\nextra-03\nextra-04\nextra-05\nextra-06\nextra-07\nextra-08\nextra-09\nextra-10\nextra-11"
+	m.handleInputMutation(before, after, "paste")
+
+	got := m.input.Value()
+	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]\[Paste #\d+ ~\d+ lines\]$`)
+	if !re.MatchString(got) {
+		t.Fatalf("expected tail to be compressed as another marker, got %q", got)
+	}
+}
+
+func TestApplyLongPastedTextPipelineAllowsTailAccumulationThenCompresses(t *testing.T) {
+	m := newImagePipelineModel(t)
+	first := strings.Join([]string{
+		"a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11",
+	}, "\n")
+	second := strings.Join([]string{
+		"b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "b10", "b11",
+	}, "\n")
+
+	m.handleInputMutation("", first, "paste")
+	before := m.input.Value()
+	if !strings.HasPrefix(before, "[Paste #") {
+		t.Fatalf("expected first marker, got %q", before)
+	}
+
+	// Simulate a terminal that emits pasted text as many tiny rune updates.
+	for _, r := range second {
+		after := before + string(r)
+		m.input.SetValue(after)
+		m.handleInputMutation(before, after, "rune")
+		before = m.input.Value()
+	}
+
+	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`)
+	if !re.MatchString(before) {
+		t.Fatalf("expected accumulated split chunks to stay in one marker, got %q", before)
+	}
+	if len(m.pastedOrder) != 1 {
+		t.Fatalf("expected one stored entry for split chunks from same paste burst, got %d", len(m.pastedOrder))
+	}
+}
+
+func TestApplyLongPastedTextPipelineTrimsShortTailAfterSecondMarker(t *testing.T) {
+	m := newImagePipelineModel(t)
+	first := strings.Join([]string{
+		"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11",
+	}, "\n")
+	second := strings.Join([]string{
+		"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11",
+	}, "\n")
+
+	m.handleInputMutation("", first, "paste")
+	before := m.input.Value()
+	m.handleInputMutation(before, before+second, "paste")
+	before = m.input.Value()
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]\[Paste #\d+ ~\d+ lines\]$`).MatchString(before) {
+		t.Fatalf("expected two-marker chain, got %q", before)
+	}
+
+	after := before + "11"
+	m.handleInputMutation(before, after, "rune")
+	if got := m.input.Value(); got != before {
+		t.Fatalf("expected short residual tail to be trimmed, got %q", got)
+	}
+}
+
+func TestApplyLongPastedTextPipelineAppendsMarkersForConsecutiveLongPastes(t *testing.T) {
+	m := newImagePipelineModel(t)
+	firstPaste := strings.Join([]string{
+		"alpha01", "alpha02", "alpha03", "alpha04", "alpha05", "alpha06",
+		"alpha07", "alpha08", "alpha09", "alpha10", "alpha11", "alpha12",
+	}, "\n")
+	secondPaste := strings.Join([]string{
+		"beta01", "beta02", "beta03", "beta04", "beta05", "beta06",
+		"beta07", "beta08", "beta09", "beta10", "beta11", "beta12",
+	}, "\n")
+
+	m.handleInputMutation("", firstPaste, "paste")
+	firstMarker := m.input.Value()
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(firstMarker) {
+		t.Fatalf("expected first marker, got %q", firstMarker)
+	}
+
+	before := firstMarker
+	after := before + secondPaste
+	m.input.SetValue(after)
+	m.handleInputMutation(before, after, "paste")
+
+	got := m.input.Value()
+	combinedRe := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]\[Paste #\d+ ~\d+ lines\]$`)
+	if !combinedRe.MatchString(got) {
+		t.Fatalf("expected two concatenated markers, got %q", got)
+	}
+	if len(m.pastedOrder) != 2 {
+		t.Fatalf("expected two stored pasted entries, got %d", len(m.pastedOrder))
+	}
+}
+
+func TestApplyLongPastedTextPipelineAppendsSecondMarkerWhenBurstIsSeparatedInTime(t *testing.T) {
+	m := newImagePipelineModel(t)
+	first := strings.Join([]string{
+		"t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10", "t11",
+	}, "\n")
+	second := strings.Join([]string{
+		"u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10", "u11",
+	}, "\n")
+
+	m.handleInputMutation("", first, "paste")
+	before := m.input.Value()
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(before) {
+		t.Fatalf("expected first marker, got %q", before)
+	}
+
+	// Simulate a user-triggered second paste separated from previous burst.
+	m.lastCompressedPasteAt = time.Now().Add(-time.Second)
+	after := before + second
+	m.input.SetValue(after)
+	m.handleInputMutation(before, after, "rune")
+
+	got := m.input.Value()
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]\[Paste #\d+ ~\d+ lines\]$`).MatchString(got) {
+		t.Fatalf("expected second separated paste to create another marker, got %q", got)
+	}
+}
+
+func TestShouldHoldCompressedMarkerWithLongTailEvenWithoutPasteSignal(t *testing.T) {
+	before := "[Paste #1 ~42 lines]"
+	after := before + " this is a long continuation chunk that should be dropped"
+	if !shouldHoldCompressedMarker(before, after, "", time.Now(), 1) {
+		t.Fatalf("expected long tail after marker to be treated as continuation")
+	}
+}
+
+func TestExtractLeadingCompressedMarkerReturnsWholeMarkerChain(t *testing.T) {
+	input := "[Paste #1 ~15 lines][Paste #2 ~15 lines] trailing"
+	got, ok := extractLeadingCompressedMarker(input)
+	if !ok {
+		t.Fatalf("expected marker chain to be detected")
+	}
+	want := "[Paste #1 ~15 lines][Paste #2 ~15 lines]"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestBuildPromptInputExpandsStoredPastedReference(t *testing.T) {
+	m := newImagePipelineModel(t)
+	marker, stored, err := m.compressPastedText("a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk")
+	if err != nil {
+		t.Fatalf("compress pasted text: %v", err)
+	}
+
+	raw := "analyze " + marker
+	input, display, err := m.buildPromptInput(raw)
+	if err != nil {
+		t.Fatalf("build prompt input: %v", err)
+	}
+	if display != raw {
+		t.Fatalf("expected display text unchanged, got %q", display)
+	}
+	text := input.UserMessage.Text()
+	if !strings.Contains(text, "```\n"+stored.Content+"\n```") {
+		t.Fatalf("expected full pasted content expansion, got %q", text)
+	}
+}
+
+func TestResolvePastedLineReferenceWithFullFormat(t *testing.T) {
+	m := newImagePipelineModel(t)
+	_, stored, err := m.compressPastedText("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11")
+	if err != nil {
+		t.Fatalf("compress pasted text: %v", err)
+	}
+
+	input := "check [Paste #" + stored.ID + " ~11 lines]"
+	result, err := m.resolvePastedLineReference(input)
+	if err != nil {
+		t.Fatalf("resolve pasted line reference: %v", err)
+	}
+	if !strings.Contains(result, "```\n"+stored.Content+"\n```") {
+		t.Fatalf("expected full content expansion, got %q", result)
+	}
+}
+
+func TestBuildPromptInputResolvesPastedLineRanges(t *testing.T) {
+	m := newImagePipelineModel(t)
+	_, stored, err := m.compressPastedText("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11")
+	if err != nil {
+		t.Fatalf("compress pasted text: %v", err)
+	}
+
+	raw := "focus [Paste #" + stored.ID + " line3~line5]"
+	input, _, err := m.buildPromptInput(raw)
+	if err != nil {
+		t.Fatalf("build prompt input: %v", err)
+	}
+	text := input.UserMessage.Text()
+	if !strings.Contains(text, "line3\nline4\nline5") {
+		t.Fatalf("expected ranged lines to be expanded, got %q", text)
+	}
+	if strings.Contains(text, "line2") || strings.Contains(text, "line6") {
+		t.Fatalf("expected only selected line range, got %q", text)
+	}
+}
+
+func TestBuildPromptInputDefaultsToLatestPastedReference(t *testing.T) {
+	m := newImagePipelineModel(t)
+	_, _, err := m.compressPastedText("old1\nold2\nold3\nold4\nold5\nold6\nold7\nold8\nold9\nold10\nold11")
+	if err != nil {
+		t.Fatalf("compress pasted text old: %v", err)
+	}
+	_, latest, err := m.compressPastedText("new1\nnew2\nnew3\nnew4\nnew5\nnew6\nnew7\nnew8\nnew9\nnew10\nnew11")
+	if err != nil {
+		t.Fatalf("compress pasted text latest: %v", err)
+	}
+
+	input, _, err := m.buildPromptInput("inspect [Paste line2]")
+	if err != nil {
+		t.Fatalf("build prompt input: %v", err)
+	}
+	text := input.UserMessage.Text()
+	if !strings.Contains(text, "```\nnew2\n```") {
+		t.Fatalf("expected latest pasted line expansion, got %q", text)
+	}
+	if strings.Contains(text, "old2") {
+		t.Fatalf("expected latest pasted content, got %q", text)
+	}
+	if latest.ID == "" {
+		t.Fatalf("expected latest pasted content id")
+	}
+}
+
+func TestStorePastedContentKeepsRecentLimit(t *testing.T) {
+	m := newImagePipelineModel(t)
+	for i := 0; i < maxStoredPastedContents+2; i++ {
+		content := strings.Repeat("x\n", longPasteLineThreshold+1) + "{\n}"
+		if _, _, err := m.compressPastedText(content); err != nil {
+			t.Fatalf("compress pasted text #%d: %v", i, err)
+		}
+	}
+	if len(m.pastedOrder) != maxStoredPastedContents {
+		t.Fatalf("expected %d stored entries, got %d", maxStoredPastedContents, len(m.pastedOrder))
+	}
+	if _, ok := m.pastedContents["1"]; ok {
+		t.Fatalf("expected oldest pasted content to be evicted")
+	}
+	if _, ok := m.pastedContents["2"]; ok {
+		t.Fatalf("expected second oldest pasted content to be evicted")
+	}
+}
+
+func TestBuildPromptInputAdjustsOutOfRangeLineReference(t *testing.T) {
+	m := newImagePipelineModel(t)
+	_, _, err := m.compressPastedText("l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\nl11")
+	if err != nil {
+		t.Fatalf("compress pasted text: %v", err)
+	}
+
+	input, _, err := m.buildPromptInput("tail [Paste line999]")
+	if err != nil {
+		t.Fatalf("build prompt input: %v", err)
+	}
+	if !strings.Contains(input.UserMessage.Text(), "```\nl11\n```") {
+		t.Fatalf("expected out-of-range line to clamp to last line, got %q", input.UserMessage.Text())
+	}
+}
+
+func TestPastedContentStatePersistsViaSessionMeta(t *testing.T) {
+	m := newImagePipelineModel(t)
+	marker, stored, err := m.compressPastedText("p1\np2\np3\np4\np5\np6\np7\np8\np9\np10\np11")
+	if err != nil {
+		t.Fatalf("compress pasted text: %v", err)
+	}
+	if marker == "" || stored.ID == "" {
+		t.Fatalf("expected stored pasted marker and id")
+	}
+
+	reloaded := newImagePipelineModel(t)
+	reloaded.sess = m.sess
+	reloaded.pastedStateLoaded = false
+	reloaded.ensurePastedContentState()
+
+	content, ok := reloaded.findPastedContent(stored.ID)
+	if !ok {
+		t.Fatalf("expected pasted content %s to be restored", stored.ID)
+	}
+	if content.Content != stored.Content {
+		t.Fatalf("expected restored content to match original")
+	}
+}
+
+func TestIsLongPastedTextDetectsFlattenedSingleLineCodeBlob(t *testing.T) {
+	m := newImagePipelineModel(t)
+	flattened := "def normalize(items): result = [] for item in items: text = item.strip() if text: result.append(text.lower()) return result def main(): data = [\"Alpha\", \"\", \"Beta\", \"GAMMA\"] print(normalize(data)) if __name__ == \"__main__\": main()"
+	if !m.isLongPastedText(flattened) {
+		t.Fatalf("expected flattened long code blob to be treated as long pasted text")
+	}
+}
+
+func TestIsLongPastedTextDetectsLongPlainSingleLine(t *testing.T) {
+	m := newImagePipelineModel(t)
+	longPlain := strings.Repeat("lorem ipsum dolor sit amet ", 10)
+	if !m.isLongPastedText(longPlain) {
+		t.Fatalf("expected long plain single line to be treated as long pasted text")
+	}
+}
+
+func TestCompressPastedTextCountsCarriageReturnSeparatedLines(t *testing.T) {
+	m := newImagePipelineModel(t)
+	raw := "l1\rl2\rl3\rl4\rl5\rl6\rl7\rl8\rl9\rl10\rl11\rl12"
+	marker, content, err := m.compressPastedText(raw)
+	if err != nil {
+		t.Fatalf("compress pasted text: %v", err)
+	}
+	if marker == "" {
+		t.Fatalf("expected marker")
+	}
+	if content.Lines != 12 {
+		t.Fatalf("expected 12 lines after newline normalization, got %d", content.Lines)
+	}
+}
+
+func TestCompressPastedTextEstimatesLinesForLongSingleParagraph(t *testing.T) {
+	m := newImagePipelineModel(t)
+	raw := strings.Repeat("在这个瞬息万变的世界里我们持续前行", 25)
+	marker, content, err := m.compressPastedText(raw)
+	if err != nil {
+		t.Fatalf("compress pasted text: %v", err)
+	}
+	if marker == "" {
+		t.Fatalf("expected marker")
+	}
+	if content.Lines <= 1 {
+		t.Fatalf("expected long single paragraph to estimate more than one line, got %d", content.Lines)
+	}
+}
+
+func TestApplyLongPastedTextPipelineMergesImmediateRuneTailIntoLatestMarker(t *testing.T) {
+	m := newImagePipelineModel(t)
+	first := strings.Join([]string{
+		"a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11",
+	}, "\n")
+	second := strings.Join([]string{
+		"b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "b10", "b11",
+	}, "\n")
+
+	m.handleInputMutation("", first, "paste")
+	chain := m.input.Value()
+	if !strings.HasPrefix(chain, "[Paste #") {
+		t.Fatalf("expected first marker, got %q", chain)
+	}
+
+	before := chain
+	after := before + second
+	got, _ := m.applyLongPastedTextPipeline(before, after, "rune")
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(got) {
+		t.Fatalf("expected immediate rune tail to merge into one marker, got %q", got)
+	}
+	if len(m.pastedOrder) != 1 {
+		t.Fatalf("expected one stored entry after merge, got %d", len(m.pastedOrder))
+	}
+}
+
+func TestApplyLongPastedTextPipelineMergesShortTrailingTextAndHidesTail(t *testing.T) {
+	m := newImagePipelineModel(t)
+	first := strings.Repeat("段落内容很长用于触发压缩。", 30)
+	m.handleInputMutation("", first, "paste")
+	chain := m.input.Value()
+	if !strings.HasPrefix(chain, "[Paste #") {
+		t.Fatalf("expected first marker, got %q", chain)
+	}
+
+	before := chain
+	after := before + "识储备的竞争"
+	got, _ := m.applyLongPastedTextPipeline(before, after, "rune")
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(got) {
+		t.Fatalf("expected short trailing text to be merged into marker, got %q", got)
+	}
+	if strings.Contains(got, "识储备的竞争") {
+		t.Fatalf("expected no visible trailing raw text, got %q", got)
+	}
+}
+
+func TestApplyLongPastedTextPipelineMergesSlashLeadingTrailingText(t *testing.T) {
+	m := newImagePipelineModel(t)
+	first := strings.Repeat("未来协作系统正在发生深刻变化。", 28)
+	m.handleInputMutation("", first, "paste")
+	chain := m.input.Value()
+	if !strings.HasPrefix(chain, "[Paste #") {
+		t.Fatalf("expected first marker, got %q", chain)
+	}
+
+	before := chain
+	after := before + "/未来风：关于AI与人类协作的展望"
+	got, _ := m.applyLongPastedTextPipeline(before, after, "rune")
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(got) {
+		t.Fatalf("expected slash-leading trailing text to be merged into marker, got %q", got)
+	}
+	if strings.Contains(got, "/未来风：") {
+		t.Fatalf("expected no visible trailing slash-leading raw text, got %q", got)
+	}
+}
+
+func TestShouldCompressPastedTextQuickThresholdWithPasteSignal(t *testing.T) {
+	m := newImagePipelineModel(t)
+	text := strings.Repeat("alpha beta gamma ", 8)
+	if !m.shouldCompressPastedText(text, "ctrl+v") {
+		t.Fatalf("expected paste signal + quick threshold to trigger compression")
+	}
+}
+
+func TestShouldCompressPastedTextQuickThresholdWithRecentPasteWindow(t *testing.T) {
+	m := newImagePipelineModel(t)
+	text := strings.Repeat("alpha beta gamma ", 8)
+	m.lastPasteAt = time.Now()
+	if !m.shouldCompressPastedText(text, "rune") {
+		t.Fatalf("expected recent paste window + quick threshold to trigger compression")
+	}
+}
+
+func TestShouldCompressPastedTextSkipsLikelyPathInput(t *testing.T) {
+	m := newImagePipelineModel(t)
+	path := `C:\Users\demo\Pictures\screenshots\capture.png`
+	if m.shouldCompressPastedText(path, "ctrl+v") {
+		t.Fatalf("expected likely path input to bypass paste compression")
+	}
+}
+
+func TestShouldCompressPastedTextDetectsFastCharacterBurstWithoutPasteSignal(t *testing.T) {
+	m := newImagePipelineModel(t)
+	text := strings.Repeat("burst payload ", 10)
+	m.inputBurstSize = pasteBurstCharThreshold
+	m.lastInputAt = time.Now()
+	if !m.shouldCompressPastedText(text, "rune") {
+		t.Fatalf("expected rapid burst fallback to trigger compression")
+	}
+}
+
+func TestExtractLineRangeClampsBounds(t *testing.T) {
+	content := "l1\nl2\nl3\nl4"
+	if got := extractLineRange(content, 0, 99); got != content {
+		t.Fatalf("expected full clamped content, got %q", got)
+	}
+	if got := extractLineRange(content, 3, 1); got != "l3" {
+		t.Fatalf("expected end line to clamp to start line, got %q", got)
+	}
+}
+
+func TestPastedRefPattern(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{input: "[Paste #1 ~11 lines]", expected: true},
+		{input: "[Paste line3]", expected: true},
+		{input: "[Paste #1 line3~line5]", expected: true},
+		{input: "[Pasted #2 ~15 lines]", expected: true},
+		{input: "[Pasted #2 line7]", expected: true},
+		{input: "[Pasted line4~line8]", expected: true},
+		{input: "[not a paste]", expected: false},
+	}
+
+	for _, tc := range tests {
+		matched := pastedRefPattern.MatchString(tc.input)
+		if matched != tc.expected {
+			t.Fatalf("input %q: expected %v, got %v", tc.input, tc.expected, matched)
+		}
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3144,7 +3144,14 @@ func (m *model) runCompactCommand(input string) error {
 	if m.sess == nil {
 		return fmt.Errorf("session is unavailable")
 	}
-	summary, changed, err := m.runner.CompactSession(context.Background(), m.sess)
+	type sessionCompactor interface {
+		CompactSession(ctx context.Context, sess *session.Session) (string, bool, error)
+	}
+	compactor, ok := any(m.runner).(sessionCompactor)
+	if !ok {
+		return fmt.Errorf("compact is unavailable in this build")
+	}
+	summary, changed, err := compactor.CompactSession(context.Background(), m.sess)
 	if err != nil {
 		return err
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -189,6 +189,7 @@ var commandItems = []commandItem{
 	{Name: "/help", Usage: "/help", Description: "Show usage and supported commands.", Kind: "command"},
 	{Name: "/session", Usage: "/session", Description: "Open the recent session list.", Kind: "command"},
 	{Name: "/new", Usage: "/new", Description: "Start a fresh session in this workspace.", Kind: "command"},
+	{Name: "/compact", Usage: "/compact", Description: "Compress long session history into a continuation summary.", Kind: "command"},
 	{Name: "/btw", Usage: "/btw <message>", Description: "Interject while a run is in progress.", Kind: "command"},
 	{Name: "/quit", Usage: "/quit", Description: "Exit the current TUI window.", Kind: "command"},
 	{Name: "/skills", Usage: "/skills", Description: "List available skills and current active skill.", Kind: "command"},
@@ -265,6 +266,11 @@ type model struct {
 	inputImageMentions    map[string]llm.AssetID
 	orphanedImages        map[llm.AssetID]time.Time
 	nextImageID           int
+	pastedContents        map[string]pastedContent
+	pastedOrder           []string
+	nextPasteID           int
+	pastedStateLoaded     bool
+	lastCompressedPasteAt time.Time
 	clipboard             clipboardImageReader
 	runCancel             context.CancelFunc
 	pendingBTW            []string
@@ -345,6 +351,9 @@ func newModel(opts Options) model {
 		inputImageMentions: make(map[string]llm.AssetID, 8),
 		orphanedImages:     make(map[llm.AssetID]time.Time, 8),
 		nextImageID:        nextSessionImageID(opts.Session),
+		pastedContents:     make(map[string]pastedContent, maxStoredPastedContents),
+		pastedOrder:        make([]string, 0, maxStoredPastedContents),
+		nextPasteID:        1,
 		clipboard:          defaultClipboardImageReader{},
 		startupGuide:       opts.StartupGuide,
 	}
@@ -359,6 +368,7 @@ func newModel(opts Options) model {
 	m.tokenUsage.SetUnavailable(!m.tokenHasOfficialUsage)
 	m.tokenUsage.SetBreakdown(m.tokenInput, m.tokenOutput, m.tokenContext)
 	m.ensureSessionImageAssets()
+	m.ensurePastedContentState()
 	m.syncInputStyle()
 	m.syncInputOverlays()
 	if m.mentionIndex != nil {
@@ -636,6 +646,17 @@ func isCtrlVPasteKey(msg tea.KeyMsg) bool {
 	return normalizeKeyName(msg.String()) == "ctrl+v"
 }
 
+func inputMutationSource(msg tea.KeyMsg) string {
+	source := strings.TrimSpace(msg.String())
+	if !msg.Paste {
+		return source
+	}
+	if source == "" {
+		return "paste"
+	}
+	return source + ":paste"
+}
+
 func isClipboardNoImageNote(note string) bool {
 	return strings.Contains(strings.ToLower(strings.TrimSpace(note)), "clipboard has no image")
 }
@@ -841,7 +862,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Preserve multiline input shortcuts without triggering submit.
 		m.input, cmd = m.input.Update(tea.KeyMsg{Type: tea.KeyEnter})
 		if m.input.Value() != before {
-			m.handleInputMutation(before, m.input.Value(), msg.String())
+			m.handleInputMutation(before, m.input.Value(), inputMutationSource(msg))
 			m.syncInputOverlays()
 		}
 		return m, cmd
@@ -893,11 +914,59 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if msg.String() == "enter" {
+	if msg.String() == "enter" && !msg.Paste {
 		if m.shouldSuppressEnterAfterPaste() {
-			return m, nil
+			if m.busy {
+				return m, nil
+			}
+			before := m.input.Value()
+			var cmd tea.Cmd
+			m.input, cmd = m.input.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			if m.input.Value() != before {
+				m.handleInputMutation(before, m.input.Value(), "paste-enter")
+				m.syncInputOverlays()
+			}
+			return m, cmd
 		}
 		rawValue := m.input.Value()
+		if markerChain, ok := extractLeadingCompressedMarker(rawValue); ok {
+			tail := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(rawValue), markerChain))
+			if tail != "" {
+				if m.shouldCompressPastedText(tail, "paste-enter") {
+					marker, content, err := m.compressPastedText(tail)
+					if err != nil {
+						m.statusNote = err.Error()
+						return m, nil
+					}
+					combined := strings.TrimSpace(markerChain) + marker
+					m.setInputValue(combined)
+					m.syncInputOverlays()
+					m.statusNote = fmt.Sprintf("Detected another pasted block and compressed it as %s (%d lines). Press Enter again to send.", marker, content.Lines)
+					return m, nil
+				}
+				if len(tail) >= 24 || strings.Contains(tail, "\n") {
+					m.setInputValue(strings.TrimSpace(markerChain))
+					m.syncInputOverlays()
+					m.statusNote = "Detected continued paste chunk after compressed marker. Kept compressed markers only; press Enter again to send."
+					return m, nil
+				}
+			}
+		}
+		// Check whether the input has already been compressed.
+		isAlreadyCompressed := strings.Contains(rawValue, "[Paste #") || strings.Contains(rawValue, "[Pasted #")
+
+		// Compress long pasted content before sending.
+		if !isAlreadyCompressed && m.shouldCompressPastedText(rawValue, inputMutationSource(msg)) {
+			marker, content, err := m.compressPastedText(rawValue)
+			if err != nil {
+				m.statusNote = err.Error()
+				return m, nil
+			}
+			m.setInputValue(marker)
+			m.syncInputOverlays()
+			m.statusNote = fmt.Sprintf("Long pasted text (%d lines) compressed as %s. Press Enter again to send. Use [Paste #%s] or [Paste #%s line10~line20] later.", content.Lines, marker, content.ID, content.ID)
+			return m, nil
+		}
 		value := strings.TrimSpace(rawValue)
 		if m.startupGuide.Active && !strings.HasPrefix(value, "/") {
 			if err := m.handleStartupGuideSubmission(rawValue); err != nil {
@@ -965,11 +1034,12 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.input, cmd = m.input.Update(msg)
 	after := m.input.Value()
+	mutationSource := inputMutationSource(msg)
 	if after != before {
-		m.handleInputMutation(before, after, msg.String())
+		m.handleInputMutation(before, after, mutationSource)
 		after = m.input.Value()
 	}
-	triggerClipboardImagePaste := shouldTriggerClipboardImagePaste(before, after, msg.String())
+	triggerClipboardImagePaste := shouldTriggerClipboardImagePaste(before, after, mutationSource)
 	if ctrlVPasteDetected {
 		triggerClipboardImagePaste = false
 	}
@@ -1432,6 +1502,7 @@ func (m *model) noteInputMutation(before, after, source string) {
 
 func (m *model) handleInputMutation(before, after, source string) {
 	m.noteInputMutation(before, after, source)
+
 	updated, note := m.applyInputImagePipeline(before, after, source)
 	if updated == after {
 		fallbackUpdated, fallbackNote := m.applyWholeInputImagePathFallback(after, source)
@@ -1442,6 +1513,15 @@ func (m *model) handleInputMutation(before, after, source string) {
 			note = fallbackNote
 		}
 	}
+
+	pasteUpdated, pasteNote := m.applyLongPastedTextPipeline(before, updated, source)
+	if pasteUpdated != updated {
+		updated = pasteUpdated
+	}
+	if strings.TrimSpace(note) == "" {
+		note = pasteNote
+	}
+
 	if updated != after {
 		m.setInputValue(updated)
 	}
@@ -2992,6 +3072,8 @@ func (m *model) handleSlashCommand(input string) error {
 		return m.runSkillCommand(input, fields)
 	case "/new":
 		return m.newSession()
+	case "/compact":
+		return m.runCompactCommand(input)
 	default:
 		return m.runDirectSkillCommand(input, fields)
 	}
@@ -3052,6 +3134,33 @@ func (m *model) runSkillCommand(input string, fields []string) error {
 	}
 	m.appendCommandExchange(input, "Active skill cleared.")
 	m.statusNote = "Skill cleared."
+	return nil
+}
+
+func (m *model) runCompactCommand(input string) error {
+	if m.runner == nil {
+		return fmt.Errorf("runner is unavailable")
+	}
+	if m.sess == nil {
+		return fmt.Errorf("session is unavailable")
+	}
+	summary, changed, err := m.runner.CompactSession(context.Background(), m.sess)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		m.appendCommandExchange(input, "No compaction needed yet. Start a longer conversation first.")
+		m.statusNote = "No compaction needed."
+		return nil
+	}
+	preview := compact(summary, 360)
+	response := "Conversation compacted for long-context continuation."
+	if strings.TrimSpace(preview) != "" {
+		response += "\nSummary preview: " + preview
+	}
+	m.chatItems, m.toolRuns = rebuildSessionTimeline(m.sess)
+	m.appendCommandExchange(input, response)
+	m.statusNote = "Conversation compacted."
 	return nil
 }
 
@@ -3159,6 +3268,12 @@ func (m *model) newSession() error {
 	m.orphanedImages = make(map[llm.AssetID]time.Time, 8)
 	m.nextImageID = nextSessionImageID(next)
 	m.ensureSessionImageAssets()
+	m.pastedContents = make(map[string]pastedContent, maxStoredPastedContents)
+	m.pastedOrder = make([]string, 0, maxStoredPastedContents)
+	m.nextPasteID = 1
+	m.pastedStateLoaded = false
+	m.lastCompressedPasteAt = time.Time{}
+	m.ensurePastedContentState()
 	m.pendingBTW = nil
 	m.interrupting = false
 	m.interruptSafe = false
@@ -3201,6 +3316,12 @@ func (m *model) resumeSession(prefix string) error {
 	m.orphanedImages = make(map[llm.AssetID]time.Time, 8)
 	m.nextImageID = nextSessionImageID(next)
 	m.ensureSessionImageAssets()
+	m.pastedContents = make(map[string]pastedContent, maxStoredPastedContents)
+	m.pastedOrder = make([]string, 0, maxStoredPastedContents)
+	m.nextPasteID = 1
+	m.pastedStateLoaded = false
+	m.lastCompressedPasteAt = time.Time{}
+	m.ensurePastedContentState()
 	m.syncInputImageRefs("")
 	m.pendingBTW = nil
 	m.interrupting = false
@@ -3364,7 +3485,7 @@ func renderChatCard(item chatEntry, width int) string {
 		return rendered
 	}
 
-	sep := lipgloss.NewStyle().Foreground(colorTool).Render("│")
+	sep := lipgloss.NewStyle().Foreground(colorTool).Render("|")
 	lines := strings.Split(rendered, "\n")
 	for i := range lines {
 		if strings.TrimSpace(lines[i]) == "" {
@@ -4151,17 +4272,12 @@ func isMeaningfulThinking(body, toolName string) bool {
 	}
 
 	cnPrefixes := []string{
-		"鎴戝皢璋冪敤",
-		"鎴戜細璋冪敤",
-		"鎴戝厛璋冪敤",
-		"鎴戣璋冪敤",
-		"先调用",
-		"鎴戝皢浣跨敤",
-		"鎴戜細浣跨敤",
-		"鎴戝厛浣跨敤",
-		"鎴戝皢杩愯",
-		"鎴戜細杩愯",
-		"鍏堟鏌ョ浉鍏充笂涓嬫枃",
+		"i will call",
+		"i will use",
+		"let me call",
+		"let me use",
+		"let me run",
+		"tool result",
 	}
 	for _, prefix := range cnPrefixes {
 		if strings.HasPrefix(raw, prefix) {
@@ -4189,12 +4305,6 @@ func shouldRenderThinkingFromDelta(body string) bool {
 		"approach",
 		"systematically",
 		"through build and test",
-		"我会先",
-		"先了解",
-		"鐒跺悗",
-		"最后",
-		"通过构建和测试",
-		"系统性",
 	}
 	for _, marker := range reasoningMarkers {
 		if strings.Contains(lower, marker) || strings.Contains(text, marker) {
@@ -4505,7 +4615,7 @@ func shouldExecuteFromPalette(item commandItem) bool {
 		return true
 	}
 	switch item.Name {
-	case "/help", "/session", "/skills", "/skill clear", "/new", "/quit":
+	case "/help", "/session", "/skills", "/skill clear", "/new", "/compact", "/quit":
 		return true
 	default:
 		return false
@@ -4526,6 +4636,7 @@ func (m model) helpText() string {
 		"/<skill-name> [k=v...]: activate a skill for this session.",
 		"/skill clear: clear the active skill.",
 		"/new: start a fresh session.",
+		"/compact: summarize long history into a compact continuation context.",
 		"/btw <message>: interject while a run is in progress.",
 		"/quit: exit the TUI.",
 		"",
@@ -4535,6 +4646,8 @@ func (m model) helpText() string {
 		"Use Ctrl+G to open or close the help panel.",
 		"Use Ctrl+F to search prompt history and restore previous input.",
 		"If provider setup is required, paste an API key in the input and press Enter.",
+		"Long pasted code/text is compressed to [Paste #N ~X lines].",
+		"Use [Paste], [Paste #N], [Paste line3], or [Paste #N line3~line7] to expand references.",
 		"After restoring a session with a saved plan, type 'continue execution' to resume it.",
 		"Approval requests appear above the input area when a shell command needs confirmation.",
 		"The footer keeps only the essential shortcuts: tab agents, / commands, Ctrl+F history, Ctrl+L sessions, Ctrl+C quit.",
@@ -5099,7 +5212,7 @@ func (m model) sessionText() string {
 func statusGlyph(status string) string {
 	switch planpkg.NormalizeStepStatus(status) {
 	case planpkg.StepCompleted:
-		return doneStyle.Render("✓")
+		return doneStyle.Render("v")
 	case planpkg.StepInProgress:
 		return accentStyle.Render(">")
 	case planpkg.StepBlocked:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -27,6 +27,36 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+type compactCommandTestClient struct {
+	replies  []llm.Message
+	requests []llm.ChatRequest
+	index    int
+}
+
+func (c *compactCommandTestClient) CreateMessage(_ context.Context, req llm.ChatRequest) (llm.Message, error) {
+	c.requests = append(c.requests, req)
+	if len(c.replies) == 0 {
+		return llm.Message{}, nil
+	}
+	if c.index >= len(c.replies) {
+		return c.replies[len(c.replies)-1], nil
+	}
+	reply := c.replies[c.index]
+	c.index++
+	return reply, nil
+}
+
+func (c *compactCommandTestClient) StreamMessage(ctx context.Context, req llm.ChatRequest, onDelta func(string)) (llm.Message, error) {
+	reply, err := c.CreateMessage(ctx, req)
+	if err != nil {
+		return llm.Message{}, err
+	}
+	if onDelta != nil && strings.TrimSpace(reply.Content) != "" {
+		onDelta(reply.Content)
+	}
+	return reply, nil
+}
+
 func TestHandleMouseScrollsViewport(t *testing.T) {
 	m := model{
 		screen: screenChat,
@@ -1496,6 +1526,61 @@ func TestImmediateEnterAfterPasteStillSubmits(t *testing.T) {
 	}
 }
 
+func TestPasteEnterDoesNotSubmitAndKeepsNewline(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	input.SetWidth(40)
+	input.SetHeight(3)
+	input.SetValue("first line")
+	input.CursorEnd()
+
+	m := model{
+		screen:    screenChat,
+		input:     input,
+		workspace: "E:\\bytemind",
+		sess:      session.New("E:\\bytemind"),
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter, Paste: true})
+	updated := got.(model)
+
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected paste enter not to submit, got %d chat items", len(updated.chatItems))
+	}
+	if !strings.Contains(updated.input.Value(), "\n") {
+		t.Fatalf("expected pasted enter to be inserted as newline, got %q", updated.input.Value())
+	}
+}
+
+func TestSuppressedEnterAfterPasteIsInsertedAsNewline(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	input.SetWidth(40)
+	input.SetHeight(3)
+	input.SetValue("line1")
+	input.CursorEnd()
+
+	m := model{
+		screen:         screenChat,
+		input:          input,
+		workspace:      "E:\\bytemind",
+		sess:           session.New("E:\\bytemind"),
+		lastPasteAt:    time.Now(),
+		lastInputAt:    time.Now(),
+		inputBurstSize: 12,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected suppressed enter not to submit, got %d chat items", len(updated.chatItems))
+	}
+	if updated.input.Value() != "line1\n" {
+		t.Fatalf("expected suppressed enter to become newline, got %q", updated.input.Value())
+	}
+}
+
 func TestEnterSubmitsMultilinePrompt(t *testing.T) {
 	input := textarea.New()
 	input.Focus()
@@ -1747,7 +1832,7 @@ func TestFilteredCommandsShowsRootSelectorGroups(t *testing.T) {
 		usages = append(usages, item.Usage)
 	}
 
-	for _, want := range []string{"/help", "/session", "/new", "/quit"} {
+	for _, want := range []string{"/help", "/session", "/new", "/compact", "/quit"} {
 		if !containsString(usages, want) {
 			t.Fatalf("expected root selector to contain %q, got %v", want, usages)
 		}
@@ -1756,6 +1841,65 @@ func TestFilteredCommandsShowsRootSelectorGroups(t *testing.T) {
 		if containsString(usages, unwanted) {
 			t.Fatalf("did not expect root selector to contain %q", unwanted)
 		}
+	}
+}
+
+func TestHandleSlashCompactCompactsSession(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	sess.Messages = append(sess.Messages,
+		llm.NewUserTextMessage("first ask"),
+		llm.NewAssistantTextMessage(strings.Repeat("history details ", 30)),
+		llm.NewUserTextMessage("second ask"),
+		llm.NewAssistantTextMessage(strings.Repeat("more details ", 30)),
+	)
+	if err := store.Save(sess); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &compactCommandTestClient{
+		replies: []llm.Message{
+			{Role: llm.RoleAssistant, Content: "Goal: keep building\nDone: reviewed history\nPending: continue coding"},
+		},
+	}
+	runner := agent.NewRunner(agent.Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider: config.ProviderConfig{Model: "test-model"},
+			Stream:   false,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	m := model{
+		runner:    runner,
+		store:     store,
+		sess:      sess,
+		workspace: workspace,
+		screen:    screenChat,
+	}
+	if err := m.handleSlashCommand("/compact"); err != nil {
+		t.Fatalf("expected /compact to succeed, got %v", err)
+	}
+	if m.statusNote != "Conversation compacted." {
+		t.Fatalf("expected compacted status note, got %q", m.statusNote)
+	}
+	if len(sess.Messages) != 1 || sess.Messages[0].Role != llm.RoleAssistant {
+		t.Fatalf("expected compacted session summary message, got %#v", sess.Messages)
+	}
+	if !strings.Contains(sess.Messages[0].Text(), "Goal: keep building") {
+		t.Fatalf("expected persisted summary content, got %q", sess.Messages[0].Text())
+	}
+	if len(client.requests) != 1 {
+		t.Fatalf("expected one compaction LLM request, got %d", len(client.requests))
 	}
 }
 


### PR DESCRIPTION
这个 PR 主要修复并稳定了 TUI 中“长文本粘贴压缩”的整套行为，让体验更接近预期的 Copilot 风格：

长文本自动压缩为 [Paste #N ~X lines]
支持连续多次粘贴并追加 marker（独立编号）
支持引用展开（整段/单行/区间行）
修复分块粘贴时 marker 后残留正文的问题
统一换行处理（\r\n / \r / \n）
对“超长单段文本”增加软换行估算，避免总是显示 ~1 lines
主要修复点
长文本压缩稳定化
在输入处理链路中完善长文本识别与压缩触发逻辑
压缩后给出更明确的状态提示
分块粘贴场景修复
处理终端把一次粘贴拆成多个事件的情况
避免出现“同一段被错误拆成多个小 marker”
避免出现“[Paste #N ...] 后面还露出正文尾巴”
行数统计修复
有真实换行时按真实行数统计
单段超长文本按显示宽度估算行数，不再固定 ~1 lines
引用解析能力完善
支持 [Paste #N ~X lines] 整段展开
支持 [Paste #N line3]、[Paste #N line3~line7]
保持会话内粘贴内容可追踪与可复用
涉及文件
internal/tui/input_paste.go
internal/tui/input_paste_test.go
internal/tui/model.go
internal/tui/model_test.go
测试与验证
已补充/更新多组回归测试，覆盖：

长文本压缩
分块粘贴稳定性
marker 追加与尾巴清理
换行归一化
单段超长文本行数估算
引用展开与行范围提取
并通过：

go test ./internal/tui
go build ./cmd/bytemind
用户可见效果
本次修复后，以下问题得到改善：

一次长粘贴被拆成多个 ~1 lines 小块
marker 后仍残留原文尾巴
长段文本总是显示 ~1 lines
整体上，粘贴压缩行为更稳定、可预期，也更利于后续引用与展开。