### PR TITLE
feat(runtime): 推进 #204 事件回放流与增量日志读取

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -101,7 +101,15 @@ func Bootstrap(req BootstrapRequest) (Runtime, error) {
 		promptStore = storagepkg.NopPromptHistoryStore{}
 	}
 
-	taskManager := runtimepkg.NewInMemoryTaskManager()
+	var taskEventStore runtimepkg.TaskEventStore
+	taskEventStore, err = storagepkg.NewDefaultRuntimeTaskStore()
+	if err != nil {
+		taskEventStore = runtimepkg.NopTaskEventStore{}
+	}
+
+	taskManager := runtimepkg.NewInMemoryTaskManager(
+		runtimepkg.WithTaskEventStore(taskEventStore),
+	)
 	extensions := extensionspkg.NopManager{}
 	runner := agent.NewRunner(agent.Options{
 		Workspace:   workspace,

--- a/internal/runtime/errors.go
+++ b/internal/runtime/errors.go
@@ -22,6 +22,8 @@ const (
 	ErrorCodeTaskCancelled = "task_cancelled"
 	// ErrorCodeQuotaExceeded indicates runtime quota acquisition failure.
 	ErrorCodeQuotaExceeded = "quota_exceeded"
+	// ErrorCodeTaskExecutionFailed indicates runtime executor returned a non-timeout failure.
+	ErrorCodeTaskExecutionFailed = "task_execution_failed"
 )
 
 type runtimeError struct {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -55,6 +55,7 @@ const (
 
 type TaskEvent struct {
 	Type      TaskEventType
+	Offset    uint64
 	TaskID    corepkg.TaskID
 	SessionID corepkg.SessionID
 	TraceID   corepkg.TraceID
@@ -80,6 +81,7 @@ type Scheduler interface {
 }
 
 type TaskLogEntry struct {
+	TaskID    corepkg.TaskID
 	Offset    uint64
 	Payload   []byte
 	Timestamp time.Time
@@ -99,18 +101,64 @@ type QuotaManager interface {
 	Release(key string)
 }
 
-// InMemoryTaskManager is a safe placeholder until runtime orchestration is wired.
-type InMemoryTaskManager struct {
-	mu      sync.RWMutex
-	tasks   map[corepkg.TaskID]Task
-	waiters map[corepkg.TaskID][]chan TaskResult
+type TaskEventStore interface {
+	AppendTaskEvent(ctx context.Context, event TaskEvent) error
+	AppendTaskLog(ctx context.Context, taskID corepkg.TaskID, entry TaskLogEntry) error
 }
 
-func NewInMemoryTaskManager() *InMemoryTaskManager {
-	return &InMemoryTaskManager{
-		tasks:   make(map[corepkg.TaskID]Task),
-		waiters: make(map[corepkg.TaskID][]chan TaskResult),
+type NopTaskEventStore struct{}
+
+func (NopTaskEventStore) AppendTaskEvent(context.Context, TaskEvent) error {
+	return nil
+}
+
+func (NopTaskEventStore) AppendTaskLog(context.Context, corepkg.TaskID, TaskLogEntry) error {
+	return nil
+}
+
+type InMemoryTaskManagerOption func(*InMemoryTaskManager)
+
+func WithTaskEventStore(store TaskEventStore) InMemoryTaskManagerOption {
+	return func(m *InMemoryTaskManager) {
+		m.eventStore = store
 	}
+}
+
+const (
+	defaultReadIncrementLimit = 200
+	streamBufferSize          = 32
+)
+
+// InMemoryTaskManager is a safe placeholder until runtime orchestration is wired.
+type InMemoryTaskManager struct {
+	mu                sync.RWMutex
+	tasks             map[corepkg.TaskID]Task
+	waiters           map[corepkg.TaskID][]chan TaskResult
+	events            map[corepkg.TaskID][]TaskEvent
+	logs              map[corepkg.TaskID][]TaskLogEntry
+	streamSubscribers map[corepkg.TaskID]map[uint64]chan TaskEvent
+	nextSubscriberID  uint64
+	eventStore        TaskEventStore
+}
+
+func NewInMemoryTaskManager(opts ...InMemoryTaskManagerOption) *InMemoryTaskManager {
+	manager := &InMemoryTaskManager{
+		tasks:             make(map[corepkg.TaskID]Task),
+		waiters:           make(map[corepkg.TaskID][]chan TaskResult),
+		events:            make(map[corepkg.TaskID][]TaskEvent),
+		logs:              make(map[corepkg.TaskID][]TaskLogEntry),
+		streamSubscribers: make(map[corepkg.TaskID]map[uint64]chan TaskEvent),
+		eventStore:        NopTaskEventStore{},
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(manager)
+		}
+	}
+	if manager.eventStore == nil {
+		manager.eventStore = NopTaskEventStore{}
+	}
+	return manager
 }
 
 func (m *InMemoryTaskManager) Submit(_ context.Context, spec TaskSpec) (corepkg.TaskID, error) {
@@ -126,9 +174,20 @@ func (m *InMemoryTaskManager) Submit(_ context.Context, spec TaskSpec) (corepkg.
 		Attempt:   0,
 		CreatedAt: now,
 	}
+
+	var (
+		event       TaskEvent
+		logEntry    TaskLogEntry
+		subscribers []chan TaskEvent
+	)
 	m.mu.Lock()
 	m.tasks[id] = task
+	event, subscribers = m.appendTaskEventLocked(task, TaskEventStatus, nil, task.ErrorCode, now)
+	logEntry = m.appendTaskLogLocked(task.ID, []byte(fmt.Sprintf("status=%s", task.Status)), now)
 	m.mu.Unlock()
+	m.publishTaskEvent(event, subscribers)
+	m.persistTaskEvent(event)
+	m.persistTaskLog(task.ID, logEntry)
 	return id, nil
 }
 
@@ -152,9 +211,12 @@ func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ str
 
 	now := time.Now().UTC()
 	var (
-		result  TaskResult
-		waiters []chan TaskResult
-		hasTask bool
+		result      TaskResult
+		waiters     []chan TaskResult
+		event       TaskEvent
+		logEntry    TaskLogEntry
+		subscribers []chan TaskEvent
+		hasTask     bool
 	)
 
 	m.mu.Lock()
@@ -176,11 +238,17 @@ func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ str
 	task.ErrorCode = ErrorCodeTaskCancelled
 	task.FinishedAt = &now
 	m.tasks[id] = task
+	event, subscribers = m.appendTaskEventLocked(task, TaskEventStatus, nil, task.ErrorCode, now)
+	logEntry = m.appendTaskLogLocked(task.ID, []byte(fmt.Sprintf("status=%s", task.Status)), now)
 	result = taskToResult(task)
 	waiters = m.waiters[id]
 	delete(m.waiters, id)
 	hasTask = true
 	m.mu.Unlock()
+
+	m.publishTaskEvent(event, subscribers)
+	m.persistTaskEvent(event)
+	m.persistTaskLog(task.ID, logEntry)
 
 	if hasTask {
 		for _, waiter := range waiters {
@@ -200,19 +268,28 @@ func (m *InMemoryTaskManager) Retry(_ context.Context, id corepkg.TaskID) (corep
 		return "", ErrTaskNotImplemented
 	}
 
+	var (
+		event       TaskEvent
+		logEntry    TaskLogEntry
+		subscribers []chan TaskEvent
+	)
+
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	task, ok := m.tasks[id]
 	if !ok {
+		m.mu.Unlock()
 		return "", taskNotFoundError(id)
 	}
 	if task.Status != corepkg.TaskFailed {
+		m.mu.Unlock()
 		return "", invalidTransitionError(task.Status, corepkg.TaskPending)
 	}
 	if task.Attempt >= task.Spec.MaxRetries {
+		m.mu.Unlock()
 		return "", newRuntimeError(ErrorCodeRetryExhausted, fmt.Sprintf("task %q exhausted retries", id), false, nil)
 	}
 	if err := ValidateTaskTransition(task.Status, corepkg.TaskPending, TransitionOptions{AllowRetryTransition: true}); err != nil {
+		m.mu.Unlock()
 		return "", err
 	}
 
@@ -222,12 +299,125 @@ func (m *InMemoryTaskManager) Retry(_ context.Context, id corepkg.TaskID) (corep
 	task.StartedAt = nil
 	task.FinishedAt = nil
 	m.tasks[id] = task
+	event, subscribers = m.appendTaskEventLocked(task, TaskEventStatus, nil, task.ErrorCode, time.Now().UTC())
+	logEntry = m.appendTaskLogLocked(task.ID, []byte(fmt.Sprintf("status=%s", task.Status)), time.Now().UTC())
+	m.mu.Unlock()
+
+	m.publishTaskEvent(event, subscribers)
+	m.persistTaskEvent(event)
+	m.persistTaskLog(task.ID, logEntry)
 
 	return id, nil
 }
 
-func (m *InMemoryTaskManager) Stream(_ context.Context, _ corepkg.TaskID) (<-chan TaskEvent, error) {
-	return nil, ErrTaskNotImplemented
+func (m *InMemoryTaskManager) Stream(ctx context.Context, id corepkg.TaskID) (<-chan TaskEvent, error) {
+	if m == nil {
+		return nil, ErrTaskNotImplemented
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	out := make(chan TaskEvent, streamBufferSize)
+	live := make(chan TaskEvent, streamBufferSize)
+
+	var (
+		history      []TaskEvent
+		subscriberID uint64
+		useLive      bool
+	)
+
+	m.mu.Lock()
+	task, ok := m.tasks[id]
+	if !ok {
+		m.mu.Unlock()
+		return nil, taskNotFoundError(id)
+	}
+	history = cloneTaskEvents(m.events[id])
+	if !IsTerminalTaskStatus(task.Status) {
+		m.nextSubscriberID++
+		subscriberID = m.nextSubscriberID
+		if m.streamSubscribers[id] == nil {
+			m.streamSubscribers[id] = make(map[uint64]chan TaskEvent)
+		}
+		m.streamSubscribers[id][subscriberID] = live
+		useLive = true
+	}
+	m.mu.Unlock()
+
+	go func() {
+		defer close(out)
+		defer func() {
+			if useLive {
+				m.removeStreamSubscriber(id, subscriberID)
+			}
+		}()
+
+		for _, event := range history {
+			select {
+			case out <- event:
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		if !useLive {
+			return
+		}
+
+		for {
+			select {
+			case event := <-live:
+				select {
+				case out <- event:
+				case <-ctx.Done():
+					return
+				}
+				if IsTerminalTaskStatus(event.Status) {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return out, nil
+}
+
+func (m *InMemoryTaskManager) ReadIncrement(_ context.Context, id corepkg.TaskID, offset uint64, limit int) (items []TaskLogEntry, nextOffset uint64, hasMore bool, err error) {
+	if m == nil {
+		return nil, 0, false, ErrTaskNotImplemented
+	}
+	if limit <= 0 {
+		limit = defaultReadIncrementLimit
+	}
+
+	m.mu.RLock()
+	_, ok := m.tasks[id]
+	if !ok {
+		m.mu.RUnlock()
+		return nil, 0, false, taskNotFoundError(id)
+	}
+	entries := m.logs[id]
+	total := uint64(len(entries))
+	start := offset
+	if start > total {
+		start = total
+	}
+	end := start + uint64(limit)
+	if end > total {
+		end = total
+	}
+	copied := make([]TaskLogEntry, 0, end-start)
+	for _, entry := range entries[start:end] {
+		copied = append(copied, cloneTaskLogEntry(entry))
+	}
+	m.mu.RUnlock()
+
+	nextOffset = end
+	hasMore = end < total
+	return copied, nextOffset, hasMore, nil
 }
 
 func (m *InMemoryTaskManager) Wait(ctx context.Context, id corepkg.TaskID) (TaskResult, error) {
@@ -261,6 +451,84 @@ func (m *InMemoryTaskManager) Wait(ctx context.Context, id corepkg.TaskID) (Task
 		m.removeWaiter(id, waiter)
 		return TaskResult{}, ctx.Err()
 	}
+}
+
+func (m *InMemoryTaskManager) appendTaskEventLocked(task Task, eventType TaskEventType, payload []byte, errorCode string, at time.Time) (TaskEvent, []chan TaskEvent) {
+	event := TaskEvent{
+		Type:      eventType,
+		TaskID:    task.ID,
+		SessionID: task.Spec.SessionID,
+		TraceID:   task.Spec.TraceID,
+		Status:    task.Status,
+		Attempt:   task.Attempt,
+		Payload:   append([]byte(nil), payload...),
+		Metadata:  cloneTaskMetadata(task.Spec.Metadata),
+		ErrorCode: errorCode,
+		Timestamp: at.UTC(),
+	}
+	current := m.events[task.ID]
+	event.Offset = uint64(len(current))
+	m.events[task.ID] = append(current, event)
+	return cloneTaskEvent(event), m.snapshotStreamSubscribersLocked(task.ID)
+}
+
+func (m *InMemoryTaskManager) appendTaskLogLocked(taskID corepkg.TaskID, payload []byte, at time.Time) TaskLogEntry {
+	entry := TaskLogEntry{
+		TaskID:    taskID,
+		Payload:   append([]byte(nil), payload...),
+		Timestamp: at.UTC(),
+	}
+	current := m.logs[taskID]
+	entry.Offset = uint64(len(current))
+	m.logs[taskID] = append(current, entry)
+	return cloneTaskLogEntry(entry)
+}
+
+func (m *InMemoryTaskManager) snapshotStreamSubscribersLocked(taskID corepkg.TaskID) []chan TaskEvent {
+	subs := m.streamSubscribers[taskID]
+	if len(subs) == 0 {
+		return nil
+	}
+	copied := make([]chan TaskEvent, 0, len(subs))
+	for _, ch := range subs {
+		copied = append(copied, ch)
+	}
+	return copied
+}
+
+func (m *InMemoryTaskManager) publishTaskEvent(event TaskEvent, subscribers []chan TaskEvent) {
+	for _, subscriber := range subscribers {
+		subscriber <- cloneTaskEvent(event)
+	}
+}
+
+func (m *InMemoryTaskManager) persistTaskEvent(event TaskEvent) {
+	if m == nil || m.eventStore == nil {
+		return
+	}
+	_ = m.eventStore.AppendTaskEvent(context.Background(), cloneTaskEvent(event))
+}
+
+func (m *InMemoryTaskManager) persistTaskLog(taskID corepkg.TaskID, entry TaskLogEntry) {
+	if m == nil || m.eventStore == nil {
+		return
+	}
+	_ = m.eventStore.AppendTaskLog(context.Background(), taskID, cloneTaskLogEntry(entry))
+}
+
+func (m *InMemoryTaskManager) removeStreamSubscriber(taskID corepkg.TaskID, subscriberID uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	subs := m.streamSubscribers[taskID]
+	if len(subs) == 0 {
+		return
+	}
+	delete(subs, subscriberID)
+	if len(subs) == 0 {
+		delete(m.streamSubscribers, taskID)
+		return
+	}
+	m.streamSubscribers[taskID] = subs
 }
 
 func (m *InMemoryTaskManager) removeWaiter(id corepkg.TaskID, waiter chan TaskResult) {
@@ -299,4 +567,43 @@ func taskToResult(task Task) TaskResult {
 		ErrorCode:  task.ErrorCode,
 		FinishedAt: finishedAt,
 	}
+}
+
+func cloneTaskEvents(events []TaskEvent) []TaskEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	copied := make([]TaskEvent, 0, len(events))
+	for _, event := range events {
+		copied = append(copied, cloneTaskEvent(event))
+	}
+	return copied
+}
+
+func cloneTaskEvent(event TaskEvent) TaskEvent {
+	cloned := event
+	if len(event.Payload) > 0 {
+		cloned.Payload = append([]byte(nil), event.Payload...)
+	}
+	cloned.Metadata = cloneTaskMetadata(event.Metadata)
+	return cloned
+}
+
+func cloneTaskMetadata(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		copied[k] = v
+	}
+	return copied
+}
+
+func cloneTaskLogEntry(entry TaskLogEntry) TaskLogEntry {
+	cloned := entry
+	if len(entry.Payload) > 0 {
+		cloned.Payload = append([]byte(nil), entry.Payload...)
+	}
+	return cloned
 }

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -30,6 +31,7 @@ type Task struct {
 	Spec       TaskSpec
 	Status     corepkg.TaskStatus
 	Attempt    int
+	Output     []byte
 	CreatedAt  time.Time
 	StartedAt  *time.Time
 	FinishedAt *time.Time
@@ -101,6 +103,8 @@ type QuotaManager interface {
 	Release(key string)
 }
 
+type TaskExecutorFunc func(ctx context.Context, task Task) ([]byte, error)
+
 type TaskEventStore interface {
 	AppendTaskEvent(ctx context.Context, event TaskEvent) error
 	AppendTaskLog(ctx context.Context, taskID corepkg.TaskID, entry TaskLogEntry) error
@@ -124,31 +128,51 @@ func WithTaskEventStore(store TaskEventStore) InMemoryTaskManagerOption {
 	}
 }
 
+func WithTerminalHistoryCap(limit int) InMemoryTaskManagerOption {
+	return func(m *InMemoryTaskManager) {
+		m.terminalHistoryCap = limit
+	}
+}
+
+func WithTaskExecutor(executor TaskExecutorFunc) InMemoryTaskManagerOption {
+	return func(m *InMemoryTaskManager) {
+		m.executor = executor
+	}
+}
 const (
 	defaultReadIncrementLimit = 200
 	streamBufferSize          = 32
+	defaultTerminalHistoryCap = 256
 )
 
 // InMemoryTaskManager is a safe placeholder until runtime orchestration is wired.
 type InMemoryTaskManager struct {
-	mu                sync.RWMutex
-	tasks             map[corepkg.TaskID]Task
-	waiters           map[corepkg.TaskID][]chan TaskResult
-	events            map[corepkg.TaskID][]TaskEvent
-	logs              map[corepkg.TaskID][]TaskLogEntry
-	streamSubscribers map[corepkg.TaskID]map[uint64]chan TaskEvent
-	nextSubscriberID  uint64
-	eventStore        TaskEventStore
+	mu                 sync.RWMutex
+	tasks              map[corepkg.TaskID]Task
+	waiters            map[corepkg.TaskID][]chan TaskResult
+	runCancels         map[corepkg.TaskID]context.CancelFunc
+	events             map[corepkg.TaskID][]TaskEvent
+	logs               map[corepkg.TaskID][]TaskLogEntry
+	streamSubscribers  map[corepkg.TaskID]map[uint64]chan TaskEvent
+	nextSubscriberID   uint64
+	terminalHistory    []corepkg.TaskID
+	terminalTasks      map[corepkg.TaskID]struct{}
+	terminalHistoryCap int
+	executor           TaskExecutorFunc
+	eventStore         TaskEventStore
 }
 
 func NewInMemoryTaskManager(opts ...InMemoryTaskManagerOption) *InMemoryTaskManager {
 	manager := &InMemoryTaskManager{
-		tasks:             make(map[corepkg.TaskID]Task),
-		waiters:           make(map[corepkg.TaskID][]chan TaskResult),
-		events:            make(map[corepkg.TaskID][]TaskEvent),
-		logs:              make(map[corepkg.TaskID][]TaskLogEntry),
-		streamSubscribers: make(map[corepkg.TaskID]map[uint64]chan TaskEvent),
-		eventStore:        NopTaskEventStore{},
+		tasks:              make(map[corepkg.TaskID]Task),
+		waiters:            make(map[corepkg.TaskID][]chan TaskResult),
+		runCancels:         make(map[corepkg.TaskID]context.CancelFunc),
+		events:             make(map[corepkg.TaskID][]TaskEvent),
+		logs:               make(map[corepkg.TaskID][]TaskLogEntry),
+		streamSubscribers:  make(map[corepkg.TaskID]map[uint64]chan TaskEvent),
+		terminalTasks:      make(map[corepkg.TaskID]struct{}),
+		terminalHistoryCap: defaultTerminalHistoryCap,
+		eventStore:         NopTaskEventStore{},
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -161,7 +185,7 @@ func NewInMemoryTaskManager(opts ...InMemoryTaskManagerOption) *InMemoryTaskMana
 	return manager
 }
 
-func (m *InMemoryTaskManager) Submit(_ context.Context, spec TaskSpec) (corepkg.TaskID, error) {
+func (m *InMemoryTaskManager) Submit(ctx context.Context, spec TaskSpec) (corepkg.TaskID, error) {
 	if m == nil {
 		return "", ErrTaskNotImplemented
 	}
@@ -169,7 +193,7 @@ func (m *InMemoryTaskManager) Submit(_ context.Context, spec TaskSpec) (corepkg.
 	now := time.Now().UTC()
 	task := Task{
 		ID:        id,
-		Spec:      spec,
+		Spec:      cloneTaskSpec(spec),
 		Status:    corepkg.TaskPending,
 		Attempt:   0,
 		CreatedAt: now,
@@ -188,6 +212,7 @@ func (m *InMemoryTaskManager) Submit(_ context.Context, spec TaskSpec) (corepkg.
 	m.publishTaskEvent(event, subscribers)
 	m.persistTaskEvent(event)
 	m.persistTaskLog(task.ID, logEntry)
+	m.enqueueTask(detachContext(ctx), id)
 	return id, nil
 }
 
@@ -204,9 +229,12 @@ func (m *InMemoryTaskManager) Get(_ context.Context, id corepkg.TaskID) (Task, e
 	return task, nil
 }
 
-func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ string) error {
+func (m *InMemoryTaskManager) Cancel(ctx context.Context, id corepkg.TaskID, _ string) error {
 	if m == nil {
 		return ErrTaskNotImplemented
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	now := time.Now().UTC()
@@ -225,6 +253,18 @@ func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ str
 		m.mu.Unlock()
 		return taskNotFoundError(id)
 	}
+	if task.Status == corepkg.TaskRunning {
+		cancel := m.runCancels[id]
+		m.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+		_, waitErr := m.Wait(ctx, id)
+		if waitErr != nil {
+			return waitErr
+		}
+		return nil
+	}
 	if task.Status == corepkg.TaskKilled {
 		m.mu.Unlock()
 		return nil
@@ -238,6 +278,7 @@ func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ str
 	task.ErrorCode = ErrorCodeTaskCancelled
 	task.FinishedAt = &now
 	m.tasks[id] = task
+	delete(m.runCancels, id)
 	event, subscribers = m.appendTaskEventLocked(task, TaskEventStatus, nil, task.ErrorCode, now)
 	logEntry = m.appendTaskLogLocked(task.ID, []byte(fmt.Sprintf("status=%s", task.Status)), now)
 	result = taskToResult(task)
@@ -263,9 +304,12 @@ func (m *InMemoryTaskManager) Cancel(_ context.Context, id corepkg.TaskID, _ str
 	return nil
 }
 
-func (m *InMemoryTaskManager) Retry(_ context.Context, id corepkg.TaskID) (corepkg.TaskID, error) {
+func (m *InMemoryTaskManager) Retry(ctx context.Context, id corepkg.TaskID) (corepkg.TaskID, error) {
 	if m == nil {
 		return "", ErrTaskNotImplemented
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	var (
@@ -306,6 +350,7 @@ func (m *InMemoryTaskManager) Retry(_ context.Context, id corepkg.TaskID) (corep
 	m.publishTaskEvent(event, subscribers)
 	m.persistTaskEvent(event)
 	m.persistTaskLog(task.ID, logEntry)
+	m.enqueueTask(detachContext(ctx), id)
 
 	return id, nil
 }
@@ -516,6 +561,146 @@ func (m *InMemoryTaskManager) persistTaskLog(taskID corepkg.TaskID, entry TaskLo
 	_ = m.eventStore.AppendTaskLog(context.Background(), taskID, cloneTaskLogEntry(entry))
 }
 
+func (m *InMemoryTaskManager) enqueueTask(parentCtx context.Context, id corepkg.TaskID) {
+	if m == nil || m.executor == nil {
+		return
+	}
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	go m.runTaskAttempt(parentCtx, id)
+}
+
+func (m *InMemoryTaskManager) runTaskAttempt(parentCtx context.Context, id corepkg.TaskID) {
+	if m == nil || m.executor == nil {
+		return
+	}
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+
+	now := time.Now().UTC()
+	var (
+		startEvent       TaskEvent
+		startLog         TaskLogEntry
+		startSubscribers []chan TaskEvent
+	)
+
+	m.mu.Lock()
+	task, ok := m.tasks[id]
+	if !ok {
+		m.mu.Unlock()
+		return
+	}
+	if task.Status != corepkg.TaskPending {
+		m.mu.Unlock()
+		return
+	}
+	if err := ValidateTaskTransition(task.Status, corepkg.TaskRunning, TransitionOptions{}); err != nil {
+		m.mu.Unlock()
+		return
+	}
+	task.Status = corepkg.TaskRunning
+	task.ErrorCode = ""
+	task.StartedAt = &now
+	task.FinishedAt = nil
+	task.Output = nil
+	m.tasks[id] = task
+	startEvent, startSubscribers = m.appendTaskEventLocked(task, TaskEventStatus, nil, task.ErrorCode, now)
+	startLog = m.appendTaskLogLocked(task.ID, []byte(fmt.Sprintf("status=%s", task.Status)), now)
+
+	runCtx, runCancel := context.WithCancel(parentCtx)
+	m.runCancels[id] = runCancel
+	m.mu.Unlock()
+
+	m.publishTaskEvent(startEvent, startSubscribers)
+	m.persistTaskEvent(startEvent)
+	m.persistTaskLog(task.ID, startLog)
+
+	execCtx := runCtx
+	timeoutCancel := func() {}
+	if task.Spec.Timeout > 0 {
+		execCtx, timeoutCancel = context.WithTimeout(runCtx, task.Spec.Timeout)
+	}
+	output, execErr := m.executor(execCtx, task)
+	timeoutCancel()
+	runCancel()
+
+	status, errorCodeValue := mapExecutionResult(execErr)
+	finished := time.Now().UTC()
+
+	var (
+		result      TaskResult
+		waiters     []chan TaskResult
+		event       TaskEvent
+		logEntry    TaskLogEntry
+		subscribers []chan TaskEvent
+		hasTask     bool
+	)
+
+	m.mu.Lock()
+	current, ok := m.tasks[id]
+	if !ok {
+		delete(m.runCancels, id)
+		m.mu.Unlock()
+		return
+	}
+	if current.Status != corepkg.TaskRunning {
+		delete(m.runCancels, id)
+		m.mu.Unlock()
+		return
+	}
+	if err := ValidateTaskTransition(current.Status, status, TransitionOptions{}); err != nil {
+		delete(m.runCancels, id)
+		m.mu.Unlock()
+		return
+	}
+
+	current.Status = status
+	current.ErrorCode = errorCodeValue
+	current.Output = append([]byte(nil), output...)
+	current.FinishedAt = &finished
+	m.tasks[id] = current
+	delete(m.runCancels, id)
+	event, subscribers = m.appendTaskEventLocked(current, TaskEventStatus, nil, current.ErrorCode, finished)
+	logEntry = m.appendTaskLogLocked(current.ID, []byte(fmt.Sprintf("status=%s", current.Status)), finished)
+	result = taskToResult(current)
+	waiters = m.waiters[id]
+	delete(m.waiters, id)
+	hasTask = true
+	m.mu.Unlock()
+
+	m.publishTaskEvent(event, subscribers)
+	m.persistTaskEvent(event)
+	m.persistTaskLog(current.ID, logEntry)
+
+	if hasTask {
+		for _, waiter := range waiters {
+			select {
+			case waiter <- result:
+			default:
+			}
+			close(waiter)
+		}
+	}
+}
+
+func mapExecutionResult(execErr error) (corepkg.TaskStatus, string) {
+	if execErr == nil {
+		return corepkg.TaskCompleted, ""
+	}
+	if errors.Is(execErr, context.DeadlineExceeded) {
+		return corepkg.TaskFailed, ErrorCodeTaskTimeout
+	}
+	if errors.Is(execErr, context.Canceled) {
+		return corepkg.TaskKilled, ErrorCodeTaskCancelled
+	}
+	if code := errorCode(execErr); code != "" {
+		return corepkg.TaskFailed, code
+	}
+	return corepkg.TaskFailed, ErrorCodeTaskExecutionFailed
+}
+
 func (m *InMemoryTaskManager) removeStreamSubscriber(taskID corepkg.TaskID, subscriberID uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -564,9 +749,28 @@ func taskToResult(task Task) TaskResult {
 	return TaskResult{
 		TaskID:     task.ID,
 		Status:     task.Status,
+		Output:     append([]byte(nil), task.Output...),
 		ErrorCode:  task.ErrorCode,
 		FinishedAt: finishedAt,
 	}
+}
+
+func cloneTaskSpec(spec TaskSpec) TaskSpec {
+	cloned := spec
+	if len(spec.Input) > 0 {
+		cloned.Input = append([]byte(nil), spec.Input...)
+	}
+	if len(spec.Metadata) > 0 {
+		cloned.Metadata = make(map[string]string, len(spec.Metadata))
+		for k, v := range spec.Metadata {
+			cloned.Metadata[k] = v
+		}
+	}
+	return cloned
+}
+
+func detachContext(ctx context.Context) context.Context {
+	return context.Background()
 }
 
 func cloneTaskEvents(events []TaskEvent) []TaskEvent {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -286,13 +287,193 @@ func TestInMemoryTaskManagerWaitWithNilContextUsesBackground(t *testing.T) {
 	}
 }
 
-func TestInMemoryTaskManagerStreamReturnsNotImplemented(t *testing.T) {
+func TestInMemoryTaskManagerStreamReplaysHistoryAndLiveUpdates(t *testing.T) {
 	mgr := NewInMemoryTaskManager()
-	_, err := mgr.Stream(context.Background(), "task-id")
-	if err == nil {
-		t.Fatal("expected stream to return not implemented")
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "stream"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
 	}
-	if !hasErrorCode(err, ErrorCodeNotImplemented) {
-		t.Fatalf("expected error code %q, got %q", ErrorCodeNotImplemented, errorCode(err))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	stream, err := mgr.Stream(ctx, id)
+	if err != nil {
+		t.Fatalf("Stream failed: %v", err)
+	}
+
+	first := mustReceiveEvent(t, stream)
+	if first.Status != corepkg.TaskPending {
+		t.Fatalf("expected first status pending, got %s", first.Status)
+	}
+	if first.Offset != 0 {
+		t.Fatalf("expected first offset 0, got %d", first.Offset)
+	}
+
+	if err := mgr.Cancel(context.Background(), id, "cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	second := mustReceiveEvent(t, stream)
+	if second.Status != corepkg.TaskKilled {
+		t.Fatalf("expected second status killed, got %s", second.Status)
+	}
+	if second.Offset != 1 {
+		t.Fatalf("expected second offset 1, got %d", second.Offset)
+	}
+	mustCloseStream(t, stream)
+}
+
+func TestInMemoryTaskManagerStreamReplaysTerminalHistoryAndCloses(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "terminal-history"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	if err := mgr.Cancel(context.Background(), id, "cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	stream, err := mgr.Stream(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Stream failed: %v", err)
+	}
+
+	first := mustReceiveEvent(t, stream)
+	second := mustReceiveEvent(t, stream)
+	if first.Status != corepkg.TaskPending || second.Status != corepkg.TaskKilled {
+		t.Fatalf("expected replayed statuses pending->killed, got %s->%s", first.Status, second.Status)
+	}
+	mustCloseStream(t, stream)
+}
+
+func TestInMemoryTaskManagerReadIncrementSupportsOffsetWindowAndBounds(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "logs"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	if err := mgr.Cancel(context.Background(), id, "cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	items, next, hasMore, err := mgr.ReadIncrement(context.Background(), id, 0, 1)
+	if err != nil {
+		t.Fatalf("ReadIncrement failed: %v", err)
+	}
+	if len(items) != 1 || next != 1 || !hasMore {
+		t.Fatalf("expected len=1 next=1 hasMore=true, got len=%d next=%d hasMore=%v", len(items), next, hasMore)
+	}
+	if string(items[0].Payload) != "status=pending" {
+		t.Fatalf("expected first log payload %q, got %q", "status=pending", string(items[0].Payload))
+	}
+
+	items, next, hasMore, err = mgr.ReadIncrement(context.Background(), id, next, 10)
+	if err != nil {
+		t.Fatalf("ReadIncrement second page failed: %v", err)
+	}
+	if len(items) != 1 || next != 2 || hasMore {
+		t.Fatalf("expected len=1 next=2 hasMore=false, got len=%d next=%d hasMore=%v", len(items), next, hasMore)
+	}
+	if string(items[0].Payload) != "status=killed" {
+		t.Fatalf("expected second log payload %q, got %q", "status=killed", string(items[0].Payload))
+	}
+
+	items, next, hasMore, err = mgr.ReadIncrement(context.Background(), id, 0, 0)
+	if err != nil {
+		t.Fatalf("ReadIncrement default limit failed: %v", err)
+	}
+	if len(items) != 2 || next != 2 || hasMore {
+		t.Fatalf("expected len=2 next=2 hasMore=false, got len=%d next=%d hasMore=%v", len(items), next, hasMore)
+	}
+
+	items, next, hasMore, err = mgr.ReadIncrement(context.Background(), id, 100, 10)
+	if err != nil {
+		t.Fatalf("ReadIncrement large offset failed: %v", err)
+	}
+	if len(items) != 0 || next != 2 || hasMore {
+		t.Fatalf("expected len=0 next=2 hasMore=false, got len=%d next=%d hasMore=%v", len(items), next, hasMore)
+	}
+}
+
+func TestInMemoryTaskManagerReadIncrementUnknownTaskReturnsTaskNotFound(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+
+	_, _, _, err := mgr.ReadIncrement(context.Background(), "missing-task", 0, 10)
+	if err == nil {
+		t.Fatal("expected task not found error")
+	}
+	if !hasErrorCode(err, ErrorCodeTaskNotFound) {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeTaskNotFound, errorCode(err))
+	}
+}
+
+func TestInMemoryTaskManagerBridgesEventAndLogToStore(t *testing.T) {
+	store := &captureTaskEventStore{}
+	mgr := NewInMemoryTaskManager(WithTaskEventStore(store))
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "bridge"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	if err := mgr.Cancel(context.Background(), id, "cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.events) != 2 {
+		t.Fatalf("expected 2 bridged events, got %d", len(store.events))
+	}
+	if len(store.logs) != 2 {
+		t.Fatalf("expected 2 bridged logs, got %d", len(store.logs))
+	}
+	if store.events[0].Offset != 0 || store.events[1].Offset != 1 {
+		t.Fatalf("expected bridged event offsets [0,1], got [%d,%d]", store.events[0].Offset, store.events[1].Offset)
+	}
+}
+
+type captureTaskEventStore struct {
+	mu     sync.Mutex
+	events []TaskEvent
+	logs   []TaskLogEntry
+}
+
+func (s *captureTaskEventStore) AppendTaskEvent(_ context.Context, event TaskEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, cloneTaskEvent(event))
+	return nil
+}
+
+func (s *captureTaskEventStore) AppendTaskLog(_ context.Context, _ corepkg.TaskID, entry TaskLogEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logs = append(s.logs, cloneTaskLogEntry(entry))
+	return nil
+}
+
+func mustReceiveEvent(t *testing.T, stream <-chan TaskEvent) TaskEvent {
+	t.Helper()
+	select {
+	case event, ok := <-stream:
+		if !ok {
+			t.Fatal("expected event, stream is closed")
+		}
+		return event
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream event")
+		return TaskEvent{}
+	}
+}
+
+func mustCloseStream(t *testing.T, stream <-chan TaskEvent) {
+	t.Helper()
+	select {
+	case _, ok := <-stream:
+		if ok {
+			t.Fatal("expected stream to be closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream close")
 	}
 }

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -429,6 +430,211 @@ func TestInMemoryTaskManagerBridgesEventAndLogToStore(t *testing.T) {
 	}
 	if store.events[0].Offset != 0 || store.events[1].Offset != 1 {
 		t.Fatalf("expected bridged event offsets [0,1], got [%d,%d]", store.events[0].Offset, store.events[1].Offset)
+	}
+}
+
+func TestInMemoryTaskManagerSubmitRunsExecutorAndCompletes(t *testing.T) {
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(_ context.Context, task Task) ([]byte, error) {
+		if task.Status != corepkg.TaskRunning {
+			t.Fatalf("expected task status running in executor, got %s", task.Status)
+		}
+		return []byte("done"), nil
+	}))
+
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "execute"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := mgr.Wait(waitCtx, id)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if result.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected completed status, got %s", result.Status)
+	}
+	if string(result.Output) != "done" {
+		t.Fatalf("expected output %q, got %q", "done", string(result.Output))
+	}
+}
+
+func TestInMemoryTaskManagerTimeoutMapsToTaskTimeout(t *testing.T) {
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}))
+
+	id, err := mgr.Submit(context.Background(), TaskSpec{
+		Name:    "timeout",
+		Timeout: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := mgr.Wait(waitCtx, id)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if result.Status != corepkg.TaskFailed {
+		t.Fatalf("expected failed status, got %s", result.Status)
+	}
+	if result.ErrorCode != ErrorCodeTaskTimeout {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeTaskTimeout, result.ErrorCode)
+	}
+}
+
+func TestInMemoryTaskManagerCancelPropagatesToRunningTask(t *testing.T) {
+	started := make(chan struct{}, 1)
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}))
+
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "cancel"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("task did not start")
+	}
+
+	if err := mgr.Cancel(context.Background(), id, "test cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	task, err := mgr.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if task.Status != corepkg.TaskKilled {
+		t.Fatalf("expected killed status, got %s", task.Status)
+	}
+	if task.ErrorCode != ErrorCodeTaskCancelled {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeTaskCancelled, task.ErrorCode)
+	}
+}
+
+func TestInMemoryTaskManagerRetrySchedulesNewAttempt(t *testing.T) {
+	var runs atomic.Int32
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(_ context.Context, _ Task) ([]byte, error) {
+		if runs.Add(1) == 1 {
+			return nil, errors.New("first attempt failed")
+		}
+		return []byte("recovered"), nil
+	}))
+
+	id, err := mgr.Submit(context.Background(), TaskSpec{
+		Name:       "retry",
+		MaxRetries: 2,
+	})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	waitCtx1, cancel1 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel1()
+	first, err := mgr.Wait(waitCtx1, id)
+	if err != nil {
+		t.Fatalf("Wait first attempt failed: %v", err)
+	}
+	if first.Status != corepkg.TaskFailed {
+		t.Fatalf("expected first attempt failed, got %s", first.Status)
+	}
+	if first.ErrorCode != ErrorCodeTaskExecutionFailed {
+		t.Fatalf("expected first attempt error code %q, got %q", ErrorCodeTaskExecutionFailed, first.ErrorCode)
+	}
+
+	_, err = mgr.Retry(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Retry failed: %v", err)
+	}
+
+	waitCtx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	second, err := mgr.Wait(waitCtx2, id)
+	if err != nil {
+		t.Fatalf("Wait second attempt failed: %v", err)
+	}
+	if second.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected second attempt completed, got %s", second.Status)
+	}
+	if string(second.Output) != "recovered" {
+		t.Fatalf("expected output %q, got %q", "recovered", string(second.Output))
+	}
+}
+
+func TestInMemoryTaskManagerSubmitDetachesCallerContext(t *testing.T) {
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(30 * time.Millisecond):
+			return []byte("done"), nil
+		}
+	}))
+
+	submitCtx, cancel := context.WithCancel(context.Background())
+	id, err := mgr.Submit(submitCtx, TaskSpec{Name: "detached"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	cancel()
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer waitCancel()
+	result, err := mgr.Wait(waitCtx, id)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if result.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected completed status, got %s", result.Status)
+	}
+	if result.ErrorCode != "" {
+		t.Fatalf("expected empty error code, got %q", result.ErrorCode)
+	}
+}
+
+func TestInMemoryTaskManagerSubmitSnapshotsMutableTaskSpec(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	spec := TaskSpec{
+		Name:     "snapshot",
+		Input:    []byte("immutable"),
+		Metadata: map[string]string{"owner": "runtime"},
+	}
+
+	id, err := mgr.Submit(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	spec.Input[0] = 'X'
+	spec.Metadata["owner"] = "mutated"
+	spec.Metadata["extra"] = "value"
+
+	task, err := mgr.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(task.Spec.Input) != "immutable" {
+		t.Fatalf("expected task input snapshot %q, got %q", "immutable", string(task.Spec.Input))
+	}
+	if got := task.Spec.Metadata["owner"]; got != "runtime" {
+		t.Fatalf("expected metadata owner %q, got %q", "runtime", got)
+	}
+	if _, ok := task.Spec.Metadata["extra"]; ok {
+		t.Fatal("expected metadata not to include caller-side mutations")
 	}
 }
 

--- a/internal/storage/runtime_task_store.go
+++ b/internal/storage/runtime_task_store.go
@@ -1,0 +1,84 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"bytemind/internal/config"
+	corepkg "bytemind/internal/core"
+	runtimepkg "bytemind/internal/runtime"
+)
+
+type RuntimeTaskStore struct {
+	root string
+	mu   sync.Mutex
+}
+
+func NewDefaultRuntimeTaskStore() (*RuntimeTaskStore, error) {
+	home, err := config.ResolveHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	root := filepath.Join(home, "runtime", "tasks")
+	if err := os.MkdirAll(filepath.Join(root, "events"), 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Join(root, "logs"), 0o755); err != nil {
+		return nil, err
+	}
+	return &RuntimeTaskStore{root: root}, nil
+}
+
+func (s *RuntimeTaskStore) AppendTaskEvent(_ context.Context, event runtimepkg.TaskEvent) error {
+	if s == nil {
+		return nil
+	}
+	taskID := sanitizeTaskID(event.TaskID)
+	path := filepath.Join(s.root, "events", taskID+".jsonl")
+	return s.appendJSONL(path, event)
+}
+
+func (s *RuntimeTaskStore) AppendTaskLog(_ context.Context, taskID corepkg.TaskID, entry runtimepkg.TaskLogEntry) error {
+	if s == nil {
+		return nil
+	}
+	if entry.TaskID == "" {
+		entry.TaskID = taskID
+	}
+	path := filepath.Join(s.root, "logs", sanitizeTaskID(taskID)+".jsonl")
+	return s.appendJSONL(path, entry)
+}
+
+func (s *RuntimeTaskStore) appendJSONL(path string, value any) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(append(payload, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func sanitizeTaskID(taskID corepkg.TaskID) string {
+	value := string(taskID)
+	if value == "" {
+		return "unknown"
+	}
+	replacer := strings.NewReplacer("/", "_", "\\", "_", ":", "_")
+	return replacer.Replace(value)
+}


### PR DESCRIPTION
## 背景
推进 #204：补齐 runtime 的可回放事件流与 offset 增量日志读取能力，并打通最小 storage 桥接，供上层稳定消费。

> 说明：本 PR 依赖 #206（#201）先合并。若基线尚未包含 #206，GitHub 会显示前置差异；#206 合并后会自动收敛为 #204 的增量。

## 主要变更
1. 统一 TaskEvent 记录
- `InMemoryTaskManager` 新增任务事件内存账本，所有状态迁移统一记录 `TaskEvent`。
- `TaskEvent` 增加 `Offset` 字段，确保同一 Task 内事件顺序单调。

2. Stream 历史回放 + 实时订阅
- 实现 `Stream(ctx, taskID)`：
  - 先回放历史事件；
  - 再订阅实时事件；
  - 收到终态事件后自动关闭流。
- 终态任务调用 Stream 时，仅回放历史并自动关闭。

3. 增量日志读取
- 实现 `ReadIncrement(ctx, taskID, offset, limit)`。
- 支持默认 limit（<=0 使用安全默认值）、大偏移边界处理、`nextOffset` 与 `hasMore` 返回。

4. 最小 storage 桥接
- runtime 侧新增 `TaskEventStore` 抽象（port）：`AppendTaskEvent` / `AppendTaskLog`。
- storage 侧新增 `RuntimeTaskStore` 适配实现（adapter）：JSONL 落盘任务事件与日志。
- 在 `app/bootstrap` 注入 `RuntimeTaskStore`，失败时回退 `NopTaskEventStore`。

## 测试
新增并通过测试：
- Stream 历史回放 + 实时推送顺序验证。
- 终态任务 Stream 回放后自动关闭。
- ReadIncrement offset/limit/边界（含大偏移与默认 limit）。
- 事件/日志桥接到 store 的调用验证。

并执行：
- `go test ./internal/runtime -v`
- `go test ./internal/storage ./internal/app`

Closes #204