### PR TITLE
Codex/pure black background

### DIFF
--- a/internal/tui/input_paste.go
+++ b/internal/tui/input_paste.go
@@ -18,6 +18,7 @@ const (
 	longPasteLineThreshold      = 10
 	longPasteCharThreshold      = 500
 	pasteQuickCharThreshold     = 80
+	pasteBurstImmediateMinChars = 12
 	flattenedPasteCharThreshold = 180
 	pasteBurstCharThreshold     = 120
 	pasteBurstWindow            = 80 * time.Millisecond
@@ -215,7 +216,16 @@ func (m *model) shouldCompressPastedText(input, source string) bool {
 	if m.isLongPastedText(input) {
 		return true
 	}
-	if trimmed == "" || len(trimmed) < pasteQuickCharThreshold {
+	if trimmed == "" {
+		return false
+	}
+	rapidBurst := !m.lastInputAt.IsZero() &&
+		time.Since(m.lastInputAt) <= pasteBurstWindow &&
+		m.inputBurstSize >= pasteBurstImmediateMinChars
+	if rapidBurst && len(trimmed) >= pasteBurstImmediateMinChars && looksLikePastedFragment(trimmed) {
+		return true
+	}
+	if len(trimmed) < pasteQuickCharThreshold {
 		return false
 	}
 	if isPasteLikeSource(source) {
@@ -231,6 +241,13 @@ func (m *model) shouldCompressPastedText(input, source string) bool {
 		return true
 	}
 	return m.inputBurstSize >= pasteBurstCharThreshold
+}
+
+func looksLikePastedFragment(value string) bool {
+	if strings.ContainsAny(value, "\r\n\t ") {
+		return true
+	}
+	return len(value) >= 64
 }
 
 func isLikelyPathInput(value string) bool {
@@ -344,7 +361,6 @@ func (m *model) applyLongPastedTextPipeline(before, after, source string) (strin
 		return after, ""
 	}
 	class, prefix, inserted, suffix := classifyInputMutation(before, after, source)
-	_, beforeHasMarkerChain := extractLeadingCompressedMarker(before)
 	if chain, ok := extractLeadingCompressedMarker(before); ok {
 		afterTrimmed := strings.TrimSpace(after)
 		if strings.HasPrefix(afterTrimmed, chain) {
@@ -382,14 +398,7 @@ func (m *model) applyLongPastedTextPipeline(before, after, source string) (strin
 	}
 	if class == inputMutationPasteFilled {
 		candidate := strings.ReplaceAll(inserted, ctrlVMarkerRune, "")
-		if m.isLongPastedText(candidate) {
-			if !beforeHasMarkerChain && strings.TrimSpace(before) != "" && isSplitPasteContinuation(before, source, m.lastPasteAt) {
-				// Looks like the same clipboard paste still streaming in chunks.
-				// Defer compression so we can fold the whole paste into one marker.
-				candidate = ""
-			}
-		}
-		if strings.TrimSpace(candidate) != "" && m.isLongPastedText(candidate) {
+		if strings.TrimSpace(candidate) != "" && m.shouldCompressPastedText(candidate, source) {
 			marker, content, err := m.compressPastedText(candidate)
 			if err != nil {
 				return after, err.Error()
@@ -423,11 +432,11 @@ func countCompressedMarkers(value string) int {
 }
 
 func shouldMergeIntoLatestMarker(source string, lastCompressedAt time.Time) bool {
-	if isPasteLikeSource(source) {
-		return false
-	}
 	if lastCompressedAt.IsZero() {
 		return false
+	}
+	if isPasteLikeSource(source) {
+		return time.Since(lastCompressedAt) <= 120*time.Millisecond
 	}
 	return time.Since(lastCompressedAt) <= 300*time.Millisecond
 }
@@ -539,6 +548,122 @@ func extractLeadingCompressedMarker(value string) (string, bool) {
 		return "", false
 	}
 	return marker, true
+}
+
+func compressedMarkerIDs(value string) []string {
+	matches := compressedPasteMarkerDetailsPattern.FindAllStringSubmatch(value, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		id := strings.TrimSpace(match[1])
+		if id == "" {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func sameMarkerIDPrefix(beforeIDs, afterIDs []string) bool {
+	if len(beforeIDs) == 0 || len(afterIDs) < len(beforeIDs) {
+		return false
+	}
+	for i := range beforeIDs {
+		if beforeIDs[i] != afterIDs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func isMarkerDeletionSource(source string) bool {
+	key := normalizeKeyName(source)
+	return key == "backspace" || key == "delete" || key == "ctrl+h"
+}
+
+func dropLatestCompressedMarker(chain string) string {
+	matches := compressedPasteMarkerAnyPattern.FindAllStringIndex(chain, -1)
+	if len(matches) == 0 {
+		return strings.TrimSpace(chain)
+	}
+	last := matches[len(matches)-1]
+	if len(last) < 2 {
+		return strings.TrimSpace(chain)
+	}
+	updated := chain[:last[0]] + chain[last[1]:]
+	return strings.TrimSpace(updated)
+}
+
+func (m *model) protectCompressedMarkerChain(before, after, source string) (string, bool) {
+	if m == nil {
+		return after, false
+	}
+	beforeChain, ok := extractLeadingCompressedMarker(before)
+	if !ok {
+		return after, false
+	}
+	beforeTrimmed := strings.TrimSpace(before)
+	afterTrimmed := strings.TrimSpace(after)
+	if afterTrimmed == beforeTrimmed {
+		return after, false
+	}
+	if afterTrimmed == "" {
+		// Allow explicit full deletion of compressed markers.
+		return after, false
+	}
+	if isMarkerDeletionSource(source) && !strings.HasPrefix(afterTrimmed, beforeChain) {
+		// Backspace/Delete on marker text removes one whole marker block.
+		beforeTail := strings.TrimSpace(strings.TrimPrefix(beforeTrimmed, beforeChain))
+		reduced := dropLatestCompressedMarker(beforeChain)
+		if reduced == "" {
+			return beforeTail, true
+		}
+		if beforeTail != "" {
+			return reduced + beforeTail, true
+		}
+		return reduced, true
+	}
+	if strings.HasPrefix(afterTrimmed, beforeChain) {
+		return after, false
+	}
+
+	afterChain, afterHasChain := extractLeadingCompressedMarker(afterTrimmed)
+	if afterHasChain {
+		beforeIDs := compressedMarkerIDs(beforeChain)
+		afterIDs := compressedMarkerIDs(afterChain)
+		if sameMarkerIDPrefix(beforeIDs, afterIDs) {
+			// Marker text is immutable for manual edits. Only allow chain text
+			// changes when they likely come from paste chunk coalescing logic.
+			if strings.TrimSpace(afterChain) == strings.TrimSpace(beforeChain) ||
+				isPasteLikeSource(source) ||
+				source == "paste-enter" {
+				return after, false
+			}
+			tail := strings.TrimSpace(strings.TrimPrefix(afterTrimmed, afterChain))
+			restored := strings.TrimSpace(beforeChain)
+			if tail != "" {
+				restored += tail
+			}
+			return restored, true
+		}
+		tail := strings.TrimSpace(strings.TrimPrefix(afterTrimmed, afterChain))
+		restored := strings.TrimSpace(beforeChain)
+		if tail != "" {
+			restored += tail
+		}
+		return restored, true
+	}
+
+	if isPasteLikeSource(source) {
+		// Keep accidental paste spill while restoring immutable marker chain.
+		return strings.TrimSpace(beforeChain) + afterTrimmed, true
+	}
+	return strings.TrimSpace(beforeChain), true
 }
 
 func isSplitPasteContinuation(input, source string, lastPasteAt time.Time) bool {

--- a/internal/tui/input_paste_test.go
+++ b/internal/tui/input_paste_test.go
@@ -60,8 +60,8 @@ func TestApplyLongPastedTextPipelineCompressesSplitPasteChunks(t *testing.T) {
 
 	m.input.SetValue(chunk1)
 	m.handleInputMutation("", chunk1, "paste")
-	if got := m.input.Value(); got != chunk1 {
-		t.Fatalf("expected first chunk to remain literal until paste is complete, got %q", got)
+	if got := m.input.Value(); got != chunk1 && !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(got) {
+		t.Fatalf("expected first chunk to be literal or already compressed, got %q", got)
 	}
 
 	before := m.input.Value()
@@ -79,7 +79,7 @@ func TestApplyLongPastedTextPipelineCompressesSplitPasteChunks(t *testing.T) {
 	}
 }
 
-func TestApplyLongPastedTextPipelineDoesNotCompressEarlyForShortInitialPasteChunk(t *testing.T) {
+func TestApplyLongPastedTextPipelineCompressesEarlyAndMergesFollowupPasteChunk(t *testing.T) {
 	m := newImagePipelineModel(t)
 	chunk1 := strings.Join([]string{
 		"# Long Paste Test Block (20 lines)",
@@ -107,8 +107,8 @@ func TestApplyLongPastedTextPipelineDoesNotCompressEarlyForShortInitialPasteChun
 
 	m.input.SetValue(chunk1)
 	m.handleInputMutation("", chunk1, "paste")
-	if got := m.input.Value(); got != chunk1 {
-		t.Fatalf("expected first short chunk to stay literal, got %q", got)
+	if got := m.input.Value(); !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(got) {
+		t.Fatalf("expected first chunk to compress immediately, got %q", got)
 	}
 
 	before := m.input.Value()
@@ -119,10 +119,10 @@ func TestApplyLongPastedTextPipelineDoesNotCompressEarlyForShortInitialPasteChun
 	got := m.input.Value()
 	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`)
 	if !re.MatchString(got) {
-		t.Fatalf("expected whole paste to compress as one marker, got %q", got)
+		t.Fatalf("expected followup paste chunk to merge into one marker, got %q", got)
 	}
 	if len(m.pastedOrder) != 1 {
-		t.Fatalf("expected exactly one stored marker for one long paste, got %d", len(m.pastedOrder))
+		t.Fatalf("expected one stored marker after merged paste chunks, got %d", len(m.pastedOrder))
 	}
 }
 
@@ -176,9 +176,9 @@ func TestApplyLongPastedTextPipelineCompressesTailAfterMarkerIntoNewMarker(t *te
 	m.handleInputMutation(before, after, "paste")
 
 	got := m.input.Value()
-	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]\[Paste #\d+ ~\d+ lines\]$`)
+	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`)
 	if !re.MatchString(got) {
-		t.Fatalf("expected tail to be compressed as another marker, got %q", got)
+		t.Fatalf("expected immediate followup paste chunk to merge into latest marker, got %q", got)
 	}
 }
 
@@ -225,6 +225,7 @@ func TestApplyLongPastedTextPipelineTrimsShortTailAfterSecondMarker(t *testing.T
 
 	m.handleInputMutation("", first, "paste")
 	before := m.input.Value()
+	m.lastCompressedPasteAt = time.Now().Add(-time.Second)
 	m.handleInputMutation(before, before+second, "paste")
 	before = m.input.Value()
 	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]\[Paste #\d+ ~\d+ lines\]$`).MatchString(before) {
@@ -257,6 +258,7 @@ func TestApplyLongPastedTextPipelineAppendsMarkersForConsecutiveLongPastes(t *te
 
 	before := firstMarker
 	after := before + secondPaste
+	m.lastCompressedPasteAt = time.Now().Add(-time.Second)
 	m.input.SetValue(after)
 	m.handleInputMutation(before, after, "paste")
 
@@ -609,6 +611,26 @@ func TestShouldCompressPastedTextDetectsFastCharacterBurstWithoutPasteSignal(t *
 	}
 }
 
+func TestShouldCompressPastedTextDetectsShortRapidBurstEarly(t *testing.T) {
+	m := newImagePipelineModel(t)
+	text := strings.Repeat("x ", pasteBurstImmediateMinChars+2)
+	m.inputBurstSize = pasteBurstImmediateMinChars
+	m.lastInputAt = time.Now()
+	if !m.shouldCompressPastedText(text, "rune") {
+		t.Fatalf("expected short rapid burst to trigger early compression")
+	}
+}
+
+func TestShouldCompressPastedTextSkipsShortRapidBurstWithoutPasteSignals(t *testing.T) {
+	m := newImagePipelineModel(t)
+	text := strings.Repeat("x", pasteBurstImmediateMinChars+2)
+	m.inputBurstSize = pasteBurstImmediateMinChars
+	m.lastInputAt = time.Now()
+	if m.shouldCompressPastedText(text, "rune") {
+		t.Fatalf("expected short compact burst without paste traits to skip compression")
+	}
+}
+
 func TestExtractLineRangeClampsBounds(t *testing.T) {
 	content := "l1\nl2\nl3\nl4"
 	if got := extractLineRange(content, 0, 99); got != content {
@@ -638,5 +660,221 @@ func TestPastedRefPattern(t *testing.T) {
 		if matched != tc.expected {
 			t.Fatalf("input %q: expected %v, got %v", tc.input, tc.expected, matched)
 		}
+	}
+}
+
+func TestCountCompressedMarkersAndLatestMarkerLookup(t *testing.T) {
+	if got := countCompressedMarkers("   "); got != 0 {
+		t.Fatalf("expected empty marker count to be 0, got %d", got)
+	}
+	value := "[Paste #1 ~11 lines][Paste #2 ~15 lines] trailing"
+	if got := countCompressedMarkers(value); got != 2 {
+		t.Fatalf("expected two markers, got %d", got)
+	}
+
+	loc := latestCompressedMarkerInChain(value)
+	if !loc.ok {
+		t.Fatalf("expected latest marker location to be found")
+	}
+	if loc.id != "2" {
+		t.Fatalf("expected latest marker id 2, got %q", loc.id)
+	}
+	if got := value[loc.start:loc.end]; got != "[Paste #2 ~15 lines]" {
+		t.Fatalf("unexpected latest marker slice %q", got)
+	}
+
+	if loc := latestCompressedMarkerInChain("no marker"); loc.ok {
+		t.Fatalf("expected no marker location for non-marker input")
+	}
+}
+
+func TestShouldHoldCompressedMarkerBranchMatrix(t *testing.T) {
+	now := time.Now()
+	marker := "[Paste #1 ~11 lines]"
+
+	if shouldHoldCompressedMarker("plain text", "plain text trailing", "", now, 0) {
+		t.Fatalf("expected non-marker prefix not to be held")
+	}
+	if shouldHoldCompressedMarker(marker, marker, "", now, 0) {
+		t.Fatalf("expected unchanged marker not to be held")
+	}
+	if shouldHoldCompressedMarker(marker, marker+" [Paste #2 ~12 lines]", "", now, 0) {
+		t.Fatalf("expected marker-only tail chain not to be held")
+	}
+
+	if !shouldHoldCompressedMarker(marker, marker+" this continuation payload should be held", "", now, 0) {
+		t.Fatalf("expected long tail after marker to be held")
+	}
+	if !shouldHoldCompressedMarker(marker, marker+" short", "paste", time.Time{}, 0) {
+		t.Fatalf("expected paste-like source to hold short tail")
+	}
+	if !shouldHoldCompressedMarker(marker, marker+" short", "rune", time.Time{}, 10) {
+		t.Fatalf("expected burst size to hold short tail")
+	}
+	if !shouldHoldCompressedMarker(marker, marker+" short", "rune", now, 0) {
+		t.Fatalf("expected recent paste window to hold short tail")
+	}
+	if shouldHoldCompressedMarker(marker, marker+" short", "rune", time.Time{}, 0) {
+		t.Fatalf("expected short stale tail without paste signals not to be held")
+	}
+}
+
+func TestMergeTailIntoLatestMarkerUpdatesLatestOnly(t *testing.T) {
+	m := newImagePipelineModel(t)
+
+	firstRaw := strings.Join([]string{"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11"}, "\n")
+	secondRaw := strings.Join([]string{"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11"}, "\n")
+	marker1, firstStored, err := m.compressPastedText(firstRaw)
+	if err != nil {
+		t.Fatalf("compress first: %v", err)
+	}
+	marker2, secondStored, err := m.compressPastedText(secondRaw)
+	if err != nil {
+		t.Fatalf("compress second: %v", err)
+	}
+	chain := marker1 + marker2
+
+	tail := "\nextra-1\nextra-2\nextra-3\nextra-4"
+	updated, merged, err := m.mergeTailIntoLatestMarker(chain, tail)
+	if err != nil {
+		t.Fatalf("merge tail: %v", err)
+	}
+	if !merged {
+		t.Fatalf("expected merge into latest marker")
+	}
+	if !strings.Contains(updated, "[Paste #"+secondStored.ID+" ~15 lines]") {
+		t.Fatalf("expected latest marker line count to be updated, got %q", updated)
+	}
+
+	firstAfter, ok := m.findPastedContent(firstStored.ID)
+	if !ok {
+		t.Fatalf("expected first stored content to remain present")
+	}
+	if firstAfter.Content != firstStored.Content {
+		t.Fatalf("expected first stored content to remain unchanged")
+	}
+	secondAfter, ok := m.findPastedContent(secondStored.ID)
+	if !ok {
+		t.Fatalf("expected latest stored content to remain present")
+	}
+	if secondAfter.Lines != 15 {
+		t.Fatalf("expected merged latest content lines=15, got %d", secondAfter.Lines)
+	}
+	if !strings.Contains(secondAfter.Content, "extra-4") {
+		t.Fatalf("expected tail to append into latest stored content")
+	}
+}
+
+func TestResolvePastedSelectionInvalidStartLine(t *testing.T) {
+	m := newImagePipelineModel(t)
+	_, stored, err := m.compressPastedText("a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk")
+	if err != nil {
+		t.Fatalf("compress pasted text: %v", err)
+	}
+
+	if _, err := m.resolvePastedSelection(stored.ID, "not-a-number", ""); err == nil {
+		t.Fatalf("expected invalid start line to return error")
+	}
+	if _, err := m.resolvePastedSelection("9999", "1", "2"); err == nil {
+		t.Fatalf("expected unknown pasted id to return error")
+	}
+}
+
+func TestProtectCompressedMarkerChainPreventsAccidentalEdits(t *testing.T) {
+	m := newImagePipelineModel(t)
+	raw := strings.Join([]string{
+		"a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11",
+	}, "\n")
+	m.handleInputMutation("", raw, "paste")
+	marker := m.input.Value()
+	if !strings.HasPrefix(marker, "[Paste #") {
+		t.Fatalf("expected compressed marker, got %q", marker)
+	}
+
+	edited := strings.Replace(marker, "Paste", "Pste", 1)
+	m.handleInputMutation(marker, edited, "rune")
+	if got := m.input.Value(); got != marker {
+		t.Fatalf("expected edited marker to be restored, got %q", got)
+	}
+
+	deleted := ""
+	m.input.SetValue(deleted)
+	m.handleInputMutation(marker, deleted, "backspace")
+	if got := m.input.Value(); got != "" {
+		t.Fatalf("expected deleting whole marker to be allowed, got %q", got)
+	}
+
+	// Editing only marker metadata should also be blocked.
+	mutatedCount := strings.Replace(marker, "~11 lines", "~99 lines", 1)
+	m.handleInputMutation(marker, mutatedCount, "rune")
+	if got := m.input.Value(); got != marker {
+		t.Fatalf("expected manual marker metadata edits to be restored, got %q", got)
+	}
+}
+
+func TestProtectCompressedMarkerChainAllowsPasteCoalescingMetadataUpdate(t *testing.T) {
+	m := newImagePipelineModel(t)
+	before := "[Paste #1 ~11 lines]"
+	after := "[Paste #1 ~14 lines]"
+
+	got, changed := m.protectCompressedMarkerChain(before, after, "paste")
+	if changed {
+		t.Fatalf("expected paste-driven marker metadata update to be allowed")
+	}
+	if got != after {
+		t.Fatalf("expected after marker to be kept, got %q", got)
+	}
+}
+
+func TestProtectCompressedMarkerChainBlocksRuneMetadataEditEvenWhenRecent(t *testing.T) {
+	m := newImagePipelineModel(t)
+	before := "[Paste #1 ~11 lines]"
+	after := "[Paste #1 ~99 lines]"
+	m.lastCompressedPasteAt = time.Now()
+
+	got, changed := m.protectCompressedMarkerChain(before, after, "rune")
+	if !changed {
+		t.Fatalf("expected rune metadata edit to be blocked")
+	}
+	if got != before {
+		t.Fatalf("expected marker metadata to be restored, got %q", got)
+	}
+}
+
+func TestProtectCompressedMarkerChainBackspaceDeletesWholeMarkerBlock(t *testing.T) {
+	m := newImagePipelineModel(t)
+	before := "[Paste #1 ~11 lines]"
+	after := "[Paste #1 ~11 line]"
+
+	got, changed := m.protectCompressedMarkerChain(before, after, "backspace")
+	if !changed {
+		t.Fatalf("expected backspace on marker to trigger block deletion")
+	}
+	if got != "" {
+		t.Fatalf("expected single marker block to be deleted, got %q", got)
+	}
+}
+
+func TestProtectCompressedMarkerChainBackspaceDeletesLatestMarkerInChain(t *testing.T) {
+	m := newImagePipelineModel(t)
+	before := "[Paste #1 ~11 lines][Paste #2 ~7 lines]"
+	after := "[Paste #1 ~11 lines][Paste #2 ~7 line]"
+
+	got, changed := m.protectCompressedMarkerChain(before, after, "backspace")
+	if !changed {
+		t.Fatalf("expected backspace on chained marker to trigger block deletion")
+	}
+	if got != "[Paste #1 ~11 lines]" {
+		t.Fatalf("expected latest marker to be removed, got %q", got)
+	}
+}
+
+func TestShouldMergeIntoLatestMarkerAllowsFastPasteChunks(t *testing.T) {
+	now := time.Now()
+	if !shouldMergeIntoLatestMarker("paste", now.Add(-80*time.Millisecond)) {
+		t.Fatalf("expected immediate paste chunk to merge into latest marker")
+	}
+	if shouldMergeIntoLatestMarker("paste", now.Add(-500*time.Millisecond)) {
+		t.Fatalf("expected delayed paste chunk not to merge into latest marker")
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2138,7 +2138,7 @@ func (m model) renderScrollbar(viewHeight, contentHeight, currentOffset int) str
 	if !visible {
 		return ""
 	}
-	trackStyle := scrollbarTrackStyle.Copy().Background(lipgloss.Color("#1B1D22"))
+	trackStyle := scrollbarTrackStyle.Copy().Background(lipgloss.Color("#000000"))
 	thumbStyle := scrollbarThumbIdleStyle.Copy().Background(lipgloss.Color("#C2C7CF"))
 	if m.draggingScrollbar {
 		thumbStyle = scrollbarThumbActiveStyle.Copy().Background(lipgloss.Color("#E5E7EB"))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -22,6 +22,7 @@ import (
 	planpkg "bytemind/internal/plan"
 	"bytemind/internal/provider"
 	"bytemind/internal/session"
+	tokentui "bytemind/internal/token/tui"
 	"bytemind/internal/tools"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -246,7 +247,7 @@ type model struct {
 	chatAutoFollow        bool
 	draggingScrollbar     bool
 	scrollbarDragOffset   int
-	tokenUsage            tokenUsageComponent
+	tokenUsage            tokentui.Component
 	tokenUsedTotal        int
 	tokenBudget           int
 	tokenInput            int
@@ -254,7 +255,7 @@ type model struct {
 	tokenContext          int
 	tokenHasOfficialUsage bool
 	tempEstimatedOutput   int
-	tokenEstimator        *realtimeTokenEstimator
+	tokenEstimator        *tokentui.RealtimeEstimator
 	promptHistoryLoaded   bool
 	promptHistoryEntries  []history.PromptEntry
 	promptSearchMode      promptSearchMode
@@ -344,9 +345,9 @@ func newModel(opts Options) model {
 		llmConnected:       true,
 		chatAutoFollow:     true,
 		mentionIndex:       mention.NewWorkspaceFileIndex(opts.Workspace),
-		tokenUsage:         newTokenUsageComponent(),
+		tokenUsage:         tokentui.NewComponent(),
 		tokenBudget:        max(1, opts.Config.TokenQuota),
-		tokenEstimator:     newRealtimeTokenEstimator(opts.Config.Provider.Model),
+		tokenEstimator:     tokentui.NewRealtimeTokenEstimator(opts.Config.Provider.Model),
 		inputImageRefs:     make(map[int]llm.AssetID, 8),
 		inputImageMentions: make(map[string]llm.AssetID, 8),
 		orphanedImages:     make(map[llm.AssetID]time.Time, 8),
@@ -381,7 +382,7 @@ func (m model) Init() tea.Cmd {
 	return tea.Batch(
 		textarea.Blink,
 		waitForAsync(m.async),
-		m.tokenUsage.tickCmd(),
+		m.tokenUsage.TickCmd(),
 		m.loadSessionsCmd(),
 	)
 }
@@ -479,7 +480,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tokenUsagePulledMsg:
 		// Account-level usage is not session-accurate; ignore in session-only mode.
 		return m, nil
-	case tokenMonitorTickMsg:
+	case tokentui.TickMsg:
 		cmd, _ := m.tokenUsage.Update(msg)
 		return m, cmd
 	case tea.MouseMsg:
@@ -1030,14 +1031,28 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.submitPrompt(value)
 	}
 
+	mutationSource := inputMutationSource(msg)
 	before := m.input.Value()
 	var cmd tea.Cmd
-	m.input, cmd = m.input.Update(msg)
-	after := m.input.Value()
-	mutationSource := inputMutationSource(msg)
-	if after != before {
+	var after string
+	if msg.Paste {
+		preview := m.input
+		preview, cmd = preview.Update(msg)
+		after = preview.Value()
+		// Apply paste pipeline before committing raw pasted text to input,
+		// so long-paste markers appear immediately without visible flicker.
 		m.handleInputMutation(before, after, mutationSource)
+		if m.input.Value() == before && after != before {
+			m.input = preview
+		}
 		after = m.input.Value()
+	} else {
+		m.input, cmd = m.input.Update(msg)
+		after = m.input.Value()
+		if after != before {
+			m.handleInputMutation(before, after, mutationSource)
+			after = m.input.Value()
+		}
 	}
 	triggerClipboardImagePaste := shouldTriggerClipboardImagePaste(before, after, mutationSource)
 	if ctrlVPasteDetected {
@@ -1520,6 +1535,12 @@ func (m *model) handleInputMutation(before, after, source string) {
 	}
 	if strings.TrimSpace(note) == "" {
 		note = pasteNote
+	}
+	if locked, changed := m.protectCompressedMarkerChain(before, updated, source); changed {
+		updated = locked
+		if strings.TrimSpace(note) == "" {
+			note = "Paste marker is locked to prevent accidental edits."
+		}
 	}
 
 	if updated != after {
@@ -2630,7 +2651,7 @@ func (m *model) verifyAndFinalizeStartupAPIKey(rawInput string) error {
 	checkCfg := m.cfg.Provider
 	checkCfg.APIKey = apiKey
 	check := provider.CheckAvailability(context.Background(), checkCfg)
-	if !check.Ready {
+	if !check.Ready && !shouldAllowStartupSaveWithoutVerification(check) {
 		m.llmConnected = false
 		m.phase = "error"
 		m.setStartupGuideStep(startupFieldAPIKey, startupGuideIssueHint(check))
@@ -2654,17 +2675,40 @@ func (m *model) verifyAndFinalizeStartupAPIKey(rawInput string) error {
 	}
 	m.cfg.Provider = checkCfg
 	m.startupGuide.Active = false
-	m.statusNote = "Provider configured and verified. You can start chatting."
-	m.llmConnected = true
+	if check.Ready {
+		m.statusNote = "Provider configured and verified. You can start chatting."
+		m.llmConnected = true
+	} else {
+		m.statusNote = "API key saved. Provider verification is temporarily unavailable; you can continue and retry later."
+		m.llmConnected = false
+	}
 	m.phase = "idle"
 	if saveErr != nil {
-		m.statusNote = "Provider verified, but config save failed: " + compact(saveErr.Error(), 80)
+		m.statusNote = "API key saved in memory, but config save failed: " + compact(saveErr.Error(), 80)
 	} else if strings.TrimSpace(writtenPath) != "" {
-		m.statusNote = "Provider configured and verified. Saved to " + compact(writtenPath, 48)
+		if check.Ready {
+			m.statusNote = "Provider configured and verified. Saved to " + compact(writtenPath, 48)
+		} else {
+			m.statusNote = "API key saved to " + compact(writtenPath, 48) + ". Verification skipped due temporary endpoint reachability issue."
+		}
 	}
 	m.syncInputStyle()
 	m.input.Reset()
 	return nil
+}
+
+func shouldAllowStartupSaveWithoutVerification(check provider.Availability) bool {
+	reason := strings.ToLower(strings.TrimSpace(check.Reason))
+	switch {
+	case strings.Contains(reason, "failed to reach provider endpoint"):
+		return true
+	case strings.Contains(reason, "provider check failed (http 5"):
+		return true
+	case strings.Contains(reason, "provider check failed (http 429"):
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *model) applyStartupConfigField(field, value string) error {
@@ -3364,7 +3408,7 @@ func (m model) loadSessionsCmd() tea.Cmd {
 
 func (m model) fetchRemoteTokenUsageCmd() tea.Cmd {
 	return func() tea.Msg {
-		usage, err := fetchCurrentMonthUsage(m.cfg)
+		usage, err := tokentui.FetchCurrentMonthUsage(m.cfg)
 		if err != nil {
 			return tokenUsagePulledMsg{Err: err}
 		}
@@ -3731,28 +3775,62 @@ func renderAssistantBody(text string, width int) string {
 	lines := strings.Split(text, "\n")
 	out := make([]string, 0, len(lines))
 	inCodeBlock := false
+	codeLines := make([]string, 0, 16)
 	prevBlank := true
+	flushCodeBlock := func() {
+		if len(codeLines) == 0 {
+			return
+		}
+		out = append(out, renderMarkdownCodeBlock(codeLines, width))
+		codeLines = codeLines[:0]
+		prevBlank = false
+	}
 
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "```") {
-			inCodeBlock = !inCodeBlock
+			if inCodeBlock {
+				flushCodeBlock()
+				inCodeBlock = false
+			} else {
+				inCodeBlock = true
+				codeLines = codeLines[:0]
+			}
 			continue
 		}
 
-		plainLine := line
-		if !inCodeBlock {
-			plainLine = normalizeAssistantMarkdownLine(line)
+		if inCodeBlock {
+			codeLines = append(codeLines, line)
+			continue
 		}
-		if strings.TrimSpace(plainLine) == "" {
+
+		if trimmed == "" {
 			if !prevBlank {
 				out = append(out, "")
 			}
 			prevBlank = true
 			continue
 		}
-		out = append(out, wrapPlainText(plainLine, width))
+
+		switch {
+		case isMarkdownHeading(trimmed):
+			out = append(out, renderMarkdownHeading(trimmed, width))
+		case isMarkdownListItem(trimmed):
+			out = append(out, renderMarkdownListItem(trimmed, width))
+		case strings.HasPrefix(trimmed, ">"):
+			out = append(out, renderMarkdownQuote(trimmed, width))
+		default:
+			plainLine := normalizeAssistantMarkdownLine(line)
+			if strings.TrimSpace(plainLine) == "" {
+				continue
+			}
+			out = append(out, wrapPlainText(plainLine, width))
+		}
 		prevBlank = false
+	}
+
+	if inCodeBlock {
+		flushCodeBlock()
 	}
 
 	return strings.Join(out, "\n")
@@ -3994,12 +4072,29 @@ func renderMarkdownListItem(line string, width int) string {
 	lines := make([]string, 0, len(wrapped))
 	for i, part := range wrapped {
 		if i == 0 {
-			lines = append(lines, indent+listMarkerStyle.Render(marker)+" "+part)
+			lines = append(lines, listMarkerStyle.Render(indent+marker+" "+part))
 			continue
 		}
 		lines = append(lines, indent+strings.Repeat(" ", runewidth.StringWidth(marker))+" "+part)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func renderMarkdownCodeBlock(codeLines []string, width int) string {
+	if len(codeLines) == 0 {
+		return ""
+	}
+	blockWidth := max(12, width)
+	contentWidth := max(8, blockWidth-codeStyle.GetHorizontalFrameSize())
+	rendered := make([]string, 0, len(codeLines))
+	for _, line := range codeLines {
+		if line == "" {
+			rendered = append(rendered, "")
+			continue
+		}
+		rendered = append(rendered, strings.Split(wrapPlainText(line, contentWidth), "\n")...)
+	}
+	return codeStyle.Width(blockWidth).Render(strings.Join(rendered, "\n"))
 }
 
 func renderMarkdownQuote(line string, width int) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -22,7 +22,6 @@ import (
 	planpkg "bytemind/internal/plan"
 	"bytemind/internal/provider"
 	"bytemind/internal/session"
-	tokentui "bytemind/internal/token/tui"
 	"bytemind/internal/tools"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -247,7 +246,7 @@ type model struct {
 	chatAutoFollow        bool
 	draggingScrollbar     bool
 	scrollbarDragOffset   int
-	tokenUsage            tokentui.Component
+	tokenUsage            tokenUsageComponent
 	tokenUsedTotal        int
 	tokenBudget           int
 	tokenInput            int
@@ -255,7 +254,7 @@ type model struct {
 	tokenContext          int
 	tokenHasOfficialUsage bool
 	tempEstimatedOutput   int
-	tokenEstimator        *tokentui.RealtimeEstimator
+	tokenEstimator        *realtimeTokenEstimator
 	promptHistoryLoaded   bool
 	promptHistoryEntries  []history.PromptEntry
 	promptSearchMode      promptSearchMode
@@ -345,9 +344,9 @@ func newModel(opts Options) model {
 		llmConnected:       true,
 		chatAutoFollow:     true,
 		mentionIndex:       mention.NewWorkspaceFileIndex(opts.Workspace),
-		tokenUsage:         tokentui.NewComponent(),
+		tokenUsage:         newTokenUsageComponent(),
 		tokenBudget:        max(1, opts.Config.TokenQuota),
-		tokenEstimator:     tokentui.NewRealtimeTokenEstimator(opts.Config.Provider.Model),
+		tokenEstimator:     newRealtimeTokenEstimator(opts.Config.Provider.Model),
 		inputImageRefs:     make(map[int]llm.AssetID, 8),
 		inputImageMentions: make(map[string]llm.AssetID, 8),
 		orphanedImages:     make(map[llm.AssetID]time.Time, 8),
@@ -480,7 +479,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tokenUsagePulledMsg:
 		// Account-level usage is not session-accurate; ignore in session-only mode.
 		return m, nil
-	case tokentui.TickMsg:
+	case tokenMonitorTickMsg:
 		cmd, _ := m.tokenUsage.Update(msg)
 		return m, cmd
 	case tea.MouseMsg:
@@ -3408,7 +3407,7 @@ func (m model) loadSessionsCmd() tea.Cmd {
 
 func (m model) fetchRemoteTokenUsageCmd() tea.Cmd {
 	return func() tea.Msg {
-		usage, err := tokentui.FetchCurrentMonthUsage(m.cfg)
+		usage, err := fetchCurrentMonthUsage(m.cfg)
 		if err != nil {
 			return tokenUsagePulledMsg{Err: err}
 		}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -21,7 +21,6 @@ import (
 	planpkg "bytemind/internal/plan"
 	"bytemind/internal/provider"
 	"bytemind/internal/session"
-	tokentui "bytemind/internal/token/tui"
 	"bytemind/internal/tools"
 
 	"github.com/charmbracelet/bubbles/textarea"
@@ -252,7 +251,7 @@ func TestRenderMainPanelShowsTokenUsageBadge(t *testing.T) {
 		height:     28,
 		input:      textarea.New(),
 		viewport:   viewport.New(60, 10),
-		tokenUsage: tokentui.NewComponent(),
+		tokenUsage: newTokenUsageComponent(),
 	}
 	m.viewport.SetContent(strings.Repeat("line\n", 40))
 	_ = m.tokenUsage.SetUsage(1234, 5000)
@@ -270,7 +269,7 @@ func TestHandleMouseHoverTokenUsageConsumesEvent(t *testing.T) {
 		height:     28,
 		input:      textarea.New(),
 		viewport:   viewport.New(60, 10),
-		tokenUsage: tokentui.NewComponent(),
+		tokenUsage: newTokenUsageComponent(),
 	}
 	m.viewport.SetContent(strings.Repeat("line\n", 60))
 	_ = m.tokenUsage.SetUsage(1500, 5000)
@@ -292,7 +291,7 @@ func TestHandleMouseHoverTokenUsageConsumesEvent(t *testing.T) {
 
 func TestHandleAgentEventUsageUpdatedAccumulatesRealTokens(t *testing.T) {
 	m := model{
-		tokenUsage:  tokentui.NewComponent(),
+		tokenUsage:  newTokenUsageComponent(),
 		tokenBudget: 5000,
 	}
 
@@ -319,7 +318,7 @@ func TestHandleAgentEventUsageUpdatedAccumulatesRealTokens(t *testing.T) {
 
 func TestAssistantDeltaDoesNotChangeUsageWithoutOfficialUsage(t *testing.T) {
 	m := model{
-		tokenUsage:  tokentui.NewComponent(),
+		tokenUsage:  newTokenUsageComponent(),
 		tokenBudget: 5000,
 	}
 
@@ -353,7 +352,7 @@ func TestAssistantDeltaDoesNotChangeUsageWithoutOfficialUsage(t *testing.T) {
 
 func TestApplyUsageFallsBackToBreakdownWhenTotalIsZero(t *testing.T) {
 	m := model{
-		tokenUsage:  tokentui.NewComponent(),
+		tokenUsage:  newTokenUsageComponent(),
 		tokenBudget: 5000,
 	}
 
@@ -426,7 +425,7 @@ func TestFetchRemoteTokenUsageCmdReturnsUsageMsgOnSuccess(t *testing.T) {
 
 func TestUpdateTokenUsagePulledMsgIgnoredForSessionOnly(t *testing.T) {
 	m := model{
-		tokenUsage:     tokentui.NewComponent(),
+		tokenUsage:     newTokenUsageComponent(),
 		tokenBudget:    5000,
 		tokenUsedTotal: 100,
 		tokenInput:     60,
@@ -4001,7 +4000,7 @@ func TestScrollbarTrackBoundsAndDragScrollbarTo(t *testing.T) {
 		height:     32,
 		input:      input,
 		viewport:   viewport.New(60, 10),
-		tokenUsage: tokentui.NewComponent(),
+		tokenUsage: newTokenUsageComponent(),
 		chatItems: []chatEntry{
 			{Kind: "assistant", Body: strings.Repeat("line\n", 260), Status: "final"},
 		},
@@ -4057,7 +4056,7 @@ func TestHandleMouseScrollbarDragLifecycle(t *testing.T) {
 		height:         32,
 		input:          input,
 		viewport:       viewport.New(60, 10),
-		tokenUsage:     tokentui.NewComponent(),
+		tokenUsage:     newTokenUsageComponent(),
 		chatAutoFollow: true,
 		chatItems: []chatEntry{
 			{Kind: "assistant", Body: strings.Repeat("row\n", 280), Status: "final"},
@@ -4120,7 +4119,7 @@ func TestHandleMouseGuardBranchesAndThumbPress(t *testing.T) {
 		height:            28,
 		input:             input,
 		viewport:          viewport.New(60, 10),
-		tokenUsage:        tokentui.NewComponent(),
+		tokenUsage:        newTokenUsageComponent(),
 		draggingScrollbar: true,
 		helpOpen:          true,
 	}
@@ -4166,7 +4165,7 @@ func TestHandleMouseGuardBranchesAndThumbPress(t *testing.T) {
 		height:     32,
 		input:      input,
 		viewport:   viewport.New(60, 10),
-		tokenUsage: tokentui.NewComponent(),
+		tokenUsage: newTokenUsageComponent(),
 		chatItems: []chatEntry{
 			{Kind: "assistant", Body: strings.Repeat("thumb\n", 220), Status: "final"},
 		},
@@ -4203,7 +4202,7 @@ func TestRenderTokenBadgeAndScrollbarHelpers(t *testing.T) {
 		height:     30,
 		input:      textarea.New(),
 		viewport:   viewport.New(50, 8),
-		tokenUsage: tokentui.NewComponent(),
+		tokenUsage: newTokenUsageComponent(),
 	}
 	m.viewport.SetContent(strings.Repeat("line\n", 120))
 	_ = m.tokenUsage.SetUsage(2345, 5000)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -18,7 +19,9 @@ import (
 	"bytemind/internal/llm"
 	"bytemind/internal/mention"
 	planpkg "bytemind/internal/plan"
+	"bytemind/internal/provider"
 	"bytemind/internal/session"
+	tokentui "bytemind/internal/token/tui"
 	"bytemind/internal/tools"
 
 	"github.com/charmbracelet/bubbles/textarea"
@@ -31,6 +34,12 @@ type compactCommandTestClient struct {
 	replies  []llm.Message
 	requests []llm.ChatRequest
 	index    int
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func (c *compactCommandTestClient) CreateMessage(_ context.Context, req llm.ChatRequest) (llm.Message, error) {
@@ -243,10 +252,9 @@ func TestRenderMainPanelShowsTokenUsageBadge(t *testing.T) {
 		height:     28,
 		input:      textarea.New(),
 		viewport:   viewport.New(60, 10),
-		tokenUsage: newTokenUsageComponent(),
+		tokenUsage: tokentui.NewComponent(),
 	}
 	m.viewport.SetContent(strings.Repeat("line\n", 40))
-	m.tokenUsage.displayUsed = 1234
 	_ = m.tokenUsage.SetUsage(1234, 5000)
 
 	panel := m.renderMainPanel()
@@ -262,28 +270,29 @@ func TestHandleMouseHoverTokenUsageConsumesEvent(t *testing.T) {
 		height:     28,
 		input:      textarea.New(),
 		viewport:   viewport.New(60, 10),
-		tokenUsage: newTokenUsageComponent(),
+		tokenUsage: tokentui.NewComponent(),
 	}
 	m.viewport.SetContent(strings.Repeat("line\n", 60))
 	_ = m.tokenUsage.SetUsage(1500, 5000)
 	m.refreshViewport()
 
-	x := m.tokenUsage.bounds.x + max(0, m.tokenUsage.bounds.w/2)
-	y := m.tokenUsage.bounds.y
+	bounds := m.tokenUsage.Bounds()
+	x := bounds.X + max(0, bounds.W/2)
+	y := bounds.Y
 	got, _ := m.handleMouse(tea.MouseMsg{
 		Action: tea.MouseActionMotion,
 		X:      x,
 		Y:      y,
 	})
 	updated := got.(model)
-	if !updated.tokenUsage.hover {
+	if !updated.tokenUsage.Hovering() {
 		t.Fatalf("expected hover state to activate over token badge")
 	}
 }
 
 func TestHandleAgentEventUsageUpdatedAccumulatesRealTokens(t *testing.T) {
 	m := model{
-		tokenUsage:  newTokenUsageComponent(),
+		tokenUsage:  tokentui.NewComponent(),
 		tokenBudget: 5000,
 	}
 
@@ -303,14 +312,14 @@ func TestHandleAgentEventUsageUpdatedAccumulatesRealTokens(t *testing.T) {
 	if m.tokenInput != 120 || m.tokenOutput != 40 || m.tokenContext != 30 {
 		t.Fatalf("unexpected token breakdown input=%d output=%d context=%d", m.tokenInput, m.tokenOutput, m.tokenContext)
 	}
-	if m.tokenUsage.used != 190 {
-		t.Fatalf("expected token component used value 190, got %d", m.tokenUsage.used)
+	if m.tokenUsage.Used() != 190 {
+		t.Fatalf("expected token component used value 190, got %d", m.tokenUsage.Used())
 	}
 }
 
 func TestAssistantDeltaDoesNotChangeUsageWithoutOfficialUsage(t *testing.T) {
 	m := model{
-		tokenUsage:  newTokenUsageComponent(),
+		tokenUsage:  tokentui.NewComponent(),
 		tokenBudget: 5000,
 	}
 
@@ -344,7 +353,7 @@ func TestAssistantDeltaDoesNotChangeUsageWithoutOfficialUsage(t *testing.T) {
 
 func TestApplyUsageFallsBackToBreakdownWhenTotalIsZero(t *testing.T) {
 	m := model{
-		tokenUsage:  newTokenUsageComponent(),
+		tokenUsage:  tokentui.NewComponent(),
 		tokenBudget: 5000,
 	}
 
@@ -417,7 +426,7 @@ func TestFetchRemoteTokenUsageCmdReturnsUsageMsgOnSuccess(t *testing.T) {
 
 func TestUpdateTokenUsagePulledMsgIgnoredForSessionOnly(t *testing.T) {
 	m := model{
-		tokenUsage:     newTokenUsageComponent(),
+		tokenUsage:     tokentui.NewComponent(),
 		tokenBudget:    5000,
 		tokenUsedTotal: 100,
 		tokenInput:     60,
@@ -943,6 +952,69 @@ func TestStartupGuideAcceptsValidKeyAndDisablesGuide(t *testing.T) {
 	}
 	if !strings.Contains(string(written), `"api_key": "test-key"`) {
 		t.Fatalf("expected config file to store api key, got %q", string(written))
+	}
+}
+
+func TestStartupGuideSavesKeyWhenProviderTemporarilyUnreachable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	serverURL := server.URL
+	server.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"provider":{"type":"openai-compatible","base_url":"`+serverURL+`","model":"gpt-5.4"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("test-key")
+	m := model{
+		input: input,
+		cfg: config.Config{
+			Provider: config.ProviderConfig{
+				Type:      "openai-compatible",
+				BaseURL:   serverURL,
+				Model:     "gpt-5.4",
+				APIKeyEnv: "BYTEMIND_API_KEY",
+			},
+		},
+		startupGuide: StartupGuide{
+			Active:       true,
+			Status:       "Bytemind needs a working API key before chat can start.",
+			ConfigPath:   configPath,
+			CurrentField: startupFieldAPIKey,
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+	if updated.startupGuide.Active {
+		t.Fatalf("expected startup guide to be disabled when key is saved under temporary network failure")
+	}
+	if !strings.Contains(strings.ToLower(updated.statusNote), "api key saved") {
+		t.Fatalf("expected save status note, got %q", updated.statusNote)
+	}
+
+	written, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(written), `"api_key": "test-key"`) {
+		t.Fatalf("expected config file to store api key, got %q", string(written))
+	}
+}
+
+func TestShouldAllowStartupSaveWithoutVerification(t *testing.T) {
+	if !shouldAllowStartupSaveWithoutVerification(provider.Availability{Ready: false, Reason: "failed to reach provider endpoint"}) {
+		t.Fatal("expected failed reach endpoint to allow save without verification")
+	}
+	if !shouldAllowStartupSaveWithoutVerification(provider.Availability{Ready: false, Reason: "provider check failed (HTTP 503)"}) {
+		t.Fatal("expected HTTP 503 check failure to allow save without verification")
+	}
+	if shouldAllowStartupSaveWithoutVerification(provider.Availability{Ready: false, Reason: "API key unauthorized"}) {
+		t.Fatal("expected unauthorized not to allow bypass")
 	}
 }
 
@@ -3929,7 +4001,7 @@ func TestScrollbarTrackBoundsAndDragScrollbarTo(t *testing.T) {
 		height:     32,
 		input:      input,
 		viewport:   viewport.New(60, 10),
-		tokenUsage: newTokenUsageComponent(),
+		tokenUsage: tokentui.NewComponent(),
 		chatItems: []chatEntry{
 			{Kind: "assistant", Body: strings.Repeat("line\n", 260), Status: "final"},
 		},
@@ -3985,7 +4057,7 @@ func TestHandleMouseScrollbarDragLifecycle(t *testing.T) {
 		height:         32,
 		input:          input,
 		viewport:       viewport.New(60, 10),
-		tokenUsage:     newTokenUsageComponent(),
+		tokenUsage:     tokentui.NewComponent(),
 		chatAutoFollow: true,
 		chatItems: []chatEntry{
 			{Kind: "assistant", Body: strings.Repeat("row\n", 280), Status: "final"},
@@ -4048,7 +4120,7 @@ func TestHandleMouseGuardBranchesAndThumbPress(t *testing.T) {
 		height:            28,
 		input:             input,
 		viewport:          viewport.New(60, 10),
-		tokenUsage:        newTokenUsageComponent(),
+		tokenUsage:        tokentui.NewComponent(),
 		draggingScrollbar: true,
 		helpOpen:          true,
 	}
@@ -4094,7 +4166,7 @@ func TestHandleMouseGuardBranchesAndThumbPress(t *testing.T) {
 		height:     32,
 		input:      input,
 		viewport:   viewport.New(60, 10),
-		tokenUsage: newTokenUsageComponent(),
+		tokenUsage: tokentui.NewComponent(),
 		chatItems: []chatEntry{
 			{Kind: "assistant", Body: strings.Repeat("thumb\n", 220), Status: "final"},
 		},
@@ -4131,10 +4203,9 @@ func TestRenderTokenBadgeAndScrollbarHelpers(t *testing.T) {
 		height:     30,
 		input:      textarea.New(),
 		viewport:   viewport.New(50, 8),
-		tokenUsage: newTokenUsageComponent(),
+		tokenUsage: tokentui.NewComponent(),
 	}
 	m.viewport.SetContent(strings.Repeat("line\n", 120))
-	m.tokenUsage.displayUsed = 2345
 	_ = m.tokenUsage.SetUsage(2345, 5000)
 	m.refreshViewport()
 
@@ -4258,4 +4329,151 @@ func containsString(items []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func TestInputMutationSourceBranches(t *testing.T) {
+	if got := inputMutationSource(tea.KeyMsg{Type: tea.KeyCtrlV}); got != "ctrl+v" {
+		t.Fatalf("expected ordinary source to stay as key string, got %q", got)
+	}
+	if got := inputMutationSource(tea.KeyMsg{Type: tea.KeyCtrlV, Paste: true}); got != "ctrl+v:paste" {
+		t.Fatalf("expected paste source suffix, got %q", got)
+	}
+	if got := inputMutationSource(tea.KeyMsg{Paste: true}); !strings.HasSuffix(got, ":paste") {
+		t.Fatalf("expected paste event source suffix, got %q", got)
+	}
+}
+
+func TestHandleKeyEnterCompressesLongRawInputBeforeSubmit(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.lastPasteAt = time.Now().Add(-2 * time.Second)
+	m.lastInputAt = time.Now().Add(-2 * time.Second)
+	m.input.SetValue(strings.Join([]string{
+		"line1", "line2", "line3", "line4", "line5", "line6",
+		"line7", "line8", "line9", "line10", "line11",
+	}, "\n"))
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected enter to compress long pasted text before submit, got %q", updated.input.Value())
+	}
+	if !strings.Contains(updated.statusNote, "Press Enter again to send") {
+		t.Fatalf("expected compression guidance note, got %q", updated.statusNote)
+	}
+}
+
+func TestHandleKeyEnterCompressesTailAfterMarkerChain(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	first := strings.Join([]string{
+		"a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11",
+	}, "\n")
+	m.handleInputMutation("", first, "paste")
+	firstMarker := m.input.Value()
+	m.lastPasteAt = time.Now().Add(-2 * time.Second)
+	m.lastInputAt = time.Now().Add(-2 * time.Second)
+
+	tail := strings.Repeat("segment ", 90)
+	m.input.SetValue(firstMarker + tail)
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]\[Paste #\d+ ~\d+ lines\]$`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected marker tail to compress into second marker, got %q", updated.input.Value())
+	}
+	if !strings.Contains(updated.statusNote, "Detected another pasted block") {
+		t.Fatalf("expected second-block compression note, got %q", updated.statusNote)
+	}
+}
+
+func TestHandleKeyEnterDropsContinuationTailAfterMarker(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	first := strings.Join([]string{
+		"u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10", "u11",
+	}, "\n")
+	m.handleInputMutation("", first, "paste")
+	firstMarker := m.input.Value()
+	m.lastPasteAt = time.Now().Add(-2 * time.Second)
+	m.lastInputAt = time.Now().Add(-2 * time.Second)
+
+	m.input.SetValue(firstMarker + " trailing continuation chunk text")
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if updated.input.Value() != firstMarker {
+		t.Fatalf("expected trailing continuation text to be dropped, got %q", updated.input.Value())
+	}
+	if !strings.Contains(updated.statusNote, "Kept compressed markers only") {
+		t.Fatalf("expected continuation-tail cleanup note, got %q", updated.statusNote)
+	}
+}
+
+func TestHandleKeyEnterSuppressAfterPasteBranches(t *testing.T) {
+	t.Run("busy-run-ignores-enter", func(t *testing.T) {
+		m := newImagePipelineModel(t)
+		m.screen = screenChat
+		m.busy = true
+		m.lastPasteAt = time.Now()
+		m.lastInputAt = time.Now()
+		m.input.SetValue("abc")
+
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+		updated := got.(model)
+		if updated.input.Value() != "abc" {
+			t.Fatalf("expected busy run to ignore suppressed enter, got %q", updated.input.Value())
+		}
+	})
+
+	t.Run("idle-run-converts-enter-to-newline", func(t *testing.T) {
+		m := newImagePipelineModel(t)
+		m.screen = screenChat
+		m.lastPasteAt = time.Now()
+		m.lastInputAt = time.Now()
+		m.input.SetValue("abc")
+
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+		updated := got.(model)
+		if !strings.Contains(updated.input.Value(), "\n") {
+			t.Fatalf("expected suppressed enter to insert newline, got %q", updated.input.Value())
+		}
+	})
+}
+
+func TestHandleKeyPasteCompressesLongTextImmediately(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	longPaste := strings.Join([]string{
+		"func normalize(items []string) []string {",
+		"    out := make([]string, 0, len(items))",
+		"    for _, item := range items {",
+		"        v := strings.TrimSpace(item)",
+		"        if v == \"\" {",
+		"            continue",
+		"        }",
+		"        out = append(out, strings.ToLower(v))",
+		"    }",
+		"    sort.Strings(out)",
+		"    return out",
+		"}",
+	}, "\n")
+
+	msg := tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune(longPaste),
+		Paste: true,
+	}
+	got, _ := m.handleKey(msg)
+	updated := got.(model)
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected immediate marker replacement for pasted long text, got %q", updated.input.Value())
+	}
+	if strings.Contains(updated.input.Value(), "normalize(items") {
+		t.Fatalf("expected no raw pasted code to remain in input, got %q", updated.input.Value())
+	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -39,7 +39,7 @@ var (
 	landingLogoStyle = landingLogoMindStyle
 
 	landingInputStyle = lipgloss.NewStyle().
-				Background(lipgloss.Color("#1A1A1A")).
+				Background(lipgloss.Color("#000000")).
 				Padding(1, 4)
 
 	landingPlaceholderStyle = lipgloss.NewStyle().
@@ -98,7 +98,7 @@ var (
 
 	helpCodeStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#F1F5F9")).
-			Background(lipgloss.Color("#101010")).
+			Background(lipgloss.Color("#000000")).
 			Padding(0, 1)
 
 	inputStyle = lipgloss.NewStyle().
@@ -140,7 +140,7 @@ var (
 
 	tableLineStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#D7E3F1")).
-			Background(lipgloss.Color("#101923"))
+			Background(lipgloss.Color("#000000"))
 
 	chatAssistantStyle = lipgloss.NewStyle().
 				Padding(1, 1)
@@ -153,7 +153,7 @@ var (
 				Faint(true)
 
 	chatUserStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("#2A2A2A")).
+			Background(lipgloss.Color("#000000")).
 			Padding(1, 1)
 
 	chatToolStyle = lipgloss.NewStyle().
@@ -169,13 +169,13 @@ var (
 	approvalBannerStyle = lipgloss.NewStyle().
 				BorderStyle(lipgloss.NormalBorder()).
 				BorderForeground(colorTool).
-				Background(lipgloss.Color("#17140D")).
+				Background(lipgloss.Color("#000000")).
 				Padding(0, 1)
 
 	activeSkillBannerStyle = lipgloss.NewStyle().
 				BorderStyle(lipgloss.NormalBorder()).
 				BorderForeground(colorAccent).
-				Background(lipgloss.Color("#0F1A28")).
+				Background(lipgloss.Color("#000000")).
 				Padding(0, 1)
 
 	statusBarStyle = lipgloss.NewStyle().
@@ -192,11 +192,11 @@ var (
 				Padding(0, 1)
 
 	commandPaletteRowStyle = lipgloss.NewStyle().
-				Background(lipgloss.Color("#0B1118")).
+				Background(lipgloss.Color("#000000")).
 				Padding(0, 1)
 
 	commandPaletteSelectedRowStyle = lipgloss.NewStyle().
-					Background(lipgloss.Color("#231421")).
+					Background(lipgloss.Color("#000000")).
 					Padding(0, 1)
 
 	commandPaletteNameStyle = lipgloss.NewStyle().
@@ -236,7 +236,7 @@ var (
 
 	codeStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#F8FAFC")).
-			Background(lipgloss.Color("#0B1220")).
+			Background(lipgloss.Color("#000000")).
 			Padding(0, 1)
 
 	mutedStyle  = lipgloss.NewStyle().Foreground(colorMuted)

--- a/internal/tui/token_monitor.go
+++ b/internal/tui/token_monitor.go
@@ -45,6 +45,13 @@ type rect struct {
 	h int
 }
 
+type tokenUsageBounds struct {
+	X int
+	Y int
+	W int
+	H int
+}
+
 func newTokenUsageComponent() tokenUsageComponent {
 	compatRing := runtime.GOOS == "windows" || readEnvFlag("BYTEMIND_TOKEN_MONITOR_COMPAT")
 	simpleRing := readEnvFlag("BYTEMIND_TOKEN_MONITOR_SIMPLE")
@@ -160,6 +167,10 @@ func (c tokenUsageComponent) tickCmd() tea.Cmd {
 	})
 }
 
+func (c tokenUsageComponent) TickCmd() tea.Cmd {
+	return c.tickCmd()
+}
+
 func (c tokenUsageComponent) Layout(containerWidth int) (x, y, w, h int) {
 	badgeW := lipgloss.Width(c.View())
 	badgeH := lipgloss.Height(c.badgeStyle().Render("x"))
@@ -173,6 +184,23 @@ func (c tokenUsageComponent) contains(x, y int) bool {
 		return false
 	}
 	return x >= c.bounds.x && x < c.bounds.x+c.bounds.w && y >= c.bounds.y && y < c.bounds.y+c.bounds.h
+}
+
+func (c tokenUsageComponent) Bounds() tokenUsageBounds {
+	return tokenUsageBounds{
+		X: c.bounds.x,
+		Y: c.bounds.y,
+		W: c.bounds.w,
+		H: c.bounds.h,
+	}
+}
+
+func (c tokenUsageComponent) Hovering() bool {
+	return c.hover
+}
+
+func (c tokenUsageComponent) Used() int {
+	return c.used
 }
 
 func (c tokenUsageComponent) usageText() string {

--- a/internal/tui/token_usage_remote_test.go
+++ b/internal/tui/token_usage_remote_test.go
@@ -10,9 +10,9 @@ import (
 	"bytemind/internal/config"
 )
 
-type roundTripFunc func(*http.Request) (*http.Response, error)
+type usageRoundTripFunc func(*http.Request) (*http.Response, error)
 
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+func (f usageRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
@@ -45,7 +45,7 @@ func TestFetchCurrentMonthUsageHTTPErrorAndDecodeError(t *testing.T) {
 		},
 	}
 
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	http.DefaultTransport = usageRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("network down")
 	})
 	_, err := fetchCurrentMonthUsage(cfg)
@@ -53,7 +53,7 @@ func TestFetchCurrentMonthUsageHTTPErrorAndDecodeError(t *testing.T) {
 		t.Fatalf("expected network error to propagate, got %v", err)
 	}
 
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	http.DefaultTransport = usageRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusBadRequest,
 			Body:       io.NopCloser(strings.NewReader("bad request")),
@@ -65,7 +65,7 @@ func TestFetchCurrentMonthUsageHTTPErrorAndDecodeError(t *testing.T) {
 		t.Fatalf("expected status error, got %v", err)
 	}
 
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	http.DefaultTransport = usageRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader("{not-json")),
@@ -89,7 +89,7 @@ func TestFetchCurrentMonthUsageSuccess(t *testing.T) {
 		},
 	}
 
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	http.DefaultTransport = usageRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET request, got %s", req.Method)
 		}
@@ -157,4 +157,3 @@ func TestNormalizeOpenAIBaseURL(t *testing.T) {
 		t.Fatalf("expected /v1 suffix to be appended, got %q", got)
 	}
 }
-


### PR DESCRIPTION
变更目的
当前 TUI 存在黑蓝相间底色，视觉上不统一。
本次改动将主界面相关背景统一为纯黑，保留文字颜色与语义色，提升一致性和可读性。

主要改动
将以下区域背景改为 #000000：
登录输入区域
帮助代码块背景
表格行背景
用户消息气泡背景
审批横幅（approval banner）背景
活跃技能横幅（active skill banner）背景
命令面板普通行与选中行背景
代码块渲染背景
调整滚动条轨道背景为 #000000：
去除滚动区域的蓝黑分层感
影响范围
文件：
/internal/tui/styles.go
/internal/tui/model.go
仅涉及样式背景色，不修改业务逻辑、状态流转或交互行为。
验证
已执行：
go test ./internal/tui -count=1
结果：通过
手动验证建议
启动 TUI 进入聊天主界面
检查消息区、代码块、命令面板、横幅、滚动条区域
确认背景为纯黑，不再出现蓝色底色块