### PR TITLE
skill测试推进

### DIFF
--- a/cmd/bytemind/install.go
+++ b/cmd/bytemind/install.go
@@ -171,7 +171,7 @@ func addInstallDirToUserPath(targetDir string) (bool, error) {
 }
 
 var windowsUserPathGetter = func() (string, error) {
-	cmd := exec.Command("powershell", "-NoProfile", "-Command", "[Environment]::GetEnvironmentVariable('Path','User')")
+	cmd := windowsPowerShellCommand("-NoProfile", "-Command", "[Environment]::GetEnvironmentVariable('Path','User')")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("read user PATH via PowerShell: %w (%s)", err, strings.TrimSpace(string(output)))
@@ -180,13 +180,82 @@ var windowsUserPathGetter = func() (string, error) {
 }
 
 var windowsUserPathSetter = func(newPath string) error {
-	cmd := exec.Command("powershell", "-NoProfile", "-Command", "[Environment]::SetEnvironmentVariable('Path', $env:BYTEMIND_USER_PATH, 'User')")
+	cmd := windowsPowerShellCommand("-NoProfile", "-Command", "[Environment]::SetEnvironmentVariable('Path', $env:BYTEMIND_USER_PATH, 'User')")
 	cmd.Env = append(os.Environ(), "BYTEMIND_USER_PATH="+newPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("write user PATH via PowerShell: %w (%s)", err, strings.TrimSpace(string(output)))
 	}
 	return nil
+}
+
+func windowsPowerShellCommand(args ...string) *exec.Cmd {
+	executable := resolveWindowsPowerShellExecutable(exec.LookPath, os.Stat, os.Getenv)
+	return exec.Command(executable, args...)
+}
+
+func resolveWindowsPowerShellExecutable(
+	lookPath func(file string) (string, error),
+	statFn func(name string) (os.FileInfo, error),
+	getenv func(key string) string,
+) string {
+	for _, candidate := range windowsPowerShellCandidates(getenv) {
+		if filepath.IsAbs(candidate) {
+			info, err := statFn(candidate)
+			if err == nil && info != nil && !info.IsDir() {
+				return candidate
+			}
+			continue
+		}
+		resolved, err := lookPath(candidate)
+		if err == nil && strings.TrimSpace(resolved) != "" {
+			return resolved
+		}
+	}
+	return "powershell"
+}
+
+func windowsPowerShellCandidates(getenv func(key string) string) []string {
+	candidates := []string{
+		"powershell.exe",
+		"powershell",
+		"pwsh.exe",
+		"pwsh",
+	}
+
+	appendWindowsRoot := func(root string) {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			return
+		}
+		candidates = append(candidates,
+			filepath.Join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+			filepath.Join(root, "Sysnative", "WindowsPowerShell", "v1.0", "powershell.exe"),
+		)
+	}
+
+	appendWindowsRoot(getenv("SystemRoot"))
+	appendWindowsRoot(getenv("WINDIR"))
+
+	if programFiles := strings.TrimSpace(getenv("ProgramFiles")); programFiles != "" {
+		candidates = append(candidates, filepath.Join(programFiles, "PowerShell", "7", "pwsh.exe"))
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	uniq := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		key := strings.ToLower(candidate)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		uniq = append(uniq, candidate)
+	}
+	return uniq
 }
 
 func addToWindowsUserPath(targetDir string) (bool, error) {

--- a/cmd/bytemind/install.go
+++ b/cmd/bytemind/install.go
@@ -200,7 +200,7 @@ func resolveWindowsPowerShellExecutable(
 	getenv func(key string) string,
 ) string {
 	for _, candidate := range windowsPowerShellCandidates(getenv) {
-		if filepath.IsAbs(candidate) {
+		if isWindowsAbsolutePath(candidate) {
 			info, err := statFn(candidate)
 			if err == nil && info != nil && !info.IsDir() {
 				return candidate
@@ -256,6 +256,23 @@ func windowsPowerShellCandidates(getenv func(key string) string) []string {
 		uniq = append(uniq, candidate)
 	}
 	return uniq
+}
+
+func isWindowsAbsolutePath(path string) bool {
+	if filepath.IsAbs(path) {
+		return true
+	}
+	if len(path) >= 3 && isASCIIAlpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/') {
+		return true
+	}
+	if len(path) >= 2 && path[0] == '\\' && path[1] == '\\' {
+		return true
+	}
+	return false
+}
+
+func isASCIIAlpha(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
 func addToWindowsUserPath(targetDir string) (bool, error) {

--- a/cmd/bytemind/install_test.go
+++ b/cmd/bytemind/install_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDefaultBinaryName(t *testing.T) {
@@ -119,6 +121,69 @@ func TestAddToWindowsUserPathUsesGetterAndSetter(t *testing.T) {
 	}
 }
 
+func TestResolveWindowsPowerShellExecutablePrefersLookPathCandidate(t *testing.T) {
+	got := resolveWindowsPowerShellExecutable(
+		func(file string) (string, error) {
+			if file == "powershell.exe" {
+				return `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, nil
+			}
+			return "", errors.New("not found")
+		},
+		func(name string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		},
+		func(key string) string { return "" },
+	)
+	if !strings.EqualFold(got, `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`) {
+		t.Fatalf("expected lookPath candidate, got %q", got)
+	}
+}
+
+func TestResolveWindowsPowerShellExecutableFallsBackToAbsoluteCandidate(t *testing.T) {
+	windowsRoot := `C:\Windows`
+	expected := filepath.Join(windowsRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+	got := resolveWindowsPowerShellExecutable(
+		func(file string) (string, error) {
+			return "", errors.New("not found")
+		},
+		func(name string) (os.FileInfo, error) {
+			if strings.EqualFold(name, expected) {
+				return stubInstallFileInfo{}, nil
+			}
+			return nil, os.ErrNotExist
+		},
+		func(key string) string {
+			if key == "SystemRoot" {
+				return windowsRoot
+			}
+			return ""
+		},
+	)
+	if !strings.EqualFold(got, expected) {
+		t.Fatalf("expected absolute fallback %q, got %q", expected, got)
+	}
+}
+
+func TestResolveWindowsPowerShellExecutableFallbacksToPowerShellLiteral(t *testing.T) {
+	got := resolveWindowsPowerShellExecutable(
+		func(file string) (string, error) { return "", errors.New("not found") },
+		func(name string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		func(key string) string { return "" },
+	)
+	if got != "powershell" {
+		t.Fatalf("expected final fallback powershell, got %q", got)
+	}
+}
+
 func samePath(a, b string) bool {
 	return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
 }
+
+type stubInstallFileInfo struct{}
+
+func (stubInstallFileInfo) Name() string       { return "powershell.exe" }
+func (stubInstallFileInfo) Size() int64        { return 0 }
+func (stubInstallFileInfo) Mode() os.FileMode  { return 0o644 }
+func (stubInstallFileInfo) ModTime() time.Time { return time.Time{} }
+func (stubInstallFileInfo) IsDir() bool        { return false }
+func (stubInstallFileInfo) Sys() any           { return nil }

--- a/docs/THIRD_PARTY_LICENSES.md
+++ b/docs/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,213 @@
+# Third-Party Licenses
+
+## skill-creator
+
+- Source path: `internal/skills/skill-creator`
+- License: Apache-2.0
+
+### Apache License 2.0 (verbatim)
+
+```text
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -104,6 +104,9 @@ func (r *Runner) compactSession(ctx context.Context, sess *session.Session, keep
 	}
 	summary = strings.TrimSpace(truncateRunes(summary, maxCompactionSummaryRunes))
 	if summary == "" {
+		summary = fallbackCompactionSummary(history)
+	}
+	if summary == "" {
 		return "", false, fmt.Errorf("compaction returned empty summary")
 	}
 
@@ -172,6 +175,39 @@ func (r *Runner) requestCompactionSummary(ctx context.Context, history []llm.Mes
 	}
 	reply.Normalize()
 	return strings.TrimSpace(reply.Text()), nil
+}
+
+func fallbackCompactionSummary(history []llm.Message) string {
+	if len(history) == 0 {
+		return ""
+	}
+
+	goal := strings.TrimSpace(firstUserGoal(history))
+	if goal == "" {
+		goal = "(unknown)"
+	}
+
+	const recentCount = 6
+	start := 0
+	if len(history) > recentCount {
+		start = len(history) - recentCount
+	}
+
+	lines := []string{
+		"Compaction fallback summary (model returned empty summary).",
+		"User goal: " + truncateRunes(goal, 320),
+		"Recent context:",
+	}
+
+	for i := start; i < len(history); i++ {
+		entry := strings.TrimSpace(formatCompactionMessage(i+1, history[i]))
+		if entry == "" {
+			continue
+		}
+		lines = append(lines, "- "+truncateRunes(entry, 420))
+	}
+
+	return strings.TrimSpace(truncateRunes(strings.Join(lines, "\n"), maxCompactionSummaryRunes))
 }
 
 func buildCompactionTranscript(messages []llm.Message, limit int) string {

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -329,6 +329,116 @@ func TestCompactSessionManualRewritesHistory(t *testing.T) {
 	}
 }
 
+func TestRunPromptAutoCompactionFallsBackWhenSummaryIsEmpty(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	for i := 0; i < 8; i++ {
+		sess.Messages = append(sess.Messages,
+			llm.NewUserTextMessage(strings.Repeat("history user segment ", 30)),
+			llm.NewAssistantTextMessage(strings.Repeat("history assistant segment ", 30)),
+		)
+	}
+	if err := store.Save(sess); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &fakeClient{
+		replies: []llm.Message{
+			{Role: llm.RoleAssistant, Content: "   "},
+			{Role: llm.RoleAssistant, Content: "done"},
+		},
+	}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 2,
+			Stream:        false,
+			TokenQuota:    220,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "continue implementation", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "done" {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+	if len(client.requests) != 2 {
+		t.Fatalf("expected one compaction request + one turn request, got %d", len(client.requests))
+	}
+	if len(sess.Messages) != 3 {
+		t.Fatalf("expected compacted session to keep summary + latest user + final assistant, got %#v", sess.Messages)
+	}
+	if !strings.Contains(sess.Messages[0].Text(), "Compaction fallback summary") {
+		t.Fatalf("expected fallback summary content, got %#v", sess.Messages[0])
+	}
+}
+
+func TestCompactSessionManualFallsBackWhenSummaryIsEmpty(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	sess.Messages = append(sess.Messages,
+		llm.NewUserTextMessage("first ask"),
+		llm.NewAssistantTextMessage("first answer"),
+		llm.NewUserTextMessage("second ask"),
+		llm.NewAssistantTextMessage("second answer"),
+	)
+	if err := store.Save(sess); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &fakeClient{
+		replies: []llm.Message{
+			{Role: llm.RoleAssistant, Content: "   "},
+		},
+	}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 2,
+			Stream:        false,
+			TokenQuota:    5000,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	summary, changed, err := runner.CompactSession(context.Background(), sess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatalf("expected compaction to change session state")
+	}
+	if strings.TrimSpace(summary) == "" {
+		t.Fatalf("expected non-empty fallback summary")
+	}
+	if !strings.Contains(summary, "Compaction fallback summary") {
+		t.Fatalf("expected fallback marker in summary, got %q", summary)
+	}
+}
+
 func TestRunPromptEncodesToolExecutionErrorsAndContinues(t *testing.T) {
 	workspace := t.TempDir()
 	store, err := session.NewStore(t.TempDir())

--- a/internal/skills/skill-creator/SKILL.md
+++ b/internal/skills/skill-creator/SKILL.md
@@ -1,0 +1,481 @@
+---
+name: skill-creator
+description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
+---
+
+# Skill Creator
+
+A skill for creating new skills and iteratively improving them.
+
+At a high level, the process of creating a skill goes like this:
+
+- Decide what you want the skill to do and roughly how it should do it
+- Write a draft of the skill
+- Create a few test prompts and run claude-with-access-to-the-skill on them
+- Help the user evaluate the results both qualitatively and quantitatively
+  - While the runs happen in the background, draft some quantitative evals if there aren't any (if there are some, you can either use as is or modify if you feel something needs to change about them). Then explain them to the user (or if they already existed, explain the ones that already exist)
+  - Use the Go review generator (`go run <skill-creator-path>/tools generate-review ...`) to show the user the results and quantitative metrics
+- Rewrite the skill based on feedback from the user's evaluation of the results (and also if there are any glaring flaws that become apparent from the quantitative benchmarks)
+- Repeat until you're satisfied
+- Expand the test set and try again at larger scale
+
+Your job when using this skill is to figure out where the user is in this process and then jump in and help them progress through these stages. So for instance, maybe they're like "I want to make a skill for X". You can help narrow down what they mean, write a draft, write the test cases, figure out how they want to evaluate, run all the prompts, and repeat.
+
+On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
+
+Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
+
+Then after the skill is done (but again, the order is flexible), you can also run the skill description improver, which we have a whole separate script for, to optimize the triggering of the skill.
+
+Cool? Cool.
+
+## Communicating with the user
+
+The skill creator is liable to be used by people across a wide range of familiarity with coding jargon. If you haven't heard (and how could you, it's only very recently that it started), there's a trend now where the power of Claude is inspiring plumbers to open up their terminals, parents and grandparents to google "how to install npm". On the other hand, the bulk of users are probably fairly computer-literate.
+
+So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
+
+- "evaluation" and "benchmark" are borderline, but OK
+- for "JSON" and "assertion" you want to see serious cues from the user that they know what those things are before using them without explaining them
+
+It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
+
+---
+
+## Creating a skill
+
+### Capture Intent
+
+Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first 鈥?the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+
+1. What should this skill enable Claude to do?
+2. When should this skill trigger? (what user phrases/contexts)
+3. What's the expected output format?
+4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+
+### Interview and Research
+
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+
+Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
+
+### Write the SKILL.md
+
+Based on the user interview, fill in these components:
+
+- **name**: Skill identifier
+- **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
+- **compatibility**: Required tools, dependencies (optional, rarely needed)
+- **the rest of the skill :)**
+
+### Skill Writing Guide
+
+#### Anatomy of a Skill
+
+```
+skill-name/
+鈹溾攢鈹€ SKILL.md (required)
+鈹?  鈹溾攢鈹€ YAML frontmatter (name, description required)
+鈹?  鈹斺攢鈹€ Markdown instructions
+鈹斺攢鈹€ Bundled Resources (optional)
+    鈹溾攢鈹€ scripts/    - Executable code for deterministic/repetitive tasks
+    鈹溾攢鈹€ references/ - Docs loaded into context as needed
+    鈹斺攢鈹€ assets/     - Optional supporting files used in outputs (sample data, docs, static resources)
+```
+
+#### Progressive Disclosure
+
+Skills use a three-level loading system:
+1. **Metadata** (name + description) - Always in context (~100 words)
+2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
+3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
+
+These word counts are approximate and you can feel free to go longer if needed.
+
+**Key patterns:**
+- Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
+- Reference files clearly from SKILL.md with guidance on when to read them
+- For large reference files (>300 lines), include a table of contents
+
+**Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
+```
+cloud-deploy/
+鈹溾攢鈹€ SKILL.md (workflow + selection)
+鈹斺攢鈹€ references/
+    鈹溾攢鈹€ aws.md
+    鈹溾攢鈹€ gcp.md
+    鈹斺攢鈹€ azure.md
+```
+Claude reads only the relevant reference file.
+
+#### Principle of Lack of Surprise
+
+This goes without saying, but skills must not contain malware, exploit code, or any content that could compromise system security. A skill's contents should not surprise the user in their intent if described. Don't go along with requests to create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like a "roleplay as an XYZ" are OK though.
+
+#### Writing Patterns
+
+Prefer using the imperative form in instructions.
+
+**Defining output formats** - You can do it like this:
+```markdown
+## Report structure
+ALWAYS use this exact template:
+# [Title]
+## Executive summary
+## Key findings
+## Recommendations
+```
+
+**Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+```markdown
+## Commit message format
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output: feat(auth): implement JWT-based authentication
+```
+
+### Writing Style
+
+Try to explain to the model why things are important in lieu of heavy-handed musty MUSTs. Use theory of mind and try to make the skill general and not super-narrow to specific examples. Start by writing a draft and then look at it with fresh eyes and improve it.
+
+### Test Cases
+
+After writing the skill draft, come up with 2-3 realistic test prompts 鈥?the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
+
+Save test cases to `evals/evals.json`. Don't write assertions yet 鈥?just the prompts. You'll draft assertions in the next step while the runs are in progress.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's task prompt",
+      "expected_output": "Description of expected result",
+      "files": []
+    }
+  ]
+}
+```
+
+See `references/schemas.md` for the full schema (including the `assertions` field, which you'll add later).
+
+## Running and evaluating test cases
+
+This section is one continuous sequence 鈥?don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
+
+Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront 鈥?just create directories as you go.
+
+### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
+
+For each test case, spawn two subagents in the same turn 鈥?one with the skill, one without. This is important: don't spawn the with-skill runs first and then come back for baselines later. Launch everything at once so it all finishes around the same time.
+
+**With-skill run:**
+
+```
+Execute this task:
+- Skill path: <path-to-skill>
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+- Save outputs to: <workspace>/iteration-<N>/eval-<ID>/with_skill/outputs/
+- Outputs to save: <what the user cares about 鈥?e.g., "the .docx file", "the final CSV">
+```
+
+**Baseline run** (same prompt, but the baseline depends on context):
+- **Creating a new skill**: no skill at all. Same prompt, no skill path, save to `without_skill/outputs/`.
+- **Improving an existing skill**: the old version. Before editing, snapshot the skill (`cp -r <skill-path> <workspace>/skill-snapshot/`), then point the baseline subagent at the snapshot. Save to `old_skill/outputs/`.
+
+Write an `eval_metadata.json` for each test case (assertions can be empty for now). Give each eval a descriptive name based on what it's testing 鈥?not just "eval-0". Use this name for the directory too. If this iteration uses new or modified eval prompts, create these files for each new eval directory 鈥?don't assume they carry over from previous iterations.
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "descriptive-name-here",
+  "prompt": "The user's task prompt",
+  "assertions": []
+}
+```
+
+### Step 2: While runs are in progress, draft assertions
+
+Don't just wait for the runs to finish 鈥?you can use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.
+
+Good assertions are objectively verifiable and have descriptive names 鈥?they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively 鈥?don't force assertions onto things that need human judgment.
+
+Update the `eval_metadata.json` files and `evals/evals.json` with the assertions once drafted. Also explain to the user what they'll see in the viewer 鈥?both the qualitative outputs and the quantitative benchmark.
+
+### Step 3: As runs complete, capture timing data
+
+When each subagent task completes, you receive a notification containing `total_tokens` and `duration_ms`. Save this data immediately to `timing.json` in the run directory:
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3
+}
+```
+
+This is the only opportunity to capture this data 鈥?it comes through the task notification and isn't persisted elsewhere. Process each notification as it arrives rather than trying to batch them.
+
+### Step 4: Grade, aggregate, and launch the viewer
+
+Once all runs are done:
+
+1. **Grade each run** 鈥?spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) 鈥?the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it 鈥?scripts are faster, more reliable, and can be reused across iterations.
+
+2. **Aggregate into benchmark** 鈥?run the aggregation script from the skill-creator directory:
+   ```bash
+   go run <skill-creator-path>/tools aggregate-benchmark <workspace>/iteration-N --skill-name <name>
+   ```
+   This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean 卤 stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
+Put each with_skill version before its baseline counterpart.
+
+3. **Do an analyst pass** 鈥?read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for 鈥?things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
+
+4. **Launch the viewer** with both qualitative outputs and quantitative data:
+   ```bash
+   go run <skill-creator-path>/tools generate-review \
+     <workspace>/iteration-N \
+     --skill-name "my-skill" \
+     --benchmark <workspace>/iteration-N/benchmark.json \
+     > /dev/null 2>&1 &
+   VIEWER_PID=$!
+   ```
+   For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
+
+   **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
+
+Note: please use the Go `generate-review` command to create the viewer; there's no need to write custom HTML.
+
+5. **Tell the user** something like: "I've opened the results in your browser. There are two tabs 鈥?'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
+
+### What the user sees in the viewer
+
+The "Outputs" tab shows one test case at a time:
+- **Prompt**: the task that was given
+- **Output**: the files the skill produced, rendered inline where possible
+- **Previous Output** (iteration 2+): collapsed section showing last iteration's output
+- **Formal Grades** (if grading was run): collapsed section showing assertion pass/fail
+- **Feedback**: a textbox that auto-saves as they type
+- **Previous Feedback** (iteration 2+): their comments from last time, shown below the textbox
+
+The "Benchmark" tab shows the stats summary: pass rates, timing, and token usage for each configuration, with per-eval breakdowns and analyst observations.
+
+Navigation is via prev/next buttons or arrow keys. When done, they click "Submit All Reviews" which saves all feedback to `feedback.json`.
+
+### Step 5: Read the feedback
+
+When the user tells you they're done, read `feedback.json`:
+
+```json
+{
+  "reviews": [
+    {"run_id": "eval-0-with_skill", "feedback": "the chart is missing axis labels", "timestamp": "..."},
+    {"run_id": "eval-1-with_skill", "feedback": "", "timestamp": "..."},
+    {"run_id": "eval-2-with_skill", "feedback": "perfect, love this", "timestamp": "..."}
+  ],
+  "status": "complete"
+}
+```
+
+Empty feedback means the user thought it was fine. Focus your improvements on the test cases where the user had specific complaints.
+
+Kill the viewer server when you're done with it:
+
+```bash
+kill $VIEWER_PID 2>/dev/null
+```
+
+---
+
+## Improving the skill
+
+This is the heart of the loop. You've run the test cases, the user has reviewed the results, and now you need to make the skill better based on their feedback.
+
+### How to think about improvements
+
+1. **Generalize from the feedback.** The big picture thing that's happening here is that we're trying to create skills that can be used a million times (maybe literally, maybe even more who knows) across many different prompts. Here you and the user are iterating on only a few examples over and over again because it helps move faster. The user knows these examples in and out and it's quick for them to assess new outputs. But if the skill you and the user are codeveloping works only for those examples, it's useless. Rather than put in fiddly overfitty changes, or oppressively constrictive MUSTs, if there's some stubborn issue, you might try branching out and using different metaphors, or recommending different patterns of working. It's relatively cheap to try and maybe you'll land on something great.
+
+2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs 鈥?if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
+
+3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag 鈥?if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
+
+4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.go` or a `build_chart.go`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
+
+This task is pretty important (we are trying to create billions a year in economic value here!) and your thinking time is not the blocker; take your time and really mull things over. I'd suggest writing a draft revision and then looking at it anew and making improvements. Really do your best to get into the head of the user and understand what they want and need.
+
+### The iteration loop
+
+After improving the skill:
+
+1. Apply your improvements to the skill
+2. Rerun all test cases into a new `iteration-<N+1>/` directory, including baseline runs. If you're creating a new skill, the baseline is always `without_skill` (no skill) 鈥?that stays the same across iterations. If you're improving an existing skill, use your judgment on what makes sense as the baseline: the original version the user came in with, or the previous iteration.
+3. Launch the reviewer with `--previous-workspace` pointing at the previous iteration
+4. Wait for the user to review and tell you they're done
+5. Read the new feedback, improve again, repeat
+
+Keep going until:
+- The user says they're happy
+- The feedback is all empty (everything looks good)
+- You're not making meaningful progress
+
+---
+
+## Advanced: Blind comparison
+
+For situations where you want a more rigorous comparison between two versions of a skill (e.g., the user asks "is the new version actually better?"), there's a blind comparison system. Read `agents/comparator.md` and `agents/analyzer.md` for the details. The basic idea is: give two outputs to an independent agent without telling it which is which, and let it judge quality. Then analyze why the winner won.
+
+This is optional, requires subagents, and most users won't need it. The human review loop is usually sufficient.
+
+---
+
+## Description Optimization
+
+The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
+
+### Step 1: Generate trigger eval queries
+
+Create 20 eval queries 鈥?a mix of should-trigger and should-not-trigger. Save as JSON:
+
+```json
+[
+  {"query": "the user prompt", "should_trigger": true},
+  {"query": "another prompt", "should_trigger": false}
+]
+```
+
+The queries must be realistic and something a Claude Code or Claude.ai user would actually type. Not abstract requests, but requests that are concrete and specific and have a good amount of detail. For instance, file paths, personal context about the user's job or situation, column names and values, company names, URLs. A little bit of backstory. Some might be in lowercase or contain abbreviations or typos or casual speech. Use a mix of different lengths, and focus on edge cases rather than making them clear-cut (the user will get a chance to sign off on them).
+
+Bad: `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
+
+Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
+
+For the **should-trigger** queries (8-10), think about coverage. You want different phrasings of the same intent 鈥?some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Throw in some uncommon use cases and cases where this skill competes with another but should win.
+
+For the **should-not-trigger** queries (8-10), the most valuable ones are the near-misses 鈥?queries that share keywords or concepts with the skill but actually need something different. Think adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches on something the skill does but in a context where another tool is more appropriate.
+
+The key thing to avoid: don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill is too easy 鈥?it doesn't test anything. The negative cases should be genuinely tricky.
+
+### Step 2: Review with user
+
+Review the eval set directly in the conversation (no frontend template files):
+
+1. Show the draft eval set as JSON in a fenced code block
+2. Ask the user to edit any query text and toggle `should_trigger` where needed
+3. Apply the approved edits and save the final JSON to the workspace (for example `eval_set.json`)
+4. Confirm counts before running: total queries, should-trigger count, should-not-trigger count
+
+This step matters - bad eval queries lead to bad descriptions.
+### Step 3: Run the optimization loop
+
+Tell the user: "This will take some time 鈥?I'll run the optimization loop in the background and check on it periodically."
+
+Save the eval set to the workspace, then run in the background:
+
+```bash
+go run <skill-creator-path>/tools run-loop \
+  --eval-set <path-to-trigger-eval.json> \
+  --skill-path <path-to-skill> \
+  --model <model-id-powering-this-session> \
+  --max-iterations 5 \
+  --verbose
+```
+
+Use the model ID from your system prompt (the one powering the current session) so the triggering test matches what the user actually experiences.
+
+While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
+
+This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` 鈥?selected by test score rather than train score to avoid overfitting.
+
+### How skill triggering works
+
+Understanding the triggering mechanism helps design better eval queries. Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description. The important thing to know is that Claude only consults skills for tasks it can't easily handle on its own 鈥?simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because Claude can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
+
+This means your eval queries should be substantive enough that Claude would actually benefit from consulting a skill. Simple queries like "read file X" are poor test cases 鈥?they won't trigger skills regardless of description quality.
+
+### Step 4: Apply the result
+
+Take `best_description` from the JSON output and update the skill's SKILL.md frontmatter. Show the user before/after and report the scores.
+
+---
+
+### Package and Present (only if `present_files` tool is available)
+
+Check whether you have access to the `present_files` tool. If you don't, skip this step. If you do, package the skill and present the .skill file to the user:
+
+```bash
+go run <skill-creator-path>/tools package-skill <path/to/skill-folder>
+```
+
+After packaging, direct the user to the resulting `.skill` file path so they can install it.
+
+---
+
+## Claude.ai-specific instructions
+
+In Claude.ai, the core workflow is the same (draft 鈫?test 鈫?review 鈫?improve 鈫?repeat), but because Claude.ai doesn't have subagents, some mechanics change. Here's what to adapt:
+
+**Running test cases**: No subagents means no parallel execution. For each test case, read the skill's SKILL.md, then follow its instructions to accomplish the test prompt yourself. Do them one at a time. This is less rigorous than independent subagents (you wrote the skill and you're also running it, so you have full context), but it's a useful sanity check 鈥?and the human review step compensates. Skip the baseline runs 鈥?just use the skill to complete the task as requested.
+
+**Reviewing results**: If you can't open a browser (e.g., Claude.ai's VM has no display, or you're on a remote server), skip the browser reviewer entirely. Instead, present results directly in the conversation. For each test case, show the prompt and the output. If the output is a file the user needs to see (like a .docx or .xlsx), save it to the filesystem and tell them where it is so they can download and inspect it. Ask for feedback inline: "How does this look? Anything you'd change?"
+
+**Benchmarking**: Skip the quantitative benchmarking 鈥?it relies on baseline comparisons which aren't meaningful without subagents. Focus on qualitative feedback from the user.
+
+**The iteration loop**: Same as before 鈥?improve the skill, rerun the test cases, ask for feedback 鈥?just without the browser reviewer in the middle. You can still organize results into iteration directories on the filesystem if you have one.
+
+**Description optimization**: This section requires the `claude` CLI tool (specifically `claude -p`) which is only available in Claude Code. Skip it if you're on Claude.ai.
+
+**Blind comparison**: Requires subagents. Skip it.
+
+**Packaging**: The `package-skill` Go command works anywhere with Go and a filesystem. On Claude.ai, you can run it and the user can download the resulting `.skill` file.
+
+**Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. In this case:
+- **Preserve the original name.** Note the skill's directory name and `name` frontmatter field -- use them unchanged. E.g., if the installed skill is `research-helper`, output `research-helper.skill` (not `research-helper-v2`).
+- **Copy to a writeable location before editing.** The installed skill path may be read-only. Copy to `/tmp/skill-name/`, edit there, and package from the copy.
+- **If packaging manually, stage in `/tmp/` first**, then copy to the output directory -- direct writes may fail due to permissions.
+
+---
+
+## Cowork-Specific Instructions
+
+If you're in Cowork, the main things to know are:
+
+- You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade, etc.) all works. (However, if you run into severe problems with timeouts, it's OK to run the test prompts in series rather than parallel.)
+- You don't have a browser or display, so when generating the eval viewer, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Then proffer a link that the user can click to open the HTML in their browser.
+- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `go run <skill-creator-path>/tools generate-review` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself. You want to get them in front of the human ASAP!
+- Feedback works differently: since there's no running server, the viewer's "Submit All Reviews" button will download `feedback.json` as a file. You can then read it from there (you may have to request access first).
+- Packaging works 鈥?`go run <skill-creator-path>/tools package-skill` just needs Go and a filesystem.
+- Description optimization (`run-loop` / `run-eval`) should work in Cowork just fine since it uses `claude -p` via subprocess, not a browser, but please save it until you've fully finished making the skill and the user agrees it's in good shape.
+- **Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. Follow the update guidance in the claude.ai section above.
+
+---
+
+## Reference files
+
+The agents/ directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
+
+- `agents/grader.md` 鈥?How to evaluate assertions against outputs
+- `agents/comparator.md` 鈥?How to do blind A/B comparison between two outputs
+- `agents/analyzer.md` 鈥?How to analyze why one version beat another
+
+The references/ directory has additional documentation:
+- `references/schemas.md` 鈥?JSON structures for evals.json, grading.json, etc.
+
+---
+
+Repeating one more time the core loop here for emphasis:
+
+- Figure out what the skill is about
+- Draft or edit the skill
+- Run claude-with-access-to-the-skill on test prompts
+- With the user, evaluate the outputs:
+  - Create benchmark.json and run `go run <skill-creator-path>/tools generate-review` to help the user review them
+  - Run quantitative evals
+- Repeat until you and the user are satisfied
+- Package the final skill and return it to the user.
+
+Please add steps to your TodoList, if you have such a thing, to make sure you don't forget. If you're in Cowork, please specifically put "Create evals JSON and run `go run <skill-creator-path>/tools generate-review` so human can review test cases" in your TodoList to make sure it happens.
+
+Good luck!
+

--- a/internal/skills/skill-creator/agents/analyzer.md
+++ b/internal/skills/skill-creator/agents/analyzer.md
@@ -1,0 +1,275 @@
+﻿# Post-hoc Analyzer Agent
+
+Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.
+
+## Role
+
+After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **winner**: "A" or "B" (from blind comparison)
+- **winner_skill_path**: Path to the skill that produced the winning output
+- **winner_transcript_path**: Path to the execution transcript for the winner
+- **loser_skill_path**: Path to the skill that produced the losing output
+- **loser_transcript_path**: Path to the execution transcript for the loser
+- **comparison_result_path**: Path to the blind comparator's output JSON
+- **output_path**: Where to save the analysis results
+
+## Process
+
+### Step 1: Read Comparison Result
+
+1. Read the blind comparator's output at comparison_result_path
+2. Note the winning side (A or B), the reasoning, and any scores
+3. Understand what the comparator valued in the winning output
+
+### Step 2: Read Both Skills
+
+1. Read the winner skill's SKILL.md and key referenced files
+2. Read the loser skill's SKILL.md and key referenced files
+3. Identify structural differences:
+   - Instructions clarity and specificity
+   - Script/tool usage patterns
+   - Example coverage
+   - Edge case handling
+
+### Step 3: Read Both Transcripts
+
+1. Read the winner's transcript
+2. Read the loser's transcript
+3. Compare execution patterns:
+   - How closely did each follow their skill's instructions?
+   - What tools were used differently?
+   - Where did the loser diverge from optimal behavior?
+   - Did either encounter errors or make recovery attempts?
+
+### Step 4: Analyze Instruction Following
+
+For each transcript, evaluate:
+- Did the agent follow the skill's explicit instructions?
+- Did the agent use the skill's provided tools/scripts?
+- Were there missed opportunities to leverage skill content?
+- Did the agent add unnecessary steps not in the skill?
+
+Score instruction following 1-10 and note specific issues.
+
+### Step 5: Identify Winner Strengths
+
+Determine what made the winner better:
+- Clearer instructions that led to better behavior?
+- Better scripts/tools that produced better output?
+- More comprehensive examples that guided edge cases?
+- Better error handling guidance?
+
+Be specific. Quote from skills/transcripts where relevant.
+
+### Step 6: Identify Loser Weaknesses
+
+Determine what held the loser back:
+- Ambiguous instructions that led to suboptimal choices?
+- Missing tools/scripts that forced workarounds?
+- Gaps in edge case coverage?
+- Poor error handling that caused failures?
+
+### Step 7: Generate Improvement Suggestions
+
+Based on the analysis, produce actionable suggestions for improving the loser skill:
+- Specific instruction changes to make
+- Tools/scripts to add or modify
+- Examples to include
+- Edge cases to address
+
+Prioritize by impact. Focus on changes that would have changed the outcome.
+
+### Step 8: Write Analysis Results
+
+Save structured analysis to `{output_path}`.
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors",
+    "Explicit guidance on fallback behavior when OCR fails"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise and made errors",
+    "No guidance on OCR failure, agent gave up instead of trying alternatives"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": [
+        "Minor: skipped optional logging step"
+      ]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3",
+        "Missed the 'always validate output' instruction"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps: 1) Extract text, 2) Identify sections, 3) Format per template",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    },
+    {
+      "priority": "high",
+      "category": "tools",
+      "suggestion": "Add validate_output.go script similar to winner skill's validation approach",
+      "expected_impact": "Would catch formatting errors before final output"
+    },
+    {
+      "priority": "medium",
+      "category": "error_handling",
+      "suggestion": "Add fallback instructions: 'If OCR fails, try: 1) different resolution, 2) image preprocessing, 3) manual extraction'",
+      "expected_impact": "Would prevent early failure on difficult documents"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script -> Fixed 2 issues -> Produced output",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods -> No validation -> Output had errors"
+  }
+}
+```
+
+## Guidelines
+
+- **Be specific**: Quote from skills and transcripts, don't just say "instructions were unclear"
+- **Be actionable**: Suggestions should be concrete changes, not vague advice
+- **Focus on skill improvements**: The goal is to improve the losing skill, not critique the agent
+- **Prioritize by impact**: Which changes would most likely have changed the outcome?
+- **Consider causation**: Did the skill weakness actually cause the worse output, or is it incidental?
+- **Stay objective**: Analyze what happened, don't editorialize
+- **Think about generalization**: Would this improvement help on other evals too?
+
+## Categories for Suggestions
+
+Use these categories to organize improvement suggestions:
+
+| Category | Description |
+|----------|-------------|
+| `instructions` | Changes to the skill's prose instructions |
+| `tools` | Scripts, templates, or utilities to add/modify |
+| `examples` | Example inputs/outputs to include |
+| `error_handling` | Guidance for handling failures |
+| `structure` | Reorganization of skill content |
+| `references` | External docs or resources to add |
+
+## Priority Levels
+
+- **high**: Would likely change the outcome of this comparison
+- **medium**: Would improve quality but may not change win/loss
+- **low**: Nice to have, marginal improvement
+
+---
+
+# Analyzing Benchmark Results
+
+When analyzing benchmark results, the analyzer's purpose is to **surface patterns and anomalies** across multiple runs, not suggest skill improvements.
+
+## Role
+
+Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns that wouldn't be visible from aggregate metrics alone.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **benchmark_data_path**: Path to the in-progress benchmark.json with all run results
+- **skill_path**: Path to the skill being benchmarked
+- **output_path**: Where to save the notes (as JSON array of strings)
+
+## Process
+
+### Step 1: Read Benchmark Data
+
+1. Read the benchmark.json containing all run results
+2. Note the configurations tested (with_skill, without_skill)
+3. Understand the run_summary aggregates already calculated
+
+### Step 2: Analyze Per-Assertion Patterns
+
+For each expectation across all runs:
+- Does it **always pass** in both configurations? (may not differentiate skill value)
+- Does it **always fail** in both configurations? (may be broken or beyond capability)
+- Does it **always pass with skill but fail without**? (skill clearly adds value here)
+- Does it **always fail with skill but pass without**? (skill may be hurting)
+- Is it **highly variable**? (flaky expectation or non-deterministic behavior)
+
+### Step 3: Analyze Cross-Eval Patterns
+
+Look for patterns across evals:
+- Are certain eval types consistently harder/easier?
+- Do some evals show high variance while others are stable?
+- Are there surprising results that contradict expectations?
+
+### Step 4: Analyze Metrics Patterns
+
+Look at time_seconds, tokens, tool_calls:
+- Does the skill significantly increase execution time?
+- Is there high variance in resource usage?
+- Are there outlier runs that skew the aggregates?
+
+### Step 5: Generate Notes
+
+Write freeform observations as a list of strings. Each note should:
+- State a specific observation
+- Be grounded in the data (not speculation)
+- Help the user understand something the aggregate metrics don't show
+
+Examples:
+- "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
+- "Eval 3 shows high variance (50% 卤 40%) - run 2 had an unusual failure that may be flaky"
+- "Without-skill runs consistently fail on table extraction expectations (0% pass rate)"
+- "Skill adds 13s average execution time but improves pass rate by 50%"
+- "Token usage is 80% higher with skill, primarily due to script output parsing"
+- "All 3 without-skill runs for eval 1 produced empty output"
+
+### Step 6: Write Notes
+
+Save notes to `{output_path}` as a JSON array of strings:
+
+```json
+[
+  "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+  "Eval 3 shows high variance (50% 卤 40%) - run 2 had an unusual failure",
+  "Without-skill runs consistently fail on table extraction expectations",
+  "Skill adds 13s average execution time but improves pass rate by 50%"
+]
+```
+
+## Guidelines
+
+**DO:**
+- Report what you observe in the data
+- Be specific about which evals, expectations, or runs you're referring to
+- Note patterns that aggregate metrics would hide
+- Provide context that helps interpret the numbers
+
+**DO NOT:**
+- Suggest improvements to the skill (that's for the improvement step, not benchmarking)
+- Make subjective quality judgments ("the output was good/bad")
+- Speculate about causes without evidence
+- Repeat information already in the run_summary aggregates
+

--- a/internal/skills/skill-creator/agents/comparator.md
+++ b/internal/skills/skill-creator/agents/comparator.md
@@ -1,0 +1,202 @@
+# Blind Comparator Agent
+
+Compare two outputs WITHOUT knowing which skill produced them.
+
+## Role
+
+The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach.
+
+Your judgment is based purely on output quality and task completion.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **output_a_path**: Path to the first output file or directory
+- **output_b_path**: Path to the second output file or directory
+- **eval_prompt**: The original task/prompt that was executed
+- **expectations**: List of expectations to check (optional - may be empty)
+
+## Process
+
+### Step 1: Read Both Outputs
+
+1. Examine output A (file or directory)
+2. Examine output B (file or directory)
+3. Note the type, structure, and content of each
+4. If outputs are directories, examine all relevant files inside
+
+### Step 2: Understand the Task
+
+1. Read the eval_prompt carefully
+2. Identify what the task requires:
+   - What should be produced?
+   - What qualities matter (accuracy, completeness, format)?
+   - What would distinguish a good output from a poor one?
+
+### Step 3: Generate Evaluation Rubric
+
+Based on the task, generate a rubric with two dimensions:
+
+**Content Rubric** (what the output contains):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Correctness | Major errors | Minor errors | Fully correct |
+| Completeness | Missing key elements | Mostly complete | All elements present |
+| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+**Structure Rubric** (how the output is organized):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Organization | Disorganized | Reasonably organized | Clear, logical structure |
+| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
+| Usability | Difficult to use | Usable with effort | Easy to use |
+
+Adapt criteria to the specific task. For example:
+- PDF form → "Field alignment", "Text readability", "Data placement"
+- Document → "Section structure", "Heading hierarchy", "Paragraph flow"
+- Data output → "Schema correctness", "Data types", "Completeness"
+
+### Step 4: Evaluate Each Output Against the Rubric
+
+For each output (A and B):
+
+1. **Score each criterion** on the rubric (1-5 scale)
+2. **Calculate dimension totals**: Content score, Structure score
+3. **Calculate overall score**: Average of dimension scores, scaled to 1-10
+
+### Step 5: Check Assertions (if provided)
+
+If expectations are provided:
+
+1. Check each expectation against output A
+2. Check each expectation against output B
+3. Count pass rates for each output
+4. Use expectation scores as secondary evidence (not the primary decision factor)
+
+### Step 6: Determine the Winner
+
+Compare A and B based on (in priority order):
+
+1. **Primary**: Overall rubric score (content + structure)
+2. **Secondary**: Assertion pass rates (if applicable)
+3. **Tiebreaker**: If truly equal, declare a TIE
+
+Be decisive - ties should be rare. One output is usually better, even if marginally.
+
+### Step 7: Write Comparison Results
+
+Save results to a JSON file at the path specified (or `comparison.json` if not specified).
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": true},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": false},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+If no expectations were provided, omit the `expectation_results` field entirely.
+
+## Field Descriptions
+
+- **winner**: "A", "B", or "TIE"
+- **reasoning**: Clear explanation of why the winner was chosen (or why it's a tie)
+- **rubric**: Structured rubric evaluation for each output
+  - **content**: Scores for content criteria (correctness, completeness, accuracy)
+  - **structure**: Scores for structure criteria (organization, formatting, usability)
+  - **content_score**: Average of content criteria (1-5)
+  - **structure_score**: Average of structure criteria (1-5)
+  - **overall_score**: Combined score scaled to 1-10
+- **output_quality**: Summary quality assessment
+  - **score**: 1-10 rating (should match rubric overall_score)
+  - **strengths**: List of positive aspects
+  - **weaknesses**: List of issues or shortcomings
+- **expectation_results**: (Only if expectations provided)
+  - **passed**: Number of expectations that passed
+  - **total**: Total number of expectations
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+  - **details**: Individual expectation results
+
+## Guidelines
+
+- **Stay blind**: DO NOT try to infer which skill produced which output. Judge purely on output quality.
+- **Be specific**: Cite specific examples when explaining strengths and weaknesses.
+- **Be decisive**: Choose a winner unless outputs are genuinely equivalent.
+- **Output quality first**: Assertion scores are secondary to overall task completion.
+- **Be objective**: Don't favor outputs based on style preferences; focus on correctness and completeness.
+- **Explain your reasoning**: The reasoning field should make it clear why you chose the winner.
+- **Handle edge cases**: If both outputs fail, pick the one that fails less badly. If both are excellent, pick the one that's marginally better.

--- a/internal/skills/skill-creator/agents/grader.md
+++ b/internal/skills/skill-creator/agents/grader.md
@@ -1,0 +1,224 @@
+﻿# Grader Agent
+
+Evaluate expectations against an execution transcript and outputs.
+
+## Role
+
+The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless 鈥?it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **expectations**: List of expectations to evaluate (strings)
+- **transcript_path**: Path to the execution transcript (markdown file)
+- **outputs_dir**: Directory containing output files from execution
+
+## Process
+
+### Step 1: Read the Transcript
+
+1. Read the transcript file completely
+2. Note the eval prompt, execution steps, and final result
+3. Identify any issues or errors documented
+
+### Step 2: Examine Output Files
+
+1. List files in outputs_dir
+2. Read/examine each file relevant to the expectations. If outputs aren't plain text, use the inspection tools provided in your prompt 鈥?don't rely solely on what the transcript says the executor produced.
+3. Note contents, structure, and quality
+
+### Step 3: Evaluate Each Assertion
+
+For each expectation:
+
+1. **Search for evidence** in the transcript and outputs
+2. **Determine verdict**:
+   - **PASS**: Clear evidence the expectation is true AND the evidence reflects genuine task completion, not just surface-level compliance
+   - **FAIL**: No evidence, or evidence contradicts the expectation, or the evidence is superficial (e.g., correct filename but empty/wrong content)
+3. **Cite the evidence**: Quote the specific text or describe what you found
+
+### Step 4: Extract and Verify Claims
+
+Beyond the predefined expectations, extract implicit claims from the outputs and verify them:
+
+1. **Extract claims** from the transcript and outputs:
+   - Factual statements ("The form has 12 fields")
+   - Process claims ("Used pypdf to fill the form")
+   - Quality claims ("All fields were filled correctly")
+
+2. **Verify each claim**:
+   - **Factual claims**: Can be checked against the outputs or external sources
+   - **Process claims**: Can be verified from the transcript
+   - **Quality claims**: Evaluate whether the claim is justified
+
+3. **Flag unverifiable claims**: Note claims that cannot be verified with available information
+
+This catches issues that predefined expectations might miss.
+
+### Step 5: Read User Notes
+
+If `{outputs_dir}/user_notes.md` exists:
+1. Read it and note any uncertainties or issues flagged by the executor
+2. Include relevant concerns in the grading output
+3. These may reveal problems even when expectations pass
+
+### Step 6: Critique the Evals
+
+After grading, consider whether the evals themselves could be improved. Only surface suggestions when there's a clear gap.
+
+Good suggestions test meaningful outcomes 鈥?assertions that are hard to satisfy without actually doing the work correctly. Think about what makes an assertion *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
+
+Suggestions worth raising:
+- An assertion that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
+- An important outcome you observed 鈥?good or bad 鈥?that no assertion covers at all
+- An assertion that can't actually be verified from the available outputs
+
+Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every assertion.
+
+### Step 7: Write Grading Results
+
+Save results to `{outputs_dir}/../grading.json` (sibling to outputs_dir).
+
+## Grading Criteria
+
+**PASS when**:
+- The transcript or outputs clearly demonstrate the expectation is true
+- Specific evidence can be cited
+- The evidence reflects genuine substance, not just surface compliance (e.g., a file exists AND contains correct content, not just the right filename)
+
+**FAIL when**:
+- No evidence found for the expectation
+- Evidence contradicts the expectation
+- The expectation cannot be verified from available information
+- The evidence is superficial 鈥?the assertion is technically satisfied but the underlying task outcome is wrong or incomplete
+- The output appears to meet the assertion by coincidence rather than by actually doing the work
+
+**When uncertain**: The burden of proof to pass is on the expectation.
+
+### Step 8: Read Executor Metrics and Timing
+
+1. If `{outputs_dir}/metrics.json` exists, read it and include in grading output
+2. If `{outputs_dir}/../timing.json` exists, read it and include timing data
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    },
+    {
+      "text": "The assistant used the skill's OCR script",
+      "passed": true,
+      "evidence": "Transcript Step 2 shows: 'Tool: Bash - go run ocr_script.go image.png'"
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    },
+    {
+      "claim": "All required fields were populated",
+      "type": "quality",
+      "verified": false,
+      "evidence": "Reference section was left blank despite data being available"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass 鈥?consider checking it appears as the primary contact with matching phone and email from the input"
+      },
+      {
+        "reason": "No assertion checks whether the extracted phone numbers match the input 鈥?I observed incorrect numbers in the output that went uncaught"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness. Consider adding content verification."
+  }
+}
+```
+
+## Field Descriptions
+
+- **expectations**: Array of graded expectations
+  - **text**: The original expectation text
+  - **passed**: Boolean - true if expectation passes
+  - **evidence**: Specific quote or description supporting the verdict
+- **summary**: Aggregate statistics
+  - **passed**: Count of passed expectations
+  - **failed**: Count of failed expectations
+  - **total**: Total expectations evaluated
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+- **execution_metrics**: Copied from executor's metrics.json (if available)
+  - **output_chars**: Total character count of output files (proxy for tokens)
+  - **transcript_chars**: Character count of transcript
+- **timing**: Wall clock timing from timing.json (if available)
+  - **executor_duration_seconds**: Time spent in executor subagent
+  - **total_duration_seconds**: Total elapsed time for the run
+- **claims**: Extracted and verified claims from the output
+  - **claim**: The statement being verified
+  - **type**: "factual", "process", or "quality"
+  - **verified**: Boolean - whether the claim holds
+  - **evidence**: Supporting or contradicting evidence
+- **user_notes_summary**: Issues flagged by the executor
+  - **uncertainties**: Things the executor wasn't sure about
+  - **needs_review**: Items requiring human attention
+  - **workarounds**: Places where the skill didn't work as expected
+- **eval_feedback**: Improvement suggestions for the evals (only when warranted)
+  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `assertion` it relates to
+  - **overall**: Brief assessment 鈥?can be "No suggestions, evals look solid" if nothing to flag
+
+## Guidelines
+
+- **Be objective**: Base verdicts on evidence, not assumptions
+- **Be specific**: Quote the exact text that supports your verdict
+- **Be thorough**: Check both transcript and output files
+- **Be consistent**: Apply the same standard to each expectation
+- **Explain failures**: Make it clear why evidence was insufficient
+- **No partial credit**: Each expectation is pass or fail, not partial
+

--- a/internal/skills/skill-creator/references/schemas.md
+++ b/internal/skills/skill-creator/references/schemas.md
@@ -1,0 +1,430 @@
+# JSON Schemas
+
+This document defines the JSON schemas used by skill-creator.
+
+---
+
+## evals.json
+
+Defines the evals for a skill. Located at `evals/evals.json` within the skill directory.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's example prompt",
+      "expected_output": "Description of expected result",
+      "files": ["evals/files/sample1.pdf"],
+      "expectations": [
+        "The output includes X",
+        "The skill used script Y"
+      ]
+    }
+  ]
+}
+```
+
+**Fields:**
+- `skill_name`: Name matching the skill's frontmatter
+- `evals[].id`: Unique integer identifier
+- `evals[].prompt`: The task to execute
+- `evals[].expected_output`: Human-readable description of success
+- `evals[].files`: Optional list of input file paths (relative to skill root)
+- `evals[].expectations`: List of verifiable statements
+
+---
+
+## history.json
+
+Tracks version progression in Improve mode. Located at workspace root.
+
+```json
+{
+  "started_at": "2026-01-15T10:30:00Z",
+  "skill_name": "pdf",
+  "current_best": "v2",
+  "iterations": [
+    {
+      "version": "v0",
+      "parent": null,
+      "expectation_pass_rate": 0.65,
+      "grading_result": "baseline",
+      "is_current_best": false
+    },
+    {
+      "version": "v1",
+      "parent": "v0",
+      "expectation_pass_rate": 0.75,
+      "grading_result": "won",
+      "is_current_best": false
+    },
+    {
+      "version": "v2",
+      "parent": "v1",
+      "expectation_pass_rate": 0.85,
+      "grading_result": "won",
+      "is_current_best": true
+    }
+  ]
+}
+```
+
+**Fields:**
+- `started_at`: ISO timestamp of when improvement started
+- `skill_name`: Name of the skill being improved
+- `current_best`: Version identifier of the best performer
+- `iterations[].version`: Version identifier (v0, v1, ...)
+- `iterations[].parent`: Parent version this was derived from
+- `iterations[].expectation_pass_rate`: Pass rate from grading
+- `iterations[].grading_result`: "baseline", "won", "lost", or "tie"
+- `iterations[].is_current_best`: Whether this is the current best version
+
+---
+
+## grading.json
+
+Output from the grader agent. Located at `<run-dir>/grading.json`.
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness."
+  }
+}
+```
+
+**Fields:**
+- `expectations[]`: Graded expectations with evidence
+- `summary`: Aggregate pass/fail counts
+- `execution_metrics`: Tool usage and output size (from executor's metrics.json)
+- `timing`: Wall clock timing (from timing.json)
+- `claims`: Extracted and verified claims from the output
+- `user_notes_summary`: Issues flagged by the executor
+- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising
+
+---
+
+## metrics.json
+
+Output from the executor agent. Located at `<run-dir>/outputs/metrics.json`.
+
+```json
+{
+  "tool_calls": {
+    "Read": 5,
+    "Write": 2,
+    "Bash": 8,
+    "Edit": 1,
+    "Glob": 2,
+    "Grep": 0
+  },
+  "total_tool_calls": 18,
+  "total_steps": 6,
+  "files_created": ["filled_form.pdf", "field_values.json"],
+  "errors_encountered": 0,
+  "output_chars": 12450,
+  "transcript_chars": 3200
+}
+```
+
+**Fields:**
+- `tool_calls`: Count per tool type
+- `total_tool_calls`: Sum of all tool calls
+- `total_steps`: Number of major execution steps
+- `files_created`: List of output files created
+- `errors_encountered`: Number of errors during execution
+- `output_chars`: Total character count of output files
+- `transcript_chars`: Character count of transcript
+
+---
+
+## timing.json
+
+Wall clock timing for a run. Located at `<run-dir>/timing.json`.
+
+**How to capture:** When a subagent task completes, the task notification includes `total_tokens` and `duration_ms`. Save these immediately — they are not persisted anywhere else and cannot be recovered after the fact.
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3,
+  "executor_start": "2026-01-15T10:30:00Z",
+  "executor_end": "2026-01-15T10:32:45Z",
+  "executor_duration_seconds": 165.0,
+  "grader_start": "2026-01-15T10:32:46Z",
+  "grader_end": "2026-01-15T10:33:12Z",
+  "grader_duration_seconds": 26.0
+}
+```
+
+---
+
+## benchmark.json
+
+Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
+
+```json
+{
+  "metadata": {
+    "skill_name": "pdf",
+    "skill_path": "/path/to/pdf",
+    "executor_model": "claude-sonnet-4-20250514",
+    "analyzer_model": "most-capable-model",
+    "timestamp": "2026-01-15T10:30:00Z",
+    "evals_run": [1, 2, 3],
+    "runs_per_configuration": 3
+  },
+
+  "runs": [
+    {
+      "eval_id": 1,
+      "eval_name": "Ocean",
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.85,
+        "passed": 6,
+        "failed": 1,
+        "total": 7,
+        "time_seconds": 42.5,
+        "tokens": 3800,
+        "tool_calls": 18,
+        "errors": 0
+      },
+      "expectations": [
+        {"text": "...", "passed": true, "evidence": "..."}
+      ],
+      "notes": [
+        "Used 2023 data, may be stale",
+        "Fell back to text overlay for non-fillable fields"
+      ]
+    }
+  ],
+
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {"mean": 0.85, "stddev": 0.05, "min": 0.80, "max": 0.90},
+      "time_seconds": {"mean": 45.0, "stddev": 12.0, "min": 32.0, "max": 58.0},
+      "tokens": {"mean": 3800, "stddev": 400, "min": 3200, "max": 4100}
+    },
+    "without_skill": {
+      "pass_rate": {"mean": 0.35, "stddev": 0.08, "min": 0.28, "max": 0.45},
+      "time_seconds": {"mean": 32.0, "stddev": 8.0, "min": 24.0, "max": 42.0},
+      "tokens": {"mean": 2100, "stddev": 300, "min": 1800, "max": 2500}
+    },
+    "delta": {
+      "pass_rate": "+0.50",
+      "time_seconds": "+13.0",
+      "tokens": "+1700"
+    }
+  },
+
+  "notes": [
+    "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+    "Eval 3 shows high variance (50% ± 40%) - may be flaky or model-dependent",
+    "Without-skill runs consistently fail on table extraction expectations",
+    "Skill adds 13s average execution time but improves pass rate by 50%"
+  ]
+}
+```
+
+**Fields:**
+- `metadata`: Information about the benchmark run
+  - `skill_name`: Name of the skill
+  - `timestamp`: When the benchmark was run
+  - `evals_run`: List of eval names or IDs
+  - `runs_per_configuration`: Number of runs per config (e.g. 3)
+- `runs[]`: Individual run results
+  - `eval_id`: Numeric eval identifier
+  - `eval_name`: Human-readable eval name (used as section header in the viewer)
+  - `configuration`: Must be `"with_skill"` or `"without_skill"` (the viewer uses this exact string for grouping and color coding)
+  - `run_number`: Integer run number (1, 2, 3...)
+  - `result`: Nested object with `pass_rate`, `passed`, `total`, `time_seconds`, `tokens`, `errors`
+- `run_summary`: Statistical aggregates per configuration
+  - `with_skill` / `without_skill`: Each contains `pass_rate`, `time_seconds`, `tokens` objects with `mean` and `stddev` fields
+  - `delta`: Difference strings like `"+0.50"`, `"+13.0"`, `"+1700"`
+- `notes`: Freeform observations from the analyzer
+
+**Important:** The viewer reads these field names exactly. Using `config` instead of `configuration`, or putting `pass_rate` at the top level of a run instead of nested under `result`, will cause the viewer to show empty/zero values. Always reference this schema when generating benchmark.json manually.
+
+---
+
+## comparison.json
+
+Output from blind comparator. Located at `<grading-dir>/comparison-N.json`.
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+---
+
+## analysis.json
+
+Output from post-hoc analyzer. Located at `<grading-dir>/analysis.json`.
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": ["Minor: skipped optional logging step"]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods"
+  }
+}
+```

--- a/internal/skills/skill-creator/skill.json
+++ b/internal/skills/skill-creator/skill.json
@@ -1,0 +1,22 @@
+{
+  "name": "skill-creator",
+  "version": "0.1.0",
+  "title": "Skill Creator",
+  "description": "Create, refine, and evaluate skills with repeatable test loops and benchmark feedback.",
+  "entry": {
+    "slash": "/skill-creator"
+  },
+  "tools": {
+    "policy": "allowlist",
+    "items": [
+      "list_files",
+      "read_file",
+      "search_text",
+      "run_shell",
+      "write_file",
+      "replace_in_file",
+      "apply_patch",
+      "update_plan"
+    ]
+  }
+}

--- a/internal/skills/skill-creator/tools/README.md
+++ b/internal/skills/skill-creator/tools/README.md
@@ -1,0 +1,16 @@
+﻿# Skill Creator Go Tools
+
+This directory is the canonical Go implementation for skill-creator tooling.
+
+Run from repository root:
+
+- `go run ./internal/skills/skill-creator/tools quick-validate <skill-dir>`
+- `go run ./internal/skills/skill-creator/tools package-skill <skill-dir> [output-dir]`
+- `go run ./internal/skills/skill-creator/tools aggregate-benchmark <workspace/iteration-N> --skill-name <name>`
+- `go run ./internal/skills/skill-creator/tools generate-report <run-loop-output.json|-> [--output report.html]`
+- `go run ./internal/skills/skill-creator/tools run-eval --eval-set <eval.json> --skill-path <skill-dir> --model <model>`
+- `go run ./internal/skills/skill-creator/tools improve-description --eval-results <eval-results.json> --skill-path <skill-dir> --model <model>`
+- `go run ./internal/skills/skill-creator/tools run-loop --eval-set <eval.json> --skill-path <skill-dir> --model <model>`
+- `go run ./internal/skills/skill-creator/tools generate-review <workspace/iteration-N> [--benchmark benchmark.json]`
+
+These commands require Go and the `claude` CLI in PATH.

--- a/internal/skills/skill-creator/tools/aggregate_benchmark.go
+++ b/internal/skills/skill-creator/tools/aggregate_benchmark.go
@@ -1,0 +1,513 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type stats struct {
+	Mean   float64 `json:"mean"`
+	Stddev float64 `json:"stddev"`
+	Min    float64 `json:"min"`
+	Max    float64 `json:"max"`
+}
+
+type runMetric struct {
+	EvalID      int              `json:"eval_id"`
+	RunNumber   int              `json:"run_number"`
+	PassRate    float64          `json:"pass_rate"`
+	Passed      int              `json:"passed"`
+	Failed      int              `json:"failed"`
+	Total       int              `json:"total"`
+	TimeSeconds float64          `json:"time_seconds"`
+	Tokens      float64          `json:"tokens"`
+	ToolCalls   int              `json:"tool_calls"`
+	Errors      int              `json:"errors"`
+	Expects     []map[string]any `json:"expectations"`
+	Notes       []string         `json:"notes"`
+}
+
+type benchMetadata struct {
+	SkillName            string `json:"skill_name"`
+	SkillPath            string `json:"skill_path"`
+	ExecutorModel        string `json:"executor_model"`
+	AnalyzerModel        string `json:"analyzer_model"`
+	Timestamp            string `json:"timestamp"`
+	EvalsRun             []int  `json:"evals_run"`
+	RunsPerConfiguration int    `json:"runs_per_configuration"`
+}
+
+type benchmark struct {
+	Metadata   benchMetadata    `json:"metadata"`
+	Runs       []map[string]any `json:"runs"`
+	RunSummary map[string]any   `json:"run_summary"`
+	Notes      []string         `json:"notes"`
+}
+
+func runAggregateBenchmark(args []string) error {
+	fs := flag.NewFlagSet("aggregate-benchmark", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	skillName := fs.String("skill-name", "", "Name of the skill")
+	skillPath := fs.String("skill-path", "", "Path of the skill")
+	output := fs.String("output", "", "Output benchmark.json path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: go run ./internal/skills/skill-creator/tools aggregate-benchmark <benchmark_dir> [--skill-name x] [--skill-path y] [--output z]")
+	}
+	benchmarkDir := mustAbs(fs.Arg(0))
+	if info, err := os.Stat(benchmarkDir); err != nil || !info.IsDir() {
+		return fmt.Errorf("directory not found: %s", benchmarkDir)
+	}
+
+	results, err := loadRunResults(benchmarkDir)
+	if err != nil {
+		return err
+	}
+	b := generateBenchmark(results, *skillName, *skillPath)
+
+	outJSON := *output
+	if strings.TrimSpace(outJSON) == "" {
+		outJSON = filepath.Join(benchmarkDir, "benchmark.json")
+	}
+	if err := writeJSONFile(outJSON, b); err != nil {
+		return err
+	}
+	fmt.Printf("Generated: %s\n", outJSON)
+
+	outMD := strings.TrimSuffix(outJSON, filepath.Ext(outJSON)) + ".md"
+	if err := os.WriteFile(outMD, []byte(generateBenchmarkMarkdown(b)+"\n"), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("Generated: %s\n", outMD)
+
+	fmt.Println("\nSummary:")
+	runSummary := b.RunSummary
+	for k, v := range runSummary {
+		if k == "delta" {
+			continue
+		}
+		m, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		pr := nestedFloat(m, "pass_rate", "mean")
+		fmt.Printf("  %s: %.1f%% pass rate\n", strings.Title(strings.ReplaceAll(k, "_", " ")), pr*100)
+	}
+	if d, ok := runSummary["delta"].(map[string]any); ok {
+		fmt.Printf("  Delta: %v\n", d["pass_rate"])
+	}
+	return nil
+}
+
+func loadRunResults(benchmarkDir string) (map[string][]runMetric, error) {
+	searchDir := ""
+	runsDir := filepath.Join(benchmarkDir, "runs")
+	if info, err := os.Stat(runsDir); err == nil && info.IsDir() {
+		searchDir = runsDir
+	} else {
+		matches, _ := filepath.Glob(filepath.Join(benchmarkDir, "eval-*"))
+		if len(matches) > 0 {
+			searchDir = benchmarkDir
+		}
+	}
+	if searchDir == "" {
+		return nil, fmt.Errorf("no eval directories found in %s or %s", benchmarkDir, runsDir)
+	}
+
+	evalDirs, err := filepath.Glob(filepath.Join(searchDir, "eval-*"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(evalDirs)
+	results := make(map[string][]runMetric)
+
+	for idx, evalDir := range evalDirs {
+		evalID := readEvalID(evalDir, idx)
+		entries, err := os.ReadDir(evalDir)
+		if err != nil {
+			continue
+		}
+		sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			configDir := filepath.Join(evalDir, e.Name())
+			runMatches, _ := filepath.Glob(filepath.Join(configDir, "run-*"))
+			if len(runMatches) == 0 {
+				continue
+			}
+			sort.Strings(runMatches)
+
+			config := e.Name()
+			for _, runDir := range runMatches {
+				runNumber := parseRunNumber(filepath.Base(runDir))
+				gradingPath := filepath.Join(runDir, "grading.json")
+				var grading map[string]any
+				if err := readJSONFile(gradingPath, &grading); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: grading.json not found/invalid in %s\n", runDir)
+					continue
+				}
+
+				metric := runMetric{
+					EvalID:      evalID,
+					RunNumber:   runNumber,
+					PassRate:    nestedFloat(grading, "summary", "pass_rate"),
+					Passed:      int(nestedFloat(grading, "summary", "passed")),
+					Failed:      int(nestedFloat(grading, "summary", "failed")),
+					Total:       int(nestedFloat(grading, "summary", "total")),
+					TimeSeconds: nestedFloat(grading, "timing", "total_duration_seconds"),
+					Tokens:      nestedFloat(grading, "execution_metrics", "output_chars"),
+					ToolCalls:   int(nestedFloat(grading, "execution_metrics", "total_tool_calls")),
+					Errors:      int(nestedFloat(grading, "execution_metrics", "errors_encountered")),
+				}
+
+				if metric.TimeSeconds == 0 {
+					var timing map[string]any
+					if err := readJSONFile(filepath.Join(runDir, "timing.json"), &timing); err == nil {
+						metric.TimeSeconds = nestedFloat(timing, "total_duration_seconds")
+						metric.Tokens = nestedFloat(timing, "total_tokens")
+					}
+				}
+
+				if rawExpects, ok := grading["expectations"].([]any); ok {
+					for _, raw := range rawExpects {
+						if obj, ok := raw.(map[string]any); ok {
+							metric.Expects = append(metric.Expects, obj)
+							if _, ok := obj["text"]; !ok {
+								fmt.Fprintf(os.Stderr, "Warning: expectation in %s missing text/passed/evidence fields\n", gradingPath)
+							}
+						}
+					}
+				}
+
+				notesSummary, _ := grading["user_notes_summary"].(map[string]any)
+				metric.Notes = append(metric.Notes, anyStringSlice(notesSummary["uncertainties"])...)
+				metric.Notes = append(metric.Notes, anyStringSlice(notesSummary["needs_review"])...)
+				metric.Notes = append(metric.Notes, anyStringSlice(notesSummary["workarounds"])...)
+
+				results[config] = append(results[config], metric)
+			}
+		}
+	}
+	return results, nil
+}
+
+func generateBenchmark(results map[string][]runMetric, skillName, skillPath string) benchmark {
+	summary := aggregateRunSummary(results)
+	var runs []map[string]any
+	evalIDSet := map[int]struct{}{}
+	for config, list := range results {
+		for _, r := range list {
+			evalIDSet[r.EvalID] = struct{}{}
+			runs = append(runs, map[string]any{
+				"eval_id":       r.EvalID,
+				"configuration": config,
+				"run_number":    r.RunNumber,
+				"result": map[string]any{
+					"pass_rate":    r.PassRate,
+					"passed":       r.Passed,
+					"failed":       r.Failed,
+					"total":        r.Total,
+					"time_seconds": r.TimeSeconds,
+					"tokens":       int(r.Tokens),
+					"tool_calls":   r.ToolCalls,
+					"errors":       r.Errors,
+				},
+				"expectations": r.Expects,
+				"notes":        r.Notes,
+			})
+		}
+	}
+	var evals []int
+	for id := range evalIDSet {
+		evals = append(evals, id)
+	}
+	sort.Ints(evals)
+
+	return benchmark{
+		Metadata: benchMetadata{
+			SkillName:            defaultString(skillName, "<skill-name>"),
+			SkillPath:            defaultString(skillPath, "<path/to/skill>"),
+			ExecutorModel:        "<model-name>",
+			AnalyzerModel:        "<model-name>",
+			Timestamp:            time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+			EvalsRun:             evals,
+			RunsPerConfiguration: 3,
+		},
+		Runs:       runs,
+		RunSummary: summary,
+		Notes:      []string{},
+	}
+}
+
+func aggregateRunSummary(results map[string][]runMetric) map[string]any {
+	out := make(map[string]any)
+	configs := make([]string, 0, len(results))
+	for config := range results {
+		configs = append(configs, config)
+	}
+	sort.Strings(configs)
+
+	for _, config := range configs {
+		list := results[config]
+		if len(list) == 0 {
+			out[config] = map[string]any{"pass_rate": stats{}, "time_seconds": stats{}, "tokens": stats{}}
+			continue
+		}
+		passRates := make([]float64, 0, len(list))
+		times := make([]float64, 0, len(list))
+		tokens := make([]float64, 0, len(list))
+		for _, r := range list {
+			passRates = append(passRates, r.PassRate)
+			times = append(times, r.TimeSeconds)
+			tokens = append(tokens, r.Tokens)
+		}
+		out[config] = map[string]any{
+			"pass_rate":    calcStats(passRates),
+			"time_seconds": calcStats(times),
+			"tokens":       calcStats(tokens),
+		}
+	}
+
+	primary := map[string]any{}
+	baseline := map[string]any{}
+	if len(configs) >= 1 {
+		primary, _ = out[configs[0]].(map[string]any)
+	}
+	if len(configs) >= 2 {
+		baseline, _ = out[configs[1]].(map[string]any)
+	}
+	deltaPassRate := nestedFloat(primary, "pass_rate", "mean") - nestedFloat(baseline, "pass_rate", "mean")
+	deltaTime := nestedFloat(primary, "time_seconds", "mean") - nestedFloat(baseline, "time_seconds", "mean")
+	deltaTokens := nestedFloat(primary, "tokens", "mean") - nestedFloat(baseline, "tokens", "mean")
+
+	out["delta"] = map[string]any{
+		"pass_rate":    fmt.Sprintf("%+.2f", deltaPassRate),
+		"time_seconds": fmt.Sprintf("%+.1f", deltaTime),
+		"tokens":       fmt.Sprintf("%+.0f", deltaTokens),
+	}
+	return out
+}
+
+func calcStats(values []float64) stats {
+	if len(values) == 0 {
+		return stats{}
+	}
+	n := float64(len(values))
+	sum := 0.0
+	minVal := values[0]
+	maxVal := values[0]
+	for _, v := range values {
+		sum += v
+		if v < minVal {
+			minVal = v
+		}
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	mean := sum / n
+	stddev := 0.0
+	if len(values) > 1 {
+		variance := 0.0
+		for _, v := range values {
+			variance += (v - mean) * (v - mean)
+		}
+		variance /= float64(len(values) - 1)
+		stddev = math.Sqrt(variance)
+	}
+	return stats{
+		Mean:   round4(mean),
+		Stddev: round4(stddev),
+		Min:    round4(minVal),
+		Max:    round4(maxVal),
+	}
+}
+
+func round4(v float64) float64 {
+	return math.Round(v*10000) / 10000
+}
+
+func defaultString(v, fallback string) string {
+	if strings.TrimSpace(v) == "" {
+		return fallback
+	}
+	return v
+}
+
+func readEvalID(evalDir string, fallback int) int {
+	metaPath := filepath.Join(evalDir, "eval_metadata.json")
+	var meta map[string]any
+	if err := readJSONFile(metaPath, &meta); err == nil {
+		return int(nestedFloat(meta, "eval_id"))
+	}
+	parts := strings.Split(filepath.Base(evalDir), "-")
+	if len(parts) >= 2 {
+		if n, err := strconv.Atoi(parts[1]); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func parseRunNumber(name string) int {
+	parts := strings.Split(name, "-")
+	if len(parts) >= 2 {
+		if n, err := strconv.Atoi(parts[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+func nestedFloat(obj map[string]any, keys ...string) float64 {
+	if obj == nil {
+		return 0
+	}
+	var curr any = obj
+	for _, key := range keys {
+		m, ok := curr.(map[string]any)
+		if !ok {
+			return 0
+		}
+		curr, ok = m[key]
+		if !ok {
+			return 0
+		}
+	}
+	switch v := curr.(type) {
+	case float64:
+		return v
+	case float32:
+		return float64(v)
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case int32:
+		return float64(v)
+	case json.Number:
+		f, _ := v.Float64()
+		return f
+	case string:
+		f, _ := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		return f
+	default:
+		return 0
+	}
+}
+
+func anyStringSlice(v any) []string {
+	if v == nil {
+		return nil
+	}
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func generateBenchmarkMarkdown(b benchmark) string {
+	runSummary := b.RunSummary
+	configs := make([]string, 0)
+	for key := range runSummary {
+		if key != "delta" {
+			configs = append(configs, key)
+		}
+	}
+	sort.Strings(configs)
+	configA := "config_a"
+	configB := "config_b"
+	if len(configs) >= 1 {
+		configA = configs[0]
+	}
+	if len(configs) >= 2 {
+		configB = configs[1]
+	}
+	labelA := strings.Title(strings.ReplaceAll(configA, "_", " "))
+	labelB := strings.Title(strings.ReplaceAll(configB, "_", " "))
+
+	aSummary, _ := runSummary[configA].(map[string]any)
+	bSummary, _ := runSummary[configB].(map[string]any)
+	delta, _ := runSummary["delta"].(map[string]any)
+
+	lines := []string{
+		fmt.Sprintf("# Skill Benchmark: %s", b.Metadata.SkillName),
+		"",
+		fmt.Sprintf("**Model**: %s", b.Metadata.ExecutorModel),
+		fmt.Sprintf("**Date**: %s", b.Metadata.Timestamp),
+		fmt.Sprintf("**Evals**: %s (%d runs each per configuration)", joinInts(b.Metadata.EvalsRun), b.Metadata.RunsPerConfiguration),
+		"",
+		"## Summary",
+		"",
+		fmt.Sprintf("| Metric | %s | %s | Delta |", labelA, labelB),
+		"|--------|------------|---------------|-------|",
+		fmt.Sprintf("| Pass Rate | %.0f%% ± %.0f%% | %.0f%% ± %.0f%% | %v |",
+			nestedFloat(aSummary, "pass_rate", "mean")*100,
+			nestedFloat(aSummary, "pass_rate", "stddev")*100,
+			nestedFloat(bSummary, "pass_rate", "mean")*100,
+			nestedFloat(bSummary, "pass_rate", "stddev")*100,
+			delta["pass_rate"],
+		),
+		fmt.Sprintf("| Time | %.1fs ± %.1fs | %.1fs ± %.1fs | %vs |",
+			nestedFloat(aSummary, "time_seconds", "mean"),
+			nestedFloat(aSummary, "time_seconds", "stddev"),
+			nestedFloat(bSummary, "time_seconds", "mean"),
+			nestedFloat(bSummary, "time_seconds", "stddev"),
+			delta["time_seconds"],
+		),
+		fmt.Sprintf("| Tokens | %.0f ± %.0f | %.0f ± %.0f | %v |",
+			nestedFloat(aSummary, "tokens", "mean"),
+			nestedFloat(aSummary, "tokens", "stddev"),
+			nestedFloat(bSummary, "tokens", "mean"),
+			nestedFloat(bSummary, "tokens", "stddev"),
+			delta["tokens"],
+		),
+	}
+	if len(b.Notes) > 0 {
+		lines = append(lines, "", "## Notes", "")
+		for _, note := range b.Notes {
+			lines = append(lines, "- "+note)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func joinInts(values []int) string {
+	if len(values) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		parts = append(parts, strconv.Itoa(v))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func requireJSONMap(v any) (map[string]any, error) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, errors.New("not an object")
+	}
+	return m, nil
+}

--- a/internal/skills/skill-creator/tools/aggregate_report_review_test.go
+++ b/internal/skills/skill-creator/tools/aggregate_report_review_test.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeGradingFixture(t *testing.T, runDir string, passRate float64, passed, failed, total int) {
+	t.Helper()
+	grading := map[string]any{
+		"summary": map[string]any{
+			"pass_rate": passRate,
+			"passed":    passed,
+			"failed":    failed,
+			"total":     total,
+		},
+		"timing": map[string]any{
+			"total_duration_seconds": 1.25,
+		},
+		"execution_metrics": map[string]any{
+			"output_chars":       123,
+			"total_tool_calls":   2,
+			"errors_encountered": 0,
+		},
+		"expectations": []any{
+			map[string]any{"text": "has text", "passed": true, "evidence": "ok"},
+		},
+		"user_notes_summary": map[string]any{
+			"uncertainties": []any{"u1"},
+			"needs_review":  []any{"n1"},
+			"workarounds":   []any{"w1"},
+		},
+	}
+	if err := writeJSONFile(filepath.Join(runDir, "grading.json"), grading); err != nil {
+		t.Fatalf("write grading: %v", err)
+	}
+}
+
+func TestAggregateBenchmarkFlow(t *testing.T) {
+	tmp := t.TempDir()
+	benchDir := filepath.Join(tmp, "bench")
+
+	eval0 := filepath.Join(benchDir, "eval-0")
+	writeTestFile(t, filepath.Join(eval0, "eval_metadata.json"), `{"eval_id":0}`)
+	runA := filepath.Join(eval0, "with_skill", "run-1")
+	runB := filepath.Join(eval0, "without_skill", "run-1")
+	if err := os.MkdirAll(runA, 0o755); err != nil {
+		t.Fatalf("mkdir runA: %v", err)
+	}
+	if err := os.MkdirAll(runB, 0o755); err != nil {
+		t.Fatalf("mkdir runB: %v", err)
+	}
+	writeGradingFixture(t, runA, 1.0, 3, 0, 3)
+	writeGradingFixture(t, runB, 0.33, 1, 2, 3)
+
+	results, err := loadRunResults(benchDir)
+	if err != nil {
+		t.Fatalf("loadRunResults: %v", err)
+	}
+	if len(results["with_skill"]) != 1 || len(results["without_skill"]) != 1 {
+		t.Fatalf("unexpected result grouping: %+v", results)
+	}
+
+	if err := runAggregateBenchmark([]string{"--skill-name", "demo", benchDir}); err != nil {
+		t.Fatalf("runAggregateBenchmark: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(benchDir, "benchmark.json")); err != nil {
+		t.Fatalf("benchmark.json missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(benchDir, "benchmark.md")); err != nil {
+		t.Fatalf("benchmark.md missing: %v", err)
+	}
+}
+
+func TestAggregateHelpers(t *testing.T) {
+	st := calcStats([]float64{1, 2, 3})
+	if st.Mean <= 0 || st.Max != 3 {
+		t.Fatalf("unexpected stats: %+v", st)
+	}
+	if parseRunNumber("run-9") != 9 {
+		t.Fatalf("parseRunNumber failed")
+	}
+	if got := joinInts([]int{1, 2, 3}); got != "1, 2, 3" {
+		t.Fatalf("joinInts failed: %q", got)
+	}
+	if _, err := requireJSONMap("x"); err == nil {
+		t.Fatalf("requireJSONMap should fail for non-map")
+	}
+}
+
+func TestGenerateReport(t *testing.T) {
+	tmp := t.TempDir()
+	inputPath := filepath.Join(tmp, "input.json")
+	outputPath := filepath.Join(tmp, "report.html")
+
+	data := map[string]any{
+		"original_description": "orig",
+		"best_description":     "best",
+		"best_score":           "1/1",
+		"iterations_run":       1,
+		"train_size":           1,
+		"test_size":            0,
+		"history": []any{
+			map[string]any{
+				"iteration":   1,
+				"description": "best",
+				"results": []any{
+					map[string]any{"query": "q", "should_trigger": true, "pass": true, "triggers": 1, "runs": 1},
+				},
+			},
+		},
+	}
+	if err := writeJSONFile(inputPath, data); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	if err := runGenerateReport([]string{"--output", outputPath, "--skill-name", "demo-skill", inputPath}); err != nil {
+		t.Fatalf("runGenerateReport: %v", err)
+	}
+
+	raw, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	s := string(raw)
+	if !strings.Contains(s, "demo-skill") || !strings.Contains(s, "Skill Description Optimization") {
+		t.Fatalf("report content mismatch")
+	}
+}
+
+func createReviewFixture(t *testing.T, workspace string) string {
+	t.Helper()
+	runDir := filepath.Join(workspace, "eval-0", "with_skill", "run-1")
+	outputsDir := filepath.Join(runDir, "outputs")
+	if err := os.MkdirAll(outputsDir, 0o755); err != nil {
+		t.Fatalf("mkdir outputs: %v", err)
+	}
+	writeTestFile(t, filepath.Join(runDir, "eval_metadata.json"), `{"eval_id":0,"prompt":"do task"}`)
+	writeTestFile(t, filepath.Join(outputsDir, "out.txt"), "hello")
+	writeTestFile(t, filepath.Join(outputsDir, "blob.bin"), "abc")
+	writeGradingFixture(t, runDir, 1.0, 1, 0, 1)
+	return runDir
+}
+
+func TestGenerateReviewStaticAndHelpers(t *testing.T) {
+	tmp := t.TempDir()
+	workspace := filepath.Join(tmp, "iter-1")
+	createReviewFixture(t, workspace)
+
+	prev := filepath.Join(tmp, "iter-0")
+	prevRun := createReviewFixture(t, prev)
+	_ = prevRun
+	feedback := map[string]any{
+		"reviews": []any{
+			map[string]any{"run_id": "eval-0-with_skill-run-1", "feedback": "looks good"},
+		},
+	}
+	if err := writeJSONFile(filepath.Join(prev, "feedback.json"), feedback); err != nil {
+		t.Fatalf("write feedback: %v", err)
+	}
+	benchPath := filepath.Join(workspace, "benchmark.json")
+	if err := writeJSONFile(benchPath, map[string]any{"ok": true}); err != nil {
+		t.Fatalf("write benchmark: %v", err)
+	}
+
+	outHTML := filepath.Join(tmp, "review.html")
+	err := runGenerateReview([]string{
+		"--skill-name", "demo",
+		"--previous-workspace", prev,
+		"--benchmark", benchPath,
+		"--static", outHTML,
+		workspace,
+	})
+	if err != nil {
+		t.Fatalf("runGenerateReview: %v", err)
+	}
+	raw, err := os.ReadFile(outHTML)
+	if err != nil {
+		t.Fatalf("read html: %v", err)
+	}
+	if !strings.Contains(string(raw), "Eval Review") {
+		t.Fatalf("html missing title marker")
+	}
+
+	runs := findReviewRuns(workspace)
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	prevMap, err := loadPreviousIteration(prev)
+	if err != nil {
+		t.Fatalf("loadPreviousIteration: %v", err)
+	}
+	if strings.TrimSpace(asString(prevMap["eval-0-with_skill-run-1"]["feedback"])) == "" {
+		t.Fatalf("expected previous feedback")
+	}
+}
+
+func TestReviewServerFeedbackHandler(t *testing.T) {
+	tmp := t.TempDir()
+	server := &reviewServer{
+		workspace:    tmp,
+		feedbackPath: filepath.Join(tmp, "feedback.json"),
+		skillName:    "demo",
+	}
+	createReviewFixture(t, tmp)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/feedback", nil)
+	w := httptest.NewRecorder()
+	server.handleFeedback(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET feedback status = %d", w.Code)
+	}
+
+	postReq := httptest.NewRequest(http.MethodPost, "/api/feedback", strings.NewReader(`{"reviews":[{"run_id":"x","feedback":"ok"}]}`))
+	postReq.Header.Set("Content-Type", "application/json")
+	postW := httptest.NewRecorder()
+	server.handleFeedback(postW, postReq)
+	if postW.Code != http.StatusOK {
+		t.Fatalf("POST feedback status = %d body=%s", postW.Code, postW.Body.String())
+	}
+
+	var saved map[string]any
+	if err := readJSONFile(server.feedbackPath, &saved); err != nil {
+		t.Fatalf("feedback not saved: %v", err)
+	}
+
+	badReq := httptest.NewRequest(http.MethodPost, "/api/feedback", strings.NewReader(`{"not_reviews":1}`))
+	badW := httptest.NewRecorder()
+	server.handleFeedback(badW, badReq)
+	if badW.Code != http.StatusBadRequest {
+		t.Fatalf("expected bad request, got %d", badW.Code)
+	}
+
+	idxReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	idxW := httptest.NewRecorder()
+	server.handleIndex(idxW, idxReq)
+	if idxW.Code != http.StatusOK {
+		t.Fatalf("handleIndex status = %d", idxW.Code)
+	}
+	body, _ := io.ReadAll(idxW.Body)
+	if !strings.Contains(string(body), "Eval Review") {
+		t.Fatalf("index should contain review page")
+	}
+}
+
+func TestEmbedReviewFileAndMIME(t *testing.T) {
+	tmp := t.TempDir()
+	textPath := filepath.Join(tmp, "a.txt")
+	binPath := filepath.Join(tmp, "b.bin")
+	if err := os.WriteFile(textPath, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write text: %v", err)
+	}
+	if err := os.WriteFile(binPath, []byte{0, 1, 2}, 0o644); err != nil {
+		t.Fatalf("write bin: %v", err)
+	}
+
+	textOut := embedReviewFile(textPath)
+	if asString(textOut["type"]) != "text" {
+		t.Fatalf("expected text type, got %+v", textOut)
+	}
+	binOut := embedReviewFile(binPath)
+	if asString(binOut["type"]) != "binary" {
+		t.Fatalf("expected binary type, got %+v", binOut)
+	}
+	if reviewMIME("x.svg") != "image/svg+xml" {
+		t.Fatalf("svg mime override failed")
+	}
+}
+
+func TestGenerateReviewHTML(t *testing.T) {
+	runs := []reviewRun{
+		{ID: "run-1", Prompt: "p", Outputs: []map[string]any{{"type": "text", "name": "a.txt", "content": "x"}}},
+	}
+	previous := map[string]map[string]any{
+		"run-1": {"feedback": "ok", "outputs": []any{}},
+	}
+	html, err := generateReviewHTML(runs, "demo", previous, map[string]any{"x": 1})
+	if err != nil {
+		t.Fatalf("generateReviewHTML: %v", err)
+	}
+	if !strings.Contains(html, "Eval Review") || !strings.Contains(html, "run-1") {
+		t.Fatalf("unexpected html output")
+	}
+	var payload map[string]any
+	start := strings.Index(html, "const EMBEDDED_DATA = ")
+	if start < 0 {
+		t.Fatalf("embedded data marker missing")
+	}
+	_ = payload
+}
+
+func TestRenderOptimizationReportHelpers(t *testing.T) {
+	results := []map[string]any{
+		{"should_trigger": true, "triggers": 2, "runs": 2},
+		{"should_trigger": false, "triggers": 0, "runs": 2},
+	}
+	c, total := aggregateCorrectRuns(results)
+	if c != 4 || total != 4 {
+		t.Fatalf("unexpected aggregateCorrectRuns result: %d/%d", c, total)
+	}
+	if scoreClass(8, 10) != "good" || scoreClass(3, 10) != "bad" {
+		t.Fatalf("scoreClass thresholds mismatch")
+	}
+}
+
+func TestAsHelpers(t *testing.T) {
+	m := asMapSlice([]any{map[string]any{"a": 1}, "x"})
+	if len(m) != 1 {
+		t.Fatalf("asMapSlice mismatch")
+	}
+	if asString(1) != "" {
+		t.Fatalf("asString should return empty for non-string")
+	}
+	if asFloat(json.Number("2.5")) != 2.5 {
+		t.Fatalf("asFloat json number mismatch")
+	}
+	if !asBoolDefault("true", false) || asBoolDefault("nope", true) != true {
+		t.Fatalf("asBoolDefault mismatch")
+	}
+}

--- a/internal/skills/skill-creator/tools/common.go
+++ b/internal/skills/skill-creator/tools/common.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type skillDoc struct {
+	Name        string
+	Description string
+	Content     string
+	Frontmatter map[string]string
+}
+
+func parseSkillMDDir(skillDir string) (skillDoc, error) {
+	path := filepath.Join(skillDir, "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return skillDoc{}, err
+	}
+	return parseSkillMDContent(string(data))
+}
+
+func parseSkillMDContent(content string) (skillDoc, error) {
+	content = strings.TrimPrefix(content, "\ufeff")
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return skillDoc{}, errors.New("SKILL.md missing frontmatter (no opening ---)")
+	}
+
+	end := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			end = i
+			break
+		}
+	}
+	if end < 0 {
+		return skillDoc{}, errors.New("SKILL.md missing frontmatter (no closing ---)")
+	}
+
+	fmLines := lines[1:end]
+	frontmatter := parseSimpleFrontmatter(fmLines)
+	name := strings.TrimSpace(frontmatter["name"])
+	description := strings.TrimSpace(frontmatter["description"])
+
+	return skillDoc{
+		Name:        name,
+		Description: description,
+		Content:     content,
+		Frontmatter: frontmatter,
+	}, nil
+}
+
+func parseSimpleFrontmatter(lines []string) map[string]string {
+	out := make(map[string]string)
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" || strings.HasPrefix(trimmedLine, "#") {
+			continue
+		}
+		colon := strings.Index(line, ":")
+		if colon <= 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:colon])
+		value := strings.TrimSpace(line[colon+1:])
+
+		if value == "|" || value == ">" || value == "|-" || value == ">-" {
+			var parts []string
+			j := i + 1
+			for ; j < len(lines); j++ {
+				next := lines[j]
+				nextTrim := strings.TrimSpace(next)
+				if nextTrim == "" {
+					parts = append(parts, "")
+					continue
+				}
+				if strings.HasPrefix(next, "  ") || strings.HasPrefix(next, "\t") {
+					parts = append(parts, strings.TrimSpace(next))
+					continue
+				}
+				break
+			}
+			out[key] = strings.TrimSpace(strings.Join(parts, " "))
+			i = j - 1
+			continue
+		}
+
+		out[key] = trimQuotes(value)
+	}
+	return out
+}
+
+func trimQuotes(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+func readJSONFile(path string, dst any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return errors.New("empty json file")
+	}
+	return json.Unmarshal(data, dst)
+}
+
+func writeJSONFile(path string, src any) error {
+	data, err := json.MarshalIndent(src, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}
+
+func parseBoolEnv(name string) bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv(name)))
+	if v == "" {
+		return false
+	}
+	ok, err := strconv.ParseBool(v)
+	return err == nil && ok
+}
+
+func findProjectRootWithClaudeDir() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	curr := wd
+	for {
+		if info, err := os.Stat(filepath.Join(curr, ".claude")); err == nil && info.IsDir() {
+			return curr
+		}
+		parent := filepath.Dir(curr)
+		if parent == curr {
+			break
+		}
+		curr = parent
+	}
+	return wd
+}
+
+func openBrowser(target string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", "", target)
+	case "darwin":
+		cmd = exec.Command("open", target)
+	default:
+		cmd = exec.Command("xdg-open", target)
+	}
+	_ = cmd.Start()
+}
+
+func callClaudeText(prompt string, model string, timeoutSeconds int) (string, error) {
+	args := []string{"-p", "--output-format", "text"}
+	if strings.TrimSpace(model) != "" {
+		args = append(args, "--model", model)
+	}
+	cmd := exec.Command("claude", args...)
+	env := make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "CLAUDECODE=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	cmd.Env = env
+	cmd.Stdin = strings.NewReader(prompt)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = 300
+	}
+
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return "", fmt.Errorf("claude -p exited with error: %w\nstderr: %s", err, strings.TrimSpace(stderr.String()))
+		}
+		return stdout.String(), nil
+	case <-time.After(time.Duration(timeoutSeconds) * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+		return "", fmt.Errorf("claude -p timed out after %ds", timeoutSeconds)
+	}
+}
+
+func mustAbs(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return path
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return abs
+}

--- a/internal/skills/skill-creator/tools/common_test.go
+++ b/internal/skills/skill-creator/tools/common_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseSkillMDContent(t *testing.T) {
+	content := strings.Join([]string{
+		"\ufeff---",
+		"name: sample-skill",
+		"description: \"Do sample things\"",
+		"compatibility: |-",
+		"  requires: none",
+		"---",
+		"# Header",
+		"Body",
+	}, "\n")
+
+	doc, err := parseSkillMDContent(content)
+	if err != nil {
+		t.Fatalf("parseSkillMDContent returned error: %v", err)
+	}
+	if doc.Name != "sample-skill" {
+		t.Fatalf("unexpected name: %q", doc.Name)
+	}
+	if doc.Description != "Do sample things" {
+		t.Fatalf("unexpected description: %q", doc.Description)
+	}
+	if got := doc.Frontmatter["compatibility"]; got != "requires: none" {
+		t.Fatalf("unexpected compatibility: %q", got)
+	}
+}
+
+func TestParseSkillMDContentErrors(t *testing.T) {
+	cases := []string{
+		"name: x\ndescription: y",
+		"---\nname: x\ndescription: y",
+	}
+	for i, c := range cases {
+		_, err := parseSkillMDContent(c)
+		if err == nil {
+			t.Fatalf("case %d expected error, got nil", i)
+		}
+	}
+}
+
+func TestParseSimpleFrontmatter(t *testing.T) {
+	lines := []string{
+		"name: test-skill",
+		"description: \"quoted\"",
+		"compatibility: |",
+		"  uses-go",
+		"  no-python",
+		"metadata: ignored",
+	}
+	fm := parseSimpleFrontmatter(lines)
+	if fm["name"] != "test-skill" {
+		t.Fatalf("unexpected name: %q", fm["name"])
+	}
+	if fm["description"] != "quoted" {
+		t.Fatalf("unexpected description: %q", fm["description"])
+	}
+	if fm["compatibility"] != "uses-go no-python" {
+		t.Fatalf("unexpected compatibility block value: %q", fm["compatibility"])
+	}
+}
+
+func TestTrimQuotes(t *testing.T) {
+	if got := trimQuotes(`"hello"`); got != "hello" {
+		t.Fatalf("trimQuotes failed: %q", got)
+	}
+	if got := trimQuotes(`'world'`); got != "world" {
+		t.Fatalf("trimQuotes failed: %q", got)
+	}
+	if got := trimQuotes(`plain`); got != "plain" {
+		t.Fatalf("trimQuotes failed: %q", got)
+	}
+}
+
+func TestReadWriteJSONFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "nested", "data.json")
+	src := map[string]any{"ok": true, "n": 3}
+	if err := writeJSONFile(path, src); err != nil {
+		t.Fatalf("writeJSONFile: %v", err)
+	}
+
+	var dst map[string]any
+	if err := readJSONFile(path, &dst); err != nil {
+		t.Fatalf("readJSONFile: %v", err)
+	}
+	if asBoolDefault(dst["ok"], false) != true {
+		t.Fatalf("unexpected ok: %#v", dst["ok"])
+	}
+	if int(asFloat(dst["n"])) != 3 {
+		t.Fatalf("unexpected n: %#v", dst["n"])
+	}
+
+	emptyPath := filepath.Join(tmp, "empty.json")
+	if err := os.WriteFile(emptyPath, []byte(" \n\t "), 0o644); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+	if err := readJSONFile(emptyPath, &dst); err == nil {
+		t.Fatalf("expected error for empty json file")
+	}
+}
+
+func TestParseBoolEnv(t *testing.T) {
+	t.Setenv("SKILL_BOOL_ENV", "true")
+	if !parseBoolEnv("SKILL_BOOL_ENV") {
+		t.Fatalf("expected true")
+	}
+	t.Setenv("SKILL_BOOL_ENV", "0")
+	if parseBoolEnv("SKILL_BOOL_ENV") {
+		t.Fatalf("expected false")
+	}
+}
+
+func TestFindProjectRootWithClaudeDir(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ".claude", "keep"), "x")
+	deep := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatalf("mkdir deep: %v", err)
+	}
+	withWorkingDir(t, deep)
+	got := findProjectRootWithClaudeDir()
+	if got != root {
+		t.Fatalf("expected root %q, got %q", root, got)
+	}
+}
+
+func TestMustAbs(t *testing.T) {
+	got := mustAbs(".")
+	if !filepath.IsAbs(got) {
+		t.Fatalf("mustAbs should return absolute path, got %q", got)
+	}
+	if got := mustAbs("  "); got != "  " {
+		t.Fatalf("empty-ish path should be returned as-is")
+	}
+}
+
+func TestParseSkillMDDir(t *testing.T) {
+	tmp := t.TempDir()
+	skillDir := createMinimalSkill(t, tmp, "dir-skill", "desc")
+	doc, err := parseSkillMDDir(skillDir)
+	if err != nil {
+		t.Fatalf("parseSkillMDDir: %v", err)
+	}
+	want := skillDoc{
+		Name:        "dir-skill",
+		Description: "desc",
+	}
+	if doc.Name != want.Name || doc.Description != want.Description {
+		t.Fatalf("unexpected doc: %+v", doc)
+	}
+}
+
+func TestExtractTopLevelKeys(t *testing.T) {
+	lines := []string{
+		"name: a",
+		"description: b",
+		"  nested: ignored",
+		"metadata: c",
+		"name: duplicate",
+	}
+	got := extractTopLevelKeys(lines)
+	want := []string{"name", "description", "metadata"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected keys: got=%v want=%v", got, want)
+	}
+}

--- a/internal/skills/skill-creator/tools/eval_loop_improve_test.go
+++ b/internal/skills/skill-creator/tools/eval_loop_improve_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTruncateString(t *testing.T) {
+	if got := truncateString("abcdef", 3); got != "abc" {
+		t.Fatalf("truncateString mismatch: %q", got)
+	}
+	if got := truncateString("abcdef", 0); got != "" {
+		t.Fatalf("truncateString expected empty")
+	}
+}
+
+func TestExtractNewDescription(t *testing.T) {
+	got := extractNewDescription(`<new_description>"hello world"</new_description>`)
+	if got != "hello world" {
+		t.Fatalf("extractNewDescription mismatch: %q", got)
+	}
+	got = extractNewDescription(`"fallback only"`)
+	if got != "fallback only" {
+		t.Fatalf("fallback extraction mismatch: %q", got)
+	}
+}
+
+func TestRunSingleQueryAndExecuteEvalWithFakeClaude(t *testing.T) {
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, ".claude", "commands"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	installFakeClaude(t, project)
+	t.Setenv("CODEX_FAKE_TRIGGER", "1")
+
+	triggered, err := runSingleQuery("query", "demo-skill", "desc", 5, project, "")
+	if err != nil {
+		t.Fatalf("runSingleQuery error: %v", err)
+	}
+	_ = triggered
+
+	out, err := executeEval([]evalQuery{{Query: "q1", ShouldTrigger: true}}, "demo-skill", "desc", 1, 5, 2, 0.5, project, "")
+	if err != nil {
+		t.Fatalf("executeEval error: %v", err)
+	}
+	if out.Summary["total"] != 1 || len(out.Results) != 1 {
+		t.Fatalf("unexpected eval output: %+v", out)
+	}
+}
+
+func TestImproveDescriptionAndRunImproveDescription(t *testing.T) {
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, ".claude", "commands"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	installFakeClaude(t, project)
+
+	params := improveParams{
+		SkillName:          "demo-skill",
+		SkillContent:       "# demo",
+		CurrentDescription: "old desc",
+		EvalResults: map[string]any{
+			"results": []any{
+				map[string]any{"query": "a", "should_trigger": true, "pass": false, "triggers": 0, "runs": 1},
+			},
+			"summary": map[string]any{"passed": 0, "failed": 1, "total": 1},
+		},
+		Model: "fake-model",
+	}
+	desc, transcript, err := improveDescription(params)
+	if err != nil {
+		t.Fatalf("improveDescription error: %v", err)
+	}
+	if desc != "Improved description for tests" {
+		t.Fatalf("unexpected description: %q", desc)
+	}
+	if strings.TrimSpace(asString(transcript["response"])) == "" {
+		t.Fatalf("expected transcript response")
+	}
+
+	skillDir := createMinimalSkill(t, project, "demo-skill", "old desc")
+	evalResultsPath := filepath.Join(project, "eval-results.json")
+	if err := writeJSONFile(evalResultsPath, params.EvalResults); err != nil {
+		t.Fatalf("write eval results: %v", err)
+	}
+	if err := runImproveDescription([]string{"--eval-results", evalResultsPath, "--skill-path", skillDir, "--model", "fake-model"}); err != nil {
+		t.Fatalf("runImproveDescription: %v", err)
+	}
+}
+
+func TestRunRunEval(t *testing.T) {
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, ".claude", "commands"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	installFakeClaude(t, project)
+	t.Setenv("CODEX_FAKE_TRIGGER", "1")
+	withWorkingDir(t, project)
+
+	skillDir := createMinimalSkill(t, project, "demo-skill", "desc")
+	evalPath := filepath.Join(project, "evals.json")
+	if err := writeJSONFile(evalPath, []map[string]any{{"query": "trigger me", "should_trigger": true}}); err != nil {
+		t.Fatalf("write eval set: %v", err)
+	}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	runErr := runRunEval([]string{"--eval-set", evalPath, "--skill-path", skillDir, "--num-workers", "1", "--runs-per-query", "1"})
+	_ = w.Close()
+	buf := new(bytes.Buffer)
+	_, _ = buf.ReadFrom(r)
+	if runErr != nil {
+		t.Fatalf("runRunEval: %v", runErr)
+	}
+	if !strings.Contains(buf.String(), `"results"`) {
+		t.Fatalf("expected JSON output, got: %s", buf.String())
+	}
+}
+
+func TestSplitEvalSetAndCountPassed(t *testing.T) {
+	evals := []evalQuery{
+		{Query: "a", ShouldTrigger: true},
+		{Query: "b", ShouldTrigger: true},
+		{Query: "c", ShouldTrigger: false},
+		{Query: "d", ShouldTrigger: false},
+	}
+	train, test := splitEvalSet(evals, 0.5, 42)
+	if len(train) == 0 || len(test) == 0 {
+		t.Fatalf("expected non-empty train/test split")
+	}
+	results := []map[string]any{
+		{"pass": true},
+		{"pass": false},
+		{"pass": true},
+	}
+	if got := countPassed(results); got != 2 {
+		t.Fatalf("countPassed mismatch: %d", got)
+	}
+}
+
+func TestRunOptimizationLoopAndRunRunLoop(t *testing.T) {
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, ".claude", "commands"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	installFakeClaude(t, project)
+	withWorkingDir(t, project)
+	t.Setenv("CODEX_FAKE_TRIGGER", "0")
+
+	doc := skillDoc{
+		Name:        "demo-skill",
+		Description: "old desc",
+		Content:     "# skill content",
+	}
+	evals := []evalQuery{{Query: "needs trigger", ShouldTrigger: true}}
+	out, err := runOptimizationLoop(evals, doc, doc.Description, 1, 5, 2, 1, 0.5, 0, "fake-model", false, "", "")
+	if err != nil {
+		t.Fatalf("runOptimizationLoop: %v", err)
+	}
+	if asString(out["best_description"]) == "" {
+		t.Fatalf("best_description should not be empty")
+	}
+	if strings.TrimSpace(asString(out["exit_reason"])) == "" {
+		t.Fatalf("exit_reason should not be empty")
+	}
+
+	skillDir := createMinimalSkill(t, project, "demo-skill", "old desc")
+	evalPath := filepath.Join(project, "eval-set.json")
+	if err := writeJSONFile(evalPath, []map[string]any{{"query": "needs trigger", "should_trigger": true}}); err != nil {
+		t.Fatalf("write eval set: %v", err)
+	}
+	resultsDir := filepath.Join(project, "results")
+	t.Setenv("CODEX_FAKE_TRIGGER", "1")
+	if err := runRunLoop([]string{
+		"--eval-set", evalPath,
+		"--skill-path", skillDir,
+		"--model", "fake-model",
+		"--report", "none",
+		"--results-dir", resultsDir,
+		"--num-workers", "1",
+		"--runs-per-query", "1",
+		"--max-iterations", "1",
+		"--holdout", "0",
+	}); err != nil {
+		t.Fatalf("runRunLoop: %v", err)
+	}
+
+	entries, err := os.ReadDir(resultsDir)
+	if err != nil {
+		t.Fatalf("read results dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("expected timestamped result directory")
+	}
+	foundResults := false
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		p := filepath.Join(resultsDir, e.Name(), "results.json")
+		if _, err := os.Stat(p); err == nil {
+			foundResults = true
+			var outObj map[string]any
+			if err := readJSONFile(p, &outObj); err != nil {
+				t.Fatalf("read results.json: %v", err)
+			}
+			if strings.TrimSpace(asString(outObj["best_description"])) == "" {
+				t.Fatalf("best_description missing in results")
+			}
+			break
+		}
+	}
+	if !foundResults {
+		t.Fatalf("results.json not found in run-loop outputs")
+	}
+}
+
+func TestPrintEvalStats(t *testing.T) {
+	var buf bytes.Buffer
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	results := []map[string]any{
+		{"query": "q1", "should_trigger": true, "triggers": 1, "runs": 1, "pass": true},
+		{"query": "q2", "should_trigger": false, "triggers": 0, "runs": 1, "pass": true},
+	}
+	printEvalStats("Test", results, 0)
+	_ = w.Close()
+	_, _ = buf.ReadFrom(r)
+	if !strings.Contains(buf.String(), "precision") {
+		t.Fatalf("expected stats output, got: %s", buf.String())
+	}
+}
+
+func TestRunRunLoopUsageAndRunRunEvalUsage(t *testing.T) {
+	if err := runRunLoop(nil); err == nil {
+		t.Fatalf("expected usage error for runRunLoop")
+	}
+	if err := runRunEval(nil); err == nil {
+		t.Fatalf("expected usage error for runRunEval")
+	}
+}
+
+func TestRunImproveDescriptionUsage(t *testing.T) {
+	if err := runImproveDescription(nil); err == nil {
+		t.Fatalf("expected usage error for runImproveDescription")
+	}
+}
+
+func TestRunOptimizationLoopOutputJSONShape(t *testing.T) {
+	out := map[string]any{
+		"best_description": "x",
+		"history":          []any{},
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), "best_description") {
+		t.Fatalf("unexpected json output: %s", string(raw))
+	}
+}

--- a/internal/skills/skill-creator/tools/generate_report.go
+++ b/internal/skills/skill-creator/tools/generate_report.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"html"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func runGenerateReport(args []string) error {
+	fs := flag.NewFlagSet("generate-report", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	output := fs.String("output", "", "Output HTML file (default stdout)")
+	skillName := fs.String("skill-name", "", "Skill name in report title")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: go run ./internal/skills/skill-creator/tools generate-report <run_loop_output.json|-> [--output file] [--skill-name name]")
+	}
+
+	inputArg := fs.Arg(0)
+	var data map[string]any
+	if inputArg == "-" {
+		raw, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(raw, &data); err != nil {
+			return err
+		}
+	} else {
+		if err := readJSONFile(inputArg, &data); err != nil {
+			return err
+		}
+	}
+
+	htmlOutput := renderOptimizationReportHTML(data, false, *skillName)
+	if strings.TrimSpace(*output) == "" {
+		_, _ = fmt.Fprint(os.Stdout, htmlOutput)
+		return nil
+	}
+	if err := os.WriteFile(*output, []byte(htmlOutput), 0o644); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "Report written to %s\n", *output)
+	return nil
+}
+
+func renderOptimizationReportHTML(data map[string]any, autoRefresh bool, skillName string) string {
+	history := asMapSlice(data["history"])
+	titlePrefix := ""
+	if strings.TrimSpace(skillName) != "" {
+		titlePrefix = html.EscapeString(skillName) + " - "
+	}
+
+	trainQueries := make([]map[string]any, 0)
+	testQueries := make([]map[string]any, 0)
+	if len(history) > 0 {
+		first := history[0]
+		trainResults := asMapSlice(first["train_results"])
+		if len(trainResults) == 0 {
+			trainResults = asMapSlice(first["results"])
+		}
+		for _, r := range trainResults {
+			trainQueries = append(trainQueries, map[string]any{
+				"query":          asString(r["query"]),
+				"should_trigger": asBoolDefault(r["should_trigger"], true),
+			})
+		}
+		for _, r := range asMapSlice(first["test_results"]) {
+			testQueries = append(testQueries, map[string]any{
+				"query":          asString(r["query"]),
+				"should_trigger": asBoolDefault(r["should_trigger"], true),
+			})
+		}
+	}
+
+	refreshTag := ""
+	if autoRefresh {
+		refreshTag = `<meta http-equiv="refresh" content="5">`
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("<!DOCTYPE html><html><head><meta charset=\"utf-8\">")
+	buf.WriteString(refreshTag)
+	buf.WriteString("<title>")
+	buf.WriteString(titlePrefix)
+	buf.WriteString("Skill Description Optimization</title>")
+	buf.WriteString(`<style>
+body{font-family:system-ui,Segoe UI,Arial,sans-serif;background:#faf9f5;color:#141413;margin:0;padding:20px}
+.summary,.explainer{background:#fff;border:1px solid #e8e6dc;border-radius:6px;padding:12px;margin-bottom:16px}
+table{border-collapse:collapse;width:100%;font-size:12px;background:#fff;border:1px solid #e8e6dc}
+th,td{border:1px solid #e8e6dc;padding:8px;vertical-align:top}
+th{background:#141413;color:#faf9f5}
+th.test{background:#6a9bcc}
+th.pos{border-bottom:3px solid #788c5d}
+th.neg{border-bottom:3px solid #c44}
+tr.best{background:#f5f8f2}
+td.desc{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;max-width:460px;word-break:break-word}
+td.result{text-align:center;min-width:48px}
+.rate{display:block;color:#777;font-size:10px}
+.pass{color:#788c5d}.fail{color:#c44}
+.score{display:inline-block;padding:2px 6px;border-radius:4px;font-weight:700}
+.good{background:#eef2e8;color:#788c5d}.ok{background:#fef3c7;color:#d97706}.bad{background:#fceaea;color:#c44}
+</style></head><body>`)
+
+	buf.WriteString("<h1>")
+	buf.WriteString(titlePrefix)
+	buf.WriteString("Skill Description Optimization</h1>")
+	buf.WriteString(`<div class="explainer"><strong>Optimizing your skill description.</strong> Each row is one iteration. Check means trigger behavior matched expected intent.</div>`)
+
+	bestDescription := html.EscapeString(asString(data["best_description"]))
+	origDescription := html.EscapeString(asString(data["original_description"]))
+	bestScore := html.EscapeString(asString(data["best_score"]))
+	buf.WriteString(`<div class="summary">`)
+	buf.WriteString("<p><strong>Original:</strong> " + origDescription + "</p>")
+	buf.WriteString("<p><strong>Best:</strong> " + bestDescription + "</p>")
+	buf.WriteString("<p><strong>Best Score:</strong> " + bestScore + "</p>")
+	buf.WriteString(fmt.Sprintf("<p><strong>Iterations:</strong> %d | <strong>Train:</strong> %d | <strong>Test:</strong> %d</p>", int(asFloat(data["iterations_run"])), int(asFloat(data["train_size"])), int(asFloat(data["test_size"]))))
+	buf.WriteString(`</div>`)
+
+	bestIter := 0
+	bestValue := -1.0
+	for _, h := range history {
+		candidate := asFloat(h["test_passed"])
+		if candidate == 0 && h["test_passed"] == nil {
+			candidate = asFloat(h["train_passed"])
+		}
+		if candidate > bestValue {
+			bestValue = candidate
+			bestIter = int(asFloat(h["iteration"]))
+		}
+	}
+
+	buf.WriteString("<table><thead><tr><th>Iter</th><th>Train</th><th>Test</th><th>Description</th>")
+	for _, q := range trainQueries {
+		polarity := "pos"
+		if !asBoolDefault(q["should_trigger"], true) {
+			polarity = "neg"
+		}
+		buf.WriteString(fmt.Sprintf("<th class=\"%s\">%s</th>", polarity, html.EscapeString(asString(q["query"]))))
+	}
+	for _, q := range testQueries {
+		polarity := "pos"
+		if !asBoolDefault(q["should_trigger"], true) {
+			polarity = "neg"
+		}
+		buf.WriteString(fmt.Sprintf("<th class=\"test %s\">%s</th>", polarity, html.EscapeString(asString(q["query"]))))
+	}
+	buf.WriteString("</tr></thead><tbody>")
+
+	for _, h := range history {
+		iter := int(asFloat(h["iteration"]))
+		trainResults := asMapSlice(h["train_results"])
+		if len(trainResults) == 0 {
+			trainResults = asMapSlice(h["results"])
+		}
+		testResults := asMapSlice(h["test_results"])
+		trainByQuery := make(map[string]map[string]any)
+		for _, r := range trainResults {
+			trainByQuery[asString(r["query"])] = r
+		}
+		testByQuery := make(map[string]map[string]any)
+		for _, r := range testResults {
+			testByQuery[asString(r["query"])] = r
+		}
+
+		trainCorrect, trainRuns := aggregateCorrectRuns(trainResults)
+		testCorrect, testRuns := aggregateCorrectRuns(testResults)
+		rowClass := ""
+		if iter == bestIter {
+			rowClass = " class=\"best\""
+		}
+
+		buf.WriteString("<tr" + rowClass + ">")
+		buf.WriteString(fmt.Sprintf("<td>%d</td>", iter))
+		buf.WriteString(fmt.Sprintf("<td><span class=\"score %s\">%d/%d</span></td>", scoreClass(trainCorrect, trainRuns), trainCorrect, trainRuns))
+		buf.WriteString(fmt.Sprintf("<td><span class=\"score %s\">%d/%d</span></td>", scoreClass(testCorrect, testRuns), testCorrect, testRuns))
+		buf.WriteString("<td class=\"desc\">" + html.EscapeString(asString(h["description"])) + "</td>")
+
+		for _, q := range trainQueries {
+			buf.WriteString(renderResultCell(trainByQuery[asString(q["query"])], false))
+		}
+		for _, q := range testQueries {
+			buf.WriteString(renderResultCell(testByQuery[asString(q["query"])], true))
+		}
+		buf.WriteString("</tr>")
+	}
+
+	buf.WriteString("</tbody></table></body></html>")
+	return buf.String()
+}
+
+func renderResultCell(result map[string]any, isTest bool) string {
+	if result == nil {
+		if isTest {
+			return `<td class="result">-</td>`
+		}
+		return `<td class="result">-</td>`
+	}
+	pass := asBoolDefault(result["pass"], false)
+	triggers := int(asFloat(result["triggers"]))
+	runs := int(asFloat(result["runs"]))
+	icon := "✗"
+	css := "fail"
+	if pass {
+		icon = "✓"
+		css = "pass"
+	}
+	return fmt.Sprintf(`<td class="result %s">%s<span class="rate">%d/%d</span></td>`, css, icon, triggers, runs)
+}
+
+func aggregateCorrectRuns(results []map[string]any) (int, int) {
+	correct := 0
+	total := 0
+	for _, r := range results {
+		runs := int(asFloat(r["runs"]))
+		triggers := int(asFloat(r["triggers"]))
+		total += runs
+		if asBoolDefault(r["should_trigger"], true) {
+			correct += triggers
+		} else {
+			correct += runs - triggers
+		}
+	}
+	return correct, total
+}
+
+func scoreClass(correct, total int) string {
+	if total <= 0 {
+		return "bad"
+	}
+	ratio := float64(correct) / float64(total)
+	if ratio >= 0.8 {
+		return "good"
+	}
+	if ratio >= 0.5 {
+		return "ok"
+	}
+	return "bad"
+}
+
+func asMapSlice(v any) []map[string]any {
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func asFloat(v any) float64 {
+	switch x := v.(type) {
+	case nil:
+		return 0
+	case float64:
+		return x
+	case float32:
+		return float64(x)
+	case int:
+		return float64(x)
+	case int64:
+		return float64(x)
+	case json.Number:
+		f, _ := x.Float64()
+		return f
+	case string:
+		f, _ := strconv.ParseFloat(strings.TrimSpace(x), 64)
+		return f
+	default:
+		return 0
+	}
+}
+
+func asBoolDefault(v any, fallback bool) bool {
+	switch x := v.(type) {
+	case nil:
+		return fallback
+	case bool:
+		return x
+	case string:
+		x = strings.TrimSpace(strings.ToLower(x))
+		if x == "true" || x == "1" {
+			return true
+		}
+		if x == "false" || x == "0" {
+			return false
+		}
+	}
+	return fallback
+}

--- a/internal/skills/skill-creator/tools/generate_review.go
+++ b/internal/skills/skill-creator/tools/generate_review.go
@@ -1,0 +1,754 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"mime"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	reviewMetadataFiles = map[string]struct{}{
+		"transcript.md": {},
+		"user_notes.md": {},
+		"metrics.json":  {},
+	}
+	reviewTextExts = map[string]struct{}{
+		".txt": {}, ".md": {}, ".json": {}, ".csv": {}, ".js": {}, ".ts": {}, ".tsx": {}, ".jsx": {},
+		".yaml": {}, ".yml": {}, ".xml": {}, ".html": {}, ".css": {}, ".sh": {}, ".rb": {}, ".go": {}, ".rs": {},
+		".java": {}, ".c": {}, ".cpp": {}, ".h": {}, ".hpp": {}, ".sql": {}, ".r": {}, ".toml": {},
+	}
+	reviewImageExts = map[string]struct{}{
+		".png": {}, ".jpg": {}, ".jpeg": {}, ".gif": {}, ".svg": {}, ".webp": {},
+	}
+	reviewMimeOverrides = map[string]string{
+		".svg":  "image/svg+xml",
+		".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+	}
+)
+
+type reviewRun struct {
+	ID      string           `json:"id"`
+	Prompt  string           `json:"prompt"`
+	EvalID  any              `json:"eval_id"`
+	Outputs []map[string]any `json:"outputs"`
+	Grading map[string]any   `json:"grading,omitempty"`
+}
+
+type reviewServer struct {
+	workspace     string
+	skillName     string
+	feedbackPath  string
+	previous      map[string]map[string]any
+	benchmarkPath string
+}
+
+func runGenerateReview(args []string) error {
+	fs := flag.NewFlagSet("generate-review", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	port := fs.Int("port", 3117, "Server port")
+	fs.IntVar(port, "p", 3117, "Server port")
+	skillName := fs.String("skill-name", "", "Skill name for header")
+	fs.StringVar(skillName, "n", "", "Skill name for header")
+	previousWorkspace := fs.String("previous-workspace", "", "Previous iteration workspace")
+	benchmarkPath := fs.String("benchmark", "", "benchmark.json path")
+	staticOut := fs.String("static", "", "Write static HTML output instead of serving")
+	fs.StringVar(staticOut, "s", "", "Write static HTML output instead of serving")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: go run ./internal/skills/skill-creator/tools generate-review <workspace-path> [--port 3117] [--skill-name name] [--previous-workspace dir] [--benchmark benchmark.json] [--static out.html]")
+	}
+
+	workspace := mustAbs(fs.Arg(0))
+	if info, err := os.Stat(workspace); err != nil || !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", workspace)
+	}
+
+	runs := findReviewRuns(workspace)
+	if len(runs) == 0 {
+		return fmt.Errorf("no runs found in %s", workspace)
+	}
+
+	name := strings.TrimSpace(*skillName)
+	if name == "" {
+		name = strings.ReplaceAll(filepath.Base(workspace), "-workspace", "")
+	}
+	feedbackPath := filepath.Join(workspace, "feedback.json")
+
+	previous := map[string]map[string]any{}
+	if strings.TrimSpace(*previousWorkspace) != "" {
+		prev, err := loadPreviousIteration(mustAbs(*previousWorkspace))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed loading previous workspace: %v\n", err)
+		} else {
+			previous = prev
+		}
+	}
+
+	benchmarkObj := map[string]any(nil)
+	if strings.TrimSpace(*benchmarkPath) != "" {
+		_ = readJSONFile(*benchmarkPath, &benchmarkObj)
+	}
+
+	if strings.TrimSpace(*staticOut) != "" {
+		html, err := generateReviewHTML(runs, name, previous, benchmarkObj)
+		if err != nil {
+			return err
+		}
+		outPath := mustAbs(*staticOut)
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(outPath, []byte(html), 0o644); err != nil {
+			return err
+		}
+		fmt.Printf("\nStatic viewer written to: %s\n", outPath)
+		return nil
+	}
+
+	srv := &reviewServer{
+		workspace:     workspace,
+		skillName:     name,
+		feedbackPath:  feedbackPath,
+		previous:      previous,
+		benchmarkPath: strings.TrimSpace(*benchmarkPath),
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", *port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		listener, err = net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return err
+		}
+	}
+	actualPort := listener.Addr().(*net.TCPAddr).Port
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", srv.handleIndex)
+	mux.HandleFunc("/index.html", srv.handleIndex)
+	mux.HandleFunc("/api/feedback", srv.handleFeedback)
+
+	url := fmt.Sprintf("http://localhost:%d", actualPort)
+	fmt.Println("\n  Eval Viewer")
+	fmt.Println("  ---------------------------------")
+	fmt.Printf("  URL:       %s\n", url)
+	fmt.Printf("  Workspace: %s\n", workspace)
+	fmt.Printf("  Feedback:  %s\n", feedbackPath)
+	if len(previous) > 0 {
+		fmt.Printf("  Previous:  %s (%d runs)\n", *previousWorkspace, len(previous))
+	}
+	if strings.TrimSpace(*benchmarkPath) != "" {
+		fmt.Printf("  Benchmark: %s\n", *benchmarkPath)
+	}
+	fmt.Println()
+	fmt.Println("  Press Ctrl+C to stop.")
+	fmt.Println()
+	openBrowser(url)
+
+	httpServer := &http.Server{Handler: mux}
+	return httpServer.Serve(listener)
+}
+
+func (s *reviewServer) handleIndex(w http.ResponseWriter, r *http.Request) {
+	runs := findReviewRuns(s.workspace)
+	benchmarkObj := map[string]any(nil)
+	if strings.TrimSpace(s.benchmarkPath) != "" {
+		_ = readJSONFile(s.benchmarkPath, &benchmarkObj)
+	}
+	html, err := generateReviewHTML(runs, s.skillName, s.previous, benchmarkObj)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(html))
+}
+
+func (s *reviewServer) handleFeedback(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		data := []byte("{}")
+		if raw, err := os.ReadFile(s.feedbackPath); err == nil {
+			data = raw
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	case http.MethodPost:
+		defer r.Body.Close()
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+			return
+		}
+		if _, ok := payload["reviews"]; !ok {
+			http.Error(w, `{"error":"Expected JSON object with 'reviews' key"}`, http.StatusBadRequest)
+			return
+		}
+		if err := writeJSONFile(s.feedbackPath, payload); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func findReviewRuns(workspace string) []reviewRun {
+	runs := make([]reviewRun, 0)
+	findRunsRecursive(workspace, workspace, &runs)
+	sort.Slice(runs, func(i, j int) bool {
+		iEval := asFloat(runs[i].EvalID)
+		jEval := asFloat(runs[j].EvalID)
+		if iEval == jEval {
+			return runs[i].ID < runs[j].ID
+		}
+		return iEval < jEval
+	})
+	return runs
+}
+
+func findRunsRecursive(root, current string, runs *[]reviewRun) {
+	entries, err := os.ReadDir(current)
+	if err != nil {
+		return
+	}
+	outputsDir := filepath.Join(current, "outputs")
+	if info, err := os.Stat(outputsDir); err == nil && info.IsDir() {
+		if run := buildReviewRun(root, current); run != nil {
+			*runs = append(*runs, *run)
+		}
+		return
+	}
+
+	skip := map[string]struct{}{"node_modules": {}, ".git": {}, "skill": {}, "inputs": {}}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, blocked := skip[entry.Name()]; blocked {
+			continue
+		}
+		findRunsRecursive(root, filepath.Join(current, entry.Name()), runs)
+	}
+}
+
+func buildReviewRun(root, runDir string) *reviewRun {
+	prompt := ""
+	var evalID any = nil
+	metaCandidates := []string{filepath.Join(runDir, "eval_metadata.json"), filepath.Join(filepath.Dir(runDir), "eval_metadata.json")}
+	for _, path := range metaCandidates {
+		var meta map[string]any
+		if err := readJSONFile(path, &meta); err == nil {
+			prompt = asString(meta["prompt"])
+			evalID = meta["eval_id"]
+			if prompt != "" {
+				break
+			}
+		}
+	}
+
+	if prompt == "" {
+		transcriptCandidates := []string{filepath.Join(runDir, "transcript.md"), filepath.Join(runDir, "outputs", "transcript.md")}
+		re := regexp.MustCompile(`(?s)## Eval Prompt\n\n(.*?)(?:\n##|$)`)
+		for _, path := range transcriptCandidates {
+			if data, err := os.ReadFile(path); err == nil {
+				match := re.FindStringSubmatch(string(data))
+				if len(match) >= 2 {
+					prompt = strings.TrimSpace(match[1])
+					break
+				}
+			}
+		}
+	}
+	if prompt == "" {
+		prompt = "(No prompt found)"
+	}
+
+	rel, err := filepath.Rel(root, runDir)
+	if err != nil {
+		rel = runDir
+	}
+	runID := strings.ReplaceAll(filepath.ToSlash(rel), "/", "-")
+
+	outputs := make([]map[string]any, 0)
+	outputDir := filepath.Join(runDir, "outputs")
+	if entries, err := os.ReadDir(outputDir); err == nil {
+		sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			if _, skip := reviewMetadataFiles[entry.Name()]; skip {
+				continue
+			}
+			outputs = append(outputs, embedReviewFile(filepath.Join(outputDir, entry.Name())))
+		}
+	}
+
+	var grading map[string]any
+	for _, p := range []string{filepath.Join(runDir, "grading.json"), filepath.Join(filepath.Dir(runDir), "grading.json")} {
+		if err := readJSONFile(p, &grading); err == nil && len(grading) > 0 {
+			break
+		}
+	}
+
+	return &reviewRun{ID: runID, Prompt: prompt, EvalID: evalID, Outputs: outputs, Grading: grading}
+}
+
+func embedReviewFile(path string) map[string]any {
+	ext := strings.ToLower(filepath.Ext(path))
+	mimeType := reviewMIME(path)
+	name := filepath.Base(path)
+
+	if _, ok := reviewTextExts[ext]; ok {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return map[string]any{"name": name, "type": "error", "content": "(Error reading file)"}
+		}
+		return map[string]any{"name": name, "type": "text", "content": string(data)}
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]any{"name": name, "type": "error", "content": "(Error reading file)"}
+	}
+	b64 := base64.StdEncoding.EncodeToString(raw)
+
+	if _, ok := reviewImageExts[ext]; ok {
+		return map[string]any{"name": name, "type": "image", "mime": mimeType, "data_uri": "data:" + mimeType + ";base64," + b64}
+	}
+	if ext == ".pdf" {
+		return map[string]any{"name": name, "type": "pdf", "data_uri": "data:" + mimeType + ";base64," + b64}
+	}
+	if ext == ".xlsx" {
+		return map[string]any{"name": name, "type": "xlsx", "data_b64": b64}
+	}
+	return map[string]any{"name": name, "type": "binary", "mime": mimeType, "data_uri": "data:" + mimeType + ";base64," + b64}
+}
+
+func reviewMIME(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	if v, ok := reviewMimeOverrides[ext]; ok {
+		return v
+	}
+	if guessed := mime.TypeByExtension(ext); guessed != "" {
+		return guessed
+	}
+	return "application/octet-stream"
+}
+
+func loadPreviousIteration(workspace string) (map[string]map[string]any, error) {
+	result := make(map[string]map[string]any)
+	feedbackMap := map[string]string{}
+	feedbackPath := filepath.Join(workspace, "feedback.json")
+	var feedback map[string]any
+	if err := readJSONFile(feedbackPath, &feedback); err == nil {
+		for _, item := range asMapSlice(feedback["reviews"]) {
+			runID := asString(item["run_id"])
+			text := strings.TrimSpace(asString(item["feedback"]))
+			if runID != "" && text != "" {
+				feedbackMap[runID] = text
+			}
+		}
+	}
+	for _, run := range findReviewRuns(workspace) {
+		outputs := make([]any, 0, len(run.Outputs))
+		for _, out := range run.Outputs {
+			outputs = append(outputs, out)
+		}
+		result[run.ID] = map[string]any{
+			"feedback": feedbackMap[run.ID],
+			"outputs":  outputs,
+		}
+	}
+	for runID, text := range feedbackMap {
+		if _, ok := result[runID]; !ok {
+			result[runID] = map[string]any{"feedback": text, "outputs": []any{}}
+		}
+	}
+	return result, nil
+}
+
+func generateReviewHTML(runs []reviewRun, skillName string, previous map[string]map[string]any, benchmark map[string]any) (string, error) {
+	previousFeedback := map[string]string{}
+	previousOutputs := map[string]any{}
+	for runID, payload := range previous {
+		if text := strings.TrimSpace(asString(payload["feedback"])); text != "" {
+			previousFeedback[runID] = text
+		}
+		if outs, ok := payload["outputs"]; ok {
+			previousOutputs[runID] = outs
+		}
+	}
+
+	runsAny := make([]any, 0, len(runs))
+	for _, run := range runs {
+		runsAny = append(runsAny, run)
+	}
+	embedded := map[string]any{
+		"skill_name":        skillName,
+		"runs":              runsAny,
+		"previous_feedback": previousFeedback,
+		"previous_outputs":  previousOutputs,
+	}
+	if benchmark != nil {
+		embedded["benchmark"] = benchmark
+	}
+
+	jsonData, err := json.Marshal(embedded)
+	if err != nil {
+		return "", err
+	}
+	return strings.Replace(reviewInlinePageTemplate, "__EMBEDDED_JSON__", string(jsonData), 1), nil
+}
+
+const reviewInlinePageTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #f7f7f5;
+      --surface: #fff;
+      --border: #e0e0dc;
+      --text: #141413;
+      --muted: #6b6b63;
+      --accent: #c4613f;
+      --green: #2f7a38;
+      --red: #b23a3a;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); }
+    .wrap { max-width: 1200px; margin: 0 auto; padding: 16px; }
+    .header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 12px; }
+    .title { font-size: 20px; font-weight: 700; }
+    .progress { color: var(--muted); font-size: 13px; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; margin-bottom: 12px; overflow: hidden; }
+    .card h3 { margin: 0; padding: 10px 12px; border-bottom: 1px solid var(--border); font-size: 13px; text-transform: uppercase; letter-spacing: 0.03em; color: var(--muted); }
+    .card .body { padding: 12px; }
+    .prompt { white-space: pre-wrap; line-height: 1.6; font-size: 14px; }
+    .output { border: 1px solid var(--border); border-radius: 6px; margin-bottom: 10px; overflow: hidden; }
+    .output-header { background: #fafaf8; border-bottom: 1px solid var(--border); padding: 8px 10px; display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .output-body { padding: 10px; overflow-x: auto; }
+    .output-body pre { margin: 0; white-space: pre-wrap; word-break: break-word; font-size: 12px; line-height: 1.5; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .output-body img { max-width: 100%; height: auto; display: block; border-radius: 4px; }
+    .output-body iframe { width: 100%; height: 560px; border: none; border-radius: 4px; }
+    .hint { color: var(--muted); font-size: 12px; }
+    textarea { width: 100%; min-height: 120px; resize: vertical; border: 1px solid var(--border); border-radius: 6px; padding: 10px; font: inherit; font-size: 14px; line-height: 1.5; }
+    .status { margin-top: 6px; color: var(--muted); font-size: 12px; min-height: 16px; }
+    .prev-feedback { margin-top: 8px; border: 1px solid var(--border); border-radius: 6px; background: #fafaf8; padding: 8px 10px; font-size: 12px; color: var(--muted); display: none; }
+    .nav { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+    button { border: 1px solid var(--border); border-radius: 6px; background: #fff; color: var(--text); cursor: pointer; padding: 8px 12px; font-size: 13px; }
+    button:hover { background: #f2f2ee; }
+    .submit { border-color: transparent; background: var(--accent); color: #fff; font-weight: 600; }
+    .submit:hover { filter: brightness(0.95); }
+    .badge { display: inline-block; margin-left: 8px; border-radius: 999px; padding: 2px 8px; font-size: 11px; background: #eee; color: #444; vertical-align: middle; }
+    .grade-ok { color: var(--green); font-weight: 600; }
+    .grade-fail { color: var(--red); font-weight: 600; }
+    .benchmark pre { margin: 0; white-space: pre-wrap; word-break: break-word; font-size: 12px; line-height: 1.5; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="header">
+      <div class="title">Eval Review: <span id="skill-name"></span></div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <div class="card">
+      <h3>Prompt <span class="badge" id="config-badge" style="display:none"></span></h3>
+      <div class="body"><div class="prompt" id="prompt"></div></div>
+    </div>
+
+    <div class="card">
+      <h3>Outputs</h3>
+      <div class="body" id="outputs"></div>
+    </div>
+
+    <div class="card">
+      <h3>Feedback</h3>
+      <div class="body">
+        <textarea id="feedback" placeholder="Describe issues, suggestions, or what looks good."></textarea>
+        <div class="status" id="status"></div>
+        <div class="prev-feedback" id="prev-feedback"></div>
+      </div>
+    </div>
+
+    <div class="card benchmark" id="benchmark-card" style="display:none">
+      <h3>Benchmark</h3>
+      <div class="body"><pre id="benchmark"></pre></div>
+    </div>
+
+    <div class="nav">
+      <button id="prev-btn" onclick="navigate(-1)">← Previous</button>
+      <button class="submit" onclick="submitAll()">Submit All Reviews</button>
+      <button id="next-btn" onclick="navigate(1)">Next →</button>
+    </div>
+  </div>
+
+  <script>
+    const EMBEDDED_DATA = __EMBEDDED_JSON__;
+    let feedbackMap = {};
+    let currentIndex = 0;
+    let saveTimer = null;
+
+    function byId(id) { return document.getElementById(id); }
+    function esc(s) { return String(s || "").replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m])); }
+
+    async function init() {
+      byId("skill-name").textContent = EMBEDDED_DATA.skill_name || "unknown";
+      try {
+        const resp = await fetch("/api/feedback");
+        if (resp.ok) {
+          const data = await resp.json();
+          if (Array.isArray(data.reviews)) {
+            for (const r of data.reviews) {
+              if (typeof r.run_id === "string") feedbackMap[r.run_id] = String(r.feedback || "");
+            }
+          }
+        }
+      } catch (_) {}
+
+      byId("feedback").addEventListener("input", () => {
+        clearTimeout(saveTimer);
+        byId("status").textContent = "";
+        saveTimer = setTimeout(saveCurrent, 700);
+      });
+
+      if (EMBEDDED_DATA.benchmark) {
+        byId("benchmark-card").style.display = "block";
+        byId("benchmark").textContent = JSON.stringify(EMBEDDED_DATA.benchmark, null, 2);
+      }
+
+      render();
+    }
+
+    function getRuns() { return Array.isArray(EMBEDDED_DATA.runs) ? EMBEDDED_DATA.runs : []; }
+    function currentRun() { const runs = getRuns(); return runs[currentIndex] || null; }
+
+    function render() {
+      const runs = getRuns();
+      if (!runs.length) {
+        byId("prompt").textContent = "No runs found.";
+        byId("outputs").innerHTML = "<div class=\"hint\">No output files.</div>";
+        byId("progress").textContent = "0 / 0";
+        return;
+      }
+      const run = currentRun();
+      byId("progress").textContent = String(currentIndex + 1) + " / " + String(runs.length);
+      byId("prompt").textContent = run.prompt || "(No prompt found)";
+      byId("prev-btn").disabled = currentIndex <= 0;
+      byId("next-btn").disabled = currentIndex >= runs.length - 1;
+
+      const configBadge = byId("config-badge");
+      const parts = String(run.id || "").split("-");
+      if (parts.length >= 2) {
+        const cfg = parts[parts.length - 2];
+        if (cfg && cfg !== "eval") {
+          configBadge.style.display = "inline-block";
+          configBadge.textContent = cfg;
+        } else {
+          configBadge.style.display = "none";
+        }
+      } else {
+        configBadge.style.display = "none";
+      }
+
+      renderOutputs(run.outputs || []);
+      byId("feedback").value = feedbackMap[run.id] || "";
+      byId("status").textContent = "";
+
+      const prev = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = byId("prev-feedback");
+      if (prev && String(prev).trim()) {
+        prevEl.style.display = "block";
+        prevEl.innerHTML = "<strong>Previous feedback:</strong><br>" + esc(prev);
+      } else {
+        prevEl.style.display = "none";
+        prevEl.textContent = "";
+      }
+    }
+
+    function renderOutputs(files) {
+      const root = byId("outputs");
+      root.innerHTML = "";
+      if (!Array.isArray(files) || files.length === 0) {
+        root.innerHTML = "<div class=\"hint\">No output files found.</div>";
+        return;
+      }
+      for (const file of files) {
+        const wrapper = document.createElement("div");
+        wrapper.className = "output";
+        const header = document.createElement("div");
+        header.className = "output-header";
+        const name = document.createElement("span");
+        name.textContent = file.name || "output";
+        header.appendChild(name);
+        const dl = document.createElement("a");
+        dl.textContent = "Download";
+        dl.href = downloadUri(file);
+        dl.download = file.name || "output";
+        dl.style.color = "#c4613f";
+        dl.style.textDecoration = "none";
+        dl.style.fontFamily = "inherit";
+        header.appendChild(dl);
+        wrapper.appendChild(header);
+
+        const body = document.createElement("div");
+        body.className = "output-body";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content || "";
+          body.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri || "";
+          img.alt = file.name || "";
+          body.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri || "";
+          body.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(body, file.data_b64 || "");
+        } else {
+          const link = document.createElement("a");
+          link.href = downloadUri(file);
+          link.download = file.name || "file";
+          link.textContent = "Download " + (file.name || "file");
+          link.style.color = "#c4613f";
+          body.appendChild(link);
+        }
+        wrapper.appendChild(body);
+        root.appendChild(wrapper);
+      }
+    }
+
+    function renderXlsx(container, b64) {
+      if (!b64) {
+        container.textContent = "No spreadsheet content.";
+        return;
+      }
+      if (typeof XLSX === "undefined") {
+        const msg = document.createElement("div");
+        msg.className = "hint";
+        msg.textContent = "SheetJS is unavailable. Please download the file to inspect.";
+        container.appendChild(msg);
+        return;
+      }
+      try {
+        const binary = atob(b64);
+        const bytes = Uint8Array.from(binary, c => c.charCodeAt(0));
+        const wb = XLSX.read(bytes, { type: "array" });
+        wb.SheetNames.forEach((sheetName, idx) => {
+          if (wb.SheetNames.length > 1) {
+            const label = document.createElement("div");
+            label.className = "hint";
+            label.style.marginBottom = "6px";
+            label.textContent = "Sheet: " + sheetName;
+            container.appendChild(label);
+          }
+          const ws = wb.Sheets[sheetName];
+          const htmlTable = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const box = document.createElement("div");
+          box.innerHTML = htmlTable;
+          container.appendChild(box);
+        });
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + String(err);
+      }
+    }
+
+    function downloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content || "");
+      return "#";
+    }
+
+    function navigate(step) {
+      saveCurrent();
+      const runs = getRuns();
+      currentIndex = Math.max(0, Math.min(runs.length - 1, currentIndex + step));
+      render();
+    }
+
+    function saveCurrent() {
+      const run = currentRun();
+      if (!run) return;
+      const value = byId("feedback").value || "";
+      if (value.trim()) feedbackMap[run.id] = value;
+      else delete feedbackMap[run.id];
+
+      const reviews = Object.entries(feedbackMap).map(([run_id, feedback]) => ({
+        run_id, feedback, timestamp: new Date().toISOString()
+      }));
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" })
+      }).then(() => {
+        byId("status").textContent = "Saved";
+      }).catch(() => {
+        byId("status").textContent = "Will download on submit";
+      });
+    }
+
+    function submitAll() {
+      saveCurrent();
+      const runs = getRuns();
+      const ts = new Date().toISOString();
+      const reviews = runs.map(r => ({
+        run_id: r.id,
+        feedback: feedbackMap[r.id] || "",
+        timestamp: ts
+      }));
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload
+      }).then(() => {
+        alert("Review complete. Return to your Codex session.");
+      }).catch(() => {
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        alert("Saved as feedback.json. Return to your Codex session.");
+      });
+    }
+
+    document.addEventListener("keydown", (e) => {
+      if (e.target && e.target.tagName === "TEXTAREA") return;
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") navigate(-1);
+      if (e.key === "ArrowRight" || e.key === "ArrowDown") navigate(1);
+    });
+
+    init();
+  </script>
+</body>
+</html>
+`

--- a/internal/skills/skill-creator/tools/improve_description.go
+++ b/internal/skills/skill-creator/tools/improve_description.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var newDescriptionRe = regexp.MustCompile(`(?s)<new_description>(.*?)</new_description>`)
+
+type improveParams struct {
+	SkillName          string
+	SkillContent       string
+	CurrentDescription string
+	EvalResults        map[string]any
+	History            []map[string]any
+	Model              string
+	TestResults        map[string]any
+	LogDir             string
+	Iteration          int
+}
+
+func runImproveDescription(args []string) error {
+	fs := flag.NewFlagSet("improve-description", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	evalResultsPath := fs.String("eval-results", "", "Eval results JSON path")
+	skillPath := fs.String("skill-path", "", "Skill directory")
+	historyPath := fs.String("history", "", "History JSON path")
+	model := fs.String("model", "", "Model for improvement")
+	verbose := fs.Bool("verbose", false, "Verbose logs")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*evalResultsPath) == "" || strings.TrimSpace(*skillPath) == "" || strings.TrimSpace(*model) == "" {
+		return fmt.Errorf("usage: go run ./internal/skills/skill-creator/tools improve-description --eval-results <file> --skill-path <dir> --model <model>")
+	}
+
+	var evalResults map[string]any
+	if err := readJSONFile(*evalResultsPath, &evalResults); err != nil {
+		return err
+	}
+	doc, err := parseSkillMDDir(*skillPath)
+	if err != nil {
+		return err
+	}
+	history := make([]map[string]any, 0)
+	if strings.TrimSpace(*historyPath) != "" {
+		if err := readJSONFile(*historyPath, &history); err != nil {
+			return err
+		}
+	}
+	currentDescription := asString(evalResults["description"])
+	if strings.TrimSpace(currentDescription) == "" {
+		currentDescription = doc.Description
+	}
+
+	if *verbose {
+		_, _ = fmt.Fprintf(os.Stderr, "Current: %s\n", currentDescription)
+	}
+
+	newDesc, _, err := improveDescription(improveParams{
+		SkillName:          doc.Name,
+		SkillContent:       doc.Content,
+		CurrentDescription: currentDescription,
+		EvalResults:        evalResults,
+		History:            history,
+		Model:              *model,
+	})
+	if err != nil {
+		return err
+	}
+
+	if *verbose {
+		_, _ = fmt.Fprintf(os.Stderr, "Improved: %s\n", newDesc)
+	}
+
+	summary, _ := evalResults["summary"].(map[string]any)
+	output := map[string]any{
+		"description": newDesc,
+		"history": append(history, map[string]any{
+			"description": currentDescription,
+			"passed":      int(asFloat(summary["passed"])),
+			"failed":      int(asFloat(summary["failed"])),
+			"total":       int(asFloat(summary["total"])),
+			"results":     evalResults["results"],
+		}),
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(output)
+}
+
+func improveDescription(params improveParams) (string, map[string]any, error) {
+	evalResults := params.EvalResults
+	results := asMapSlice(evalResults["results"])
+	failedTriggers := make([]map[string]any, 0)
+	falseTriggers := make([]map[string]any, 0)
+	for _, r := range results {
+		should := asBoolDefault(r["should_trigger"], true)
+		passed := asBoolDefault(r["pass"], false)
+		if should && !passed {
+			failedTriggers = append(failedTriggers, r)
+		}
+		if !should && !passed {
+			falseTriggers = append(falseTriggers, r)
+		}
+	}
+
+	summary, _ := evalResults["summary"].(map[string]any)
+	trainScore := fmt.Sprintf("%d/%d", int(asFloat(summary["passed"])), int(asFloat(summary["total"])))
+	scoresSummary := "Train: " + trainScore
+	if params.TestResults != nil {
+		testSummary, _ := params.TestResults["summary"].(map[string]any)
+		scoresSummary = fmt.Sprintf("Train: %s, Test: %d/%d", trainScore, int(asFloat(testSummary["passed"])), int(asFloat(testSummary["total"])))
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("You are optimizing a skill description for a Claude Code skill called \"%s\".\n\n", params.SkillName))
+	b.WriteString("Current description:\n")
+	b.WriteString("<current_description>\n\"")
+	b.WriteString(params.CurrentDescription)
+	b.WriteString("\"\n</current_description>\n\n")
+	b.WriteString("Current scores (")
+	b.WriteString(scoresSummary)
+	b.WriteString("):\n")
+
+	if len(failedTriggers) > 0 {
+		b.WriteString("FAILED TO TRIGGER (should have triggered but did not):\n")
+		for _, r := range failedTriggers {
+			b.WriteString(fmt.Sprintf("- \"%s\" (triggered %d/%d times)\n", asString(r["query"]), int(asFloat(r["triggers"])), int(asFloat(r["runs"]))))
+		}
+		b.WriteString("\n")
+	}
+	if len(falseTriggers) > 0 {
+		b.WriteString("FALSE TRIGGERS (triggered but should not):\n")
+		for _, r := range falseTriggers {
+			b.WriteString(fmt.Sprintf("- \"%s\" (triggered %d/%d times)\n", asString(r["query"]), int(asFloat(r["triggers"])), int(asFloat(r["runs"]))))
+		}
+		b.WriteString("\n")
+	}
+
+	if len(params.History) > 0 {
+		b.WriteString("PREVIOUS ATTEMPTS (avoid repeating same style):\n\n")
+		for _, h := range params.History {
+			train := fmt.Sprintf("%d/%d", int(asFloat(h["train_passed"])+asFloat(h["passed"])), int(asFloat(h["train_total"])+asFloat(h["total"])))
+			b.WriteString(fmt.Sprintf("<attempt train=%s>\n", train))
+			b.WriteString("Description: \"")
+			b.WriteString(asString(h["description"]))
+			b.WriteString("\"\n")
+			for _, r := range asMapSlice(h["results"]) {
+				status := "FAIL"
+				if asBoolDefault(r["pass"], false) {
+					status = "PASS"
+				}
+				b.WriteString(fmt.Sprintf("  [%s] \"%s\" (%d/%d)\n", status, truncateString(asString(r["query"]), 80), int(asFloat(r["triggers"])), int(asFloat(r["runs"]))))
+			}
+			if note := strings.TrimSpace(asString(h["note"])); note != "" {
+				b.WriteString("Note: " + note + "\n")
+			}
+			b.WriteString("</attempt>\n\n")
+		}
+	}
+
+	b.WriteString("Skill content for context:\n<skill_content>\n")
+	b.WriteString(params.SkillContent)
+	b.WriteString("\n</skill_content>\n\n")
+	b.WriteString("Write a new description that generalizes from failure patterns, is concise (100-200 words preferred, hard limit 1024 chars), and focuses on user intent. ")
+	b.WriteString("Respond only with the new description wrapped in <new_description>...</new_description>.\n")
+
+	prompt := b.String()
+	response, err := callClaudeText(prompt, params.Model, 300)
+	if err != nil {
+		return "", nil, err
+	}
+	description := extractNewDescription(response)
+	transcript := map[string]any{
+		"iteration":          params.Iteration,
+		"prompt":             prompt,
+		"response":           response,
+		"parsed_description": description,
+		"char_count":         len(description),
+		"over_limit":         len(description) > 1024,
+	}
+
+	if len(description) > 1024 {
+		shortenPrompt := fmt.Sprintf("%s\n\nA previous attempt produced this description (%d chars, over limit):\n\"%s\"\nRewrite under 1024 chars and respond only in <new_description> tags.", prompt, len(description), description)
+		shortenResp, err := callClaudeText(shortenPrompt, params.Model, 300)
+		if err == nil {
+			shortened := extractNewDescription(shortenResp)
+			if strings.TrimSpace(shortened) != "" {
+				description = shortened
+			}
+			transcript["rewrite_prompt"] = shortenPrompt
+			transcript["rewrite_response"] = shortenResp
+			transcript["rewrite_description"] = description
+			transcript["rewrite_char_count"] = len(description)
+		}
+	}
+	transcript["final_description"] = description
+
+	if strings.TrimSpace(params.LogDir) != "" {
+		if err := os.MkdirAll(params.LogDir, 0o755); err == nil {
+			name := fmt.Sprintf("improve_iter_%d.json", params.Iteration)
+			if params.Iteration <= 0 {
+				name = "improve_iter_unknown.json"
+			}
+			_ = writeJSONFile(filepath.Join(params.LogDir, name), transcript)
+		}
+	}
+
+	return description, transcript, nil
+}
+
+func extractNewDescription(text string) string {
+	m := newDescriptionRe.FindStringSubmatch(text)
+	if len(m) >= 2 {
+		return strings.TrimSpace(strings.Trim(m[1], "\"'"))
+	}
+	return strings.TrimSpace(strings.Trim(text, "\"'"))
+}

--- a/internal/skills/skill-creator/tools/main.go
+++ b/internal/skills/skill-creator/tools/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	subcommand := os.Args[1]
+	args := os.Args[2:]
+
+	var err error
+	switch subcommand {
+	case "quick-validate":
+		err = runQuickValidate(args)
+	case "package-skill":
+		err = runPackageSkill(args)
+	case "aggregate-benchmark":
+		err = runAggregateBenchmark(args)
+	case "generate-report":
+		err = runGenerateReport(args)
+	case "run-eval":
+		err = runRunEval(args)
+	case "improve-description":
+		err = runImproveDescription(args)
+	case "run-loop":
+		err = runRunLoop(args)
+	case "generate-review":
+		err = runGenerateReview(args)
+	case "help", "-h", "--help":
+		printUsage()
+		return
+	default:
+		printUsage()
+		err = fmt.Errorf("unknown subcommand: %s", subcommand)
+	}
+
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func parseFlagSet(name string, args []string) (*flag.FlagSet, error) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return fs, nil
+}
+
+func printUsage() {
+	_, _ = fmt.Fprintln(os.Stderr, "Skill Creator Go tools")
+	_, _ = fmt.Fprintln(os.Stderr, "Usage: go run ./internal/skills/skill-creator/tools <subcommand> [flags]")
+	_, _ = fmt.Fprintln(os.Stderr, "Subcommands:")
+	_, _ = fmt.Fprintln(os.Stderr, "  quick-validate")
+	_, _ = fmt.Fprintln(os.Stderr, "  package-skill")
+	_, _ = fmt.Fprintln(os.Stderr, "  aggregate-benchmark")
+	_, _ = fmt.Fprintln(os.Stderr, "  generate-report")
+	_, _ = fmt.Fprintln(os.Stderr, "  run-eval")
+	_, _ = fmt.Fprintln(os.Stderr, "  improve-description")
+	_, _ = fmt.Fprintln(os.Stderr, "  run-loop")
+	_, _ = fmt.Fprintln(os.Stderr, "  generate-review")
+}

--- a/internal/skills/skill-creator/tools/main_test.go
+++ b/internal/skills/skill-creator/tools/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseFlagSet(t *testing.T) {
+	fs, err := parseFlagSet("x", []string{})
+	if err != nil {
+		t.Fatalf("parseFlagSet with empty args should succeed: %v", err)
+	}
+	if fs == nil {
+		t.Fatalf("expected non-nil flagset")
+	}
+	if _, err := parseFlagSet("x", []string{"--bad-flag"}); err == nil {
+		t.Fatalf("expected parse error for bad flag")
+	}
+}
+
+func TestPrintUsage(t *testing.T) {
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	printUsage()
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	text := buf.String()
+	if !strings.Contains(text, "Subcommands:") || !strings.Contains(text, "generate-review") {
+		t.Fatalf("unexpected usage output: %s", text)
+	}
+}

--- a/internal/skills/skill-creator/tools/package_skill.go
+++ b/internal/skills/skill-creator/tools/package_skill.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	excludeDirs     = map[string]struct{}{"node_modules": {}}
+	excludeFiles    = map[string]struct{}{".DS_Store": {}}
+	excludeGlobs    = []string{}
+	rootExcludeDirs = map[string]struct{}{"evals": {}}
+)
+
+func runPackageSkill(args []string) error {
+	fs, err := parseFlagSet("package-skill", args)
+	if err != nil {
+		return err
+	}
+	if fs.NArg() < 1 || fs.NArg() > 2 {
+		return fmt.Errorf("usage: go run ./internal/skills/skill-creator/tools package-skill <path/to/skill-folder> [output-directory]")
+	}
+
+	skillPath := fs.Arg(0)
+	outputDir := ""
+	if fs.NArg() == 2 {
+		outputDir = fs.Arg(1)
+	}
+
+	fmt.Printf("Packaging skill: %s\n", skillPath)
+	if outputDir != "" {
+		fmt.Printf("Output directory: %s\n", outputDir)
+	}
+
+	out, err := packageSkill(skillPath, outputDir)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Successfully packaged skill to: %s\n", out)
+	return nil
+}
+
+func packageSkill(skillPath string, outputDir string) (string, error) {
+	skillAbs := mustAbs(strings.TrimSpace(skillPath))
+	info, err := os.Stat(skillAbs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("skill folder not found: %s", skillAbs)
+		}
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("path is not a directory: %s", skillAbs)
+	}
+	if _, err := os.Stat(filepath.Join(skillAbs, "SKILL.md")); err != nil {
+		return "", fmt.Errorf("SKILL.md not found in %s", skillAbs)
+	}
+
+	fmt.Println("Validating skill...")
+	v := validateSkill(skillAbs)
+	if !v.Valid {
+		return "", fmt.Errorf("validation failed: %s", v.Message)
+	}
+	fmt.Println(v.Message)
+
+	outDir := ""
+	if strings.TrimSpace(outputDir) != "" {
+		outDir = mustAbs(outputDir)
+		if err := os.MkdirAll(outDir, 0o755); err != nil {
+			return "", err
+		}
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		outDir = cwd
+	}
+
+	skillName := filepath.Base(skillAbs)
+	outPath := filepath.Join(outDir, skillName+".skill")
+
+	file, err := os.Create(outPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	zipWriter := zip.NewWriter(file)
+	defer zipWriter.Close()
+
+	skillParent := filepath.Dir(skillAbs)
+	err = filepath.WalkDir(skillAbs, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(skillParent, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "." {
+			return nil
+		}
+		if shouldExcludePath(rel) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			fmt.Printf("Skipped: %s\n", rel)
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		src, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			_ = src.Close()
+			return err
+		}
+		hdr, err := zip.FileInfoHeader(info)
+		if err != nil {
+			_ = src.Close()
+			return err
+		}
+		hdr.Name = rel
+		hdr.Method = zip.Deflate
+
+		w, err := zipWriter.CreateHeader(hdr)
+		if err != nil {
+			_ = src.Close()
+			return err
+		}
+		if _, err := io.Copy(w, src); err != nil {
+			_ = src.Close()
+			return err
+		}
+		_ = src.Close()
+		fmt.Printf("Added: %s\n", rel)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return outPath, nil
+}
+
+func shouldExcludePath(relPath string) bool {
+	parts := strings.Split(filepath.ToSlash(relPath), "/")
+	for _, p := range parts {
+		if _, ok := excludeDirs[p]; ok {
+			return true
+		}
+	}
+	if len(parts) > 1 {
+		if _, ok := rootExcludeDirs[parts[1]]; ok {
+			return true
+		}
+	}
+	name := parts[len(parts)-1]
+	if _, ok := excludeFiles[name]; ok {
+		return true
+	}
+	for _, pattern := range excludeGlobs {
+		if ok, _ := filepath.Match(pattern, name); ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/skills/skill-creator/tools/quick_validate.go
+++ b/internal/skills/skill-creator/tools/quick_validate.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	kebabNameRe            = regexp.MustCompile(`^[a-z0-9-]+$`)
+	allowedFrontmatterKeys = map[string]struct{}{
+		"name":          {},
+		"description":   {},
+		"license":       {},
+		"allowed-tools": {},
+		"metadata":      {},
+		"compatibility": {},
+	}
+)
+
+type validateResult struct {
+	Valid   bool
+	Message string
+}
+
+func runQuickValidate(args []string) error {
+	fs, err := parseFlagSet("quick-validate", args)
+	if err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: go run ./internal/skills/skill-creator/tools quick-validate <skill_directory>")
+	}
+
+	res := validateSkill(fs.Arg(0))
+	_, _ = fmt.Fprintln(os.Stdout, res.Message)
+	if !res.Valid {
+		return fmt.Errorf("validation failed")
+	}
+	return nil
+}
+
+func validateSkill(skillPath string) validateResult {
+	skillPath = mustAbs(strings.TrimSpace(skillPath))
+	skillMDPath := filepath.Join(skillPath, "SKILL.md")
+	data, err := os.ReadFile(skillMDPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return validateResult{Valid: false, Message: "SKILL.md not found"}
+		}
+		return validateResult{Valid: false, Message: fmt.Sprintf("read SKILL.md failed: %v", err)}
+	}
+
+	doc, err := parseSkillMDContent(string(data))
+	if err != nil {
+		return validateResult{Valid: false, Message: err.Error()}
+	}
+
+	lines := strings.Split(doc.Content, "\n")
+	end := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			end = i
+			break
+		}
+	}
+	if end < 0 {
+		return validateResult{Valid: false, Message: "Invalid frontmatter format"}
+	}
+	frontmatterLines := lines[1:end]
+	keys := extractTopLevelKeys(frontmatterLines)
+	unexpected := make([]string, 0)
+	for _, k := range keys {
+		if _, ok := allowedFrontmatterKeys[k]; !ok {
+			unexpected = append(unexpected, k)
+		}
+	}
+	if len(unexpected) > 0 {
+		sort.Strings(unexpected)
+		allowed := make([]string, 0, len(allowedFrontmatterKeys))
+		for k := range allowedFrontmatterKeys {
+			allowed = append(allowed, k)
+		}
+		sort.Strings(allowed)
+		return validateResult{Valid: false, Message: fmt.Sprintf("Unexpected key(s) in SKILL.md frontmatter: %s. Allowed properties are: %s", strings.Join(unexpected, ", "), strings.Join(allowed, ", "))}
+	}
+
+	name := strings.TrimSpace(doc.Frontmatter["name"])
+	if name == "" {
+		return validateResult{Valid: false, Message: "Missing 'name' in frontmatter"}
+	}
+	if !kebabNameRe.MatchString(name) {
+		return validateResult{Valid: false, Message: fmt.Sprintf("Name '%s' should be kebab-case (lowercase letters, digits, and hyphens only)", name)}
+	}
+	if strings.HasPrefix(name, "-") || strings.HasSuffix(name, "-") || strings.Contains(name, "--") {
+		return validateResult{Valid: false, Message: fmt.Sprintf("Name '%s' cannot start/end with hyphen or contain consecutive hyphens", name)}
+	}
+	if len(name) > 64 {
+		return validateResult{Valid: false, Message: fmt.Sprintf("Name is too long (%d characters). Maximum is 64 characters.", len(name))}
+	}
+
+	description := strings.TrimSpace(doc.Frontmatter["description"])
+	if description == "" {
+		return validateResult{Valid: false, Message: "Missing 'description' in frontmatter"}
+	}
+	if strings.Contains(description, "<") || strings.Contains(description, ">") {
+		return validateResult{Valid: false, Message: "Description cannot contain angle brackets (< or >)"}
+	}
+	if len(description) > 1024 {
+		return validateResult{Valid: false, Message: fmt.Sprintf("Description is too long (%d characters). Maximum is 1024 characters.", len(description))}
+	}
+
+	compat := strings.TrimSpace(doc.Frontmatter["compatibility"])
+	if len(compat) > 500 {
+		return validateResult{Valid: false, Message: fmt.Sprintf("Compatibility is too long (%d characters). Maximum is 500 characters.", len(compat))}
+	}
+
+	return validateResult{Valid: true, Message: "Skill is valid!"}
+}
+
+func extractTopLevelKeys(lines []string) []string {
+	keys := make([]string, 0)
+	seen := map[string]struct{}{}
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			continue
+		}
+		idx := strings.Index(line, ":")
+		if idx <= 0 {
+			continue
+		}
+		k := strings.TrimSpace(line[:idx])
+		if k == "" {
+			continue
+		}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/skills/skill-creator/tools/quick_validate_package_test.go
+++ b/internal/skills/skill-creator/tools/quick_validate_package_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateSkill(t *testing.T) {
+	tmp := t.TempDir()
+	validDir := createMinimalSkill(t, tmp, "valid-skill", "valid description")
+	res := validateSkill(validDir)
+	if !res.Valid {
+		t.Fatalf("expected valid skill, got: %s", res.Message)
+	}
+}
+
+func TestValidateSkillErrors(t *testing.T) {
+	tmp := t.TempDir()
+	skillDir := filepath.Join(tmp, "bad-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	res := validateSkill(skillDir)
+	if res.Valid || !strings.Contains(res.Message, "SKILL.md not found") {
+		t.Fatalf("expected missing SKILL.md error, got: %+v", res)
+	}
+
+	writeTestFile(t, filepath.Join(skillDir, "SKILL.md"), strings.Join([]string{
+		"---",
+		"name: Bad_Name",
+		"description: desc",
+		"bad-key: x",
+		"---",
+		"# body",
+	}, "\n"))
+	res = validateSkill(skillDir)
+	if res.Valid || !strings.Contains(res.Message, "Unexpected key(s)") {
+		t.Fatalf("expected unexpected key error, got: %+v", res)
+	}
+}
+
+func TestRunQuickValidateUsage(t *testing.T) {
+	if err := runQuickValidate(nil); err == nil {
+		t.Fatalf("expected usage error")
+	}
+}
+
+func TestPackageSkill(t *testing.T) {
+	tmp := t.TempDir()
+	skillDir := createMinimalSkill(t, tmp, "pack-skill", "pack desc")
+	writeTestFile(t, filepath.Join(skillDir, "README.md"), "hello")
+	writeTestFile(t, filepath.Join(skillDir, "evals", "should_skip.txt"), "skip")
+	writeTestFile(t, filepath.Join(skillDir, "node_modules", "a.txt"), "skip")
+	writeTestFile(t, filepath.Join(skillDir, ".DS_Store"), "skip")
+
+	outDir := filepath.Join(tmp, "out")
+	outPath, err := packageSkill(skillDir, outDir)
+	if err != nil {
+		t.Fatalf("packageSkill: %v", err)
+	}
+	if !strings.HasSuffix(outPath, ".skill") {
+		t.Fatalf("unexpected output path: %s", outPath)
+	}
+
+	zr, err := zip.OpenReader(outPath)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer zr.Close()
+
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	joined := strings.Join(names, "\n")
+	if !strings.Contains(joined, "pack-skill/SKILL.md") {
+		t.Fatalf("zip missing SKILL.md: %v", names)
+	}
+	if strings.Contains(joined, "pack-skill/evals/should_skip.txt") {
+		t.Fatalf("zip should exclude evals dir: %v", names)
+	}
+	if strings.Contains(joined, "pack-skill/node_modules/a.txt") {
+		t.Fatalf("zip should exclude node_modules: %v", names)
+	}
+	if strings.Contains(joined, ".DS_Store") {
+		t.Fatalf("zip should exclude .DS_Store: %v", names)
+	}
+}
+
+func TestShouldExcludePath(t *testing.T) {
+	if !shouldExcludePath("x/node_modules/a.txt") {
+		t.Fatalf("node_modules should be excluded")
+	}
+	if !shouldExcludePath("x/evals/a.txt") {
+		t.Fatalf("root evals should be excluded")
+	}
+	if !shouldExcludePath("x/.DS_Store") {
+		t.Fatalf(".DS_Store should be excluded")
+	}
+	if shouldExcludePath("x/src/a.txt") {
+		t.Fatalf("regular files should not be excluded")
+	}
+}
+
+func TestRunPackageSkillUsage(t *testing.T) {
+	if err := runPackageSkill(nil); err == nil {
+		t.Fatalf("expected usage error")
+	}
+}

--- a/internal/skills/skill-creator/tools/run_eval.go
+++ b/internal/skills/skill-creator/tools/run_eval.go
@@ -1,0 +1,366 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+type evalQuery struct {
+	Query         string `json:"query"`
+	ShouldTrigger bool   `json:"should_trigger"`
+}
+
+type evalResult struct {
+	Query         string  `json:"query"`
+	ShouldTrigger bool    `json:"should_trigger"`
+	TriggerRate   float64 `json:"trigger_rate"`
+	Triggers      int     `json:"triggers"`
+	Runs          int     `json:"runs"`
+	Pass          bool    `json:"pass"`
+}
+
+type evalOutput struct {
+	SkillName   string         `json:"skill_name"`
+	Description string         `json:"description"`
+	Results     []evalResult   `json:"results"`
+	Summary     map[string]int `json:"summary"`
+}
+
+func runRunEval(args []string) error {
+	fs := flag.NewFlagSet("run-eval", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	evalSetPath := fs.String("eval-set", "", "Path to eval set JSON file")
+	skillPath := fs.String("skill-path", "", "Path to skill directory")
+	descriptionOverride := fs.String("description", "", "Override description")
+	numWorkers := fs.Int("num-workers", 10, "Parallel workers")
+	timeout := fs.Int("timeout", 30, "Timeout per query in seconds")
+	runsPerQuery := fs.Int("runs-per-query", 3, "Runs per query")
+	threshold := fs.Float64("trigger-threshold", 0.5, "Trigger threshold")
+	model := fs.String("model", "", "Model for claude -p")
+	verbose := fs.Bool("verbose", false, "Verbose logging")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*evalSetPath) == "" || strings.TrimSpace(*skillPath) == "" {
+		return fmt.Errorf("usage: go run ./internal/skills/skill-creator/tools run-eval --eval-set <file> --skill-path <dir> [--description ...]")
+	}
+
+	var evalSet []evalQuery
+	if err := readJSONFile(*evalSetPath, &evalSet); err != nil {
+		return err
+	}
+	doc, err := parseSkillMDDir(*skillPath)
+	if err != nil {
+		return err
+	}
+	description := doc.Description
+	if strings.TrimSpace(*descriptionOverride) != "" {
+		description = *descriptionOverride
+	}
+	projectRoot := findProjectRootWithClaudeDir()
+	if *verbose {
+		_, _ = fmt.Fprintf(os.Stderr, "Evaluating description: %s\n", description)
+	}
+
+	out, err := executeEval(evalSet, doc.Name, description, *numWorkers, *timeout, *runsPerQuery, *threshold, projectRoot, *model)
+	if err != nil {
+		return err
+	}
+
+	if *verbose {
+		_, _ = fmt.Fprintf(os.Stderr, "Results: %d/%d passed\n", out.Summary["passed"], out.Summary["total"])
+		for _, r := range out.Results {
+			status := "FAIL"
+			if r.Pass {
+				status = "PASS"
+			}
+			_, _ = fmt.Fprintf(os.Stderr, "  [%s] rate=%d/%d expected=%v: %s\n", status, r.Triggers, r.Runs, r.ShouldTrigger, truncateString(r.Query, 70))
+		}
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func executeEval(evalSet []evalQuery, skillName, description string, numWorkers, timeoutSec, runsPerQuery int, triggerThreshold float64, projectRoot, model string) (evalOutput, error) {
+	if numWorkers <= 0 {
+		numWorkers = 1
+	}
+	if runsPerQuery <= 0 {
+		runsPerQuery = 1
+	}
+
+	type runTask struct {
+		Query evalQuery
+	}
+	type runOutcome struct {
+		Query     evalQuery
+		Triggered bool
+		Err       error
+	}
+
+	tasks := make(chan runTask)
+	results := make(chan runOutcome)
+	var wg sync.WaitGroup
+
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for task := range tasks {
+				triggered, err := runSingleQuery(task.Query.Query, skillName, description, timeoutSec, projectRoot, model)
+				results <- runOutcome{Query: task.Query, Triggered: triggered, Err: err}
+			}
+		}()
+	}
+
+	go func() {
+		for _, item := range evalSet {
+			for i := 0; i < runsPerQuery; i++ {
+				tasks <- runTask{Query: item}
+			}
+		}
+		close(tasks)
+		wg.Wait()
+		close(results)
+	}()
+
+	triggerMap := make(map[string][]bool)
+	queryMeta := make(map[string]evalQuery)
+	for outcome := range results {
+		queryMeta[outcome.Query.Query] = outcome.Query
+		if _, ok := triggerMap[outcome.Query.Query]; !ok {
+			triggerMap[outcome.Query.Query] = make([]bool, 0, runsPerQuery)
+		}
+		if outcome.Err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: query failed: %v\n", outcome.Err)
+			triggerMap[outcome.Query.Query] = append(triggerMap[outcome.Query.Query], false)
+			continue
+		}
+		triggerMap[outcome.Query.Query] = append(triggerMap[outcome.Query.Query], outcome.Triggered)
+	}
+
+	keys := make([]string, 0, len(triggerMap))
+	for q := range triggerMap {
+		keys = append(keys, q)
+	}
+	sort.Strings(keys)
+
+	resultsList := make([]evalResult, 0, len(keys))
+	passed := 0
+	for _, query := range keys {
+		triggers := triggerMap[query]
+		countTrue := 0
+		for _, t := range triggers {
+			if t {
+				countTrue++
+			}
+		}
+		triggerRate := float64(countTrue) / float64(len(triggers))
+		meta := queryMeta[query]
+		didPass := false
+		if meta.ShouldTrigger {
+			didPass = triggerRate >= triggerThreshold
+		} else {
+			didPass = triggerRate < triggerThreshold
+		}
+		if didPass {
+			passed++
+		}
+		resultsList = append(resultsList, evalResult{
+			Query:         query,
+			ShouldTrigger: meta.ShouldTrigger,
+			TriggerRate:   triggerRate,
+			Triggers:      countTrue,
+			Runs:          len(triggers),
+			Pass:          didPass,
+		})
+	}
+
+	total := len(resultsList)
+	return evalOutput{
+		SkillName:   skillName,
+		Description: description,
+		Results:     resultsList,
+		Summary: map[string]int{
+			"total":  total,
+			"passed": passed,
+			"failed": total - passed,
+		},
+	}, nil
+}
+
+func runSingleQuery(query, skillName, skillDescription string, timeoutSec int, projectRoot, model string) (bool, error) {
+	uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
+	cleanName := fmt.Sprintf("%s-skill-%s", skillName, uniqueID)
+	commandsDir := filepath.Join(projectRoot, ".claude", "commands")
+	if err := os.MkdirAll(commandsDir, 0o755); err != nil {
+		return false, err
+	}
+	commandFile := filepath.Join(commandsDir, cleanName+".md")
+
+	indented := strings.ReplaceAll(skillDescription, "\n", "\n  ")
+	commandContent := fmt.Sprintf("---\ndescription: |\n  %s\n---\n\n# %s\n\nThis skill handles: %s\n", indented, skillName, skillDescription)
+	if err := os.WriteFile(commandFile, []byte(commandContent), 0o644); err != nil {
+		return false, err
+	}
+	defer os.Remove(commandFile)
+
+	if timeoutSec <= 0 {
+		timeoutSec = 30
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSec)*time.Second)
+	defer cancel()
+
+	args := []string{"-p", query, "--output-format", "stream-json", "--verbose", "--include-partial-messages"}
+	if strings.TrimSpace(model) != "" {
+		args = append(args, "--model", model)
+	}
+	cmd := exec.CommandContext(ctx, "claude", args...)
+	cmd.Dir = projectRoot
+	env := make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "CLAUDECODE=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	cmd.Env = env
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return false, err
+	}
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return false, err
+	}
+
+	triggered := false
+	pendingTool := ""
+	accumulated := ""
+
+	scanner := bufio.NewScanner(stdout)
+	buf := make([]byte, 0, 128*1024)
+	scanner.Buffer(buf, 4*1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var event map[string]any
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+
+		eventType := asString(event["type"])
+		if eventType == "stream_event" {
+			se, _ := event["event"].(map[string]any)
+			seType := asString(se["type"])
+			switch seType {
+			case "content_block_start":
+				cb, _ := se["content_block"].(map[string]any)
+				if asString(cb["type"]) == "tool_use" {
+					toolName := asString(cb["name"])
+					if toolName == "Skill" || toolName == "Read" {
+						pendingTool = toolName
+						accumulated = ""
+					} else {
+						_ = cmd.Process.Kill()
+						_ = cmd.Wait()
+						return false, nil
+					}
+				}
+			case "content_block_delta":
+				if pendingTool != "" {
+					delta, _ := se["delta"].(map[string]any)
+					if asString(delta["type"]) == "input_json_delta" {
+						accumulated += asString(delta["partial_json"])
+						if strings.Contains(accumulated, cleanName) {
+							_ = cmd.Process.Kill()
+							_ = cmd.Wait()
+							return true, nil
+						}
+					}
+				}
+			case "content_block_stop", "message_stop":
+				if pendingTool != "" {
+					_ = cmd.Process.Kill()
+					_ = cmd.Wait()
+					return strings.Contains(accumulated, cleanName), nil
+				}
+				if seType == "message_stop" {
+					_ = cmd.Process.Kill()
+					_ = cmd.Wait()
+					return false, nil
+				}
+			}
+			continue
+		}
+
+		if eventType == "assistant" {
+			msg, _ := event["message"].(map[string]any)
+			content, _ := msg["content"].([]any)
+			for _, raw := range content {
+				item, ok := raw.(map[string]any)
+				if !ok || asString(item["type"]) != "tool_use" {
+					continue
+				}
+				toolName := asString(item["name"])
+				input, _ := item["input"].(map[string]any)
+				if toolName == "Skill" && strings.Contains(asString(input["skill"]), cleanName) {
+					triggered = true
+				}
+				if toolName == "Read" && strings.Contains(asString(input["file_path"]), cleanName) {
+					triggered = true
+				}
+				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
+				return triggered, nil
+			}
+		}
+		if eventType == "result" {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			return triggered, nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		_ = cmd.Wait()
+		return false, err
+	}
+	waitErr := cmd.Wait()
+	if ctx.Err() == context.DeadlineExceeded {
+		return false, fmt.Errorf("timeout after %ds", timeoutSec)
+	}
+	if waitErr != nil {
+		return false, waitErr
+	}
+	return triggered, nil
+}
+
+func truncateString(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxRunes])
+}

--- a/internal/skills/skill-creator/tools/run_loop.go
+++ b/internal/skills/skill-creator/tools/run_loop.go
@@ -1,0 +1,401 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runRunLoop(args []string) error {
+	fs := flag.NewFlagSet("run-loop", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	evalSetPath := fs.String("eval-set", "", "Eval set JSON file")
+	skillPath := fs.String("skill-path", "", "Skill directory")
+	description := fs.String("description", "", "Override starting description")
+	numWorkers := fs.Int("num-workers", 10, "Parallel workers")
+	timeout := fs.Int("timeout", 30, "Timeout seconds per query")
+	maxIterations := fs.Int("max-iterations", 5, "Max iterations")
+	runsPerQuery := fs.Int("runs-per-query", 3, "Runs per query")
+	triggerThreshold := fs.Float64("trigger-threshold", 0.5, "Trigger threshold")
+	holdout := fs.Float64("holdout", 0.4, "Holdout fraction")
+	model := fs.String("model", "", "Model for improvement")
+	verbose := fs.Bool("verbose", false, "Verbose logs")
+	report := fs.String("report", "auto", "Report path: auto|none|<path>")
+	resultsDir := fs.String("results-dir", "", "Save outputs to timestamped subdir")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*evalSetPath) == "" || strings.TrimSpace(*skillPath) == "" || strings.TrimSpace(*model) == "" {
+		return fmt.Errorf("usage: go run ./internal/skills/skill-creator/tools run-loop --eval-set <file> --skill-path <dir> --model <model>")
+	}
+
+	var evalSet []evalQuery
+	if err := readJSONFile(*evalSetPath, &evalSet); err != nil {
+		return err
+	}
+	doc, err := parseSkillMDDir(*skillPath)
+	if err != nil {
+		return err
+	}
+	currentDescription := doc.Description
+	if strings.TrimSpace(*description) != "" {
+		currentDescription = *description
+	}
+
+	var liveReportPath string
+	if *report != "none" {
+		if *report == "auto" {
+			name := fmt.Sprintf("skill_description_report_%s_%s.html", filepath.Base(*skillPath), time.Now().Format("20060102_150405"))
+			liveReportPath = filepath.Join(os.TempDir(), name)
+		} else {
+			liveReportPath = mustAbs(*report)
+		}
+		_ = os.WriteFile(liveReportPath, []byte("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>"), 0o644)
+		openBrowser(liveReportPath)
+	}
+
+	var resultsRoot string
+	if strings.TrimSpace(*resultsDir) != "" {
+		resultsRoot = filepath.Join(mustAbs(*resultsDir), time.Now().Format("2006-01-02_150405"))
+		if err := os.MkdirAll(resultsRoot, 0o755); err != nil {
+			return err
+		}
+	}
+	logDir := ""
+	if resultsRoot != "" {
+		logDir = filepath.Join(resultsRoot, "logs")
+	}
+
+	output, err := runOptimizationLoop(evalSet, doc, currentDescription, *numWorkers, *timeout, *maxIterations, *runsPerQuery, *triggerThreshold, *holdout, *model, *verbose, liveReportPath, logDir)
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(output); err != nil {
+		return err
+	}
+
+	if resultsRoot != "" {
+		if err := writeJSONFile(filepath.Join(resultsRoot, "results.json"), output); err != nil {
+			return err
+		}
+	}
+
+	if liveReportPath != "" {
+		finalHTML := renderOptimizationReportHTML(output, false, doc.Name)
+		_ = os.WriteFile(liveReportPath, []byte(finalHTML), 0o644)
+		fmt.Fprintf(os.Stderr, "\nReport: %s\n", liveReportPath)
+		if resultsRoot != "" {
+			_ = os.WriteFile(filepath.Join(resultsRoot, "report.html"), []byte(finalHTML), 0o644)
+		}
+	}
+	if resultsRoot != "" {
+		fmt.Fprintf(os.Stderr, "Results saved to: %s\n", resultsRoot)
+	}
+	return nil
+}
+
+func runOptimizationLoop(evalSet []evalQuery, doc skillDoc, currentDescription string, numWorkers, timeout, maxIterations, runsPerQuery int, triggerThreshold, holdout float64, model string, verbose bool, liveReportPath, logDir string) (map[string]any, error) {
+	trainSet, testSet := splitEvalSet(evalSet, holdout, 42)
+	if holdout <= 0 {
+		trainSet = evalSet
+		testSet = nil
+	}
+	if verbose {
+		fmt.Fprintf(os.Stderr, "Split: %d train, %d test (holdout=%.2f)\n", len(trainSet), len(testSet), holdout)
+	}
+
+	history := make([]map[string]any, 0)
+	exitReason := "unknown"
+	projectRoot := findProjectRootWithClaudeDir()
+
+	for iteration := 1; iteration <= maxIterations; iteration++ {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "\n%s\nIteration %d/%d\nDescription: %s\n%s\n", strings.Repeat("=", 60), iteration, maxIterations, currentDescription, strings.Repeat("=", 60))
+		}
+
+		allQueries := append([]evalQuery{}, trainSet...)
+		allQueries = append(allQueries, testSet...)
+		start := time.Now()
+		allResults, err := executeEval(allQueries, doc.Name, currentDescription, numWorkers, timeout, runsPerQuery, triggerThreshold, projectRoot, model)
+		if err != nil {
+			return nil, err
+		}
+		evalElapsed := time.Since(start)
+
+		trainQuerySet := map[string]struct{}{}
+		for _, q := range trainSet {
+			trainQuerySet[q.Query] = struct{}{}
+		}
+		trainResults := make([]map[string]any, 0)
+		testResults := make([]map[string]any, 0)
+		for _, r := range allResults.Results {
+			entry := map[string]any{
+				"query":          r.Query,
+				"should_trigger": r.ShouldTrigger,
+				"trigger_rate":   r.TriggerRate,
+				"triggers":       r.Triggers,
+				"runs":           r.Runs,
+				"pass":           r.Pass,
+			}
+			if _, ok := trainQuerySet[r.Query]; ok {
+				trainResults = append(trainResults, entry)
+			} else {
+				testResults = append(testResults, entry)
+			}
+		}
+		sort.Slice(trainResults, func(i, j int) bool { return asString(trainResults[i]["query"]) < asString(trainResults[j]["query"]) })
+		sort.Slice(testResults, func(i, j int) bool { return asString(testResults[i]["query"]) < asString(testResults[j]["query"]) })
+
+		trainPassed := countPassed(trainResults)
+		trainTotal := len(trainResults)
+		testPassed := countPassed(testResults)
+		testTotal := len(testResults)
+
+		historyEntry := map[string]any{
+			"iteration":     iteration,
+			"description":   currentDescription,
+			"train_passed":  trainPassed,
+			"train_failed":  trainTotal - trainPassed,
+			"train_total":   trainTotal,
+			"train_results": trainResults,
+			"test_passed":   nil,
+			"test_failed":   nil,
+			"test_total":    nil,
+			"test_results":  nil,
+			"passed":        trainPassed,
+			"failed":        trainTotal - trainPassed,
+			"total":         trainTotal,
+			"results":       trainResults,
+		}
+		if len(testSet) > 0 {
+			historyEntry["test_passed"] = testPassed
+			historyEntry["test_failed"] = testTotal - testPassed
+			historyEntry["test_total"] = testTotal
+			historyEntry["test_results"] = testResults
+		}
+		history = append(history, historyEntry)
+
+		if liveReportPath != "" {
+			partial := map[string]any{
+				"original_description": doc.Description,
+				"best_description":     currentDescription,
+				"best_score":           "in progress",
+				"iterations_run":       len(history),
+				"holdout":              holdout,
+				"train_size":           len(trainSet),
+				"test_size":            len(testSet),
+				"history":              history,
+			}
+			_ = os.WriteFile(liveReportPath, []byte(renderOptimizationReportHTML(partial, true, doc.Name)), 0o644)
+		}
+
+		if verbose {
+			printEvalStats("Train", trainResults, evalElapsed)
+			if len(testSet) > 0 {
+				printEvalStats("Test ", testResults, 0)
+			}
+		}
+
+		if trainTotal-trainPassed == 0 {
+			exitReason = fmt.Sprintf("all_passed (iteration %d)", iteration)
+			if verbose {
+				fmt.Fprintf(os.Stderr, "\nAll train queries passed on iteration %d!\n", iteration)
+			}
+			break
+		}
+		if iteration == maxIterations {
+			exitReason = fmt.Sprintf("max_iterations (%d)", maxIterations)
+			if verbose {
+				fmt.Fprintf(os.Stderr, "\nMax iterations reached (%d).\n", maxIterations)
+			}
+			break
+		}
+
+		if verbose {
+			fmt.Fprintln(os.Stderr, "\nImproving description...")
+		}
+		improveStart := time.Now()
+		blindedHistory := make([]map[string]any, 0, len(history))
+		for _, h := range history {
+			item := make(map[string]any)
+			for k, v := range h {
+				if strings.HasPrefix(k, "test_") {
+					continue
+				}
+				item[k] = v
+			}
+			blindedHistory = append(blindedHistory, item)
+		}
+		newDesc, _, err := improveDescription(improveParams{
+			SkillName:          doc.Name,
+			SkillContent:       doc.Content,
+			CurrentDescription: currentDescription,
+			EvalResults: map[string]any{
+				"results": trainResults,
+				"summary": map[string]any{"passed": trainPassed, "failed": trainTotal - trainPassed, "total": trainTotal},
+			},
+			History:   blindedHistory,
+			Model:     model,
+			LogDir:    logDir,
+			Iteration: iteration,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if verbose {
+			fmt.Fprintf(os.Stderr, "Proposed (%.1fs): %s\n", time.Since(improveStart).Seconds(), newDesc)
+		}
+		currentDescription = newDesc
+	}
+
+	best := map[string]any{}
+	if len(history) == 0 {
+		best = map[string]any{"description": currentDescription, "iteration": 0, "train_passed": 0, "train_total": 0}
+	} else if len(testSet) > 0 {
+		best = history[0]
+		for _, h := range history[1:] {
+			if int(asFloat(h["test_passed"])) > int(asFloat(best["test_passed"])) {
+				best = h
+			}
+		}
+	} else {
+		best = history[0]
+		for _, h := range history[1:] {
+			if int(asFloat(h["train_passed"])) > int(asFloat(best["train_passed"])) {
+				best = h
+			}
+		}
+	}
+
+	bestScore := fmt.Sprintf("%d/%d", int(asFloat(best["train_passed"])), int(asFloat(best["train_total"])))
+	bestTestScore := any(nil)
+	if len(testSet) > 0 {
+		bestScore = fmt.Sprintf("%d/%d", int(asFloat(best["test_passed"])), int(asFloat(best["test_total"])))
+		bestTestScore = bestScore
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "\nExit reason: %s\n", exitReason)
+		fmt.Fprintf(os.Stderr, "Best score: %s (iteration %d)\n", bestScore, int(asFloat(best["iteration"])))
+	}
+
+	output := map[string]any{
+		"exit_reason":          exitReason,
+		"original_description": doc.Description,
+		"best_description":     asString(best["description"]),
+		"best_score":           bestScore,
+		"best_train_score":     fmt.Sprintf("%d/%d", int(asFloat(best["train_passed"])), int(asFloat(best["train_total"]))),
+		"best_test_score":      bestTestScore,
+		"final_description":    currentDescription,
+		"iterations_run":       len(history),
+		"holdout":              holdout,
+		"train_size":           len(trainSet),
+		"test_size":            len(testSet),
+		"history":              history,
+	}
+	return output, nil
+}
+
+func splitEvalSet(evalSet []evalQuery, holdout float64, seed int64) (trainSet, testSet []evalQuery) {
+	if holdout <= 0 || len(evalSet) == 0 {
+		return append([]evalQuery{}, evalSet...), nil
+	}
+	trigger := make([]evalQuery, 0)
+	noTrigger := make([]evalQuery, 0)
+	for _, e := range evalSet {
+		if e.ShouldTrigger {
+			trigger = append(trigger, e)
+		} else {
+			noTrigger = append(noTrigger, e)
+		}
+	}
+	rng := rand.New(rand.NewSource(seed))
+	rng.Shuffle(len(trigger), func(i, j int) { trigger[i], trigger[j] = trigger[j], trigger[i] })
+	rng.Shuffle(len(noTrigger), func(i, j int) { noTrigger[i], noTrigger[j] = noTrigger[j], noTrigger[i] })
+
+	nTrigTest := int(float64(len(trigger)) * holdout)
+	nNoTrigTest := int(float64(len(noTrigger)) * holdout)
+	if len(trigger) > 0 && nTrigTest < 1 {
+		nTrigTest = 1
+	}
+	if len(noTrigger) > 0 && nNoTrigTest < 1 {
+		nNoTrigTest = 1
+	}
+	if nTrigTest > len(trigger) {
+		nTrigTest = len(trigger)
+	}
+	if nNoTrigTest > len(noTrigger) {
+		nNoTrigTest = len(noTrigger)
+	}
+	testSet = append(testSet, trigger[:nTrigTest]...)
+	testSet = append(testSet, noTrigger[:nNoTrigTest]...)
+	trainSet = append(trainSet, trigger[nTrigTest:]...)
+	trainSet = append(trainSet, noTrigger[nNoTrigTest:]...)
+	return trainSet, testSet
+}
+
+func countPassed(results []map[string]any) int {
+	count := 0
+	for _, r := range results {
+		if asBoolDefault(r["pass"], false) {
+			count++
+		}
+	}
+	return count
+}
+
+func printEvalStats(label string, results []map[string]any, elapsed time.Duration) {
+	pos := make([]map[string]any, 0)
+	neg := make([]map[string]any, 0)
+	for _, r := range results {
+		if asBoolDefault(r["should_trigger"], true) {
+			pos = append(pos, r)
+		} else {
+			neg = append(neg, r)
+		}
+	}
+	tp := 0
+	posRuns := 0
+	for _, r := range pos {
+		tp += int(asFloat(r["triggers"]))
+		posRuns += int(asFloat(r["runs"]))
+	}
+	fn := posRuns - tp
+	fp := 0
+	negRuns := 0
+	for _, r := range neg {
+		fp += int(asFloat(r["triggers"]))
+		negRuns += int(asFloat(r["runs"]))
+	}
+	tn := negRuns - fp
+	total := tp + tn + fp + fn
+	precision := 1.0
+	if tp+fp > 0 {
+		precision = float64(tp) / float64(tp+fp)
+	}
+	recall := 1.0
+	if tp+fn > 0 {
+		recall = float64(tp) / float64(tp+fn)
+	}
+	accuracy := 0.0
+	if total > 0 {
+		accuracy = float64(tp+tn) / float64(total)
+	}
+	fmt.Fprintf(os.Stderr, "%s: %d/%d correct, precision=%.0f%% recall=%.0f%% accuracy=%.0f%% (%.1fs)\n", label, tp+tn, total, precision*100, recall*100, accuracy*100, elapsed.Seconds())
+	for _, r := range results {
+		status := "FAIL"
+		if asBoolDefault(r["pass"], false) {
+			status = "PASS"
+		}
+		fmt.Fprintf(os.Stderr, "  [%s] rate=%d/%d expected=%v: %s\n", status, int(asFloat(r["triggers"])), int(asFloat(r["runs"])), asBoolDefault(r["should_trigger"], true), truncateString(asString(r["query"]), 60))
+	}
+}

--- a/internal/skills/skill-creator/tools/test_helpers_test.go
+++ b/internal/skills/skill-creator/tools/test_helpers_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func withWorkingDir(t *testing.T, dir string) {
+	t.Helper()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(old)
+	})
+}
+
+func installFakeClaude(t *testing.T, projectRoot string) {
+	t.Helper()
+
+	binDir := filepath.Join(projectRoot, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake bin: %v", err)
+	}
+
+	scriptPath := filepath.Join(binDir, "claude")
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+
+mode=""
+prev=""
+for arg in "$@"; do
+  if [[ "$prev" == "--output-format" ]]; then
+    mode="$arg"
+    break
+  fi
+  prev="$arg"
+done
+
+if [[ "$mode" == "text" ]]; then
+  echo "<new_description>Improved description for tests</new_description>"
+  exit 0
+fi
+
+if [[ "$mode" == "stream-json" ]]; then
+  latest=$(ls -1 .claude/commands/*.md 2>/dev/null | tail -n 1 || true)
+  name=""
+  if [[ -n "$latest" ]]; then
+    base=$(basename "$latest")
+    name="${base%.md}"
+  fi
+
+  if [[ "${CODEX_FAKE_TRIGGER:-0}" == "1" ]]; then
+    if [[ -n "$name" ]]; then
+      printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"skill":"%s"}}]}}' "$name"
+      printf '\n'
+    else
+      echo '{"type":"result"}'
+    fi
+    exit 0
+  fi
+
+  if [[ -n "$latest" ]] && grep -q "Improved description for tests" "$latest"; then
+    printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"skill":"%s"}}]}}' "$name"
+    printf '\n'
+  else
+    echo '{"type":"result"}'
+  fi
+  exit 0
+fi
+
+echo "unsupported invocation: $*" >&2
+exit 1
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	cmdPath := filepath.Join(binDir, "claude.cmd")
+	cmdScript := `@echo off
+setlocal EnableDelayedExpansion
+set MODE=
+set PREV=
+
+:args
+if "%~1"=="" goto afterArgs
+if /I "!PREV!"=="--output-format" set MODE=%~1
+set PREV=%~1
+shift
+goto args
+
+:afterArgs
+if /I "%MODE%"=="text" (
+  echo ^<new_description^>Improved description for tests^</new_description^>
+  exit /b 0
+)
+
+if /I "%MODE%"=="stream-json" (
+  set CMD_DIR=.claude\commands
+  set LATEST=
+  for %%f in ("%CMD_DIR%\*.md") do set LATEST=%%f
+  set NAME=
+  if defined LATEST (
+    for %%n in ("!LATEST!") do set NAME=%%~nn
+  )
+
+  if /I "%CODEX_FAKE_TRIGGER%"=="1" (
+    if defined NAME (
+      echo {"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"skill":"!NAME!"}}]}}
+    ) else (
+      echo {"type":"result"}
+    )
+    exit /b 0
+  )
+
+  if defined LATEST (
+    findstr /C:"Improved description for tests" "!LATEST!" >nul
+    if !errorlevel! EQU 0 (
+      echo {"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"skill":"!NAME!"}}]}}
+      exit /b 0
+    )
+  )
+
+  echo {"type":"result"}
+  exit /b 0
+)
+
+echo unsupported invocation>&2
+exit /b 1
+`
+	if err := os.WriteFile(cmdPath, []byte(cmdScript), 0o755); err != nil {
+		t.Fatalf("write fake claude cmd: %v", err)
+	}
+
+	pathEnv := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+pathEnv)
+}
+
+func createMinimalSkill(t *testing.T, root, name, desc string) string {
+	t.Helper()
+	skillDir := filepath.Join(root, name)
+	skill := strings.Join([]string{
+		"---",
+		"name: " + name,
+		"description: \"" + desc + "\"",
+		"---",
+		"",
+		"# Skill Body",
+		"",
+	}, "\n")
+	writeTestFile(t, filepath.Join(skillDir, "SKILL.md"), skill)
+	return skillDir
+}

--- a/internal/tools/run_shell.go
+++ b/internal/tools/run_shell.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -496,7 +497,72 @@ func isOneOf(value string, options ...string) bool {
 
 func shellCommand(ctx context.Context, command string) *exec.Cmd {
 	if runtime.GOOS == "windows" {
-		return exec.CommandContext(ctx, "powershell", "-NoProfile", "-Command", command)
+		executable := resolveWindowsShellExecutable(exec.LookPath, os.Stat, os.Getenv)
+		return exec.CommandContext(ctx, executable, "-NoProfile", "-Command", command)
 	}
 	return exec.CommandContext(ctx, "sh", "-lc", command)
+}
+
+func resolveWindowsShellExecutable(
+	lookPath func(file string) (string, error),
+	statFn func(name string) (os.FileInfo, error),
+	getenv func(key string) string,
+) string {
+	for _, candidate := range windowsShellCandidates(getenv) {
+		if filepath.IsAbs(candidate) {
+			info, err := statFn(candidate)
+			if err == nil && info != nil && !info.IsDir() {
+				return candidate
+			}
+			continue
+		}
+		resolved, err := lookPath(candidate)
+		if err == nil && strings.TrimSpace(resolved) != "" {
+			return resolved
+		}
+	}
+	return "powershell"
+}
+
+func windowsShellCandidates(getenv func(key string) string) []string {
+	candidates := []string{
+		"powershell.exe",
+		"powershell",
+		"pwsh.exe",
+		"pwsh",
+	}
+
+	appendWindowsRoot := func(root string) {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			return
+		}
+		candidates = append(candidates,
+			filepath.Join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+			filepath.Join(root, "Sysnative", "WindowsPowerShell", "v1.0", "powershell.exe"),
+		)
+	}
+
+	appendWindowsRoot(getenv("SystemRoot"))
+	appendWindowsRoot(getenv("WINDIR"))
+
+	if programFiles := strings.TrimSpace(getenv("ProgramFiles")); programFiles != "" {
+		candidates = append(candidates, filepath.Join(programFiles, "PowerShell", "7", "pwsh.exe"))
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	uniq := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		key := strings.ToLower(candidate)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		uniq = append(uniq, candidate)
+	}
+	return uniq
 }

--- a/internal/tools/run_shell.go
+++ b/internal/tools/run_shell.go
@@ -509,7 +509,7 @@ func resolveWindowsShellExecutable(
 	getenv func(key string) string,
 ) string {
 	for _, candidate := range windowsShellCandidates(getenv) {
-		if filepath.IsAbs(candidate) {
+		if isWindowsAbsolutePath(candidate) {
 			info, err := statFn(candidate)
 			if err == nil && info != nil && !info.IsDir() {
 				return candidate
@@ -565,4 +565,21 @@ func windowsShellCandidates(getenv func(key string) string) []string {
 		uniq = append(uniq, candidate)
 	}
 	return uniq
+}
+
+func isWindowsAbsolutePath(path string) bool {
+	if filepath.IsAbs(path) {
+		return true
+	}
+	if len(path) >= 3 && isASCIIAlpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/') {
+		return true
+	}
+	if len(path) >= 2 && path[0] == '\\' && path[1] == '\\' {
+		return true
+	}
+	return false
+}
+
+func isASCIIAlpha(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }

--- a/internal/tools/run_shell_test.go
+++ b/internal/tools/run_shell_test.go
@@ -3,9 +3,13 @@ package tools
 import (
 	"bytes"
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAssessShellCommandAllowsReadOnlyCommands(t *testing.T) {
@@ -154,6 +158,60 @@ func TestRequireApprovalReturnsClearDenialMessage(t *testing.T) {
 	}
 }
 
+func TestResolveWindowsShellExecutablePrefersLookPathCandidate(t *testing.T) {
+	got := resolveWindowsShellExecutable(
+		func(file string) (string, error) {
+			if file == "powershell.exe" {
+				return `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, nil
+			}
+			return "", errors.New("not found")
+		},
+		func(name string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		},
+		func(key string) string { return "" },
+	)
+	if !strings.EqualFold(got, `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`) {
+		t.Fatalf("expected lookPath candidate, got %q", got)
+	}
+}
+
+func TestResolveWindowsShellExecutableFallsBackToAbsoluteCandidate(t *testing.T) {
+	windowsRoot := `C:\Windows`
+	expected := filepath.Join(windowsRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+	got := resolveWindowsShellExecutable(
+		func(file string) (string, error) {
+			return "", errors.New("not found")
+		},
+		func(name string) (os.FileInfo, error) {
+			if strings.EqualFold(name, expected) {
+				return stubFileInfo{}, nil
+			}
+			return nil, os.ErrNotExist
+		},
+		func(key string) string {
+			if key == "SystemRoot" {
+				return windowsRoot
+			}
+			return ""
+		},
+	)
+	if !strings.EqualFold(got, expected) {
+		t.Fatalf("expected absolute fallback %q, got %q", expected, got)
+	}
+}
+
+func TestResolveWindowsShellExecutableFallbacksToPowerShellLiteral(t *testing.T) {
+	got := resolveWindowsShellExecutable(
+		func(file string) (string, error) { return "", errors.New("not found") },
+		func(name string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		func(key string) string { return "" },
+	)
+	if got != "powershell" {
+		t.Fatalf("expected final fallback powershell, got %q", got)
+	}
+}
+
 func TestRunShellToolReturnsTimeoutError(t *testing.T) {
 	tool := RunShellTool{}
 	command := "sleep 2"
@@ -173,3 +231,12 @@ func TestRunShellToolReturnsTimeoutError(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+type stubFileInfo struct{}
+
+func (stubFileInfo) Name() string       { return "powershell.exe" }
+func (stubFileInfo) Size() int64        { return 0 }
+func (stubFileInfo) Mode() os.FileMode  { return 0o644 }
+func (stubFileInfo) ModTime() time.Time { return time.Time{} }
+func (stubFileInfo) IsDir() bool        { return false }
+func (stubFileInfo) Sys() any           { return nil }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -193,7 +193,6 @@ var commandItems = []commandItem{
 	{Name: "/btw", Usage: "/btw <message>", Description: "Interject while a run is in progress.", Kind: "command"},
 	{Name: "/quit", Usage: "/quit", Description: "Exit the current TUI window.", Kind: "command"},
 	{Name: "/skills", Usage: "/skills", Description: "List available skills and current active skill.", Kind: "command"},
-	{Name: "/skill author", Usage: "/skill author [name]", Description: "Enter skill author mode and create/update a scaffold.", Kind: "command"},
 	{Name: "/skill clear", Usage: "/skill clear", Description: "Clear active skill for this session.", Kind: "command"},
 	{Name: "/skill delete", Usage: "/skill delete <name>", Description: "Delete a project skill by name.", Kind: "command"},
 }
@@ -286,8 +285,6 @@ type model struct {
 	pendingBTW            []string
 	interrupting          bool
 	interruptSafe         bool
-	skillAuthorMode       bool
-	skillAuthorName       string
 	runSeq                int
 	activeRunID           int
 	startupGuide          StartupGuide
@@ -1038,9 +1035,6 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			return next, cmd
-		}
-		if m.skillAuthorMode {
-			return m.submitSkillAuthorInput(value)
 		}
 		return m.submitPrompt(value)
 	}
@@ -3142,60 +3136,16 @@ func (m *model) runSkillCommand(input string, fields []string) error {
 		return fmt.Errorf("runner is unavailable")
 	}
 	if len(fields) < 2 {
-		return fmt.Errorf("usage: /skill <author|clear|delete> ...")
+		return fmt.Errorf("usage: /skill <clear|delete> ...")
 	}
 	switch strings.ToLower(strings.TrimSpace(fields[1])) {
-	case "author":
-		return m.runSkillAuthorCommand(input, fields)
 	case "clear":
 		return m.runSkillStateClearCommand(input, fields)
 	case "delete":
 		return m.runSkillDeleteCommand(input, fields)
 	default:
-		return fmt.Errorf("usage: /skill <author|clear|delete> ...")
+		return fmt.Errorf("usage: /skill <clear|delete> ...")
 	}
-}
-
-func (m *model) runSkillAuthorCommand(input string, fields []string) error {
-	if len(fields) == 2 {
-		m.skillAuthorMode = true
-		m.skillAuthorName = ""
-		m.syncInputStyle()
-		m.appendCommandExchange(input, strings.Join([]string{
-			"Skill author mode enabled.",
-			"Step 1/2 (name): send only the skill name, for example `review-plus`.",
-			"Step 2/2 (content): after the name is set, send requirements to refine that skill.",
-			"Use `/skill author done` to exit this mode.",
-		}, "\n"))
-		m.statusNote = "Skill author mode: step 1/2 (name)"
-		return nil
-	}
-
-	control := strings.ToLower(strings.TrimSpace(fields[2]))
-	if len(fields) == 3 && (control == "done" || control == "exit" || control == "cancel") {
-		m.skillAuthorMode = false
-		m.skillAuthorName = ""
-		m.syncInputStyle()
-		m.appendCommandExchange(input, "Skill author mode closed.")
-		m.statusNote = "Skill author mode closed"
-		return nil
-	}
-
-	name, brief, err := parseSkillAuthorArgs(fields)
-	if err != nil {
-		return err
-	}
-	response, err := m.authorSkill(name, brief)
-	if err != nil {
-		return err
-	}
-	m.skillAuthorMode = true
-	m.skillAuthorName = name
-	m.syncInputStyle()
-
-	m.appendCommandExchange(input, response+"\nCurrent skill locked: `"+name+"`.\nNow in step 2/2 (content), keep sending requirements.")
-	m.statusNote = "Skill author mode: step 2/2 (content)"
-	return nil
 }
 
 func (m *model) runSkillStateClearCommand(input string, fields []string) error {
@@ -3244,13 +3194,6 @@ func (m *model) runSkillDeleteCommand(input string, fields []string) error {
 			lines = append(lines, "Cleared active skill in this session as well.")
 		}
 	}
-	if strings.EqualFold(strings.TrimSpace(m.skillAuthorName), strings.TrimSpace(result.Name)) {
-		m.skillAuthorName = ""
-		m.skillAuthorMode = false
-		m.syncInputStyle()
-		lines = append(lines, "Deleted skill matched author mode target; author mode closed.")
-	}
-
 	m.appendCommandExchange(input, strings.Join(lines, "\n"))
 	m.statusNote = "Skill deleted"
 	return nil
@@ -3354,147 +3297,6 @@ func parseSkillArgs(parts []string) (map[string]string, error) {
 	return args, nil
 }
 
-func parseSkillAuthorArgs(fields []string) (string, string, error) {
-	if len(fields) < 3 {
-		return "", "", fmt.Errorf("usage: /skill author [name]")
-	}
-	name := strings.TrimSpace(strings.TrimPrefix(fields[2], "/"))
-	if name == "" {
-		return "", "", fmt.Errorf("usage: /skill author [name]")
-	}
-	brief := strings.TrimSpace(strings.Join(fields[3:], " "))
-	return name, brief, nil
-}
-
-func parseSkillAuthorModeInput(value string) (string, string, error) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "", "", fmt.Errorf("please provide a skill name first, for example: review-plus")
-	}
-	fields := strings.Fields(value)
-	if len(fields) == 0 {
-		return "", "", fmt.Errorf("please provide a skill name first, for example: review-plus")
-	}
-	if len(fields) > 1 {
-		return "", "", fmt.Errorf("stage 1/2 expects only a skill name, for example: review-plus")
-	}
-	name := strings.TrimSpace(strings.TrimPrefix(fields[0], "/"))
-	if !isValidSkillAuthorName(name) {
-		return "", "", fmt.Errorf("invalid skill name: use letters, digits, or . _ : - , for example `review-plus`")
-	}
-	brief := strings.TrimSpace(strings.TrimPrefix(value, fields[0]))
-	return name, brief, nil
-}
-
-func isValidSkillAuthorName(name string) bool {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return false
-	}
-
-	runes := []rune(name)
-	for i, r := range runes {
-		isASCIIAlpha := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
-		isASCIIDigit := r >= '0' && r <= '9'
-		if isASCIIAlpha || isASCIIDigit {
-			continue
-		}
-		if i > 0 && (r == '.' || r == '_' || r == ':' || r == '-') {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
-func (m model) submitSkillAuthorInput(value string) (tea.Model, tea.Cmd) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return m, nil
-	}
-	m.input.Reset()
-
-	name := strings.TrimSpace(m.skillAuthorName)
-	brief := value
-	if name == "" {
-		var err error
-		name, brief, err = parseSkillAuthorModeInput(value)
-		if err != nil {
-			m.statusNote = err.Error()
-			m.appendCommandExchange(value, "Skill author mode notice:\n"+err.Error())
-			return m, nil
-		}
-		response, err := m.authorSkill(name, "")
-		if err != nil {
-			m.statusNote = err.Error()
-			m.appendCommandExchange(value, "Skill author mode notice:\n"+err.Error())
-			return m, nil
-		}
-		m.skillAuthorMode = true
-		m.skillAuthorName = name
-		m.syncInputStyle()
-		response += "\nEntered step 2/2 (content).\nContinue describing requirements; use `/skill author done` to exit."
-		m.appendCommandExchange(value, response)
-		m.statusNote = "Skill author mode: step 2/2 (content)"
-		return m, m.loadSessionsCmd()
-	}
-
-	response, err := m.authorSkill(name, brief)
-	if err != nil {
-		m.statusNote = err.Error()
-		m.appendCommandExchange(value, "Skill author mode notice:\n"+err.Error())
-		return m, nil
-	}
-
-	m.skillAuthorMode = true
-	m.skillAuthorName = name
-	m.syncInputStyle()
-	response += "\nCurrent step: 2/2 (content). Keep sending updates to refine; use `/skill author done` to exit."
-	m.appendCommandExchange(value, response)
-	m.statusNote = "Skill author mode: step 2/2 (content)"
-	return m, m.loadSessionsCmd()
-}
-
-func (m *model) authorSkill(name, brief string) (string, error) {
-	result, err := m.runner.AuthorSkill(name, brief)
-	if err != nil {
-		return "", err
-	}
-
-	state := "updated"
-	if result.Created {
-		state = "created"
-	} else {
-		state = "updated"
-	}
-	lines := []string{
-		fmt.Sprintf("Skill `%s` %s.", result.Name, state),
-		fmt.Sprintf("Dir: %s", result.Dir),
-		fmt.Sprintf("Manifest: %s", result.ManifestPath),
-		fmt.Sprintf("Skill doc: %s", result.SkillPath),
-		fmt.Sprintf("Activate with `/%s`.", result.Name),
-	}
-	if strings.TrimSpace(brief) == "" {
-		lines = append(lines, "Next: describe requirements in natural language and continue refining this skill.")
-	}
-
-	skillsList, diagnostics := m.runner.ListSkills()
-	for _, skill := range skillsList {
-		if !strings.EqualFold(strings.TrimSpace(skill.Name), strings.TrimSpace(result.Name)) {
-			continue
-		}
-		lines = append(lines, fmt.Sprintf("Resolved as: `%s` (%s).", skill.Name, skill.Scope))
-		break
-	}
-	for _, diag := range diagnostics {
-		if !strings.EqualFold(strings.TrimSpace(diag.Skill), strings.TrimSpace(result.Name)) {
-			continue
-		}
-		lines = append(lines, fmt.Sprintf("Diagnostic [%s] %s: %s", diag.Level, diag.Path, diag.Message))
-	}
-	return strings.Join(lines, "\n"), nil
-}
-
 func (m *model) appendCommandExchange(command, response string) {
 	m.screen = screenChat
 	m.appendChat(chatEntry{
@@ -3544,8 +3346,6 @@ func (m *model) newSession() error {
 	m.pendingBTW = nil
 	m.interrupting = false
 	m.interruptSafe = false
-	m.skillAuthorMode = false
-	m.skillAuthorName = ""
 	m.runCancel = nil
 	m.activeRunID = 0
 	m.input.Reset()
@@ -3596,8 +3396,6 @@ func (m *model) resumeSession(prefix string) error {
 	m.pendingBTW = nil
 	m.interrupting = false
 	m.interruptSafe = false
-	m.skillAuthorMode = false
-	m.skillAuthorName = ""
 	m.runCancel = nil
 	m.activeRunID = 0
 	m.syncInputStyle()
@@ -4900,7 +4698,7 @@ func shouldExecuteFromPalette(item commandItem) bool {
 		return true
 	}
 	switch item.Name {
-	case "/help", "/session", "/skills", "/skill author", "/skill clear", "/new", "/compact", "/quit":
+	case "/help", "/session", "/skills", "/skill clear", "/new", "/compact", "/quit":
 		return true
 	default:
 		return false
@@ -4919,9 +4717,6 @@ func (m model) helpText() string {
 		"/session: open recent sessions.",
 		"/skills: list available skills and diagnostics.",
 		"/<skill-name> [k=v...]: activate a skill for this session.",
-		"/skill author: enter skill author mode (name first, then content).",
-		"/skill author [name]: create/update the skill and enter content stage.",
-		"/skill author done: exit skill author mode.",
 		"/skill clear: clear the active skill in this session.",
 		"/skill delete <name>: delete the specified project skill.",
 		"/new: start a fresh session.",
@@ -5091,20 +4886,11 @@ func (m model) modeAccentColor() lipgloss.Color {
 func (m *model) syncInputStyle() {
 	if m.startupGuide.Active {
 		m.input.Placeholder = startupGuideInputPlaceholder(m.startupGuide.CurrentField)
-	} else if m.skillAuthorMode {
-		m.input.Placeholder = m.skillAuthorInputPlaceholder()
 	} else {
 		m.input.Placeholder = "Ask Bytemind to inspect, change, or verify this workspace..."
 	}
 	m.input.Prompt = ""
 	setInputHeightSafe(&m.input, 2)
-}
-
-func (m model) skillAuthorInputPlaceholder() string {
-	if strings.TrimSpace(m.skillAuthorName) == "" {
-		return "Skill author mode step 1/2: enter only the skill name, for example: review-plus"
-	}
-	return "Skill author mode step 2/2 (" + strings.TrimSpace(m.skillAuthorName) + "): enter skill content and requirements..."
 }
 
 func setInputHeightSafe(input *textarea.Model, height int) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1627,7 +1627,6 @@ func TestHelpTextOnlyMentionsSupportedEntryPoints(t *testing.T) {
 		"go run ./cmd/bytemind chat",
 		"go run ./cmd/bytemind run -prompt",
 		"/session",
-		"/skill author",
 		"/skill clear",
 		"/skill delete <name>",
 		"/quit",
@@ -2031,7 +2030,7 @@ func TestHandleSlashSkillActivateAndSwitch(t *testing.T) {
 	}
 }
 
-func TestHandleSlashSkillAuthorCreatesProjectSkill(t *testing.T) {
+func TestHandleSlashSkillAuthorIsUnsupported(t *testing.T) {
 	workspace := t.TempDir()
 
 	store, err := session.NewStore(t.TempDir())
@@ -2057,34 +2056,15 @@ func TestHandleSlashSkillAuthorCreatesProjectSkill(t *testing.T) {
 		input:     textarea.New(),
 	}
 
-	if err := m.handleSlashCommand("/skill author review-plus review backend changes and report risks"); err != nil {
-		t.Fatalf("expected /skill author to succeed, got %v", err)
+	if err := m.handleSlashCommand("/skill author"); err == nil {
+		t.Fatalf("expected /skill author to fail")
+	} else if !strings.Contains(err.Error(), "usage: /skill <clear|delete> ...") {
+		t.Fatalf("unexpected error for /skill author: %v", err)
 	}
-
-	skillDir := filepath.Join(workspace, ".bytemind", "skills", "review-plus")
-	if _, err := os.Stat(filepath.Join(skillDir, "skill.json")); err != nil {
-		t.Fatalf("expected generated skill.json, got %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
-		t.Fatalf("expected generated SKILL.md, got %v", err)
-	}
-
-	if len(m.chatItems) < 2 {
-		t.Fatalf("expected command exchange in chat, got %#v", m.chatItems)
-	}
-	response := m.chatItems[len(m.chatItems)-1].Body
-	if !strings.Contains(response, "Skill `review-plus`") {
-		t.Fatalf("expected response to reference authored skill, got %q", response)
-	}
-	if !strings.Contains(response, "Activate with `/review-plus`") {
-		t.Fatalf("expected response to include activation hint, got %q", response)
-	}
-
-	if err := m.handleSlashCommand("/review-plus"); err != nil {
-		t.Fatalf("expected /review-plus activation to succeed, got %v", err)
-	}
-	if m.sess.ActiveSkill == nil || m.sess.ActiveSkill.Name != "review-plus" {
-		t.Fatalf("expected active skill review-plus, got %#v", m.sess.ActiveSkill)
+	if err := m.handleSlashCommand("/skill author review-plus review backend changes and report risks"); err == nil {
+		t.Fatalf("expected /skill author <name> to fail")
+	} else if !strings.Contains(err.Error(), "usage: /skill <clear|delete> ...") {
+		t.Fatalf("unexpected error for /skill author <name>: %v", err)
 	}
 }
 
@@ -2194,125 +2174,15 @@ func TestHandleSlashSkillClearOnlyClearsActiveSkill(t *testing.T) {
 	}
 }
 
-func TestHandleSlashSkillAuthorWithoutNameEntersAuthorMode(t *testing.T) {
-	workspace := t.TempDir()
-
-	store, err := session.NewStore(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	sess := session.New(workspace)
-	runner := agent.NewRunner(agent.Options{
-		Workspace: workspace,
-		Config: config.Config{
-			Provider: config.ProviderConfig{Model: "test-model"},
-		},
-		Store:    store,
-		Registry: tools.DefaultRegistry(),
-	})
-
+func TestCommandPaletteDoesNotExposeSkillAuthor(t *testing.T) {
 	input := textarea.New()
-	m := model{
-		runner:    runner,
-		store:     store,
-		sess:      sess,
-		workspace: workspace,
-		screen:    screenChat,
-		input:     input,
-	}
-
-	if err := m.handleSlashCommand("/skill author"); err != nil {
-		t.Fatalf("expected /skill author to enable mode, got %v", err)
-	}
-	if !m.skillAuthorMode {
-		t.Fatalf("expected skillAuthorMode enabled")
-	}
-	if strings.TrimSpace(m.skillAuthorName) != "" {
-		t.Fatalf("expected no skillAuthorName yet, got %q", m.skillAuthorName)
-	}
-	if !strings.Contains(m.input.Placeholder, "step 1/2") {
-		t.Fatalf("expected author-mode placeholder, got %q", m.input.Placeholder)
-	}
-
-	m.input.SetValue("review-ops")
-	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := got.(model)
-
-	if !updated.skillAuthorMode {
-		t.Fatalf("expected author mode to stay active")
-	}
-	if updated.skillAuthorName != "review-ops" {
-		t.Fatalf("expected target skill name review-ops, got %q", updated.skillAuthorName)
-	}
-	if !strings.Contains(updated.input.Placeholder, "step 2/2") || !strings.Contains(updated.input.Placeholder, "review-ops") {
-		t.Fatalf("expected author-mode placeholder to track skill name, got %q", updated.input.Placeholder)
-	}
-	if _, err := os.Stat(filepath.Join(workspace, ".bytemind", "skills", "review-ops", "skill.json")); err != nil {
-		t.Fatalf("expected generated skill scaffold, got %v", err)
-	}
-
-	updated.input.SetValue("Used for code review, prioritizing regression risk and missing tests.")
-	next, _ := updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	updated2 := next.(model)
-	if !updated2.skillAuthorMode {
-		t.Fatalf("expected author mode to stay active after content update")
-	}
-	if !strings.Contains(updated2.chatItems[len(updated2.chatItems)-1].Body, "Current step: 2/2 (content)") {
-		t.Fatalf("expected stage 2 guidance after content update, got %q", updated2.chatItems[len(updated2.chatItems)-1].Body)
-	}
-
-	if err := updated2.handleSlashCommand("/skill author done"); err != nil {
-		t.Fatalf("expected /skill author done to exit mode, got %v", err)
-	}
-	if updated2.skillAuthorMode {
-		t.Fatalf("expected skillAuthorMode disabled")
-	}
-}
-
-func TestSkillAuthorModeShowsVisibleGuidanceOnInvalidName(t *testing.T) {
-	workspace := t.TempDir()
-
-	store, err := session.NewStore(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	sess := session.New(workspace)
-	runner := agent.NewRunner(agent.Options{
-		Workspace: workspace,
-		Config: config.Config{
-			Provider: config.ProviderConfig{Model: "test-model"},
-		},
-		Store:    store,
-		Registry: tools.DefaultRegistry(),
-	})
-
-	input := textarea.New()
-	m := model{
-		runner:    runner,
-		store:     store,
-		sess:      sess,
-		workspace: workspace,
-		screen:    screenChat,
-		input:     input,
-	}
-
-	if err := m.handleSlashCommand("/skill author"); err != nil {
-		t.Fatalf("expected /skill author to enable mode, got %v", err)
-	}
-
-	m.input.SetValue("review+skill")
-	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := got.(model)
-
-	if !updated.skillAuthorMode {
-		t.Fatalf("expected author mode to remain enabled")
-	}
-	if len(updated.chatItems) < 2 {
-		t.Fatalf("expected visible assistant guidance, got %#v", updated.chatItems)
-	}
-	body := updated.chatItems[len(updated.chatItems)-1].Body
-	if !strings.Contains(body, "invalid skill name") {
-		t.Fatalf("expected invalid-name guidance in chat, got %q", body)
+	input.SetValue("/skill")
+	m := model{input: input}
+	items := m.filteredCommands()
+	for _, item := range items {
+		if strings.EqualFold(strings.TrimSpace(item.Name), "/skill author") {
+			t.Fatalf("command palette should not expose /skill author, got %+v", item)
+		}
 	}
 }
 


### PR DESCRIPTION
前要问题：

Background
在 Windows 环境下，run_shell 可能因 powershell 不在 %PATH% 中而失败，报错 exec: "powershell": executable file not found in %PATH%。
长会话触发自动压缩时，若模型返回空摘要，会直接中断请求，报错 compaction returned empty summary。

What Changed
为 run_shell 增加 Windows shell 可执行文件解析与回退策略。

为安装流程中读取/写入用户 PATH 的 PowerShell 调用增加同样的解析与回退策略。

对会话压缩增加空摘要兜底逻辑：当模型返回空摘要时，生成本地 fallback summary 并继续流程，不再直接失败。

Behavior Impact
Windows 下即使 %PATH% 未包含 powershell，run_shell/安装流程更高概率可正常执行。
长会话压缩阶段更稳健，避免因空摘要导致整次请求失败。