### PR TITLE
refactor(tui): extract status bar and scrollbar component

### DIFF
--- a/internal/tui/component_status_scroll.go
+++ b/internal/tui/component_status_scroll.go
@@ -1,0 +1,164 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+)
+
+func (m model) renderTopRightCluster(width int) string {
+	parts := make([]string, 0, 2)
+	if toast := strings.TrimSpace(m.selectionToast); toast != "" {
+		parts = append(parts, selectionToastStyle.Render(toast))
+	}
+	if badge := strings.TrimSpace(m.renderTokenBadge(width)); badge != "" {
+		parts = append(parts, badge)
+	}
+	return strings.Join(parts, "  ")
+}
+
+func (m model) renderTokenBadge(width int) string {
+	return m.tokenUsage.View()
+}
+
+func (m model) renderScrollbar(viewHeight, contentHeight, currentOffset int) string {
+	thumbTop, thumbHeight, _, visible := m.scrollbarLayout(viewHeight, contentHeight, currentOffset)
+	if !visible {
+		return ""
+	}
+	trackStyle := scrollbarTrackStyle.Copy().Background(lipgloss.Color("#1B1D22"))
+	thumbStyle := scrollbarThumbIdleStyle.Copy().Background(lipgloss.Color("#C2C7CF"))
+	if m.draggingScrollbar {
+		thumbStyle = scrollbarThumbActiveStyle.Copy().Background(lipgloss.Color("#E5E7EB"))
+	}
+	lines := make([]string, 0, viewHeight)
+	for row := 0; row < viewHeight; row++ {
+		if row >= thumbTop && row < thumbTop+thumbHeight {
+			lines = append(lines, thumbStyle.Render(" "))
+			continue
+		}
+		lines = append(lines, trackStyle.Render(" "))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m model) scrollbarLayout(viewHeight, contentHeight, currentOffset int) (thumbTop, thumbHeight, maxOffset int, visible bool) {
+	if viewHeight <= 0 {
+		return 0, 0, 0, false
+	}
+	if contentHeight <= 0 {
+		contentHeight = viewHeight
+	}
+	maxOffset = max(0, contentHeight-viewHeight)
+	if maxOffset == 0 {
+		return 0, viewHeight, 0, true
+	}
+
+	thumbHeight = roundedScaledDivision(viewHeight, viewHeight, contentHeight)
+	thumbHeight = clamp(thumbHeight, 1, viewHeight)
+
+	trackRange := max(0, viewHeight-thumbHeight)
+	if trackRange == 0 {
+		return 0, thumbHeight, maxOffset, true
+	}
+	offset := clamp(currentOffset, 0, maxOffset)
+	thumbTop = roundedScaledDivision(offset, trackRange, maxOffset)
+	thumbTop = clamp(thumbTop, 0, trackRange)
+	return thumbTop, thumbHeight, maxOffset, true
+}
+
+func (m model) scrollbarTrackBounds() (x, top, bottom int, ok bool) {
+	if m.screen != screenChat || m.viewport.Width <= 0 || m.viewport.Height <= 0 {
+		return 0, 0, 0, false
+	}
+	left, right, top, bottom, ok := m.conversationViewportBoundsByLayout()
+	if !ok {
+		return 0, 0, 0, false
+	}
+	return right + 1, top, bottom, left >= 0
+}
+
+func (m *model) dragScrollbarTo(mouseY int) {
+	_, trackTop, _, ok := m.scrollbarTrackBounds()
+	if !ok {
+		return
+	}
+	_, thumbHeight, maxOffset, visible := m.scrollbarLayout(m.viewport.Height, m.viewport.TotalLineCount(), m.viewport.YOffset)
+	if !visible || maxOffset == 0 {
+		return
+	}
+	trackRange := max(0, m.viewport.Height-thumbHeight)
+	if trackRange == 0 {
+		m.viewport.SetYOffset(0)
+		m.syncCopyViewOffset()
+		return
+	}
+	desiredTop := mouseY - trackTop - m.scrollbarDragOffset
+	desiredTop = clamp(desiredTop, 0, trackRange)
+	offset := roundedScaledDivision(desiredTop, maxOffset, trackRange)
+	m.viewport.SetYOffset(clamp(offset, 0, maxOffset))
+	m.syncCopyViewOffset()
+}
+
+func roundedScaledDivision(value, scale, denominator int) int {
+	if denominator <= 0 || value <= 0 || scale <= 0 {
+		return 0
+	}
+	// Use int64 math to avoid overflow when terminal dimensions are large.
+	numerator := int64(value)*int64(scale) + int64(denominator)/2
+	result := numerator / int64(denominator)
+	maxInt := int64(^uint(0) >> 1)
+	if result > maxInt {
+		return int(maxInt)
+	}
+	return int(result)
+}
+
+func stripANSIText(value string) string {
+	return xansi.Strip(value)
+}
+
+func (m model) renderStatusBar() string {
+	return m.renderStatusBarWithWidth(max(24, m.chatPanelInnerWidth()))
+}
+
+func (m model) renderStatusBarWithWidth(width int) string {
+	stepTitle := currentOrNextStepTitle(m.plan)
+	if stepTitle == "" {
+		stepTitle = "-"
+	}
+	left := strings.Join([]string{
+		"Mode: " + strings.ToUpper(string(m.mode)),
+		"Phase: " + m.currentPhaseLabel(),
+		"Step: " + stepTitle,
+		"Skill: " + m.currentSkillLabel(),
+	}, "  |  ")
+	right := strings.Join([]string{
+		fmt.Sprintf("%d msgs", len(m.chatItems)),
+		"Session: " + m.currentSessionLabel(),
+		"Follow: " + m.autoFollowLabel(),
+		"Model: " + m.currentModelLabel(),
+	}, "  |  ")
+
+	line := m.renderTopInfoLine(left, right, width)
+	return statusBarStyle.Width(width).Render(line)
+}
+
+func (m model) renderTopInfoLine(left, right string, width int) string {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if width <= 0 {
+		return strings.TrimSpace(left + " | " + right)
+	}
+
+	leftW := runewidth.StringWidth(left)
+	rightW := runewidth.StringWidth(right)
+	if leftW+rightW+2 > width {
+		return compact(left+"  |  "+right, width)
+	}
+	gap := width - leftW - rightW
+	return left + strings.Repeat(" ", max(2, gap)) + right
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -30,7 +30,6 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	xansi "github.com/charmbracelet/x/ansi"
 	zone "github.com/lrstanley/bubblezone"
 	"github.com/mattn/go-runewidth"
 )
@@ -2172,118 +2171,6 @@ func (m model) renderMainPanel() string {
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
-func (m model) renderTopRightCluster(width int) string {
-	parts := make([]string, 0, 2)
-	if toast := strings.TrimSpace(m.selectionToast); toast != "" {
-		parts = append(parts, selectionToastStyle.Render(toast))
-	}
-	if badge := strings.TrimSpace(m.renderTokenBadge(width)); badge != "" {
-		parts = append(parts, badge)
-	}
-	return strings.Join(parts, "  ")
-}
-
-func (m model) renderTokenBadge(width int) string {
-	return m.tokenUsage.View()
-}
-
-func (m model) renderScrollbar(viewHeight, contentHeight, currentOffset int) string {
-	thumbTop, thumbHeight, _, visible := m.scrollbarLayout(viewHeight, contentHeight, currentOffset)
-	if !visible {
-		return ""
-	}
-	trackStyle := scrollbarTrackStyle.Copy().Background(lipgloss.Color("#1B1D22"))
-	thumbStyle := scrollbarThumbIdleStyle.Copy().Background(lipgloss.Color("#C2C7CF"))
-	if m.draggingScrollbar {
-		thumbStyle = scrollbarThumbActiveStyle.Copy().Background(lipgloss.Color("#E5E7EB"))
-	}
-	lines := make([]string, 0, viewHeight)
-	for row := 0; row < viewHeight; row++ {
-		if row >= thumbTop && row < thumbTop+thumbHeight {
-			lines = append(lines, thumbStyle.Render(" "))
-			continue
-		}
-		lines = append(lines, trackStyle.Render(" "))
-	}
-	return strings.Join(lines, "\n")
-}
-
-func (m model) scrollbarLayout(viewHeight, contentHeight, currentOffset int) (thumbTop, thumbHeight, maxOffset int, visible bool) {
-	if viewHeight <= 0 {
-		return 0, 0, 0, false
-	}
-	if contentHeight <= 0 {
-		contentHeight = viewHeight
-	}
-	maxOffset = max(0, contentHeight-viewHeight)
-	if maxOffset == 0 {
-		return 0, viewHeight, 0, true
-	}
-
-	thumbHeight = roundedScaledDivision(viewHeight, viewHeight, contentHeight)
-	thumbHeight = clamp(thumbHeight, 1, viewHeight)
-
-	trackRange := max(0, viewHeight-thumbHeight)
-	if trackRange == 0 {
-		return 0, thumbHeight, maxOffset, true
-	}
-	offset := clamp(currentOffset, 0, maxOffset)
-	thumbTop = roundedScaledDivision(offset, trackRange, maxOffset)
-	thumbTop = clamp(thumbTop, 0, trackRange)
-	return thumbTop, thumbHeight, maxOffset, true
-}
-
-func (m model) scrollbarTrackBounds() (x, top, bottom int, ok bool) {
-	if m.screen != screenChat || m.viewport.Width <= 0 || m.viewport.Height <= 0 {
-		return 0, 0, 0, false
-	}
-	left, right, top, bottom, ok := m.conversationViewportBoundsByLayout()
-	if !ok {
-		return 0, 0, 0, false
-	}
-	return right + 1, top, bottom, left >= 0
-}
-
-func (m *model) dragScrollbarTo(mouseY int) {
-	_, trackTop, _, ok := m.scrollbarTrackBounds()
-	if !ok {
-		return
-	}
-	_, thumbHeight, maxOffset, visible := m.scrollbarLayout(m.viewport.Height, m.viewport.TotalLineCount(), m.viewport.YOffset)
-	if !visible || maxOffset == 0 {
-		return
-	}
-	trackRange := max(0, m.viewport.Height-thumbHeight)
-	if trackRange == 0 {
-		m.viewport.SetYOffset(0)
-		m.syncCopyViewOffset()
-		return
-	}
-	desiredTop := mouseY - trackTop - m.scrollbarDragOffset
-	desiredTop = clamp(desiredTop, 0, trackRange)
-	offset := roundedScaledDivision(desiredTop, maxOffset, trackRange)
-	m.viewport.SetYOffset(clamp(offset, 0, maxOffset))
-	m.syncCopyViewOffset()
-}
-
-func roundedScaledDivision(value, scale, denominator int) int {
-	if denominator <= 0 || value <= 0 || scale <= 0 {
-		return 0
-	}
-	// Use int64 math to avoid overflow when terminal dimensions are large.
-	numerator := int64(value)*int64(scale) + int64(denominator)/2
-	result := numerator / int64(denominator)
-	maxInt := int64(^uint(0) >> 1)
-	if result > maxInt {
-		return int(maxInt)
-	}
-	return int(result)
-}
-
-func stripANSIText(value string) string {
-	return xansi.Strip(value)
-}
-
 func (m model) renderLanding() string {
 	ensureZoneManager()
 	logo := landingLogoStyle.Render(strings.Join([]string{
@@ -2415,48 +2302,6 @@ func (m model) renderActiveSkillBanner() string {
 
 	width := max(24, m.chatPanelInnerWidth())
 	return activeSkillBannerStyle.Width(width).Render(accentStyle.Render(line))
-}
-
-func (m model) renderStatusBar() string {
-	return m.renderStatusBarWithWidth(max(24, m.chatPanelInnerWidth()))
-}
-
-func (m model) renderStatusBarWithWidth(width int) string {
-	stepTitle := currentOrNextStepTitle(m.plan)
-	if stepTitle == "" {
-		stepTitle = "-"
-	}
-	left := strings.Join([]string{
-		"Mode: " + strings.ToUpper(string(m.mode)),
-		"Phase: " + m.currentPhaseLabel(),
-		"Step: " + stepTitle,
-		"Skill: " + m.currentSkillLabel(),
-	}, "  |  ")
-	right := strings.Join([]string{
-		fmt.Sprintf("%d msgs", len(m.chatItems)),
-		"Session: " + m.currentSessionLabel(),
-		"Follow: " + m.autoFollowLabel(),
-		"Model: " + m.currentModelLabel(),
-	}, "  |  ")
-
-	line := m.renderTopInfoLine(left, right, width)
-	return statusBarStyle.Width(width).Render(line)
-}
-
-func (m model) renderTopInfoLine(left, right string, width int) string {
-	left = strings.TrimSpace(left)
-	right = strings.TrimSpace(right)
-	if width <= 0 {
-		return strings.TrimSpace(left + " | " + right)
-	}
-
-	leftW := runewidth.StringWidth(left)
-	rightW := runewidth.StringWidth(right)
-	if leftW+rightW+2 > width {
-		return compact(left+"  |  "+right, width)
-	}
-	gap := width - leftW - rightW
-	return left + strings.Repeat(" ", max(2, gap)) + right
 }
 
 func (m model) renderStartupGuidePanel() string {


### PR DESCRIPTION
新增 internal/tui/component_footer.go
Footer 渲染、模式 tabs、底部信息/快捷键提示渲染。
新增 internal/tui/component_palettes.go
命令面板、@引用面板、历史搜索面板渲染。
新增 internal/tui/component_plan_panel.go
Plan 侧栏与步骤卡片渲染。
新增 internal/tui/component_conversation.go
会话列表、消息卡片/行、assistant/tool 分组渲染、模态框定位渲染。
新增 internal/tui/component_input.go
输入框尺寸/边框/样式同步、启动引导 placeholder/hint 逻辑。
新增 internal/tui/component_text_render.go
消息正文格式化管线、Markdown 规范化、语义行渲染与换行辅助。
新增 internal/tui/component_command_utils.go
帮助文案、命令过滤匹配、技能命令归一化/识别、历史搜索查询解析。
新增 internal/tui/component_status_scroll.go
状态栏、右上角集群、滚动条布局/拖拽/渲染辅助。
新增 internal/tui/component_render_test.go
针对新组件的渲染覆盖测试。
更新 internal/tui/model.go
删除已迁移实现，保留调用与编排逻辑。
更新 internal/tui/model_test.go
对齐当前命令顺序与语义格式输出的断言。
验证情况
已执行并通过：
go test ./internal/tui -v
过程中也执行了多轮聚焦测试（命令面板、历史搜索、会话渲染、文本语义渲染、状态栏与滚动条、输入框样式等），均通过。
说明
本次以“结构重构”为主，目标是降低 model.go 复杂度并提高复用性。
未引入有意的运行流程变更；主要是组件拆分与测试补强。