### PR TITLE
feat(agent/policy): Phase 2-1 工具权限前置决策链与 permission_decision 审计（#194）

### DIFF
--- a/internal/agent/policy_gateway.go
+++ b/internal/agent/policy_gateway.go
@@ -1,0 +1,163 @@
+package agent
+
+import (
+	"context"
+	"strings"
+
+	corepkg "bytemind/internal/core"
+	"bytemind/internal/tools"
+)
+
+const (
+	policyReasonHardDeny      = "hard_deny"
+	policyReasonExplicitDeny  = "explicit_deny"
+	policyReasonRiskRule      = "risk_rule"
+	policyReasonExplicitAllow = "explicit_allow"
+	policyReasonModeDefault   = "mode_default"
+	policyReasonFallbackAsk   = "fallback_ask"
+)
+
+type ToolDecisionInput struct {
+	ToolName       string
+	AllowedTools   map[string]struct{}
+	DeniedTools    map[string]struct{}
+	ApprovalPolicy string
+	SafetyClass    tools.SafetyClass
+}
+
+type ToolDecision struct {
+	Decision   corepkg.Decision
+	ReasonCode string
+	Reason     string
+	RiskLevel  corepkg.RiskLevel
+}
+
+type PolicyGateway interface {
+	DecideTool(context.Context, ToolDecisionInput) (ToolDecision, error)
+}
+
+type defaultPolicyGateway struct{}
+
+func NewDefaultPolicyGateway() PolicyGateway {
+	return defaultPolicyGateway{}
+}
+
+func (defaultPolicyGateway) DecideTool(_ context.Context, in ToolDecisionInput) (ToolDecision, error) {
+	name := strings.TrimSpace(in.ToolName)
+	if name == "" {
+		return ToolDecision{
+			Decision:   corepkg.DecisionDeny,
+			ReasonCode: policyReasonHardDeny,
+			Reason:     "tool name is empty",
+			RiskLevel:  corepkg.RiskHigh,
+		}, nil
+	}
+
+	if len(in.DeniedTools) > 0 {
+		if _, blocked := in.DeniedTools[name]; blocked {
+			return ToolDecision{
+				Decision:   corepkg.DecisionDeny,
+				ReasonCode: policyReasonExplicitDeny,
+				Reason:     "tool is in active denylist",
+				RiskLevel:  toRiskLevel(in.SafetyClass),
+			}, nil
+		}
+	}
+
+	allowlistActive := len(in.AllowedTools) > 0
+	if allowlistActive {
+		if _, allowed := in.AllowedTools[name]; !allowed {
+			return ToolDecision{
+				Decision:   corepkg.DecisionDeny,
+				ReasonCode: policyReasonExplicitDeny,
+				Reason:     "tool is not in active allowlist",
+				RiskLevel:  toRiskLevel(in.SafetyClass),
+			}, nil
+		}
+	}
+
+	if decision, ok := decideByRiskRule(in); ok {
+		return decision, nil
+	}
+
+	if allowlistActive {
+		return ToolDecision{
+			Decision:   corepkg.DecisionAllow,
+			ReasonCode: policyReasonExplicitAllow,
+			Reason:     "tool is explicitly allowed by active allowlist",
+			RiskLevel:  toRiskLevel(in.SafetyClass),
+		}, nil
+	}
+
+	approval := normalizeApprovalPolicy(in.ApprovalPolicy)
+	if approval == "" {
+		return ToolDecision{
+			Decision:   corepkg.DecisionAsk,
+			ReasonCode: policyReasonFallbackAsk,
+			Reason:     "approval policy is unknown; fallback to ask",
+			RiskLevel:  toRiskLevel(in.SafetyClass),
+		}, nil
+	}
+
+	return ToolDecision{
+		Decision:   corepkg.DecisionAllow,
+		ReasonCode: policyReasonModeDefault,
+		Reason:     "tool is allowed by mode default policy",
+		RiskLevel:  toRiskLevel(in.SafetyClass),
+	}, nil
+}
+
+func decideByRiskRule(in ToolDecisionInput) (ToolDecision, bool) {
+	approval := normalizeApprovalPolicy(in.ApprovalPolicy)
+	if approval == "" {
+		return ToolDecision{}, false
+	}
+
+	risk := toRiskLevel(in.SafetyClass)
+	if risk != corepkg.RiskHigh {
+		return ToolDecision{}, false
+	}
+
+	switch approval {
+	case "never":
+		return ToolDecision{
+			Decision:   corepkg.DecisionDeny,
+			ReasonCode: policyReasonRiskRule,
+			Reason:     "high-risk tools are blocked under never approval policy",
+			RiskLevel:  risk,
+		}, true
+	case "on-request":
+		return ToolDecision{
+			Decision:   corepkg.DecisionAsk,
+			ReasonCode: policyReasonRiskRule,
+			Reason:     "high-risk tools require explicit approval",
+			RiskLevel:  risk,
+		}, true
+	default:
+		return ToolDecision{}, false
+	}
+}
+
+func normalizeApprovalPolicy(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return "on-request"
+	case "always", "on-request", "never":
+		return strings.ToLower(strings.TrimSpace(value))
+	default:
+		return ""
+	}
+}
+
+func toRiskLevel(class tools.SafetyClass) corepkg.RiskLevel {
+	switch class {
+	case tools.SafetyClassSafe:
+		return corepkg.RiskLow
+	case tools.SafetyClassModerate:
+		return corepkg.RiskMedium
+	case tools.SafetyClassSensitive, tools.SafetyClassDestructive:
+		return corepkg.RiskHigh
+	default:
+		return corepkg.RiskMedium
+	}
+}

--- a/internal/agent/policy_gateway_test.go
+++ b/internal/agent/policy_gateway_test.go
@@ -1,0 +1,130 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	corepkg "bytemind/internal/core"
+	"bytemind/internal/tools"
+)
+
+func TestDefaultPolicyGatewayDecisionPriority(t *testing.T) {
+	gateway := NewDefaultPolicyGateway()
+
+	tests := []struct {
+		name string
+		in   ToolDecisionInput
+		want ToolDecision
+	}{
+		{
+			name: "hard_deny_empty_name",
+			in:   ToolDecisionInput{ToolName: "", ApprovalPolicy: "always"},
+			want: ToolDecision{
+				Decision:   corepkg.DecisionDeny,
+				ReasonCode: policyReasonHardDeny,
+				RiskLevel:  corepkg.RiskHigh,
+			},
+		},
+		{
+			name: "explicit_deny_from_denylist",
+			in: ToolDecisionInput{
+				ToolName:       "run_shell",
+				DeniedTools:    map[string]struct{}{"run_shell": {}},
+				ApprovalPolicy: "always",
+				SafetyClass:    tools.SafetyClassSensitive,
+			},
+			want: ToolDecision{
+				Decision:   corepkg.DecisionDeny,
+				ReasonCode: policyReasonExplicitDeny,
+				RiskLevel:  corepkg.RiskHigh,
+			},
+		},
+		{
+			name: "risk_rule_ask_for_high_risk_on_request",
+			in: ToolDecisionInput{
+				ToolName:       "run_shell",
+				ApprovalPolicy: "on-request",
+				SafetyClass:    tools.SafetyClassSensitive,
+			},
+			want: ToolDecision{
+				Decision:   corepkg.DecisionAsk,
+				ReasonCode: policyReasonRiskRule,
+				RiskLevel:  corepkg.RiskHigh,
+			},
+		},
+		{
+			name: "risk_rule_deny_for_high_risk_never",
+			in: ToolDecisionInput{
+				ToolName:       "apply_patch",
+				ApprovalPolicy: "never",
+				SafetyClass:    tools.SafetyClassDestructive,
+			},
+			want: ToolDecision{
+				Decision:   corepkg.DecisionDeny,
+				ReasonCode: policyReasonRiskRule,
+				RiskLevel:  corepkg.RiskHigh,
+			},
+		},
+		{
+			name: "explicit_allow_from_allowlist",
+			in: ToolDecisionInput{
+				ToolName:       "read_file",
+				AllowedTools:   map[string]struct{}{"read_file": {}},
+				ApprovalPolicy: "always",
+				SafetyClass:    tools.SafetyClassSafe,
+			},
+			want: ToolDecision{
+				Decision:   corepkg.DecisionAllow,
+				ReasonCode: policyReasonExplicitAllow,
+				RiskLevel:  corepkg.RiskLow,
+			},
+		},
+		{
+			name: "mode_default_without_lists",
+			in: ToolDecisionInput{
+				ToolName:       "read_file",
+				ApprovalPolicy: "always",
+				SafetyClass:    tools.SafetyClassSafe,
+			},
+			want: ToolDecision{
+				Decision:   corepkg.DecisionAllow,
+				ReasonCode: policyReasonModeDefault,
+				RiskLevel:  corepkg.RiskLow,
+			},
+		},
+		{
+			name: "fallback_ask_unknown_approval_policy",
+			in: ToolDecisionInput{
+				ToolName:       "read_file",
+				ApprovalPolicy: "unknown-policy",
+				SafetyClass:    tools.SafetyClassSafe,
+			},
+			want: ToolDecision{
+				Decision:   corepkg.DecisionAsk,
+				ReasonCode: policyReasonFallbackAsk,
+				RiskLevel:  corepkg.RiskLow,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := gateway.DecideTool(context.Background(), tt.in)
+			if err != nil {
+				t.Fatalf("DecideTool failed: %v", err)
+			}
+			if got.Decision != tt.want.Decision {
+				t.Fatalf("Decision mismatch: got %s want %s", got.Decision, tt.want.Decision)
+			}
+			if got.ReasonCode != tt.want.ReasonCode {
+				t.Fatalf("ReasonCode mismatch: got %s want %s", got.ReasonCode, tt.want.ReasonCode)
+			}
+			if got.RiskLevel != tt.want.RiskLevel {
+				t.Fatalf("RiskLevel mismatch: got %s want %s", got.RiskLevel, tt.want.RiskLevel)
+			}
+			if got.Reason == "" {
+				t.Fatal("expected non-empty reason")
+			}
+		})
+	}
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -35,22 +35,23 @@ const (
 )
 
 type Options struct {
-	Workspace    string
-	Config       config.Config
-	Client       llm.Client
-	Store        SessionStore
-	Registry     ToolRegistry
-	Executor     ToolExecutor
-	TaskManager  runtimepkg.TaskManager
-	Extensions   extensionspkg.Manager
-	SkillManager *skills.Manager
-	TokenManager *tokenusage.TokenUsageManager
-	AuditStore   storagepkg.AuditStore
-	PromptStore  storagepkg.PromptHistoryWriter
-	Observer     Observer
-	Approval     tools.ApprovalHandler
-	Stdin        io.Reader
-	Stdout       io.Writer
+	Workspace     string
+	Config        config.Config
+	Client        llm.Client
+	Store         SessionStore
+	Registry      ToolRegistry
+	Executor      ToolExecutor
+	PolicyGateway PolicyGateway
+	TaskManager   runtimepkg.TaskManager
+	Extensions    extensionspkg.Manager
+	SkillManager  *skills.Manager
+	TokenManager  *tokenusage.TokenUsageManager
+	AuditStore    storagepkg.AuditStore
+	PromptStore   storagepkg.PromptHistoryWriter
+	Observer      Observer
+	Approval      tools.ApprovalHandler
+	Stdin         io.Reader
+	Stdout        io.Writer
 }
 
 type RunPromptInput struct {
@@ -60,22 +61,23 @@ type RunPromptInput struct {
 }
 
 type Runner struct {
-	workspace    string
-	config       config.Config
-	client       llm.Client
-	store        SessionStore
-	registry     ToolRegistry
-	executor     ToolExecutor
-	taskManager  runtimepkg.TaskManager
-	extensions   extensionspkg.Manager
-	skillManager *skills.Manager
-	tokenManager *tokenusage.TokenUsageManager
-	auditStore   storagepkg.AuditStore
-	promptStore  storagepkg.PromptHistoryWriter
-	observer     Observer
-	approval     tools.ApprovalHandler
-	stdin        io.Reader
-	stdout       io.Writer
+	workspace     string
+	config        config.Config
+	client        llm.Client
+	store         SessionStore
+	registry      ToolRegistry
+	executor      ToolExecutor
+	policyGateway PolicyGateway
+	taskManager   runtimepkg.TaskManager
+	extensions    extensionspkg.Manager
+	skillManager  *skills.Manager
+	tokenManager  *tokenusage.TokenUsageManager
+	auditStore    storagepkg.AuditStore
+	promptStore   storagepkg.PromptHistoryWriter
+	observer      Observer
+	approval      tools.ApprovalHandler
+	stdin         io.Reader
+	stdout        io.Writer
 }
 
 func NewRunner(opts Options) *Runner {
@@ -92,6 +94,10 @@ func NewRunner(opts Options) *Runner {
 		if concrete, ok := registry.(*tools.Registry); ok {
 			executor = tools.NewExecutor(concrete)
 		}
+	}
+	policyGateway := opts.PolicyGateway
+	if policyGateway == nil {
+		policyGateway = NewDefaultPolicyGateway()
 	}
 	auditStore := opts.AuditStore
 	if auditStore == nil {
@@ -110,22 +116,23 @@ func NewRunner(opts Options) *Runner {
 		extensions = extensionspkg.NopManager{}
 	}
 	return &Runner{
-		workspace:    opts.Workspace,
-		config:       opts.Config,
-		client:       opts.Client,
-		store:        opts.Store,
-		registry:     registry,
-		executor:     executor,
-		taskManager:  taskManager,
-		extensions:   extensions,
-		skillManager: manager,
-		tokenManager: opts.TokenManager,
-		auditStore:   auditStore,
-		promptStore:  promptStore,
-		observer:     opts.Observer,
-		approval:     opts.Approval,
-		stdin:        opts.Stdin,
-		stdout:       opts.Stdout,
+		workspace:     opts.Workspace,
+		config:        opts.Config,
+		client:        opts.Client,
+		store:         opts.Store,
+		registry:      registry,
+		executor:      executor,
+		policyGateway: policyGateway,
+		taskManager:   taskManager,
+		extensions:    extensions,
+		skillManager:  manager,
+		tokenManager:  opts.TokenManager,
+		auditStore:    auditStore,
+		promptStore:   promptStore,
+		observer:      opts.Observer,
+		approval:      opts.Approval,
+		stdin:         opts.Stdin,
+		stdout:        opts.Stdout,
 	}
 }
 

--- a/internal/agent/runner_policy_test.go
+++ b/internal/agent/runner_policy_test.go
@@ -136,3 +136,129 @@ func TestRunPromptPolicyGatewayDeniesToolBeforeExecutor(t *testing.T) {
 		t.Fatal("did not expect tool_execute_start audit event for denied tool")
 	}
 }
+
+func TestRunPromptPolicyGatewayAskRequestsApprovalAndExecutesTool(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+
+	executed := false
+	approvalRequested := false
+	askTool := &fakeTool{
+		name: "ask_tool",
+		run: func(raw json.RawMessage, execCtx *tools.ExecutionContext) (string, error) {
+			if execCtx == nil || execCtx.Approval == nil {
+				t.Fatal("expected approval handler in execution context")
+			}
+			approved, approvalErr := execCtx.Approval(tools.ApprovalRequest{
+				Command: "ask_tool",
+				Reason:  "high-risk tool requires approval",
+			})
+			if approvalErr != nil {
+				t.Fatalf("unexpected approval error: %v", approvalErr)
+			}
+			approvalRequested = true
+			if !approved {
+				t.Fatal("expected approval handler to approve execution")
+			}
+			executed = true
+			return `{"ok":true,"status":"executed"}`, nil
+		},
+	}
+	registry := tools.DefaultRegistry()
+	registry.Add(askTool)
+
+	client := &recordingClient{replies: []llm.Message{
+		{
+			Role: "assistant",
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-ask",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "ask_tool",
+					Arguments: `{}`,
+				},
+			}},
+		},
+		{
+			Role:    "assistant",
+			Content: "Ask path handled.",
+		},
+	}}
+
+	auditStore := &recordingAuditStore{}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:       config.ProviderConfig{Type: "openai-compatible", Model: "test-model"},
+			MaxIterations:  3,
+			Stream:         false,
+			TokenQuota:     generousTokenQuota,
+			ApprovalPolicy: "on-request",
+		},
+		Client:   client,
+		Store:    store,
+		Registry: registry,
+		PolicyGateway: policyGatewayFunc(func(_ context.Context, in ToolDecisionInput) (ToolDecision, error) {
+			if in.ToolName != "ask_tool" {
+				t.Fatalf("unexpected tool name: %q", in.ToolName)
+			}
+			return ToolDecision{
+				Decision:   corepkg.DecisionAsk,
+				ReasonCode: policyReasonRiskRule,
+				Reason:     "requires explicit approval",
+				RiskLevel:  corepkg.RiskHigh,
+			}, nil
+		}),
+		AuditStore: auditStore,
+		Approval: func(req tools.ApprovalRequest) (bool, error) {
+			if req.Command != "ask_tool" {
+				t.Fatalf("unexpected approval command: %q", req.Command)
+			}
+			return true, nil
+		},
+		Stdin:  strings.NewReader(""),
+		Stdout: io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "run ask tool", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "Ask path handled." {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+	if !approvalRequested {
+		t.Fatal("expected approval to be requested for ask decision path")
+	}
+	if !executed {
+		t.Fatal("expected tool execution after approval for ask decision path")
+	}
+
+	foundPermissionDecisionAsk := false
+	foundExecuteStart := false
+	foundExecuteResult := false
+	for _, event := range auditStore.snapshot() {
+		if event.Action == "permission_decision" && event.Decision == corepkg.DecisionAsk && event.ReasonCode == policyReasonRiskRule {
+			foundPermissionDecisionAsk = true
+		}
+		if event.Action == "tool_execute_start" && event.Metadata["tool_name"] == "ask_tool" {
+			foundExecuteStart = true
+		}
+		if event.Action == "tool_execute_result" && event.Metadata["tool_name"] == "ask_tool" && event.Result == "ok" {
+			foundExecuteResult = true
+		}
+	}
+	if !foundPermissionDecisionAsk {
+		t.Fatal("expected permission_decision audit event for ask tool")
+	}
+	if !foundExecuteStart {
+		t.Fatal("expected tool_execute_start audit event for ask tool")
+	}
+	if !foundExecuteResult {
+		t.Fatal("expected successful tool_execute_result audit event for ask tool")
+	}
+}

--- a/internal/agent/runner_policy_test.go
+++ b/internal/agent/runner_policy_test.go
@@ -1,0 +1,138 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"bytemind/internal/config"
+	corepkg "bytemind/internal/core"
+	"bytemind/internal/llm"
+	"bytemind/internal/session"
+	storagepkg "bytemind/internal/storage"
+	"bytemind/internal/tools"
+)
+
+type recordingAuditStore struct {
+	mu     sync.Mutex
+	events []storagepkg.AuditEvent
+}
+
+func (s *recordingAuditStore) Append(_ context.Context, event storagepkg.AuditEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+	return nil
+}
+
+func (s *recordingAuditStore) snapshot() []storagepkg.AuditEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]storagepkg.AuditEvent, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+type policyGatewayFunc func(context.Context, ToolDecisionInput) (ToolDecision, error)
+
+func (f policyGatewayFunc) DecideTool(ctx context.Context, in ToolDecisionInput) (ToolDecision, error) {
+	return f(ctx, in)
+}
+
+func TestRunPromptPolicyGatewayDeniesToolBeforeExecutor(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+
+	executed := false
+	blockedTool := &fakeTool{
+		name: "blocked_tool",
+		run: func(raw json.RawMessage, execCtx *tools.ExecutionContext) (string, error) {
+			executed = true
+			return `{"ok":true}`, nil
+		},
+	}
+	registry := tools.DefaultRegistry()
+	registry.Add(blockedTool)
+
+	client := &recordingClient{replies: []llm.Message{
+		{
+			Role: "assistant",
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-blocked",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "blocked_tool",
+					Arguments: `{}`,
+				},
+			}},
+		},
+		{
+			Role:    "assistant",
+			Content: "Policy handled.",
+		},
+	}}
+
+	auditStore := &recordingAuditStore{}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:       config.ProviderConfig{Type: "openai-compatible", Model: "test-model"},
+			MaxIterations:  3,
+			Stream:         false,
+			TokenQuota:     generousTokenQuota,
+			ApprovalPolicy: "on-request",
+		},
+		Client:   client,
+		Store:    store,
+		Registry: registry,
+		PolicyGateway: policyGatewayFunc(func(_ context.Context, in ToolDecisionInput) (ToolDecision, error) {
+			if in.ToolName != "blocked_tool" {
+				t.Fatalf("unexpected tool name: %q", in.ToolName)
+			}
+			return ToolDecision{
+				Decision:   corepkg.DecisionDeny,
+				ReasonCode: policyReasonExplicitDeny,
+				Reason:     "blocked by test policy",
+				RiskLevel:  corepkg.RiskHigh,
+			}, nil
+		}),
+		AuditStore: auditStore,
+		Stdin:      strings.NewReader(""),
+		Stdout:     io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "run blocked tool", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "Policy handled." {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+	if executed {
+		t.Fatal("expected tool execution to be blocked by policy")
+	}
+
+	foundPermissionDecision := false
+	foundExecuteStart := false
+	for _, event := range auditStore.snapshot() {
+		if event.Action == "permission_decision" && event.Decision == corepkg.DecisionDeny && event.ReasonCode == policyReasonExplicitDeny {
+			foundPermissionDecision = true
+		}
+		if event.Action == "tool_execute_start" && event.Metadata["tool_name"] == "blocked_tool" {
+			foundExecuteStart = true
+		}
+	}
+	if !foundPermissionDecision {
+		t.Fatal("expected permission_decision audit event for denied tool")
+	}
+	if foundExecuteStart {
+		t.Fatal("did not expect tool_execute_start audit event for denied tool")
+	}
+}

--- a/internal/agent/tool_execution.go
+++ b/internal/agent/tool_execution.go
@@ -26,6 +26,37 @@ func (r *Runner) executeToolCall(
 	if r.executor == nil {
 		return fmt.Errorf("tool executor is unavailable")
 	}
+	if r.policyGateway == nil {
+		return fmt.Errorf("policy gateway is unavailable")
+	}
+
+	decision, err := r.policyGateway.DecideTool(ctx, ToolDecisionInput{
+		ToolName:       call.Function.Name,
+		AllowedTools:   allowedTools,
+		DeniedTools:    deniedTools,
+		ApprovalPolicy: r.config.ApprovalPolicy,
+		SafetyClass:    r.toolSafetyClass(call.Function.Name),
+	})
+	if err != nil {
+		return err
+	}
+	r.appendAudit(ctx, storagepkg.AuditEvent{
+		SessionID:  corepkg.SessionID(sess.ID),
+		Actor:      "agent",
+		Action:     "permission_decision",
+		Decision:   decision.Decision,
+		ReasonCode: decision.ReasonCode,
+		RiskLevel:  decision.RiskLevel,
+		Metadata: map[string]string{
+			"tool_name": call.Function.Name,
+			"reason":    decision.Reason,
+		},
+	})
+
+	if decision.Decision != corepkg.DecisionAllow {
+		return r.handleRejectedToolCall(ctx, sess, call, out, decision)
+	}
+
 	r.emit(Event{
 		Type:          EventToolCallStarted,
 		SessionID:     corepkg.SessionID(sess.ID),
@@ -112,6 +143,76 @@ func (r *Runner) executeToolCall(
 			SessionID: corepkg.SessionID(sess.ID),
 			Plan:      planpkg.CloneState(sess.Plan),
 		})
+	}
+	return nil
+}
+
+func (r *Runner) toolSafetyClass(name string) tools.SafetyClass {
+	type toolSpecLookup interface {
+		Spec(name string) (tools.ToolSpec, bool)
+	}
+	lookup, ok := r.registry.(toolSpecLookup)
+	if !ok {
+		return tools.SafetyClassModerate
+	}
+	spec, ok := lookup.Spec(name)
+	if !ok || spec.SafetyClass == "" {
+		return tools.SafetyClassModerate
+	}
+	return spec.SafetyClass
+}
+
+func (r *Runner) handleRejectedToolCall(
+	ctx context.Context,
+	sess *session.Session,
+	call llm.ToolCall,
+	out io.Writer,
+	decision ToolDecision,
+) error {
+	errorText := fmt.Sprintf("tool %q blocked by policy (%s): %s", call.Function.Name, decision.ReasonCode, decision.Reason)
+	if decision.ReasonCode == policyReasonExplicitDeny {
+		errorText = fmt.Sprintf("tool %q is unavailable by active skill policy: %s", call.Function.Name, decision.Reason)
+	}
+	result := marshalToolResult(map[string]any{
+		"ok":          false,
+		"error":       errorText,
+		"decision":    decision.Decision,
+		"reason_code": decision.ReasonCode,
+	})
+
+	if out != nil {
+		r.renderToolFeedback(out, call.Function.Name, result)
+	}
+
+	r.emit(Event{
+		Type:       EventToolCallCompleted,
+		SessionID:  corepkg.SessionID(sess.ID),
+		ToolName:   call.Function.Name,
+		ToolResult: result,
+		Error:      errorText,
+	})
+
+	r.appendAudit(ctx, storagepkg.AuditEvent{
+		SessionID: corepkg.SessionID(sess.ID),
+		Actor:     "agent",
+		Action:    "tool_execute_result",
+		Result:    "denied",
+		Metadata: map[string]string{
+			"tool_name": call.Function.Name,
+			"error":     errorText,
+			"decision":  string(decision.Decision),
+		},
+	})
+
+	toolMessage := llm.NewToolResultMessage(call.ID, result)
+	if err := llm.ValidateMessage(toolMessage); err != nil {
+		return err
+	}
+	sess.Messages = append(sess.Messages, toolMessage)
+	if r.store != nil {
+		if err := r.store.Save(sess); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/agent/tool_execution.go
+++ b/internal/agent/tool_execution.go
@@ -53,7 +53,7 @@ func (r *Runner) executeToolCall(
 		},
 	})
 
-	if decision.Decision != corepkg.DecisionAllow {
+	if decision.Decision == corepkg.DecisionDeny {
 		return r.handleRejectedToolCall(ctx, sess, call, out, decision)
 	}
 


### PR DESCRIPTION
## 变更摘要
- 新增 `PolicyGateway`（默认实现）并固化决策优先级链：
  `hard_deny > explicit_deny > risk_rule > explicit_allow > mode_default > fallback_ask`
- 在 `executeToolCall` 中前置策略决策：仅 `allow` 才进入 executor 执行
- 增加 `permission_decision` 审计事件，补齐 `decision/reason_code/risk_level`
- 对 `deny/ask` 返回结构化 tool_result，并跳过实际工具执行

## 测试
- `go test ./internal/agent -v`
- `go test ./internal/runtime -v`
- `go test ./internal/policy -v`
- `go test ./internal/app -v`

Closes #194
Parent #178