### PR TITLE
Provider丨step2补齐 Provider 领域契约层

### DIFF
--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"context"
+	"strings"
+
+	"bytemind/internal/llm"
+)
+
+type clientAdapter struct {
+	providerID   ProviderID
+	defaultModel ModelID
+	client       llm.Client
+}
+
+func WrapClient(providerID ProviderID, defaultModel ModelID, client llm.Client) Client {
+	if client == nil {
+		return nil
+	}
+	id := ProviderID(strings.TrimSpace(string(providerID)))
+	if id == "" {
+		id = ProviderID("unknown")
+	}
+	return &clientAdapter{
+		providerID:   id,
+		defaultModel: ModelID(strings.TrimSpace(string(defaultModel))),
+		client:       client,
+	}
+}
+
+func (a *clientAdapter) ProviderID() ProviderID {
+	return a.providerID
+}
+
+func (a *clientAdapter) ListModels(context.Context) ([]ModelInfo, error) {
+	if a.defaultModel == "" {
+		return nil, nil
+	}
+	return []ModelInfo{{
+		ProviderID: a.providerID,
+		ModelID:    a.defaultModel,
+	}}, nil
+}
+
+func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, error) {
+	stream := make(chan Event, 4)
+	go func() {
+		defer close(stream)
+		modelID := ModelID(strings.TrimSpace(req.Model))
+		if modelID == "" {
+			modelID = a.defaultModel
+		}
+		stream <- Event{
+			Type:       EventStart,
+			TraceID:    req.TraceID,
+			ProviderID: a.providerID,
+			ModelID:    modelID,
+		}
+		message, err := a.client.StreamMessage(ctx, req.ChatRequest, func(delta string) {
+			if strings.TrimSpace(delta) == "" {
+				return
+			}
+			stream <- Event{
+				Type:       EventDelta,
+				TraceID:    req.TraceID,
+				ProviderID: a.providerID,
+				ModelID:    modelID,
+				Delta:      delta,
+			}
+		})
+		if err != nil {
+			stream <- Event{
+				Type:       EventError,
+				TraceID:    req.TraceID,
+				ProviderID: a.providerID,
+				ModelID:    modelID,
+				Error: &Error{
+					Code:      ErrCodeUnavailable,
+					Provider:  a.providerID,
+					Message:   err.Error(),
+					Retryable: false,
+					Err:       err,
+				},
+			}
+			return
+		}
+		if message.Usage != nil {
+			stream <- Event{
+				Type:       EventUsage,
+				TraceID:    req.TraceID,
+				ProviderID: a.providerID,
+				ModelID:    modelID,
+				Usage: &Usage{
+					InputTokens:  int64(message.Usage.InputTokens),
+					OutputTokens: int64(message.Usage.OutputTokens),
+					TotalTokens:  int64(message.Usage.TotalTokens),
+				},
+			}
+		}
+		message.Normalize()
+		for _, toolCall := range message.ToolCalls {
+			call := toolCall
+			stream <- Event{
+				Type:       EventToolCall,
+				TraceID:    req.TraceID,
+				ProviderID: a.providerID,
+				ModelID:    modelID,
+				ToolCall:   &call,
+			}
+		}
+		stream <- Event{
+			Type:       EventResult,
+			TraceID:    req.TraceID,
+			ProviderID: a.providerID,
+			ModelID:    modelID,
+			Result:     &message,
+		}
+	}()
+	return stream, nil
+}

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"bytemind/internal/llm"
@@ -50,42 +51,38 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 		if modelID == "" {
 			modelID = a.defaultModel
 		}
-		stream <- Event{
+		if !emit(ctx, stream, Event{
 			Type:       EventStart,
 			TraceID:    req.TraceID,
 			ProviderID: a.providerID,
 			ModelID:    modelID,
+		}) {
+			return
 		}
 		message, err := a.client.StreamMessage(ctx, req.ChatRequest, func(delta string) {
 			if strings.TrimSpace(delta) == "" {
 				return
 			}
-			stream <- Event{
+			_ = emit(ctx, stream, Event{
 				Type:       EventDelta,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
 				ModelID:    modelID,
 				Delta:      delta,
-			}
+			})
 		})
 		if err != nil {
-			stream <- Event{
+			_ = emit(ctx, stream, Event{
 				Type:       EventError,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
 				ModelID:    modelID,
-				Error: &Error{
-					Code:      ErrCodeUnavailable,
-					Provider:  a.providerID,
-					Message:   err.Error(),
-					Retryable: false,
-					Err:       err,
-				},
-			}
+				Error:      mapCompatError(a.providerID, err),
+			})
 			return
 		}
 		if message.Usage != nil {
-			stream <- Event{
+			if !emit(ctx, stream, Event{
 				Type:       EventUsage,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
@@ -95,26 +92,65 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 					OutputTokens: int64(message.Usage.OutputTokens),
 					TotalTokens:  int64(message.Usage.TotalTokens),
 				},
+			}) {
+				return
 			}
 		}
 		message.Normalize()
 		for _, toolCall := range message.ToolCalls {
 			call := toolCall
-			stream <- Event{
+			if !emit(ctx, stream, Event{
 				Type:       EventToolCall,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
 				ModelID:    modelID,
 				ToolCall:   &call,
+			}) {
+				return
 			}
 		}
-		stream <- Event{
+		_ = emit(ctx, stream, Event{
 			Type:       EventResult,
 			TraceID:    req.TraceID,
 			ProviderID: a.providerID,
 			ModelID:    modelID,
 			Result:     &message,
-		}
+		})
 	}()
 	return stream, nil
+}
+
+func emit(ctx context.Context, ch chan<- Event, evt Event) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case ch <- evt:
+		return true
+	}
+}
+
+func mapCompatError(providerID ProviderID, err error) *Error {
+	mapped := &Error{
+		Code:      ErrCodeUnavailable,
+		Provider:  providerID,
+		Message:   "provider request failed",
+		Retryable: false,
+		Err:       err,
+	}
+	var providerErr *llm.ProviderError
+	if !errors.As(err, &providerErr) || providerErr == nil {
+		return mapped
+	}
+	mapped.Retryable = providerErr.Retryable
+	switch providerErr.Code {
+	case llm.ErrorCodeRateLimited:
+		mapped.Code = ErrCodeRateLimited
+		mapped.Message = "provider rate limited"
+	case llm.ErrorCodeContextTooLong:
+		mapped.Code = ErrCodeBadRequest
+		mapped.Message = "request exceeds provider context limit"
+	default:
+		mapped.Message = "provider unavailable"
+	}
+	return mapped
 }

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"bytemind/internal/llm"
+)
+
+type stubCompatClient struct {
+	message llm.Message
+	err     error
+}
+
+func (s stubCompatClient) CreateMessage(context.Context, llm.ChatRequest) (llm.Message, error) {
+	return s.message, s.err
+}
+
+func (s stubCompatClient) StreamMessage(_ context.Context, _ llm.ChatRequest, onDelta func(string)) (llm.Message, error) {
+	if onDelta != nil {
+		onDelta("hello")
+		onDelta(" world")
+	}
+	return s.message, s.err
+}
+
+func TestWrapClientStreamEmitsNormalizedEvents(t *testing.T) {
+	adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), stubCompatClient{message: llm.Message{
+		Role:    llm.RoleAssistant,
+		Content: "hello world",
+		ToolCalls: []llm.ToolCall{{
+			ID:   "call-1",
+			Type: "function",
+			Function: llm.ToolFunctionCall{
+				Name:      "list_files",
+				Arguments: "{}",
+			},
+		}},
+		Usage: &llm.Usage{InputTokens: 3, OutputTokens: 2, TotalTokens: 5},
+	}})
+	stream, err := adapter.Stream(context.Background(), Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}, TraceID: "trace-1"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	var events []Event
+	for event := range stream {
+		events = append(events, event)
+	}
+	if len(events) != 6 {
+		t.Fatalf("expected 6 events, got %#v", events)
+	}
+	if events[0].Type != EventStart || events[0].TraceID != "trace-1" {
+		t.Fatalf("unexpected start event %#v", events[0])
+	}
+	if events[1].Type != EventDelta || events[1].Delta != "hello" {
+		t.Fatalf("unexpected first delta %#v", events[1])
+	}
+	if events[2].Type != EventDelta || events[2].Delta != " world" {
+		t.Fatalf("unexpected second delta %#v", events[2])
+	}
+	if events[3].Type != EventUsage || events[3].Usage == nil || events[3].Usage.TotalTokens != 5 {
+		t.Fatalf("unexpected usage event %#v", events[3])
+	}
+	if events[4].Type != EventToolCall || events[4].ToolCall == nil || events[4].ToolCall.Function.Name != "list_files" {
+		t.Fatalf("unexpected tool call event %#v", events[4])
+	}
+	if events[5].Type != EventResult || events[5].Result == nil || events[5].Result.Content != "hello world" {
+		t.Fatalf("expected final result event, got %#v", events[5])
+	}
+}
+
+func TestWrapClientStreamEmitsErrorEvent(t *testing.T) {
+	adapter := WrapClient(ProviderAnthropic, ModelID("claude"), stubCompatClient{err: errors.New("boom")})
+	stream, err := adapter.Stream(context.Background(), Request{ChatRequest: llm.ChatRequest{}, TraceID: "trace-2"})
+	if err != nil {
+		t.Fatalf("expected no setup error, got %v", err)
+	}
+	var events []Event
+	for event := range stream {
+		events = append(events, event)
+	}
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %#v", events)
+	}
+	if events[0].Type != EventStart {
+		t.Fatalf("expected start event, got %#v", events[0])
+	}
+	if events[1].Type != EventDelta || events[2].Type != EventDelta {
+		t.Fatalf("expected delta events before error, got %#v", events)
+	}
+	if events[3].Type != EventError || events[3].Error == nil {
+		t.Fatalf("expected error event, got %#v", events[3])
+	}
+	if events[3].Error.Code != ErrCodeUnavailable {
+		t.Fatalf("unexpected error code %#v", events[3].Error)
+	}
+}

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"bytemind/internal/llm"
 )
@@ -94,5 +95,97 @@ func TestWrapClientStreamEmitsErrorEvent(t *testing.T) {
 	}
 	if events[3].Error.Code != ErrCodeUnavailable {
 		t.Fatalf("unexpected error code %#v", events[3].Error)
+	}
+}
+
+func TestWrapClientStreamMapsProviderErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		code      ErrorCode
+		retryable bool
+		message   string
+	}{
+		{
+			name: "rate limited",
+			err:  &llm.ProviderError{Code: llm.ErrorCodeRateLimited, Provider: "openai", Status: 429, Retryable: true, Message: "429: raw upstream body"},
+			code: ErrCodeRateLimited, retryable: true, message: "provider rate limited",
+		},
+		{
+			name: "context too long",
+			err:  &llm.ProviderError{Code: llm.ErrorCodeContextTooLong, Provider: "anthropic", Status: 413, Retryable: false, Message: "prompt is too long with raw details"},
+			code: ErrCodeBadRequest, retryable: false, message: "request exceeds provider context limit",
+		},
+		{
+			name: "fallback unavailable",
+			err:  errors.New("sensitive raw body"),
+			code: ErrCodeUnavailable, retryable: false, message: "provider request failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), stubCompatClient{err: tt.err})
+			stream, err := adapter.Stream(context.Background(), Request{ChatRequest: llm.ChatRequest{}, TraceID: "trace-map"})
+			if err != nil {
+				t.Fatalf("expected no setup error, got %v", err)
+			}
+			var got *Error
+			for event := range stream {
+				if event.Type == EventError {
+					got = event.Error
+				}
+			}
+			if got == nil {
+				t.Fatal("expected error event")
+			}
+			if got.Code != tt.code || got.Retryable != tt.retryable || got.Provider != ProviderOpenAI || got.Message != tt.message {
+				t.Fatalf("unexpected mapped error %#v", got)
+			}
+		})
+	}
+}
+
+func TestWrapClientStreamStopsWhenContextCancelled(t *testing.T) {
+	adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), stubCompatClient{message: llm.Message{Role: llm.RoleAssistant, Content: "hello world"}})
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := adapter.Stream(ctx, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}, TraceID: "trace-cancel"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	<-stream
+	cancel()
+	select {
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected stream to stop after cancellation")
+	case _, ok := <-stream:
+		if ok {
+			for range stream {
+			}
+		}
+	}
+}
+
+func TestWrapClientCoversNilClientAndEmptyModel(t *testing.T) {
+	if WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), nil) != nil {
+		t.Fatal("expected nil client to return nil adapter")
+	}
+	adapter := WrapClient("", ModelID(""), stubCompatClient{})
+	if adapter.ProviderID() != ProviderID("unknown") {
+		t.Fatalf("unexpected provider id %q", adapter.ProviderID())
+	}
+	models, err := adapter.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if models != nil {
+		t.Fatalf("expected nil models, got %#v", models)
+	}
+}
+
+func TestMapCompatErrorDefaultProviderErrorBranch(t *testing.T) {
+	mapped := mapCompatError(ProviderAnthropic, &llm.ProviderError{Code: llm.ErrorCodeUnknown, Retryable: true, Message: "hidden upstream body"})
+	if mapped.Code != ErrCodeUnavailable || !mapped.Retryable || mapped.Message != "provider unavailable" || mapped.Provider != ProviderAnthropic {
+		t.Fatalf("unexpected mapped error %#v", mapped)
 	}
 }

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 
 	"bytemind/internal/config"
 	"bytemind/internal/llm"
@@ -24,4 +25,19 @@ func NewClient(cfg config.ProviderConfig) (llm.Client, error) {
 	default:
 		return nil, fmt.Errorf("unsupported provider type %q", cfg.Type)
 	}
+}
+
+func NewDomainClient(cfg config.ProviderConfig) (Client, error) {
+	baseClient, err := NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	providerID := ProviderID(strings.TrimSpace(cfg.Type))
+	if providerID == "openai-compatible" {
+		providerID = ProviderOpenAI
+	}
+	if providerID == "" {
+		providerID = ProviderID("unknown")
+	}
+	return WrapClient(providerID, ModelID(strings.TrimSpace(cfg.Model)), baseClient), nil
 }

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -65,5 +66,27 @@ func TestNewClientRejectsUnsupportedProviderType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported provider type") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewDomainClientWrapsBaseClient(t *testing.T) {
+	client, err := NewDomainClient(config.ProviderConfig{
+		Type:    "openai-compatible",
+		BaseURL: "https://api.openai.com/v1",
+		APIKey:  "test-key",
+		Model:   "gpt-5.4",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.ProviderID() != ProviderOpenAI {
+		t.Fatalf("expected provider id %q, got %q", ProviderOpenAI, client.ProviderID())
+	}
+	models, err := client.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error listing models, got %v", err)
+	}
+	if len(models) != 1 || models[0].ModelID != ModelID("gpt-5.4") {
+		t.Fatalf("unexpected models: %#v", models)
 	}
 }

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -90,3 +90,18 @@ func TestNewDomainClientWrapsBaseClient(t *testing.T) {
 		t.Fatalf("unexpected models: %#v", models)
 	}
 }
+
+func TestNewDomainClientRejectsEmptyType(t *testing.T) {
+	client, err := NewDomainClient(config.ProviderConfig{
+		Type:    "",
+		BaseURL: "https://example.com",
+		APIKey:  "test-key",
+		Model:   "test-model",
+	})
+	if err == nil {
+		t.Fatal("expected unsupported provider type error")
+	}
+	if client != nil {
+		t.Fatalf("expected nil client, got %v", client)
+	}
+}

--- a/internal/provider/interfaces.go
+++ b/internal/provider/interfaces.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"context"
+
+	"bytemind/internal/llm"
+)
+
+type ProviderID string
+
+type ModelID string
+
+type Client interface {
+	ProviderID() ProviderID
+	ListModels(ctx context.Context) ([]ModelInfo, error)
+	Stream(ctx context.Context, req Request) (<-chan Event, error)
+}
+
+type Registry interface {
+	Register(ctx context.Context, client Client) error
+	Get(ctx context.Context, id ProviderID) (Client, bool)
+	List(ctx context.Context) ([]ProviderID, error)
+}
+
+type Router interface {
+	Route(ctx context.Context, requestedModel ModelID, rc RouteContext) (RouteResult, error)
+}
+
+type HealthChecker interface {
+	Check(ctx context.Context, id ProviderID) error
+}
+
+type Request struct {
+	llm.ChatRequest
+	TraceID string
+	Tags    map[string]string
+}
+
+type RouteContext struct {
+	Scenario      string
+	Region        string
+	PreferLatency bool
+	PreferLowCost bool
+	AllowFallback bool
+	Tags          map[string]string
+}
+
+type RouteResult struct {
+	Primary   RouteTarget
+	Fallbacks []RouteTarget
+}
+
+type RouteTarget struct {
+	ProviderID ProviderID
+	ModelID    ModelID
+	Client     Client
+}

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -1,0 +1,112 @@
+package provider
+
+import (
+	"errors"
+	"strings"
+
+	"bytemind/internal/llm"
+)
+
+const (
+	ProviderOpenAI    ProviderID = "openai"
+	ProviderAnthropic ProviderID = "anthropic"
+)
+
+type ErrorCode string
+
+type EventType string
+
+type HealthStatus string
+
+const (
+	ErrCodeUnauthorized      ErrorCode = "unauthorized"
+	ErrCodeRateLimited       ErrorCode = "rate_limited"
+	ErrCodeTimeout           ErrorCode = "timeout"
+	ErrCodeUnavailable       ErrorCode = "unavailable"
+	ErrCodeBadRequest        ErrorCode = "bad_request"
+	ErrCodeProviderNotFound  ErrorCode = "provider_not_found"
+	ErrCodeDuplicateProvider ErrorCode = "duplicate_provider"
+)
+
+const (
+	EventStart    EventType = "start"
+	EventDelta    EventType = "delta"
+	EventToolCall EventType = "tool_call"
+	EventUsage    EventType = "usage"
+	EventResult   EventType = "result"
+	EventError    EventType = "error"
+)
+
+const (
+	HealthStatusHealthy     HealthStatus = "healthy"
+	HealthStatusDegraded    HealthStatus = "degraded"
+	HealthStatusUnavailable HealthStatus = "unavailable"
+	HealthStatusHalfOpen    HealthStatus = "half_open"
+)
+
+var (
+	ErrProviderNotFound  = errors.New(string(ErrCodeProviderNotFound))
+	ErrDuplicateProvider = errors.New(string(ErrCodeDuplicateProvider))
+)
+
+type ModelInfo struct {
+	ProviderID   ProviderID
+	ModelID      ModelID
+	DisplayAlias string
+	Metadata     map[string]string
+}
+
+type Warning struct {
+	ProviderID ProviderID
+	Reason     string
+}
+
+type Usage struct {
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+	Cost         float64
+	Currency     string
+	IsEstimated  bool
+}
+
+type Error struct {
+	Code      ErrorCode
+	Provider  ProviderID
+	Message   string
+	Retryable bool
+	Err       error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return string(e.Code)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+type Event struct {
+	ID         string
+	TraceID    string
+	ProviderID ProviderID
+	ModelID    ModelID
+	Type       EventType
+	Delta      string
+	ToolCall   *llm.ToolCall
+	Usage      *Usage
+	Result     *llm.Message
+	Error      *Error
+}

--- a/internal/provider/types_test.go
+++ b/internal/provider/types_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestProviderErrorStringAndUnwrap(t *testing.T) {
+	base := errors.New("base error")
+
+	if (*Error)(nil).Error() != "" {
+		t.Fatal("expected nil error string to be empty")
+	}
+	if (*Error)(nil).Unwrap() != nil {
+		t.Fatal("expected nil unwrap to be nil")
+	}
+
+	withMessage := &Error{Code: ErrCodeUnavailable, Message: "trimmed message", Err: base}
+	if withMessage.Error() != "trimmed message" {
+		t.Fatalf("unexpected message: %q", withMessage.Error())
+	}
+
+	withWrapped := &Error{Code: ErrCodeUnavailable, Err: base}
+	if withWrapped.Error() != "base error" {
+		t.Fatalf("unexpected wrapped message: %q", withWrapped.Error())
+	}
+	if !errors.Is(withWrapped, base) {
+		t.Fatal("expected unwrap to expose base error")
+	}
+
+	withCodeOnly := &Error{Code: ErrCodeBadRequest}
+	if withCodeOnly.Error() != string(ErrCodeBadRequest) {
+		t.Fatalf("unexpected code-only message: %q", withCodeOnly.Error())
+	}
+}


### PR DESCRIPTION
方案来源 #209 step2
> 先把 PRD 中的核心接口落地为独立文件，但暂不要求所有调用方一次切换完成

本次迭代内容

新增 Provider 领域契约：internal/provider/interfaces.go
新增 Provider 领域类型：internal/provider/types.go
新增兼容适配层：internal/provider/compat.go
扩展工厂支持领域 client：internal/provider/factory.go:29
新增测试：internal/provider/compat_test.go、更新 internal/provider/factory_test.go
核心实现

定义 ProviderID / ModelID / Request / RouteContext / RouteResult
定义 Client / Registry / Router / HealthChecker 契约
定义 ModelInfo / Usage / Event / Error / HealthStatus
提供 WrapClient(...)，把现有 llm.Client 包装成领域 provider.Client
提供 NewDomainClient(...)，在不影响现有 NewClient(...) 的前提下补齐 Step1 契约入口
当前边界

只补“契约层 + 兼容层”，未引入 registry/router/health 真正实现
未改 agent.Runner 主链路，保证兼容
Stream 目前是基于现有 StreamMessage 的事件适配版本，满足 Step1 过渡目标
验证