### PR TITLE
tools: 收紧执行器风控与严格参数校验语义

### DIFF
--- a/internal/agent/runner_complex_test.go
+++ b/internal/agent/runner_complex_test.go
@@ -60,6 +60,10 @@ func (t *fakeTool) Definition() llm.ToolDefinition {
 		Type: "function",
 		Function: llm.FunctionDefinition{
 			Name: t.name,
+			Parameters: map[string]any{
+				"type":                 "object",
+				"additionalProperties": true,
+			},
 		},
 	}
 }

--- a/internal/tools/errors_test.go
+++ b/internal/tools/errors_test.go
@@ -1,0 +1,99 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestToolExecErrorFormatsCodeAndMessage(t *testing.T) {
+	err := NewToolExecError(ToolErrorInvalidArgs, "  bad input  ", false, nil)
+	if err.Error() != "invalid_args: bad input" {
+		t.Fatalf("unexpected formatted error: %q", err.Error())
+	}
+	if err.Retryable {
+		t.Fatal("expected retryable=false")
+	}
+}
+
+func TestToolExecErrorUnwrapAndAs(t *testing.T) {
+	cause := errors.New("root cause")
+	base := NewToolExecError(ToolErrorToolFailed, "tool crashed", true, cause)
+	wrapped := fmt.Errorf("wrapped: %w", base)
+
+	execErr, ok := AsToolExecError(wrapped)
+	if !ok {
+		t.Fatalf("expected wrapped ToolExecError, got %T", wrapped)
+	}
+	if execErr.Code != ToolErrorToolFailed {
+		t.Fatalf("unexpected code: %s", execErr.Code)
+	}
+	if !errors.Is(execErr, cause) {
+		t.Fatalf("expected errors.Is to match cause")
+	}
+	if !execErr.Retryable {
+		t.Fatal("expected retryable=true")
+	}
+}
+
+func TestNormalizeToolErrorMappings(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     error
+		wantCode  ToolErrorCode
+		retryable bool
+	}{
+		{
+			name:      "timeout",
+			input:     context.DeadlineExceeded,
+			wantCode:  ToolErrorTimeout,
+			retryable: true,
+		},
+		{
+			name:      "permission",
+			input:     errors.New("permission denied by policy"),
+			wantCode:  ToolErrorPermissionDenied,
+			retryable: false,
+		},
+		{
+			name:      "invalid args",
+			input:     errors.New(`unknown argument "x"`),
+			wantCode:  ToolErrorInvalidArgs,
+			retryable: false,
+		},
+		{
+			name:      "generic failure",
+			input:     errors.New("unexpected execution failure"),
+			wantCode:  ToolErrorToolFailed,
+			retryable: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := normalizeToolError(tc.input)
+			execErr, ok := AsToolExecError(err)
+			if !ok {
+				t.Fatalf("expected ToolExecError, got %T", err)
+			}
+			if execErr.Code != tc.wantCode {
+				t.Fatalf("unexpected code: got=%s want=%s", execErr.Code, tc.wantCode)
+			}
+			if execErr.Retryable != tc.retryable {
+				t.Fatalf("unexpected retryable: got=%v want=%v", execErr.Retryable, tc.retryable)
+			}
+			if !errors.Is(execErr, tc.input) {
+				t.Fatalf("expected normalized error to unwrap original input")
+			}
+		})
+	}
+}
+
+func TestNormalizeToolErrorPassThroughExistingToolExecError(t *testing.T) {
+	original := NewToolExecError(ToolErrorPermissionDenied, "already normalized", false, nil)
+	got := normalizeToolError(original)
+	if got != original {
+		t.Fatal("expected normalizeToolError to return existing ToolExecError unchanged")
+	}
+}

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -1,10 +1,12 @@
 package tools
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -81,22 +83,18 @@ func (e *Executor) ExecuteRequest(ctx context.Context, req ExecuteRequest) (Exec
 	if err != nil {
 		return ExecuteResult{}, err
 	}
-	if req.Context != nil {
-		req.Context.Mode = planpkg.NormalizeMode(string(req.Mode))
+	execCtx := req.Context
+	if execCtx == nil {
+		execCtx = &ExecutionContext{}
 	}
+	execCtx.Mode = planpkg.NormalizeMode(string(req.Mode))
 
 	raw, err := e.argumentDecoder.Decode(req.RawArgs, resolved)
 	if err != nil {
 		return ExecuteResult{}, err
 	}
-	if err := e.permissionEngine.Check(ctx, resolved, req.Context); err != nil {
+	if err := e.permissionEngine.Check(ctx, resolved, execCtx); err != nil {
 		return ExecuteResult{}, err
-	}
-
-	execCtx := req.Context
-	if execCtx == nil {
-		execCtx = &ExecutionContext{}
-		execCtx.Mode = planpkg.NormalizeMode(string(req.Mode))
 	}
 
 	runCtx, cancel := context.WithTimeout(ctx, executionTimeout(raw, resolved.Spec))
@@ -132,6 +130,11 @@ func (defaultPermissionEngine) Check(_ context.Context, resolved ResolvedTool, e
 		}
 		return NewToolExecError(ToolErrorPermissionDenied, fmt.Sprintf("tool %q is unavailable by active skill policy: %s", resolved.Definition.Function.Name, reason), false, nil)
 	}
+	if resolved.Spec.Destructive {
+		if err := requireDestructiveApproval(resolved.Definition.Function.Name, execCtx); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -157,14 +160,11 @@ func (strictJSONArgumentDecoder) Decode(rawArgs string, resolved ResolvedTool) (
 		return nil, NewToolExecError(ToolErrorInvalidArgs, "tool arguments must be a JSON object", false, nil)
 	}
 
-	if !schemaRejectsUnknownFields(resolved.Definition.Function.Parameters) {
+	if schemaAllowsUnknownFields(resolved.Definition.Function.Parameters) {
 		return json.RawMessage(rawArgs), nil
 	}
 
 	allowedFields := schemaPropertyNames(resolved.Definition.Function.Parameters)
-	if len(allowedFields) == 0 {
-		return json.RawMessage(rawArgs), nil
-	}
 	for key := range objectPayload {
 		if _, ok := allowedFields[key]; ok {
 			continue
@@ -241,13 +241,70 @@ func schemaPropertyNames(parameters map[string]any) map[string]struct{} {
 	return names
 }
 
-func schemaRejectsUnknownFields(parameters map[string]any) bool {
+func schemaAllowsUnknownFields(parameters map[string]any) bool {
 	value, ok := parameters["additionalProperties"]
 	if !ok {
 		return false
 	}
-	allowed, ok := value.(bool)
-	return ok && !allowed
+	switch allowed := value.(type) {
+	case bool:
+		return allowed
+	case map[string]any:
+		return true
+	default:
+		return false
+	}
+}
+
+func requireDestructiveApproval(toolName string, execCtx *ExecutionContext) error {
+	if execCtx == nil {
+		return nil
+	}
+	switch strings.TrimSpace(execCtx.ApprovalPolicy) {
+	case "never":
+		return nil
+	case "always", "on-request", "":
+		return promptDestructiveApproval(toolName, execCtx)
+	default:
+		return promptDestructiveApproval(toolName, execCtx)
+	}
+}
+
+func promptDestructiveApproval(toolName string, execCtx *ExecutionContext) error {
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		toolName = "unknown_tool"
+	}
+	reason := fmt.Sprintf("destructive tool may modify workspace files: %s", toolName)
+	if execCtx.Approval != nil {
+		approved, err := execCtx.Approval(ApprovalRequest{
+			Command: toolName,
+			Reason:  reason,
+		})
+		if err != nil {
+			return NewToolExecError(ToolErrorPermissionDenied, err.Error(), false, err)
+		}
+		if !approved {
+			return NewToolExecError(ToolErrorPermissionDenied, fmt.Sprintf("tool %q was not run because approval was denied", toolName), false, nil)
+		}
+		return nil
+	}
+	if execCtx.Stdin == nil {
+		return NewToolExecError(ToolErrorPermissionDenied, fmt.Sprintf("tool %q requires approval but no stdin is available", toolName), false, nil)
+	}
+	if execCtx.Stdout != nil {
+		fmt.Fprintf(execCtx.Stdout, "Approve destructive tool (%s) %q? [y/N]: ", reason, toolName)
+	}
+	reader := bufio.NewReader(execCtx.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return NewToolExecError(ToolErrorPermissionDenied, err.Error(), false, err)
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	if answer != "y" && answer != "yes" {
+		return NewToolExecError(ToolErrorPermissionDenied, fmt.Sprintf("tool %q was not run because approval was denied", toolName), false, nil)
+	}
+	return nil
 }
 
 func executionTimeout(raw json.RawMessage, spec ToolSpec) time.Duration {

--- a/internal/tools/executor_test.go
+++ b/internal/tools/executor_test.go
@@ -41,17 +41,55 @@ func (t executorTestTool) Run(ctx context.Context, raw json.RawMessage, execCtx 
 	return t.result, t.err
 }
 
-func TestExecutorAllowsUnknownArgumentsUnlessSchemaForbidsThem(t *testing.T) {
+func TestExecutorRejectsUnknownArgumentsByDefault(t *testing.T) {
 	registry := &Registry{}
 	registry.Add(executorTestTool{name: "strict_tool", result: `{"ok":true}`})
 	executor := NewExecutor(registry)
 
-	got, err := executor.Execute(context.Background(), "strict_tool", `{"path":"a.txt","extra":true}`, &ExecutionContext{})
-	if err != nil {
-		t.Fatalf("expected extra field to be ignored, got %v", err)
+	_, err := executor.Execute(context.Background(), "strict_tool", `{"path":"a.txt","extra":true}`, &ExecutionContext{})
+	if err == nil {
+		t.Fatal("expected argument validation error")
 	}
-	if got != `{"ok":true}` {
-		t.Fatalf("unexpected result: %q", got)
+	execErr, ok := AsToolExecError(err)
+	if !ok {
+		t.Fatalf("expected ToolExecError, got %T", err)
+	}
+	if execErr.Code != ToolErrorInvalidArgs {
+		t.Fatalf("unexpected code: %s", execErr.Code)
+	}
+}
+
+func TestExecutorRejectsUnknownArgumentsWhenSchemaHasNoProperties(t *testing.T) {
+	registry := &Registry{}
+	registry.Add(executorTestTool{
+		name:   "strict_tool",
+		result: `{"ok":true}`,
+	})
+	registry.tools["strict_tool"] = ResolvedTool{
+		Definition: llm.ToolDefinition{
+			Type: "function",
+			Function: llm.FunctionDefinition{
+				Name: "strict_tool",
+				Parameters: map[string]any{
+					"type": "object",
+				},
+			},
+		},
+		Spec: registry.tools["strict_tool"].Spec,
+		Tool: registry.tools["strict_tool"].Tool,
+	}
+	executor := NewExecutor(registry)
+
+	_, err := executor.Execute(context.Background(), "strict_tool", `{"extra":true}`, &ExecutionContext{})
+	if err == nil {
+		t.Fatal("expected argument validation error")
+	}
+	execErr, ok := AsToolExecError(err)
+	if !ok {
+		t.Fatalf("expected ToolExecError, got %T", err)
+	}
+	if execErr.Code != ToolErrorInvalidArgs {
+		t.Fatalf("unexpected code: %s", execErr.Code)
 	}
 }
 
@@ -113,6 +151,40 @@ func TestExecutorRejectsUnknownArgumentsWhenSchemaForbidsThem(t *testing.T) {
 	}
 	if execErr.Code != ToolErrorInvalidArgs {
 		t.Fatalf("unexpected code: %s", execErr.Code)
+	}
+}
+
+func TestExecutorAllowsUnknownArgumentsWhenSchemaAllowsAdditionalProperties(t *testing.T) {
+	registry := &Registry{}
+	registry.Add(executorTestTool{
+		name:   "strict_tool",
+		result: `{"ok":true}`,
+	})
+	registry.tools["strict_tool"] = ResolvedTool{
+		Definition: llm.ToolDefinition{
+			Type: "function",
+			Function: llm.FunctionDefinition{
+				Name: "strict_tool",
+				Parameters: map[string]any{
+					"type":                 "object",
+					"additionalProperties": true,
+					"properties": map[string]any{
+						"path": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+		Spec: registry.tools["strict_tool"].Spec,
+		Tool: registry.tools["strict_tool"].Tool,
+	}
+	executor := NewExecutor(registry)
+
+	got, err := executor.Execute(context.Background(), "strict_tool", `{"path":"a.txt","extra":true}`, &ExecutionContext{})
+	if err != nil {
+		t.Fatalf("expected additionalProperties=true to allow unknown fields, got %v", err)
+	}
+	if got != `{"ok":true}` {
+		t.Fatalf("unexpected result: %q", got)
 	}
 }
 
@@ -199,5 +271,84 @@ func TestExecutorHonorsRequestedTimeoutSeconds(t *testing.T) {
 
 	if _, err := executor.Execute(context.Background(), "strict_tool", `{"path":"a.txt","timeout_seconds":60}`, &ExecutionContext{}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestExecutorRequiresApprovalForDestructiveToolsByDefault(t *testing.T) {
+	registry := &Registry{}
+	registry.Add(executorTestTool{name: "write_file", result: `{"ok":true}`})
+	executor := NewExecutor(registry)
+
+	_, err := executor.Execute(context.Background(), "write_file", `{"path":"a.txt"}`, &ExecutionContext{
+		ApprovalPolicy: "on-request",
+	})
+	if err == nil {
+		t.Fatal("expected approval error")
+	}
+	execErr, ok := AsToolExecError(err)
+	if !ok {
+		t.Fatalf("expected ToolExecError, got %T", err)
+	}
+	if execErr.Code != ToolErrorPermissionDenied {
+		t.Fatalf("unexpected code: %s", execErr.Code)
+	}
+}
+
+func TestExecutorRequiresApprovalForDestructiveToolsWhenContextMissing(t *testing.T) {
+	registry := &Registry{}
+	registry.Add(executorTestTool{name: "write_file", result: `{"ok":true}`})
+	executor := NewExecutor(registry)
+
+	_, err := executor.Execute(context.Background(), "write_file", `{"path":"a.txt"}`, nil)
+	if err == nil {
+		t.Fatal("expected approval error")
+	}
+	execErr, ok := AsToolExecError(err)
+	if !ok {
+		t.Fatalf("expected ToolExecError, got %T", err)
+	}
+	if execErr.Code != ToolErrorPermissionDenied {
+		t.Fatalf("unexpected code: %s", execErr.Code)
+	}
+}
+
+func TestExecutorAllowsDestructiveToolWhenApprovalGranted(t *testing.T) {
+	registry := &Registry{}
+	registry.Add(executorTestTool{name: "write_file", result: `{"ok":true}`})
+	executor := NewExecutor(registry)
+
+	got, err := executor.Execute(context.Background(), "write_file", `{"path":"a.txt"}`, &ExecutionContext{
+		ApprovalPolicy: "on-request",
+		Approval: func(req ApprovalRequest) (bool, error) {
+			if req.Command != "write_file" {
+				t.Fatalf("unexpected approval command: %q", req.Command)
+			}
+			if !strings.Contains(req.Reason, "destructive tool") {
+				t.Fatalf("unexpected approval reason: %q", req.Reason)
+			}
+			return true, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected approval success, got %v", err)
+	}
+	if got != `{"ok":true}` {
+		t.Fatalf("unexpected result: %q", got)
+	}
+}
+
+func TestExecutorSkipsDestructiveApprovalWhenPolicyNever(t *testing.T) {
+	registry := &Registry{}
+	registry.Add(executorTestTool{name: "write_file", result: `{"ok":true}`})
+	executor := NewExecutor(registry)
+
+	got, err := executor.Execute(context.Background(), "write_file", `{"path":"a.txt"}`, &ExecutionContext{
+		ApprovalPolicy: "never",
+	})
+	if err != nil {
+		t.Fatalf("expected no approval under never policy, got %v", err)
+	}
+	if got != `{"ok":true}` {
+		t.Fatalf("unexpected result: %q", got)
 	}
 }

--- a/internal/tools/spec.go
+++ b/internal/tools/spec.go
@@ -114,6 +114,9 @@ func NormalizeToolSpec(spec ToolSpec) ToolSpec {
 			spec.SafetyClass = SafetyClassModerate
 		}
 	}
+	if spec.SafetyClass == SafetyClassDestructive {
+		spec.Destructive = true
+	}
 	if spec.MaxTimeoutS <= 0 {
 		spec.MaxTimeoutS = 300
 	}

--- a/internal/tools/spec_test.go
+++ b/internal/tools/spec_test.go
@@ -43,6 +43,16 @@ func TestNormalizeToolSpecFillsDefaults(t *testing.T) {
 	}
 }
 
+func TestNormalizeToolSpecMarksDestructiveFromSafetyClass(t *testing.T) {
+	spec := NormalizeToolSpec(ToolSpec{
+		Name:        "custom_write_tool",
+		SafetyClass: SafetyClassDestructive,
+	})
+	if !spec.Destructive {
+		t.Fatal("expected destructive safety class to imply destructive tool")
+	}
+}
+
 func TestValidateToolSpecRejectsConflictingFlags(t *testing.T) {
 	err := ValidateToolSpec(ToolSpec{
 		Name:            "bad_tool",


### PR DESCRIPTION
## 变更摘要
- 在 Executor 层补齐 destructive 工具的审批门控
- 将 strict args 语义收紧为“默认拒绝未知参数字段”
- 修复 `execCtx == nil` 时可能绕过 destructive 审批的缺口
- 对齐 `SafetyClassDestructive` 与 `Destructive` 标记的一致性推导
- 新增 `ToolExecError` 契约测试（Code/Retryable/Cause）
- 调整 runner 复杂场景测试桩的参数 schema 以兼容 strict args 规则

## 验证结果
- 已执行：`go test ./...`
- 结果：通过
