### PR TITLE
feat(runtime): 推进 #202 执行闭环（timeout/cancel/retry/wait）

### DIFF
--- a/internal/runtime/errors.go
+++ b/internal/runtime/errors.go
@@ -1,0 +1,97 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+
+	corepkg "bytemind/internal/core"
+)
+
+const (
+	// ErrorCodeNotImplemented indicates a placeholder runtime capability.
+	ErrorCodeNotImplemented = "not_implemented"
+	// ErrorCodeTaskNotFound indicates the task ID does not exist.
+	ErrorCodeTaskNotFound = "task_not_found"
+	// ErrorCodeInvalidTransition indicates an illegal status transition.
+	ErrorCodeInvalidTransition = "invalid_transition"
+	// ErrorCodeRetryExhausted indicates no retry budget remains.
+	ErrorCodeRetryExhausted = "retry_exhausted"
+	// ErrorCodeTaskTimeout is the canonical timeout code for runtime tasks.
+	ErrorCodeTaskTimeout = "task_timeout"
+	// ErrorCodeTaskCancelled is the canonical cancellation code for runtime tasks.
+	ErrorCodeTaskCancelled = "task_cancelled"
+	// ErrorCodeQuotaExceeded indicates runtime quota acquisition failure.
+	ErrorCodeQuotaExceeded = "quota_exceeded"
+)
+
+type runtimeError struct {
+	code      string
+	message   string
+	retryable bool
+	cause     error
+}
+
+func (e *runtimeError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.cause == nil {
+		return e.message
+	}
+	return fmt.Sprintf("%s: %v", e.message, e.cause)
+}
+
+func (e *runtimeError) Code() string {
+	if e == nil {
+		return ""
+	}
+	return e.code
+}
+
+func (e *runtimeError) Retryable() bool {
+	if e == nil {
+		return false
+	}
+	return e.retryable
+}
+
+func (e *runtimeError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func newRuntimeError(code, message string, retryable bool, cause error) error {
+	return &runtimeError{
+		code:      code,
+		message:   message,
+		retryable: retryable,
+		cause:     cause,
+	}
+}
+
+func errorCode(err error) string {
+	var semantic corepkg.SemanticError
+	if errors.As(err, &semantic) {
+		return semantic.Code()
+	}
+	return ""
+}
+
+func hasErrorCode(err error, code string) bool {
+	return errorCode(err) == code
+}
+
+func taskNotFoundError(id corepkg.TaskID) error {
+	return newRuntimeError(ErrorCodeTaskNotFound, fmt.Sprintf("task %q not found", id), false, nil)
+}
+
+func invalidTransitionError(from, to corepkg.TaskStatus) error {
+	return newRuntimeError(
+		ErrorCodeInvalidTransition,
+		fmt.Sprintf("invalid task transition: %s -> %s", from, to),
+		false,
+		nil,
+	)
+}

--- a/internal/runtime/errors.go
+++ b/internal/runtime/errors.go
@@ -22,6 +22,8 @@ const (
 	ErrorCodeTaskCancelled = "task_cancelled"
 	// ErrorCodeQuotaExceeded indicates runtime quota acquisition failure.
 	ErrorCodeQuotaExceeded = "quota_exceeded"
+	// ErrorCodeTaskExecutionFailed indicates task executor returned a non-timeout failure.
+	ErrorCodeTaskExecutionFailed = "task_execution_failed"
 )
 
 type runtimeError struct {

--- a/internal/runtime/errors_test.go
+++ b/internal/runtime/errors_test.go
@@ -1,0 +1,42 @@
+package runtime
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	corepkg "bytemind/internal/core"
+)
+
+func TestRuntimeErrorImplementsSemanticErrorAndWrapsCause(t *testing.T) {
+	cause := errors.New("boom")
+	err := newRuntimeError(ErrorCodeTaskTimeout, "task timed out", true, cause)
+
+	var semantic corepkg.SemanticError
+	if !errors.As(err, &semantic) {
+		t.Fatal("expected runtime error to implement SemanticError")
+	}
+	if semantic.Code() != ErrorCodeTaskTimeout {
+		t.Fatalf("expected code %q, got %q", ErrorCodeTaskTimeout, semantic.Code())
+	}
+	if !semantic.Retryable() {
+		t.Fatal("expected retryable=true")
+	}
+	if !errors.Is(err, cause) {
+		t.Fatal("expected wrapped cause to be discoverable with errors.Is")
+	}
+	if !strings.Contains(err.Error(), "task timed out") || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected formatted error to include message and cause, got %q", err.Error())
+	}
+}
+
+func TestRuntimeErrorHelpersHandleNonSemanticErrors(t *testing.T) {
+	plain := errors.New("plain")
+
+	if code := errorCode(plain); code != "" {
+		t.Fatalf("expected empty code for plain error, got %q", code)
+	}
+	if hasErrorCode(plain, ErrorCodeTaskNotFound) {
+		t.Fatal("expected hasErrorCode to be false for plain error")
+	}
+}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -30,6 +31,7 @@ type Task struct {
 	Spec       TaskSpec
 	Status     corepkg.TaskStatus
 	Attempt    int
+	Output     []byte
 	CreatedAt  time.Time
 	StartedAt  *time.Time
 	FinishedAt *time.Time
@@ -99,21 +101,40 @@ type QuotaManager interface {
 	Release(key string)
 }
 
-// InMemoryTaskManager is a safe placeholder until runtime orchestration is wired.
-type InMemoryTaskManager struct {
-	mu      sync.RWMutex
-	tasks   map[corepkg.TaskID]Task
-	waiters map[corepkg.TaskID][]chan TaskResult
-}
+type TaskExecutorFunc func(ctx context.Context, task Task) ([]byte, error)
 
-func NewInMemoryTaskManager() *InMemoryTaskManager {
-	return &InMemoryTaskManager{
-		tasks:   make(map[corepkg.TaskID]Task),
-		waiters: make(map[corepkg.TaskID][]chan TaskResult),
+type InMemoryTaskManagerOption func(*InMemoryTaskManager)
+
+func WithTaskExecutor(executor TaskExecutorFunc) InMemoryTaskManagerOption {
+	return func(m *InMemoryTaskManager) {
+		m.executor = executor
 	}
 }
 
-func (m *InMemoryTaskManager) Submit(_ context.Context, spec TaskSpec) (corepkg.TaskID, error) {
+// InMemoryTaskManager is a safe placeholder until runtime orchestration is wired.
+type InMemoryTaskManager struct {
+	mu         sync.RWMutex
+	tasks      map[corepkg.TaskID]Task
+	waiters    map[corepkg.TaskID][]chan TaskResult
+	runCancels map[corepkg.TaskID]context.CancelFunc
+	executor   TaskExecutorFunc
+}
+
+func NewInMemoryTaskManager(opts ...InMemoryTaskManagerOption) *InMemoryTaskManager {
+	manager := &InMemoryTaskManager{
+		tasks:      make(map[corepkg.TaskID]Task),
+		waiters:    make(map[corepkg.TaskID][]chan TaskResult),
+		runCancels: make(map[corepkg.TaskID]context.CancelFunc),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(manager)
+		}
+	}
+	return manager
+}
+
+func (m *InMemoryTaskManager) Submit(ctx context.Context, spec TaskSpec) (corepkg.TaskID, error) {
 	if m == nil {
 		return "", ErrTaskNotImplemented
 	}
@@ -129,6 +150,9 @@ func (m *InMemoryTaskManager) Submit(_ context.Context, spec TaskSpec) (corepkg.
 	m.mu.Lock()
 	m.tasks[id] = task
 	m.mu.Unlock()
+
+	m.enqueueTask(ctx, id)
+
 	return id, nil
 }
 
@@ -145,9 +169,12 @@ func (m *InMemoryTaskManager) Get(_ context.Context, id corepkg.TaskID) (Task, e
 	return task, nil
 }
 
-func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ string) error {
+func (m *InMemoryTaskManager) Cancel(ctx context.Context, id corepkg.TaskID, _ string) error {
 	if m == nil {
 		return ErrTaskNotImplemented
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	now := time.Now().UTC()
@@ -163,6 +190,18 @@ func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ str
 		m.mu.Unlock()
 		return taskNotFoundError(id)
 	}
+	if task.Status == corepkg.TaskRunning {
+		cancel := m.runCancels[id]
+		m.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+		_, waitErr := m.Wait(ctx, id)
+		if waitErr != nil {
+			return waitErr
+		}
+		return nil
+	}
 	if task.Status == corepkg.TaskKilled {
 		m.mu.Unlock()
 		return nil
@@ -176,6 +215,7 @@ func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ str
 	task.ErrorCode = ErrorCodeTaskCancelled
 	task.FinishedAt = &now
 	m.tasks[id] = task
+	delete(m.runCancels, id)
 	result = taskToResult(task)
 	waiters = m.waiters[id]
 	delete(m.waiters, id)
@@ -195,24 +235,30 @@ func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ str
 	return nil
 }
 
-func (m *InMemoryTaskManager) Retry(_ context.Context, id corepkg.TaskID) (corepkg.TaskID, error) {
+func (m *InMemoryTaskManager) Retry(ctx context.Context, id corepkg.TaskID) (corepkg.TaskID, error) {
 	if m == nil {
 		return "", ErrTaskNotImplemented
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	task, ok := m.tasks[id]
 	if !ok {
+		m.mu.Unlock()
 		return "", taskNotFoundError(id)
 	}
 	if task.Status != corepkg.TaskFailed {
+		m.mu.Unlock()
 		return "", invalidTransitionError(task.Status, corepkg.TaskPending)
 	}
 	if task.Attempt >= task.Spec.MaxRetries {
+		m.mu.Unlock()
 		return "", newRuntimeError(ErrorCodeRetryExhausted, fmt.Sprintf("task %q exhausted retries", id), false, nil)
 	}
 	if err := ValidateTaskTransition(task.Status, corepkg.TaskPending, TransitionOptions{AllowRetryTransition: true}); err != nil {
+		m.mu.Unlock()
 		return "", err
 	}
 
@@ -222,6 +268,9 @@ func (m *InMemoryTaskManager) Retry(_ context.Context, id corepkg.TaskID) (corep
 	task.StartedAt = nil
 	task.FinishedAt = nil
 	m.tasks[id] = task
+	m.mu.Unlock()
+
+	m.enqueueTask(ctx, id)
 
 	return id, nil
 }
@@ -263,6 +312,122 @@ func (m *InMemoryTaskManager) Wait(ctx context.Context, id corepkg.TaskID) (Task
 	}
 }
 
+func (m *InMemoryTaskManager) enqueueTask(parentCtx context.Context, id corepkg.TaskID) {
+	if m == nil || m.executor == nil {
+		return
+	}
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	go m.runTaskAttempt(parentCtx, id)
+}
+
+func (m *InMemoryTaskManager) runTaskAttempt(parentCtx context.Context, id corepkg.TaskID) {
+	if m == nil || m.executor == nil {
+		return
+	}
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+
+	now := time.Now().UTC()
+
+	m.mu.Lock()
+	task, ok := m.tasks[id]
+	if !ok {
+		m.mu.Unlock()
+		return
+	}
+	if task.Status != corepkg.TaskPending {
+		m.mu.Unlock()
+		return
+	}
+	if err := ValidateTaskTransition(task.Status, corepkg.TaskRunning, TransitionOptions{}); err != nil {
+		m.mu.Unlock()
+		return
+	}
+	task.Status = corepkg.TaskRunning
+	task.ErrorCode = ""
+	task.StartedAt = &now
+	task.FinishedAt = nil
+	m.tasks[id] = task
+
+	runCtx, runCancel := context.WithCancel(parentCtx)
+	m.runCancels[id] = runCancel
+	m.mu.Unlock()
+
+	execCtx := runCtx
+	timeoutCancel := func() {}
+	if task.Spec.Timeout > 0 {
+		execCtx, timeoutCancel = context.WithTimeout(runCtx, task.Spec.Timeout)
+	}
+	output, execErr := m.executor(execCtx, task)
+	timeoutCancel()
+	runCancel()
+
+	status, errorCodeValue := mapExecutionResult(execErr)
+	finished := time.Now().UTC()
+
+	var (
+		result  TaskResult
+		waiters []chan TaskResult
+	)
+
+	m.mu.Lock()
+	current, ok := m.tasks[id]
+	if !ok {
+		delete(m.runCancels, id)
+		m.mu.Unlock()
+		return
+	}
+	if current.Status != corepkg.TaskRunning {
+		delete(m.runCancels, id)
+		m.mu.Unlock()
+		return
+	}
+	if err := ValidateTaskTransition(current.Status, status, TransitionOptions{}); err != nil {
+		delete(m.runCancels, id)
+		m.mu.Unlock()
+		return
+	}
+
+	current.Status = status
+	current.ErrorCode = errorCodeValue
+	current.Output = append([]byte(nil), output...)
+	current.FinishedAt = &finished
+	m.tasks[id] = current
+	delete(m.runCancels, id)
+
+	result = taskToResult(current)
+	waiters = m.waiters[id]
+	delete(m.waiters, id)
+	m.mu.Unlock()
+
+	for _, waiter := range waiters {
+		select {
+		case waiter <- result:
+		default:
+		}
+		close(waiter)
+	}
+}
+
+func mapExecutionResult(execErr error) (corepkg.TaskStatus, string) {
+	if execErr == nil {
+		return corepkg.TaskCompleted, ""
+	}
+	if errors.Is(execErr, context.DeadlineExceeded) {
+		return corepkg.TaskFailed, ErrorCodeTaskTimeout
+	}
+	if errors.Is(execErr, context.Canceled) {
+		return corepkg.TaskKilled, ErrorCodeTaskCancelled
+	}
+	if code := errorCode(execErr); code != "" {
+		return corepkg.TaskFailed, code
+	}
+	return corepkg.TaskFailed, ErrorCodeTaskExecutionFailed
+}
+
 func (m *InMemoryTaskManager) removeWaiter(id corepkg.TaskID, waiter chan TaskResult) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -296,6 +461,7 @@ func taskToResult(task Task) TaskResult {
 	return TaskResult{
 		TaskID:     task.ID,
 		Status:     task.Status,
+		Output:     append([]byte(nil), task.Output...),
 		ErrorCode:  task.ErrorCode,
 		FinishedAt: finishedAt,
 	}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -2,14 +2,14 @@ package runtime
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"sync"
 	"time"
 
 	corepkg "bytemind/internal/core"
 )
 
-var ErrTaskNotImplemented = errors.New("runtime task manager is not wired")
+var ErrTaskNotImplemented = newRuntimeError(ErrorCodeNotImplemented, "runtime task manager is not wired", false, nil)
 
 type TaskSpec struct {
 	SessionID        corepkg.SessionID
@@ -56,8 +56,12 @@ const (
 type TaskEvent struct {
 	Type      TaskEventType
 	TaskID    corepkg.TaskID
+	SessionID corepkg.SessionID
+	TraceID   corepkg.TraceID
 	Status    corepkg.TaskStatus
+	Attempt   int
 	Payload   []byte
+	Metadata  map[string]string
 	ErrorCode string
 	Timestamp time.Time
 }
@@ -68,26 +72,62 @@ type TaskManager interface {
 	Cancel(ctx context.Context, id corepkg.TaskID, reason string) error
 	Retry(ctx context.Context, id corepkg.TaskID) (corepkg.TaskID, error)
 	Stream(ctx context.Context, id corepkg.TaskID) (<-chan TaskEvent, error)
+	Wait(ctx context.Context, id corepkg.TaskID) (TaskResult, error)
+}
+
+type Scheduler interface {
+	Enqueue(ctx context.Context, taskID corepkg.TaskID) error
+}
+
+type TaskLogEntry struct {
+	Offset    uint64
+	Payload   []byte
+	Timestamp time.Time
+}
+
+type LogReader interface {
+	ReadIncrement(ctx context.Context, taskID corepkg.TaskID, offset uint64, limit int) (items []TaskLogEntry, nextOffset uint64, hasMore bool, err error)
+}
+
+type SubAgentCoordinator interface {
+	Spawn(ctx context.Context, spec TaskSpec) (corepkg.TaskID, error)
+	Wait(ctx context.Context, id corepkg.TaskID) (TaskResult, error)
+}
+
+type QuotaManager interface {
+	Acquire(ctx context.Context, key string) error
+	Release(key string)
 }
 
 // InMemoryTaskManager is a safe placeholder until runtime orchestration is wired.
 type InMemoryTaskManager struct {
-	mu    sync.Mutex
-	tasks map[corepkg.TaskID]Task
+	mu      sync.RWMutex
+	tasks   map[corepkg.TaskID]Task
+	waiters map[corepkg.TaskID][]chan TaskResult
 }
 
 func NewInMemoryTaskManager() *InMemoryTaskManager {
-	return &InMemoryTaskManager{tasks: make(map[corepkg.TaskID]Task)}
+	return &InMemoryTaskManager{
+		tasks:   make(map[corepkg.TaskID]Task),
+		waiters: make(map[corepkg.TaskID][]chan TaskResult),
+	}
 }
 
 func (m *InMemoryTaskManager) Submit(_ context.Context, spec TaskSpec) (corepkg.TaskID, error) {
 	if m == nil {
 		return "", ErrTaskNotImplemented
 	}
-	id := corepkg.TaskID(time.Now().UTC().Format("20060102150405.000000000"))
+	id := newTaskID(time.Now().UTC())
 	now := time.Now().UTC()
+	task := Task{
+		ID:        id,
+		Spec:      spec,
+		Status:    corepkg.TaskPending,
+		Attempt:   0,
+		CreatedAt: now,
+	}
 	m.mu.Lock()
-	m.tasks[id] = Task{ID: id, Spec: spec, Status: corepkg.TaskPending, CreatedAt: now}
+	m.tasks[id] = task
 	m.mu.Unlock()
 	return id, nil
 }
@@ -96,11 +136,11 @@ func (m *InMemoryTaskManager) Get(_ context.Context, id corepkg.TaskID) (Task, e
 	if m == nil {
 		return Task{}, ErrTaskNotImplemented
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	task, ok := m.tasks[id]
 	if !ok {
-		return Task{}, ErrTaskNotImplemented
+		return Task{}, taskNotFoundError(id)
 	}
 	return task, nil
 }
@@ -109,23 +149,154 @@ func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ str
 	if m == nil {
 		return ErrTaskNotImplemented
 	}
+
+	now := time.Now().UTC()
+	var (
+		result  TaskResult
+		waiters []chan TaskResult
+		hasTask bool
+	)
+
+	m.mu.Lock()
+	task, ok := m.tasks[id]
+	if !ok {
+		m.mu.Unlock()
+		return taskNotFoundError(id)
+	}
+	if task.Status == corepkg.TaskKilled {
+		m.mu.Unlock()
+		return nil
+	}
+	if err := ValidateTaskTransition(task.Status, corepkg.TaskKilled, TransitionOptions{}); err != nil {
+		m.mu.Unlock()
+		return err
+	}
+
+	task.Status = corepkg.TaskKilled
+	task.ErrorCode = ErrorCodeTaskCancelled
+	task.FinishedAt = &now
+	m.tasks[id] = task
+	result = taskToResult(task)
+	waiters = m.waiters[id]
+	delete(m.waiters, id)
+	hasTask = true
+	m.mu.Unlock()
+
+	if hasTask {
+		for _, waiter := range waiters {
+			select {
+			case waiter <- result:
+			default:
+			}
+			close(waiter)
+		}
+	}
+
+	return nil
+}
+
+func (m *InMemoryTaskManager) Retry(_ context.Context, id corepkg.TaskID) (corepkg.TaskID, error) {
+	if m == nil {
+		return "", ErrTaskNotImplemented
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	task, ok := m.tasks[id]
 	if !ok {
-		return ErrTaskNotImplemented
+		return "", taskNotFoundError(id)
 	}
-	task.Status = corepkg.TaskKilled
-	finished := time.Now().UTC()
-	task.FinishedAt = &finished
-	m.tasks[id] = task
-	return nil
-}
+	if task.Status != corepkg.TaskFailed {
+		return "", invalidTransitionError(task.Status, corepkg.TaskPending)
+	}
+	if task.Attempt >= task.Spec.MaxRetries {
+		return "", newRuntimeError(ErrorCodeRetryExhausted, fmt.Sprintf("task %q exhausted retries", id), false, nil)
+	}
+	if err := ValidateTaskTransition(task.Status, corepkg.TaskPending, TransitionOptions{AllowRetryTransition: true}); err != nil {
+		return "", err
+	}
 
-func (m *InMemoryTaskManager) Retry(_ context.Context, _ corepkg.TaskID) (corepkg.TaskID, error) {
-	return "", ErrTaskNotImplemented
+	task.Attempt++
+	task.Status = corepkg.TaskPending
+	task.ErrorCode = ""
+	task.StartedAt = nil
+	task.FinishedAt = nil
+	m.tasks[id] = task
+
+	return id, nil
 }
 
 func (m *InMemoryTaskManager) Stream(_ context.Context, _ corepkg.TaskID) (<-chan TaskEvent, error) {
 	return nil, ErrTaskNotImplemented
+}
+
+func (m *InMemoryTaskManager) Wait(ctx context.Context, id corepkg.TaskID) (TaskResult, error) {
+	if m == nil {
+		return TaskResult{}, ErrTaskNotImplemented
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	waiter := make(chan TaskResult, 1)
+
+	m.mu.Lock()
+	task, ok := m.tasks[id]
+	if !ok {
+		m.mu.Unlock()
+		return TaskResult{}, taskNotFoundError(id)
+	}
+	if IsTerminalTaskStatus(task.Status) {
+		result := taskToResult(task)
+		m.mu.Unlock()
+		return result, nil
+	}
+	m.waiters[id] = append(m.waiters[id], waiter)
+	m.mu.Unlock()
+
+	select {
+	case result := <-waiter:
+		return result, nil
+	case <-ctx.Done():
+		m.removeWaiter(id, waiter)
+		return TaskResult{}, ctx.Err()
+	}
+}
+
+func (m *InMemoryTaskManager) removeWaiter(id corepkg.TaskID, waiter chan TaskResult) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	waiters := m.waiters[id]
+	if len(waiters) == 0 {
+		return
+	}
+	filtered := waiters[:0]
+	for _, current := range waiters {
+		if current == waiter {
+			continue
+		}
+		filtered = append(filtered, current)
+	}
+	if len(filtered) == 0 {
+		delete(m.waiters, id)
+		return
+	}
+	m.waiters[id] = filtered
+}
+
+func newTaskID(ts time.Time) corepkg.TaskID {
+	return corepkg.TaskID(ts.Format("20060102150405.000000000"))
+}
+
+func taskToResult(task Task) TaskResult {
+	finishedAt := task.CreatedAt
+	if task.FinishedAt != nil {
+		finishedAt = *task.FinishedAt
+	}
+	return TaskResult{
+		TaskID:     task.ID,
+		Status:     task.Status,
+		ErrorCode:  task.ErrorCode,
+		FinishedAt: finishedAt,
+	}
 }

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -142,7 +142,7 @@ func (m *InMemoryTaskManager) Submit(ctx context.Context, spec TaskSpec) (corepk
 	now := time.Now().UTC()
 	task := Task{
 		ID:        id,
-		Spec:      spec,
+		Spec:      cloneTaskSpec(spec),
 		Status:    corepkg.TaskPending,
 		Attempt:   0,
 		CreatedAt: now,
@@ -151,7 +151,7 @@ func (m *InMemoryTaskManager) Submit(ctx context.Context, spec TaskSpec) (corepk
 	m.tasks[id] = task
 	m.mu.Unlock()
 
-	m.enqueueTask(ctx, id)
+	m.enqueueTask(detachContext(ctx), id)
 
 	return id, nil
 }
@@ -270,7 +270,7 @@ func (m *InMemoryTaskManager) Retry(ctx context.Context, id corepkg.TaskID) (cor
 	m.tasks[id] = task
 	m.mu.Unlock()
 
-	m.enqueueTask(ctx, id)
+	m.enqueueTask(detachContext(ctx), id)
 
 	return id, nil
 }
@@ -465,4 +465,24 @@ func taskToResult(task Task) TaskResult {
 		ErrorCode:  task.ErrorCode,
 		FinishedAt: finishedAt,
 	}
+}
+
+func cloneTaskSpec(spec TaskSpec) TaskSpec {
+	cloned := spec
+	if len(spec.Input) > 0 {
+		cloned.Input = append([]byte(nil), spec.Input...)
+	}
+	if len(spec.Metadata) > 0 {
+		cloned.Metadata = make(map[string]string, len(spec.Metadata))
+		for k, v := range spec.Metadata {
+			cloned.Metadata[k] = v
+		}
+	}
+	return cloned
+}
+
+func detachContext(ctx context.Context) context.Context {
+	// Keep execution lifecycle independent from request-scoped cancellation.
+	// Task timeout and explicit Cancel(...) remain the runtime controls.
+	return context.Background()
 }

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -294,5 +295,147 @@ func TestInMemoryTaskManagerStreamReturnsNotImplemented(t *testing.T) {
 	}
 	if !hasErrorCode(err, ErrorCodeNotImplemented) {
 		t.Fatalf("expected error code %q, got %q", ErrorCodeNotImplemented, errorCode(err))
+	}
+}
+
+func TestInMemoryTaskManagerSubmitRunsExecutorAndCompletes(t *testing.T) {
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(_ context.Context, task Task) ([]byte, error) {
+		if task.Status != corepkg.TaskRunning {
+			t.Fatalf("expected task status running in executor, got %s", task.Status)
+		}
+		return []byte("done"), nil
+	}))
+
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "execute"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := mgr.Wait(waitCtx, id)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if result.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected completed status, got %s", result.Status)
+	}
+	if string(result.Output) != "done" {
+		t.Fatalf("expected output %q, got %q", "done", string(result.Output))
+	}
+}
+
+func TestInMemoryTaskManagerTimeoutMapsToTaskTimeout(t *testing.T) {
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}))
+
+	id, err := mgr.Submit(context.Background(), TaskSpec{
+		Name:    "timeout",
+		Timeout: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := mgr.Wait(waitCtx, id)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if result.Status != corepkg.TaskFailed {
+		t.Fatalf("expected failed status, got %s", result.Status)
+	}
+	if result.ErrorCode != ErrorCodeTaskTimeout {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeTaskTimeout, result.ErrorCode)
+	}
+}
+
+func TestInMemoryTaskManagerCancelPropagatesToRunningTask(t *testing.T) {
+	started := make(chan struct{}, 1)
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}))
+
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "cancel"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("task did not start")
+	}
+
+	if err := mgr.Cancel(context.Background(), id, "test cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	task, err := mgr.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if task.Status != corepkg.TaskKilled {
+		t.Fatalf("expected killed status, got %s", task.Status)
+	}
+	if task.ErrorCode != ErrorCodeTaskCancelled {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeTaskCancelled, task.ErrorCode)
+	}
+}
+
+func TestInMemoryTaskManagerRetrySchedulesNewAttempt(t *testing.T) {
+	var runs atomic.Int32
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(_ context.Context, _ Task) ([]byte, error) {
+		if runs.Add(1) == 1 {
+			return nil, errors.New("first attempt failed")
+		}
+		return []byte("recovered"), nil
+	}))
+
+	id, err := mgr.Submit(context.Background(), TaskSpec{
+		Name:       "retry",
+		MaxRetries: 2,
+	})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	waitCtx1, cancel1 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel1()
+	first, err := mgr.Wait(waitCtx1, id)
+	if err != nil {
+		t.Fatalf("Wait first attempt failed: %v", err)
+	}
+	if first.Status != corepkg.TaskFailed {
+		t.Fatalf("expected first attempt failed, got %s", first.Status)
+	}
+	if first.ErrorCode != ErrorCodeTaskExecutionFailed {
+		t.Fatalf("expected first attempt error code %q, got %q", ErrorCodeTaskExecutionFailed, first.ErrorCode)
+	}
+
+	_, err = mgr.Retry(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Retry failed: %v", err)
+	}
+
+	waitCtx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	second, err := mgr.Wait(waitCtx2, id)
+	if err != nil {
+		t.Fatalf("Wait second attempt failed: %v", err)
+	}
+	if second.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected second attempt completed, got %s", second.Status)
+	}
+	if string(second.Output) != "recovered" {
+		t.Fatalf("expected output %q, got %q", "recovered", string(second.Output))
 	}
 }

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -1,24 +1,101 @@
 package runtime
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
 
 func TestInMemoryTaskManagerSubmitAndCancel(t *testing.T) {
 	mgr := NewInMemoryTaskManager()
-	id, err := mgr.Submit(nil, TaskSpec{Name: "demo"})
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
 	if err != nil {
 		t.Fatalf("Submit failed: %v", err)
 	}
 	if id == "" {
 		t.Fatal("expected task id")
 	}
-	if err := mgr.Cancel(nil, id, "test"); err != nil {
+	if err := mgr.Cancel(context.Background(), id, "test"); err != nil {
 		t.Fatalf("Cancel failed: %v", err)
 	}
-	task, err := mgr.Get(nil, id)
+	task, err := mgr.Get(context.Background(), id)
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
 	if task.Status != "killed" {
 		t.Fatalf("expected killed status, got %s", task.Status)
+	}
+	if task.ErrorCode != ErrorCodeTaskCancelled {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeTaskCancelled, task.ErrorCode)
+	}
+}
+
+func TestInMemoryTaskManagerWaitReturnsTerminalResult(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	results := make(chan TaskResult, 1)
+	waitErrs := make(chan error, 1)
+	go func() {
+		result, err := mgr.Wait(context.Background(), id)
+		if err != nil {
+			waitErrs <- err
+			return
+		}
+		results <- result
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	if err := mgr.Cancel(context.Background(), id, "test"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	select {
+	case err := <-waitErrs:
+		t.Fatalf("Wait failed: %v", err)
+	case result := <-results:
+		if result.TaskID != id {
+			t.Fatalf("expected task id %q, got %q", id, result.TaskID)
+		}
+		if result.Status != "killed" {
+			t.Fatalf("expected killed status, got %s", result.Status)
+		}
+		if result.ErrorCode != ErrorCodeTaskCancelled {
+			t.Fatalf("expected error code %q, got %q", ErrorCodeTaskCancelled, result.ErrorCode)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait timed out")
+	}
+}
+
+func TestInMemoryTaskManagerWaitRespectsContextCancellation(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err = mgr.Wait(ctx, id)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+}
+
+func TestInMemoryTaskManagerGetUnknownTaskReturnsTaskNotFound(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+
+	_, err := mgr.Get(context.Background(), "unknown-task")
+	if err == nil {
+		t.Fatal("expected error for unknown task")
+	}
+	if !hasErrorCode(err, ErrorCodeTaskNotFound) {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeTaskNotFound, errorCode(err))
 	}
 }

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	corepkg "bytemind/internal/core"
 )
 
 func TestInMemoryTaskManagerSubmitAndCancel(t *testing.T) {
@@ -97,5 +99,200 @@ func TestInMemoryTaskManagerGetUnknownTaskReturnsTaskNotFound(t *testing.T) {
 	}
 	if !hasErrorCode(err, ErrorCodeTaskNotFound) {
 		t.Fatalf("expected error code %q, got %q", ErrorCodeTaskNotFound, errorCode(err))
+	}
+}
+
+func TestInMemoryTaskManagerRetryFromFailedResetsTaskForRetry(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{
+		Name:       "demo",
+		MaxRetries: 3,
+	})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	startedAt := time.Now().UTC().Add(-2 * time.Second)
+	finishedAt := time.Now().UTC().Add(-1 * time.Second)
+	mgr.mu.Lock()
+	task := mgr.tasks[id]
+	task.Status = corepkg.TaskFailed
+	task.Attempt = 1
+	task.StartedAt = &startedAt
+	task.FinishedAt = &finishedAt
+	task.ErrorCode = ErrorCodeTaskTimeout
+	mgr.tasks[id] = task
+	mgr.mu.Unlock()
+
+	retriedID, err := mgr.Retry(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Retry failed: %v", err)
+	}
+	if retriedID != id {
+		t.Fatalf("expected retried id %q, got %q", id, retriedID)
+	}
+
+	task, err = mgr.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if task.Status != corepkg.TaskPending {
+		t.Fatalf("expected pending status, got %s", task.Status)
+	}
+	if task.Attempt != 2 {
+		t.Fatalf("expected attempt 2, got %d", task.Attempt)
+	}
+	if task.ErrorCode != "" {
+		t.Fatalf("expected cleared error code, got %q", task.ErrorCode)
+	}
+	if task.StartedAt != nil {
+		t.Fatal("expected startedAt to reset on retry")
+	}
+	if task.FinishedAt != nil {
+		t.Fatal("expected finishedAt to reset on retry")
+	}
+}
+
+func TestInMemoryTaskManagerRetryRejectsNonFailedTask(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	_, err = mgr.Retry(context.Background(), id)
+	if err == nil {
+		t.Fatal("expected retry error for non-failed task")
+	}
+	if !hasErrorCode(err, ErrorCodeInvalidTransition) {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeInvalidTransition, errorCode(err))
+	}
+}
+
+func TestInMemoryTaskManagerRetryExhausted(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{
+		Name:       "demo",
+		MaxRetries: 1,
+	})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	mgr.mu.Lock()
+	task := mgr.tasks[id]
+	task.Status = corepkg.TaskFailed
+	task.Attempt = 1
+	mgr.tasks[id] = task
+	mgr.mu.Unlock()
+
+	_, err = mgr.Retry(context.Background(), id)
+	if err == nil {
+		t.Fatal("expected retry exhausted error")
+	}
+	if !hasErrorCode(err, ErrorCodeRetryExhausted) {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeRetryExhausted, errorCode(err))
+	}
+}
+
+func TestInMemoryTaskManagerRetryUnknownTaskReturnsTaskNotFound(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+
+	_, err := mgr.Retry(context.Background(), "missing-task")
+	if err == nil {
+		t.Fatal("expected retry error for unknown task")
+	}
+	if !hasErrorCode(err, ErrorCodeTaskNotFound) {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeTaskNotFound, errorCode(err))
+	}
+}
+
+func TestInMemoryTaskManagerCancelIsIdempotent(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	if err := mgr.Cancel(context.Background(), id, "first cancel"); err != nil {
+		t.Fatalf("first cancel failed: %v", err)
+	}
+	if err := mgr.Cancel(context.Background(), id, "second cancel"); err != nil {
+		t.Fatalf("second cancel should be idempotent, got: %v", err)
+	}
+}
+
+func TestInMemoryTaskManagerCancelRejectsCompletedTask(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	finishedAt := time.Now().UTC()
+	mgr.mu.Lock()
+	task := mgr.tasks[id]
+	task.Status = corepkg.TaskCompleted
+	task.FinishedAt = &finishedAt
+	mgr.tasks[id] = task
+	mgr.mu.Unlock()
+
+	err = mgr.Cancel(context.Background(), id, "cancel completed")
+	if err == nil {
+		t.Fatal("expected invalid transition error")
+	}
+	if !hasErrorCode(err, ErrorCodeInvalidTransition) {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeInvalidTransition, errorCode(err))
+	}
+}
+
+func TestInMemoryTaskManagerWaitReturnsImmediatelyForTerminalTask(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	if err := mgr.Cancel(context.Background(), id, "terminal"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	result, err := mgr.Wait(ctx, id)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if result.Status != corepkg.TaskKilled {
+		t.Fatalf("expected killed status, got %s", result.Status)
+	}
+}
+
+func TestInMemoryTaskManagerWaitWithNilContextUsesBackground(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	if err := mgr.Cancel(context.Background(), id, "terminal"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	result, err := mgr.Wait(nil, id)
+	if err != nil {
+		t.Fatalf("Wait with nil context failed: %v", err)
+	}
+	if result.TaskID != id {
+		t.Fatalf("expected task id %q, got %q", id, result.TaskID)
+	}
+}
+
+func TestInMemoryTaskManagerStreamReturnsNotImplemented(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	_, err := mgr.Stream(context.Background(), "task-id")
+	if err == nil {
+		t.Fatal("expected stream to return not implemented")
+	}
+	if !hasErrorCode(err, ErrorCodeNotImplemented) {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeNotImplemented, errorCode(err))
 	}
 }

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -439,3 +439,66 @@ func TestInMemoryTaskManagerRetrySchedulesNewAttempt(t *testing.T) {
 		t.Fatalf("expected output %q, got %q", "recovered", string(second.Output))
 	}
 }
+
+func TestInMemoryTaskManagerSubmitDetachesCallerContext(t *testing.T) {
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(30 * time.Millisecond):
+			return []byte("done"), nil
+		}
+	}))
+
+	submitCtx, cancel := context.WithCancel(context.Background())
+	id, err := mgr.Submit(submitCtx, TaskSpec{Name: "detached"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	cancel()
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer waitCancel()
+	result, err := mgr.Wait(waitCtx, id)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if result.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected completed status, got %s", result.Status)
+	}
+	if result.ErrorCode != "" {
+		t.Fatalf("expected empty error code, got %q", result.ErrorCode)
+	}
+}
+
+func TestInMemoryTaskManagerSubmitSnapshotsMutableTaskSpec(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	spec := TaskSpec{
+		Name:     "snapshot",
+		Input:    []byte("immutable"),
+		Metadata: map[string]string{"owner": "runtime"},
+	}
+
+	id, err := mgr.Submit(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	spec.Input[0] = 'X'
+	spec.Metadata["owner"] = "mutated"
+	spec.Metadata["extra"] = "value"
+
+	task, err := mgr.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(task.Spec.Input) != "immutable" {
+		t.Fatalf("expected task input snapshot %q, got %q", "immutable", string(task.Spec.Input))
+	}
+	if got := task.Spec.Metadata["owner"]; got != "runtime" {
+		t.Fatalf("expected metadata owner %q, got %q", "runtime", got)
+	}
+	if _, ok := task.Spec.Metadata["extra"]; ok {
+		t.Fatal("expected metadata not to include caller-side mutations")
+	}
+}

--- a/internal/runtime/state_machine.go
+++ b/internal/runtime/state_machine.go
@@ -1,0 +1,50 @@
+package runtime
+
+import corepkg "bytemind/internal/core"
+
+var baseAllowedTransitions = map[corepkg.TaskStatus]map[corepkg.TaskStatus]struct{}{
+	corepkg.TaskPending: {
+		corepkg.TaskRunning: {},
+		corepkg.TaskKilled:  {},
+	},
+	corepkg.TaskRunning: {
+		corepkg.TaskCompleted: {},
+		corepkg.TaskFailed:    {},
+		corepkg.TaskKilled:    {},
+	},
+}
+
+type TransitionOptions struct {
+	AllowRetryTransition bool
+}
+
+func IsTerminalTaskStatus(status corepkg.TaskStatus) bool {
+	switch status {
+	case corepkg.TaskCompleted, corepkg.TaskFailed, corepkg.TaskKilled:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidateTaskTransition(from, to corepkg.TaskStatus, opts TransitionOptions) error {
+	if from == to {
+		return nil
+	}
+
+	if from == corepkg.TaskFailed && to == corepkg.TaskPending {
+		if opts.AllowRetryTransition {
+			return nil
+		}
+		return invalidTransitionError(from, to)
+	}
+
+	targets, ok := baseAllowedTransitions[from]
+	if !ok {
+		return invalidTransitionError(from, to)
+	}
+	if _, ok := targets[to]; !ok {
+		return invalidTransitionError(from, to)
+	}
+	return nil
+}

--- a/internal/runtime/state_machine_test.go
+++ b/internal/runtime/state_machine_test.go
@@ -1,0 +1,115 @@
+package runtime
+
+import (
+	"testing"
+
+	corepkg "bytemind/internal/core"
+)
+
+func TestValidateTaskTransitionAllowsKnownTransitions(t *testing.T) {
+	tests := []struct {
+		name string
+		from corepkg.TaskStatus
+		to   corepkg.TaskStatus
+		opts TransitionOptions
+	}{
+		{
+			name: "pending to running",
+			from: corepkg.TaskPending,
+			to:   corepkg.TaskRunning,
+		},
+		{
+			name: "pending to killed",
+			from: corepkg.TaskPending,
+			to:   corepkg.TaskKilled,
+		},
+		{
+			name: "running to completed",
+			from: corepkg.TaskRunning,
+			to:   corepkg.TaskCompleted,
+		},
+		{
+			name: "running to failed",
+			from: corepkg.TaskRunning,
+			to:   corepkg.TaskFailed,
+		},
+		{
+			name: "running to killed",
+			from: corepkg.TaskRunning,
+			to:   corepkg.TaskKilled,
+		},
+		{
+			name: "failed to pending through retry",
+			from: corepkg.TaskFailed,
+			to:   corepkg.TaskPending,
+			opts: TransitionOptions{AllowRetryTransition: true},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateTaskTransition(tt.from, tt.to, tt.opts); err != nil {
+				t.Fatalf("expected transition %s -> %s to be valid: %v", tt.from, tt.to, err)
+			}
+		})
+	}
+}
+
+func TestValidateTaskTransitionRejectsIllegalTransitions(t *testing.T) {
+	tests := []struct {
+		name string
+		from corepkg.TaskStatus
+		to   corepkg.TaskStatus
+		opts TransitionOptions
+	}{
+		{
+			name: "completed to running",
+			from: corepkg.TaskCompleted,
+			to:   corepkg.TaskRunning,
+		},
+		{
+			name: "killed to running",
+			from: corepkg.TaskKilled,
+			to:   corepkg.TaskRunning,
+		},
+		{
+			name: "running to pending without retry path",
+			from: corepkg.TaskRunning,
+			to:   corepkg.TaskPending,
+		},
+		{
+			name: "failed to pending without retry flag",
+			from: corepkg.TaskFailed,
+			to:   corepkg.TaskPending,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTaskTransition(tt.from, tt.to, tt.opts)
+			if err == nil {
+				t.Fatalf("expected transition %s -> %s to fail", tt.from, tt.to)
+			}
+			if !hasErrorCode(err, ErrorCodeInvalidTransition) {
+				t.Fatalf("expected error code %q, got %q", ErrorCodeInvalidTransition, errorCode(err))
+			}
+		})
+	}
+}
+
+func TestIsTerminalTaskStatus(t *testing.T) {
+	if !IsTerminalTaskStatus(corepkg.TaskCompleted) {
+		t.Fatal("expected completed to be terminal")
+	}
+	if !IsTerminalTaskStatus(corepkg.TaskFailed) {
+		t.Fatal("expected failed to be terminal")
+	}
+	if !IsTerminalTaskStatus(corepkg.TaskKilled) {
+		t.Fatal("expected killed to be terminal")
+	}
+	if IsTerminalTaskStatus(corepkg.TaskRunning) {
+		t.Fatal("expected running to be non-terminal")
+	}
+}


### PR DESCRIPTION
## 背景
推进 #202：在已有 runtime 契约基础上，补齐执行闭环，确保任务具备 `Submit -> Run -> terminal` 能力，并明确 timeout/cancel/retry/wait 语义。

> 说明：本 PR 依赖 #206（#201）先合并。当前基线尚未包含 #206 时，这个 PR 会显示包含前置提交；#206 合并后将自动收敛为 #202 的增量变更。

## 主要变更
1. InMemoryTaskManager 增加最小执行调度闭环
- 新增可注入执行器：`TaskExecutorFunc` + `WithTaskExecutor(...)`。
- `Submit`/`Retry` 在有执行器时自动入队执行。
- 执行阶段状态迁移：`pending -> running -> completed|failed|killed`。

2. timeout 与 cancel 传播
- 运行 attempt 时按 `TaskSpec.Timeout` 创建 `context.WithTimeout`。
- `Cancel` 对 running 任务触发 cancel，并等待任务收敛到终态。
- 错误码映射：
  - `context.DeadlineExceeded` -> `failed + task_timeout`
  - `context.Canceled` -> `killed + task_cancelled`
  - 其他执行错误 -> `failed + task_execution_failed`

3. retry 行为对齐
- `Retry` 仅允许 `failed` 任务。
- attempt 递增后回到 `pending` 并重新入队。
- 超出上限返回 `retry_exhausted`。

4. Wait 语义保持一致
- 终态立即返回。
- 非终态阻塞等待到终态或 `ctx.Done()`。

## 测试
新增并通过以下关键行为测试：
- 提交后自动执行并完成（含输出收敛）。
- timeout 映射到 `task_timeout`。
- running 任务 cancel 传播并收敛为 `task_cancelled`。
- retry 后重新调度并成功完成。

并执行：
- `go test ./internal/runtime -v`
- `go test ./internal/agent ./internal/tools ./internal/app`

Closes #202