### PR TITLE
feat(runtime): 推进 #203 配额控制与同步子代理 MVP（runtime 侧）

### DIFF
--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	corepkg "bytemind/internal/core"
@@ -119,6 +120,7 @@ type InMemoryTaskManager struct {
 	runCancels     map[corepkg.TaskID]context.CancelFunc
 	parentChildren map[corepkg.TaskID]map[corepkg.TaskID]struct{}
 	childParent    map[corepkg.TaskID]corepkg.TaskID
+	idSeq          atomic.Uint64
 	executor       TaskExecutorFunc
 }
 
@@ -142,7 +144,7 @@ func (m *InMemoryTaskManager) Submit(ctx context.Context, spec TaskSpec) (corepk
 	if m == nil {
 		return "", ErrTaskNotImplemented
 	}
-	id := newTaskID(time.Now().UTC())
+	id := newTaskID(time.Now().UTC(), m.idSeq.Add(1))
 	now := time.Now().UTC()
 	task := Task{
 		ID:        id,
@@ -524,8 +526,8 @@ func (m *InMemoryTaskManager) removeWaiter(id corepkg.TaskID, waiter chan TaskRe
 	m.waiters[id] = filtered
 }
 
-func newTaskID(ts time.Time) corepkg.TaskID {
-	return corepkg.TaskID(ts.Format("20060102150405.000000000"))
+func newTaskID(ts time.Time, seq uint64) corepkg.TaskID {
+	return corepkg.TaskID(fmt.Sprintf("%s-%06d", ts.Format("20060102150405.000000000"), seq))
 }
 
 func taskToResult(task Task) TaskResult {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -113,18 +113,22 @@ func WithTaskExecutor(executor TaskExecutorFunc) InMemoryTaskManagerOption {
 
 // InMemoryTaskManager is a safe placeholder until runtime orchestration is wired.
 type InMemoryTaskManager struct {
-	mu         sync.RWMutex
-	tasks      map[corepkg.TaskID]Task
-	waiters    map[corepkg.TaskID][]chan TaskResult
-	runCancels map[corepkg.TaskID]context.CancelFunc
-	executor   TaskExecutorFunc
+	mu             sync.RWMutex
+	tasks          map[corepkg.TaskID]Task
+	waiters        map[corepkg.TaskID][]chan TaskResult
+	runCancels     map[corepkg.TaskID]context.CancelFunc
+	parentChildren map[corepkg.TaskID]map[corepkg.TaskID]struct{}
+	childParent    map[corepkg.TaskID]corepkg.TaskID
+	executor       TaskExecutorFunc
 }
 
 func NewInMemoryTaskManager(opts ...InMemoryTaskManagerOption) *InMemoryTaskManager {
 	manager := &InMemoryTaskManager{
-		tasks:      make(map[corepkg.TaskID]Task),
-		waiters:    make(map[corepkg.TaskID][]chan TaskResult),
-		runCancels: make(map[corepkg.TaskID]context.CancelFunc),
+		tasks:          make(map[corepkg.TaskID]Task),
+		waiters:        make(map[corepkg.TaskID][]chan TaskResult),
+		runCancels:     make(map[corepkg.TaskID]context.CancelFunc),
+		parentChildren: make(map[corepkg.TaskID]map[corepkg.TaskID]struct{}),
+		childParent:    make(map[corepkg.TaskID]corepkg.TaskID),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -149,6 +153,7 @@ func (m *InMemoryTaskManager) Submit(ctx context.Context, spec TaskSpec) (corepk
 	}
 	m.mu.Lock()
 	m.tasks[id] = task
+	m.registerParentChildLocked(id, task.Spec.ParentTaskID)
 	m.mu.Unlock()
 
 	m.enqueueTask(detachContext(ctx), id)
@@ -179,9 +184,10 @@ func (m *InMemoryTaskManager) Cancel(ctx context.Context, id corepkg.TaskID, _ s
 
 	now := time.Now().UTC()
 	var (
-		result  TaskResult
-		waiters []chan TaskResult
-		hasTask bool
+		result   TaskResult
+		waiters  []chan TaskResult
+		hasTask  bool
+		childIDs []corepkg.TaskID
 	)
 
 	m.mu.Lock()
@@ -190,11 +196,15 @@ func (m *InMemoryTaskManager) Cancel(ctx context.Context, id corepkg.TaskID, _ s
 		m.mu.Unlock()
 		return taskNotFoundError(id)
 	}
+	childIDs = m.snapshotChildIDsLocked(id)
 	if task.Status == corepkg.TaskRunning {
 		cancel := m.runCancels[id]
 		m.mu.Unlock()
 		if cancel != nil {
 			cancel()
+		}
+		if err := m.cancelChildTasks(ctx, childIDs, "parent_cancelled"); err != nil {
+			return err
 		}
 		_, waitErr := m.Wait(ctx, id)
 		if waitErr != nil {
@@ -204,6 +214,9 @@ func (m *InMemoryTaskManager) Cancel(ctx context.Context, id corepkg.TaskID, _ s
 	}
 	if task.Status == corepkg.TaskKilled {
 		m.mu.Unlock()
+		if err := m.cancelChildTasks(ctx, childIDs, "parent_cancelled"); err != nil {
+			return err
+		}
 		return nil
 	}
 	if err := ValidateTaskTransition(task.Status, corepkg.TaskKilled, TransitionOptions{}); err != nil {
@@ -216,11 +229,16 @@ func (m *InMemoryTaskManager) Cancel(ctx context.Context, id corepkg.TaskID, _ s
 	task.FinishedAt = &now
 	m.tasks[id] = task
 	delete(m.runCancels, id)
+	m.detachParentChildLinkLocked(id)
 	result = taskToResult(task)
 	waiters = m.waiters[id]
 	delete(m.waiters, id)
 	hasTask = true
 	m.mu.Unlock()
+
+	if err := m.cancelChildTasks(ctx, childIDs, "parent_cancelled"); err != nil {
+		return err
+	}
 
 	if hasTask {
 		for _, waiter := range waiters {
@@ -397,6 +415,7 @@ func (m *InMemoryTaskManager) runTaskAttempt(parentCtx context.Context, id corep
 	current.FinishedAt = &finished
 	m.tasks[id] = current
 	delete(m.runCancels, id)
+	m.detachParentChildLinkLocked(id)
 
 	result = taskToResult(current)
 	waiters = m.waiters[id]
@@ -426,6 +445,62 @@ func mapExecutionResult(execErr error) (corepkg.TaskStatus, string) {
 		return corepkg.TaskFailed, code
 	}
 	return corepkg.TaskFailed, ErrorCodeTaskExecutionFailed
+}
+
+func (m *InMemoryTaskManager) registerParentChildLocked(childID, parentID corepkg.TaskID) {
+	if parentID == "" {
+		return
+	}
+	if m.parentChildren[parentID] == nil {
+		m.parentChildren[parentID] = make(map[corepkg.TaskID]struct{})
+	}
+	m.parentChildren[parentID][childID] = struct{}{}
+	m.childParent[childID] = parentID
+}
+
+func (m *InMemoryTaskManager) detachParentChildLinkLocked(taskID corepkg.TaskID) {
+	parentID, hasParent := m.childParent[taskID]
+	if hasParent {
+		delete(m.childParent, taskID)
+		children := m.parentChildren[parentID]
+		delete(children, taskID)
+		if len(children) == 0 {
+			delete(m.parentChildren, parentID)
+		}
+	}
+	if children, ok := m.parentChildren[taskID]; ok {
+		delete(m.parentChildren, taskID)
+		for childID := range children {
+			delete(m.childParent, childID)
+		}
+	}
+}
+
+func (m *InMemoryTaskManager) snapshotChildIDsLocked(parentID corepkg.TaskID) []corepkg.TaskID {
+	children := m.parentChildren[parentID]
+	if len(children) == 0 {
+		return nil
+	}
+	ids := make([]corepkg.TaskID, 0, len(children))
+	for childID := range children {
+		ids = append(ids, childID)
+	}
+	return ids
+}
+
+func (m *InMemoryTaskManager) cancelChildTasks(ctx context.Context, childIDs []corepkg.TaskID, reason string) error {
+	for _, childID := range childIDs {
+		err := m.Cancel(ctx, childID, reason)
+		if err == nil {
+			continue
+		}
+		code := errorCode(err)
+		if code == ErrorCodeTaskNotFound || code == ErrorCodeInvalidTransition {
+			continue
+		}
+		return err
+	}
+	return nil
 }
 
 func (m *InMemoryTaskManager) removeWaiter(id corepkg.TaskID, waiter chan TaskResult) {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -58,6 +58,7 @@ const (
 
 type TaskEvent struct {
 	Type      TaskEventType
+	Offset    uint64
 	TaskID    corepkg.TaskID
 	SessionID corepkg.SessionID
 	TraceID   corepkg.TraceID
@@ -83,6 +84,7 @@ type Scheduler interface {
 }
 
 type TaskLogEntry struct {
+	TaskID    corepkg.TaskID
 	Offset    uint64
 	Payload   []byte
 	Timestamp time.Time
@@ -104,7 +106,34 @@ type QuotaManager interface {
 
 type TaskExecutorFunc func(ctx context.Context, task Task) ([]byte, error)
 
+type TaskEventStore interface {
+	AppendTaskEvent(ctx context.Context, event TaskEvent) error
+	AppendTaskLog(ctx context.Context, taskID corepkg.TaskID, entry TaskLogEntry) error
+}
+
+type NopTaskEventStore struct{}
+
+func (NopTaskEventStore) AppendTaskEvent(context.Context, TaskEvent) error {
+	return nil
+}
+
+func (NopTaskEventStore) AppendTaskLog(context.Context, corepkg.TaskID, TaskLogEntry) error {
+	return nil
+}
+
 type InMemoryTaskManagerOption func(*InMemoryTaskManager)
+
+func WithTaskEventStore(store TaskEventStore) InMemoryTaskManagerOption {
+	return func(m *InMemoryTaskManager) {
+		m.eventStore = store
+	}
+}
+
+func WithTerminalHistoryCap(limit int) InMemoryTaskManagerOption {
+	return func(m *InMemoryTaskManager) {
+		m.terminalHistoryCap = limit
+	}
+}
 
 func WithTaskExecutor(executor TaskExecutorFunc) InMemoryTaskManagerOption {
 	return func(m *InMemoryTaskManager) {
@@ -112,30 +141,53 @@ func WithTaskExecutor(executor TaskExecutorFunc) InMemoryTaskManagerOption {
 	}
 }
 
+const (
+	defaultReadIncrementLimit = 200
+	streamBufferSize          = 32
+	defaultTerminalHistoryCap = 256
+)
+
 // InMemoryTaskManager is a safe placeholder until runtime orchestration is wired.
 type InMemoryTaskManager struct {
-	mu             sync.RWMutex
-	tasks          map[corepkg.TaskID]Task
-	waiters        map[corepkg.TaskID][]chan TaskResult
-	runCancels     map[corepkg.TaskID]context.CancelFunc
-	parentChildren map[corepkg.TaskID]map[corepkg.TaskID]struct{}
-	childParent    map[corepkg.TaskID]corepkg.TaskID
-	idSeq          atomic.Uint64
-	executor       TaskExecutorFunc
+	mu                 sync.RWMutex
+	tasks              map[corepkg.TaskID]Task
+	waiters            map[corepkg.TaskID][]chan TaskResult
+	runCancels         map[corepkg.TaskID]context.CancelFunc
+	parentChildren     map[corepkg.TaskID]map[corepkg.TaskID]struct{}
+	childParent        map[corepkg.TaskID]corepkg.TaskID
+	idSeq              atomic.Uint64
+	events             map[corepkg.TaskID][]TaskEvent
+	logs               map[corepkg.TaskID][]TaskLogEntry
+	streamSubscribers  map[corepkg.TaskID]map[uint64]chan TaskEvent
+	nextSubscriberID   uint64
+	terminalHistory    []corepkg.TaskID
+	terminalTasks      map[corepkg.TaskID]struct{}
+	terminalHistoryCap int
+	executor           TaskExecutorFunc
+	eventStore         TaskEventStore
 }
 
 func NewInMemoryTaskManager(opts ...InMemoryTaskManagerOption) *InMemoryTaskManager {
 	manager := &InMemoryTaskManager{
-		tasks:          make(map[corepkg.TaskID]Task),
-		waiters:        make(map[corepkg.TaskID][]chan TaskResult),
-		runCancels:     make(map[corepkg.TaskID]context.CancelFunc),
-		parentChildren: make(map[corepkg.TaskID]map[corepkg.TaskID]struct{}),
-		childParent:    make(map[corepkg.TaskID]corepkg.TaskID),
+		tasks:              make(map[corepkg.TaskID]Task),
+		waiters:            make(map[corepkg.TaskID][]chan TaskResult),
+		runCancels:         make(map[corepkg.TaskID]context.CancelFunc),
+		parentChildren:     make(map[corepkg.TaskID]map[corepkg.TaskID]struct{}),
+		childParent:        make(map[corepkg.TaskID]corepkg.TaskID),
+		events:             make(map[corepkg.TaskID][]TaskEvent),
+		logs:               make(map[corepkg.TaskID][]TaskLogEntry),
+		streamSubscribers:  make(map[corepkg.TaskID]map[uint64]chan TaskEvent),
+		terminalTasks:      make(map[corepkg.TaskID]struct{}),
+		terminalHistoryCap: defaultTerminalHistoryCap,
+		eventStore:         NopTaskEventStore{},
 	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(manager)
 		}
+	}
+	if manager.eventStore == nil {
+		manager.eventStore = NopTaskEventStore{}
 	}
 	return manager
 }
@@ -153,13 +205,22 @@ func (m *InMemoryTaskManager) Submit(ctx context.Context, spec TaskSpec) (corepk
 		Attempt:   0,
 		CreatedAt: now,
 	}
+
+	var (
+		event       TaskEvent
+		logEntry    TaskLogEntry
+		subscribers []chan TaskEvent
+	)
 	m.mu.Lock()
 	m.tasks[id] = task
 	m.registerParentChildLocked(id, task.Spec.ParentTaskID)
+	event, subscribers = m.appendTaskEventLocked(task, TaskEventStatus, nil, task.ErrorCode, now)
+	logEntry = m.appendTaskLogLocked(task.ID, []byte(fmt.Sprintf("status=%s", task.Status)), now)
 	m.mu.Unlock()
-
+	m.publishTaskEvent(event, subscribers)
+	m.persistTaskEvent(event)
+	m.persistTaskLog(task.ID, logEntry)
 	m.enqueueTask(detachContext(ctx), id)
-
 	return id, nil
 }
 
@@ -186,10 +247,13 @@ func (m *InMemoryTaskManager) Cancel(ctx context.Context, id corepkg.TaskID, _ s
 
 	now := time.Now().UTC()
 	var (
-		result   TaskResult
-		waiters  []chan TaskResult
-		hasTask  bool
-		childIDs []corepkg.TaskID
+		result      TaskResult
+		waiters     []chan TaskResult
+		event       TaskEvent
+		logEntry    TaskLogEntry
+		subscribers []chan TaskEvent
+		hasTask     bool
+		childIDs    []corepkg.TaskID
 	)
 
 	m.mu.Lock()
@@ -232,12 +296,17 @@ func (m *InMemoryTaskManager) Cancel(ctx context.Context, id corepkg.TaskID, _ s
 	m.tasks[id] = task
 	delete(m.runCancels, id)
 	m.detachParentChildLinkLocked(id)
+	event, subscribers = m.appendTaskEventLocked(task, TaskEventStatus, nil, task.ErrorCode, now)
+	logEntry = m.appendTaskLogLocked(task.ID, []byte(fmt.Sprintf("status=%s", task.Status)), now)
 	result = taskToResult(task)
 	waiters = m.waiters[id]
 	delete(m.waiters, id)
 	hasTask = true
 	m.mu.Unlock()
 
+	m.publishTaskEvent(event, subscribers)
+	m.persistTaskEvent(event)
+	m.persistTaskLog(task.ID, logEntry)
 	if err := m.cancelChildTasks(ctx, childIDs, "parent_cancelled"); err != nil {
 		return err
 	}
@@ -262,6 +331,12 @@ func (m *InMemoryTaskManager) Retry(ctx context.Context, id corepkg.TaskID) (cor
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	var (
+		event       TaskEvent
+		logEntry    TaskLogEntry
+		subscribers []chan TaskEvent
+	)
 
 	m.mu.Lock()
 	task, ok := m.tasks[id]
@@ -288,15 +363,126 @@ func (m *InMemoryTaskManager) Retry(ctx context.Context, id corepkg.TaskID) (cor
 	task.StartedAt = nil
 	task.FinishedAt = nil
 	m.tasks[id] = task
+	event, subscribers = m.appendTaskEventLocked(task, TaskEventStatus, nil, task.ErrorCode, time.Now().UTC())
+	logEntry = m.appendTaskLogLocked(task.ID, []byte(fmt.Sprintf("status=%s", task.Status)), time.Now().UTC())
 	m.mu.Unlock()
 
+	m.publishTaskEvent(event, subscribers)
+	m.persistTaskEvent(event)
+	m.persistTaskLog(task.ID, logEntry)
 	m.enqueueTask(detachContext(ctx), id)
 
 	return id, nil
 }
 
-func (m *InMemoryTaskManager) Stream(_ context.Context, _ corepkg.TaskID) (<-chan TaskEvent, error) {
-	return nil, ErrTaskNotImplemented
+func (m *InMemoryTaskManager) Stream(ctx context.Context, id corepkg.TaskID) (<-chan TaskEvent, error) {
+	if m == nil {
+		return nil, ErrTaskNotImplemented
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	out := make(chan TaskEvent, streamBufferSize)
+	live := make(chan TaskEvent, streamBufferSize)
+
+	var (
+		history      []TaskEvent
+		subscriberID uint64
+		useLive      bool
+	)
+
+	m.mu.Lock()
+	task, ok := m.tasks[id]
+	if !ok {
+		m.mu.Unlock()
+		return nil, taskNotFoundError(id)
+	}
+	history = cloneTaskEvents(m.events[id])
+	if !IsTerminalTaskStatus(task.Status) {
+		m.nextSubscriberID++
+		subscriberID = m.nextSubscriberID
+		if m.streamSubscribers[id] == nil {
+			m.streamSubscribers[id] = make(map[uint64]chan TaskEvent)
+		}
+		m.streamSubscribers[id][subscriberID] = live
+		useLive = true
+	}
+	m.mu.Unlock()
+
+	go func() {
+		defer close(out)
+		defer func() {
+			if useLive {
+				m.removeStreamSubscriber(id, subscriberID)
+			}
+		}()
+
+		for _, event := range history {
+			select {
+			case out <- event:
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		if !useLive {
+			return
+		}
+
+		for {
+			select {
+			case event := <-live:
+				select {
+				case out <- event:
+				case <-ctx.Done():
+					return
+				}
+				if IsTerminalTaskStatus(event.Status) {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return out, nil
+}
+
+func (m *InMemoryTaskManager) ReadIncrement(_ context.Context, id corepkg.TaskID, offset uint64, limit int) (items []TaskLogEntry, nextOffset uint64, hasMore bool, err error) {
+	if m == nil {
+		return nil, 0, false, ErrTaskNotImplemented
+	}
+	if limit <= 0 {
+		limit = defaultReadIncrementLimit
+	}
+
+	m.mu.RLock()
+	_, ok := m.tasks[id]
+	if !ok {
+		m.mu.RUnlock()
+		return nil, 0, false, taskNotFoundError(id)
+	}
+	entries := m.logs[id]
+	total := uint64(len(entries))
+	start := offset
+	if start > total {
+		start = total
+	}
+	end := start + uint64(limit)
+	if end > total {
+		end = total
+	}
+	copied := make([]TaskLogEntry, 0, end-start)
+	for _, entry := range entries[start:end] {
+		copied = append(copied, cloneTaskLogEntry(entry))
+	}
+	m.mu.RUnlock()
+
+	nextOffset = end
+	hasMore = end < total
+	return copied, nextOffset, hasMore, nil
 }
 
 func (m *InMemoryTaskManager) Wait(ctx context.Context, id corepkg.TaskID) (TaskResult, error) {
@@ -332,6 +518,69 @@ func (m *InMemoryTaskManager) Wait(ctx context.Context, id corepkg.TaskID) (Task
 	}
 }
 
+func (m *InMemoryTaskManager) appendTaskEventLocked(task Task, eventType TaskEventType, payload []byte, errorCode string, at time.Time) (TaskEvent, []chan TaskEvent) {
+	event := TaskEvent{
+		Type:      eventType,
+		TaskID:    task.ID,
+		SessionID: task.Spec.SessionID,
+		TraceID:   task.Spec.TraceID,
+		Status:    task.Status,
+		Attempt:   task.Attempt,
+		Payload:   append([]byte(nil), payload...),
+		Metadata:  cloneTaskMetadata(task.Spec.Metadata),
+		ErrorCode: errorCode,
+		Timestamp: at.UTC(),
+	}
+	current := m.events[task.ID]
+	event.Offset = uint64(len(current))
+	m.events[task.ID] = append(current, event)
+	return cloneTaskEvent(event), m.snapshotStreamSubscribersLocked(task.ID)
+}
+
+func (m *InMemoryTaskManager) appendTaskLogLocked(taskID corepkg.TaskID, payload []byte, at time.Time) TaskLogEntry {
+	entry := TaskLogEntry{
+		TaskID:    taskID,
+		Payload:   append([]byte(nil), payload...),
+		Timestamp: at.UTC(),
+	}
+	current := m.logs[taskID]
+	entry.Offset = uint64(len(current))
+	m.logs[taskID] = append(current, entry)
+	return cloneTaskLogEntry(entry)
+}
+
+func (m *InMemoryTaskManager) snapshotStreamSubscribersLocked(taskID corepkg.TaskID) []chan TaskEvent {
+	subs := m.streamSubscribers[taskID]
+	if len(subs) == 0 {
+		return nil
+	}
+	copied := make([]chan TaskEvent, 0, len(subs))
+	for _, ch := range subs {
+		copied = append(copied, ch)
+	}
+	return copied
+}
+
+func (m *InMemoryTaskManager) publishTaskEvent(event TaskEvent, subscribers []chan TaskEvent) {
+	for _, subscriber := range subscribers {
+		subscriber <- cloneTaskEvent(event)
+	}
+}
+
+func (m *InMemoryTaskManager) persistTaskEvent(event TaskEvent) {
+	if m == nil || m.eventStore == nil {
+		return
+	}
+	_ = m.eventStore.AppendTaskEvent(context.Background(), cloneTaskEvent(event))
+}
+
+func (m *InMemoryTaskManager) persistTaskLog(taskID corepkg.TaskID, entry TaskLogEntry) {
+	if m == nil || m.eventStore == nil {
+		return
+	}
+	_ = m.eventStore.AppendTaskLog(context.Background(), taskID, cloneTaskLogEntry(entry))
+}
+
 func (m *InMemoryTaskManager) enqueueTask(parentCtx context.Context, id corepkg.TaskID) {
 	if m == nil || m.executor == nil {
 		return
@@ -351,6 +600,11 @@ func (m *InMemoryTaskManager) runTaskAttempt(parentCtx context.Context, id corep
 	}
 
 	now := time.Now().UTC()
+	var (
+		startEvent       TaskEvent
+		startLog         TaskLogEntry
+		startSubscribers []chan TaskEvent
+	)
 
 	m.mu.Lock()
 	task, ok := m.tasks[id]
@@ -370,11 +624,18 @@ func (m *InMemoryTaskManager) runTaskAttempt(parentCtx context.Context, id corep
 	task.ErrorCode = ""
 	task.StartedAt = &now
 	task.FinishedAt = nil
+	task.Output = nil
 	m.tasks[id] = task
+	startEvent, startSubscribers = m.appendTaskEventLocked(task, TaskEventStatus, nil, task.ErrorCode, now)
+	startLog = m.appendTaskLogLocked(task.ID, []byte(fmt.Sprintf("status=%s", task.Status)), now)
 
 	runCtx, runCancel := context.WithCancel(parentCtx)
 	m.runCancels[id] = runCancel
 	m.mu.Unlock()
+
+	m.publishTaskEvent(startEvent, startSubscribers)
+	m.persistTaskEvent(startEvent)
+	m.persistTaskLog(task.ID, startLog)
 
 	execCtx := runCtx
 	timeoutCancel := func() {}
@@ -389,8 +650,12 @@ func (m *InMemoryTaskManager) runTaskAttempt(parentCtx context.Context, id corep
 	finished := time.Now().UTC()
 
 	var (
-		result  TaskResult
-		waiters []chan TaskResult
+		result      TaskResult
+		waiters     []chan TaskResult
+		event       TaskEvent
+		logEntry    TaskLogEntry
+		subscribers []chan TaskEvent
+		hasTask     bool
 	)
 
 	m.mu.Lock()
@@ -418,18 +683,26 @@ func (m *InMemoryTaskManager) runTaskAttempt(parentCtx context.Context, id corep
 	m.tasks[id] = current
 	delete(m.runCancels, id)
 	m.detachParentChildLinkLocked(id)
-
+	event, subscribers = m.appendTaskEventLocked(current, TaskEventStatus, nil, current.ErrorCode, finished)
+	logEntry = m.appendTaskLogLocked(current.ID, []byte(fmt.Sprintf("status=%s", current.Status)), finished)
 	result = taskToResult(current)
 	waiters = m.waiters[id]
 	delete(m.waiters, id)
+	hasTask = true
 	m.mu.Unlock()
 
-	for _, waiter := range waiters {
-		select {
-		case waiter <- result:
-		default:
+	m.publishTaskEvent(event, subscribers)
+	m.persistTaskEvent(event)
+	m.persistTaskLog(current.ID, logEntry)
+
+	if hasTask {
+		for _, waiter := range waiters {
+			select {
+			case waiter <- result:
+			default:
+			}
+			close(waiter)
 		}
-		close(waiter)
 	}
 }
 
@@ -447,6 +720,21 @@ func mapExecutionResult(execErr error) (corepkg.TaskStatus, string) {
 		return corepkg.TaskFailed, code
 	}
 	return corepkg.TaskFailed, ErrorCodeTaskExecutionFailed
+}
+
+func (m *InMemoryTaskManager) removeStreamSubscriber(taskID corepkg.TaskID, subscriberID uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	subs := m.streamSubscribers[taskID]
+	if len(subs) == 0 {
+		return
+	}
+	delete(subs, subscriberID)
+	if len(subs) == 0 {
+		delete(m.streamSubscribers, taskID)
+		return
+	}
+	m.streamSubscribers[taskID] = subs
 }
 
 func (m *InMemoryTaskManager) registerParentChildLocked(childID, parentID corepkg.TaskID) {
@@ -559,7 +847,44 @@ func cloneTaskSpec(spec TaskSpec) TaskSpec {
 }
 
 func detachContext(ctx context.Context) context.Context {
-	// Keep execution lifecycle independent from request-scoped cancellation.
-	// Task timeout and explicit Cancel(...) remain the runtime controls.
 	return context.Background()
+}
+
+func cloneTaskEvents(events []TaskEvent) []TaskEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	copied := make([]TaskEvent, 0, len(events))
+	for _, event := range events {
+		copied = append(copied, cloneTaskEvent(event))
+	}
+	return copied
+}
+
+func cloneTaskEvent(event TaskEvent) TaskEvent {
+	cloned := event
+	if len(event.Payload) > 0 {
+		cloned.Payload = append([]byte(nil), event.Payload...)
+	}
+	cloned.Metadata = cloneTaskMetadata(event.Metadata)
+	return cloned
+}
+
+func cloneTaskMetadata(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		copied[k] = v
+	}
+	return copied
+}
+
+func cloneTaskLogEntry(entry TaskLogEntry) TaskLogEntry {
+	cloned := entry
+	if len(entry.Payload) > 0 {
+		cloned.Payload = append([]byte(nil), entry.Payload...)
+	}
+	return cloned
 }

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -502,3 +502,17 @@ func TestInMemoryTaskManagerSubmitSnapshotsMutableTaskSpec(t *testing.T) {
 		t.Fatal("expected metadata not to include caller-side mutations")
 	}
 }
+
+func TestNewTaskIDWithSameTimestampUsesSequenceSuffix(t *testing.T) {
+	ts := time.Date(2026, time.January, 1, 10, 11, 12, 123456789, time.UTC)
+
+	id1 := newTaskID(ts, 1)
+	id2 := newTaskID(ts, 2)
+
+	if id1 == "" || id2 == "" {
+		t.Fatal("expected non-empty task ids")
+	}
+	if id1 == id2 {
+		t.Fatalf("expected unique task ids for different sequence, got %q", id1)
+	}
+}

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -287,14 +288,148 @@ func TestInMemoryTaskManagerWaitWithNilContextUsesBackground(t *testing.T) {
 	}
 }
 
-func TestInMemoryTaskManagerStreamReturnsNotImplemented(t *testing.T) {
+func TestInMemoryTaskManagerStreamReplaysHistoryAndLiveUpdates(t *testing.T) {
 	mgr := NewInMemoryTaskManager()
-	_, err := mgr.Stream(context.Background(), "task-id")
-	if err == nil {
-		t.Fatal("expected stream to return not implemented")
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "stream"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
 	}
-	if !hasErrorCode(err, ErrorCodeNotImplemented) {
-		t.Fatalf("expected error code %q, got %q", ErrorCodeNotImplemented, errorCode(err))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	stream, err := mgr.Stream(ctx, id)
+	if err != nil {
+		t.Fatalf("Stream failed: %v", err)
+	}
+
+	first := mustReceiveEvent(t, stream)
+	if first.Status != corepkg.TaskPending {
+		t.Fatalf("expected first status pending, got %s", first.Status)
+	}
+	if first.Offset != 0 {
+		t.Fatalf("expected first offset 0, got %d", first.Offset)
+	}
+
+	if err := mgr.Cancel(context.Background(), id, "cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	second := mustReceiveEvent(t, stream)
+	if second.Status != corepkg.TaskKilled {
+		t.Fatalf("expected second status killed, got %s", second.Status)
+	}
+	if second.Offset != 1 {
+		t.Fatalf("expected second offset 1, got %d", second.Offset)
+	}
+	mustCloseStream(t, stream)
+}
+
+func TestInMemoryTaskManagerStreamReplaysTerminalHistoryAndCloses(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "terminal-history"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	if err := mgr.Cancel(context.Background(), id, "cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	stream, err := mgr.Stream(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Stream failed: %v", err)
+	}
+
+	first := mustReceiveEvent(t, stream)
+	second := mustReceiveEvent(t, stream)
+	if first.Status != corepkg.TaskPending || second.Status != corepkg.TaskKilled {
+		t.Fatalf("expected replayed statuses pending->killed, got %s->%s", first.Status, second.Status)
+	}
+	mustCloseStream(t, stream)
+}
+
+func TestInMemoryTaskManagerReadIncrementSupportsOffsetWindowAndBounds(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "logs"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	if err := mgr.Cancel(context.Background(), id, "cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	items, next, hasMore, err := mgr.ReadIncrement(context.Background(), id, 0, 1)
+	if err != nil {
+		t.Fatalf("ReadIncrement failed: %v", err)
+	}
+	if len(items) != 1 || next != 1 || !hasMore {
+		t.Fatalf("expected len=1 next=1 hasMore=true, got len=%d next=%d hasMore=%v", len(items), next, hasMore)
+	}
+	if string(items[0].Payload) != "status=pending" {
+		t.Fatalf("expected first log payload %q, got %q", "status=pending", string(items[0].Payload))
+	}
+
+	items, next, hasMore, err = mgr.ReadIncrement(context.Background(), id, next, 10)
+	if err != nil {
+		t.Fatalf("ReadIncrement second page failed: %v", err)
+	}
+	if len(items) != 1 || next != 2 || hasMore {
+		t.Fatalf("expected len=1 next=2 hasMore=false, got len=%d next=%d hasMore=%v", len(items), next, hasMore)
+	}
+	if string(items[0].Payload) != "status=killed" {
+		t.Fatalf("expected second log payload %q, got %q", "status=killed", string(items[0].Payload))
+	}
+
+	items, next, hasMore, err = mgr.ReadIncrement(context.Background(), id, 0, 0)
+	if err != nil {
+		t.Fatalf("ReadIncrement default limit failed: %v", err)
+	}
+	if len(items) != 2 || next != 2 || hasMore {
+		t.Fatalf("expected len=2 next=2 hasMore=false, got len=%d next=%d hasMore=%v", len(items), next, hasMore)
+	}
+
+	items, next, hasMore, err = mgr.ReadIncrement(context.Background(), id, 100, 10)
+	if err != nil {
+		t.Fatalf("ReadIncrement large offset failed: %v", err)
+	}
+	if len(items) != 0 || next != 2 || hasMore {
+		t.Fatalf("expected len=0 next=2 hasMore=false, got len=%d next=%d hasMore=%v", len(items), next, hasMore)
+	}
+}
+
+func TestInMemoryTaskManagerReadIncrementUnknownTaskReturnsTaskNotFound(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+
+	_, _, _, err := mgr.ReadIncrement(context.Background(), "missing-task", 0, 10)
+	if err == nil {
+		t.Fatal("expected task not found error")
+	}
+	if !hasErrorCode(err, ErrorCodeTaskNotFound) {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeTaskNotFound, errorCode(err))
+	}
+}
+
+func TestInMemoryTaskManagerBridgesEventAndLogToStore(t *testing.T) {
+	store := &captureTaskEventStore{}
+	mgr := NewInMemoryTaskManager(WithTaskEventStore(store))
+	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "bridge"})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+	if err := mgr.Cancel(context.Background(), id, "cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.events) != 2 {
+		t.Fatalf("expected 2 bridged events, got %d", len(store.events))
+	}
+	if len(store.logs) != 2 {
+		t.Fatalf("expected 2 bridged logs, got %d", len(store.logs))
+	}
+	if store.events[0].Offset != 0 || store.events[1].Offset != 1 {
+		t.Fatalf("expected bridged event offsets [0,1], got [%d,%d]", store.events[0].Offset, store.events[1].Offset)
 	}
 }
 
@@ -514,5 +649,51 @@ func TestNewTaskIDWithSameTimestampUsesSequenceSuffix(t *testing.T) {
 	}
 	if id1 == id2 {
 		t.Fatalf("expected unique task ids for different sequence, got %q", id1)
+	}
+}
+
+type captureTaskEventStore struct {
+	mu     sync.Mutex
+	events []TaskEvent
+	logs   []TaskLogEntry
+}
+
+func (s *captureTaskEventStore) AppendTaskEvent(_ context.Context, event TaskEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, cloneTaskEvent(event))
+	return nil
+}
+
+func (s *captureTaskEventStore) AppendTaskLog(_ context.Context, _ corepkg.TaskID, entry TaskLogEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logs = append(s.logs, cloneTaskLogEntry(entry))
+	return nil
+}
+
+func mustReceiveEvent(t *testing.T, stream <-chan TaskEvent) TaskEvent {
+	t.Helper()
+	select {
+	case event, ok := <-stream:
+		if !ok {
+			t.Fatal("expected event, stream is closed")
+		}
+		return event
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream event")
+		return TaskEvent{}
+	}
+}
+
+func mustCloseStream(t *testing.T, stream <-chan TaskEvent) {
+	t.Helper()
+	select {
+	case _, ok := <-stream:
+		if ok {
+			t.Fatal("expected stream to be closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream close")
 	}
 }

--- a/internal/runtime/quota.go
+++ b/internal/runtime/quota.go
@@ -1,0 +1,87 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type InMemoryQuotaManager struct {
+	mu           sync.Mutex
+	defaultLimit int
+	limits       map[string]int
+	inUse        map[string]int
+}
+
+func NewInMemoryQuotaManager(defaultLimit int, perKeyLimits map[string]int) *InMemoryQuotaManager {
+	if defaultLimit <= 0 {
+		defaultLimit = 1
+	}
+	limits := make(map[string]int, len(perKeyLimits))
+	for key, value := range perKeyLimits {
+		limits[key] = value
+	}
+	return &InMemoryQuotaManager{
+		defaultLimit: defaultLimit,
+		limits:       limits,
+		inUse:        make(map[string]int),
+	}
+}
+
+func (q *InMemoryQuotaManager) Acquire(ctx context.Context, key string) error {
+	if q == nil {
+		return nil
+	}
+	if key == "" {
+		key = "global"
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	limit := q.limitForKeyLocked(key)
+	if q.inUse[key] >= limit {
+		return newRuntimeError(
+			ErrorCodeQuotaExceeded,
+			fmt.Sprintf("quota exceeded for key %q", key),
+			true,
+			nil,
+		)
+	}
+	q.inUse[key]++
+	return nil
+}
+
+func (q *InMemoryQuotaManager) Release(key string) {
+	if q == nil {
+		return
+	}
+	if key == "" {
+		key = "global"
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	current := q.inUse[key]
+	if current <= 1 {
+		delete(q.inUse, key)
+		return
+	}
+	q.inUse[key] = current - 1
+}
+
+func (q *InMemoryQuotaManager) limitForKeyLocked(key string) int {
+	limit := q.defaultLimit
+	if configured, ok := q.limits[key]; ok && configured > 0 {
+		limit = configured
+	}
+	if limit <= 0 {
+		limit = 1
+	}
+	return limit
+}

--- a/internal/runtime/quota.go
+++ b/internal/runtime/quota.go
@@ -32,6 +32,9 @@ func (q *InMemoryQuotaManager) Acquire(ctx context.Context, key string) error {
 	if q == nil {
 		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if key == "" {
 		key = "global"
 	}

--- a/internal/runtime/quota_test.go
+++ b/internal/runtime/quota_test.go
@@ -1,0 +1,10 @@
+package runtime
+
+import "testing"
+
+func TestInMemoryQuotaManagerAcquireWithNilContextUsesBackground(t *testing.T) {
+	quota := NewInMemoryQuotaManager(1, nil)
+	if err := quota.Acquire(nil, "shared"); err != nil {
+		t.Fatalf("Acquire with nil context failed: %v", err)
+	}
+}

--- a/internal/runtime/subagent.go
+++ b/internal/runtime/subagent.go
@@ -60,7 +60,9 @@ func (c *InMemorySubAgentCoordinator) Wait(ctx context.Context, id corepkg.TaskI
 		return TaskResult{}, ErrTaskNotImplemented
 	}
 	result, err := c.taskManager.Wait(ctx, id)
-	c.releaseQuota(id)
+	if err == nil && IsTerminalTaskStatus(result.Status) {
+		c.releaseQuota(id)
+	}
 	return result, err
 }
 

--- a/internal/runtime/subagent.go
+++ b/internal/runtime/subagent.go
@@ -1,0 +1,95 @@
+package runtime
+
+import (
+	"context"
+	"sync"
+
+	corepkg "bytemind/internal/core"
+)
+
+type InMemorySubAgentCoordinator struct {
+	taskManager  TaskManager
+	quotaManager QuotaManager
+
+	mu        sync.Mutex
+	quotaKeys map[corepkg.TaskID]string
+}
+
+func NewInMemorySubAgentCoordinator(taskManager TaskManager, quotaManager QuotaManager) *InMemorySubAgentCoordinator {
+	return &InMemorySubAgentCoordinator{
+		taskManager:  taskManager,
+		quotaManager: quotaManager,
+		quotaKeys:    make(map[corepkg.TaskID]string),
+	}
+}
+
+func (c *InMemorySubAgentCoordinator) Spawn(ctx context.Context, spec TaskSpec) (corepkg.TaskID, error) {
+	if c == nil || c.taskManager == nil {
+		return "", ErrTaskNotImplemented
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	quotaKey := deriveQuotaKey(spec)
+	if c.quotaManager != nil {
+		if err := c.quotaManager.Acquire(ctx, quotaKey); err != nil {
+			return "", err
+		}
+	}
+
+	taskID, err := c.taskManager.Submit(ctx, spec)
+	if err != nil {
+		if c.quotaManager != nil {
+			c.quotaManager.Release(quotaKey)
+		}
+		return "", err
+	}
+
+	if c.quotaManager != nil {
+		c.mu.Lock()
+		c.quotaKeys[taskID] = quotaKey
+		c.mu.Unlock()
+	}
+
+	return taskID, nil
+}
+
+func (c *InMemorySubAgentCoordinator) Wait(ctx context.Context, id corepkg.TaskID) (TaskResult, error) {
+	if c == nil || c.taskManager == nil {
+		return TaskResult{}, ErrTaskNotImplemented
+	}
+	result, err := c.taskManager.Wait(ctx, id)
+	c.releaseQuota(id)
+	return result, err
+}
+
+func (c *InMemorySubAgentCoordinator) releaseQuota(id corepkg.TaskID) {
+	if c == nil || c.quotaManager == nil {
+		return
+	}
+	c.mu.Lock()
+	quotaKey, ok := c.quotaKeys[id]
+	if ok {
+		delete(c.quotaKeys, id)
+	}
+	c.mu.Unlock()
+	if ok {
+		c.quotaManager.Release(quotaKey)
+	}
+}
+
+func deriveQuotaKey(spec TaskSpec) string {
+	if spec.Metadata != nil {
+		if key := spec.Metadata["quota_key"]; key != "" {
+			return key
+		}
+	}
+	if spec.SessionID != "" {
+		return "session:" + string(spec.SessionID)
+	}
+	if spec.Kind != "" {
+		return "kind:" + spec.Kind
+	}
+	return "global"
+}

--- a/internal/runtime/subagent_test.go
+++ b/internal/runtime/subagent_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -142,6 +143,71 @@ func TestInMemoryTaskManagerParentCancelPropagatesToChild(t *testing.T) {
 	}
 	if childResult.ErrorCode != ErrorCodeTaskCancelled {
 		t.Fatalf("expected child cancel error code %q, got %q", ErrorCodeTaskCancelled, childResult.ErrorCode)
+	}
+}
+
+func TestInMemorySubAgentCoordinatorWaitContextTimeoutDoesNotPrematurelyReleaseQuota(t *testing.T) {
+	blocker := make(chan struct{})
+	manager := NewInMemoryTaskManager(
+		WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+			select {
+			case <-blocker:
+				return []byte("done"), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}),
+	)
+	quota := NewInMemoryQuotaManager(1, map[string]int{"shared": 1})
+	coordinator := NewInMemorySubAgentCoordinator(manager, quota)
+
+	firstID, err := coordinator.Spawn(context.Background(), TaskSpec{
+		Name: "first",
+		Metadata: map[string]string{
+			"quota_key": "shared",
+		},
+	})
+	if err != nil {
+		t.Fatalf("first Spawn failed: %v", err)
+	}
+	waitUntilTaskStatus(t, manager, firstID, corepkg.TaskRunning, 2*time.Second)
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = coordinator.Wait(waitCtx, firstID)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected wait timeout, got %v", err)
+	}
+
+	_, err = coordinator.Spawn(context.Background(), TaskSpec{
+		Name: "second",
+		Metadata: map[string]string{
+			"quota_key": "shared",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected quota exceeded while first task is still running")
+	}
+	if !hasErrorCode(err, ErrorCodeQuotaExceeded) {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeQuotaExceeded, errorCode(err))
+	}
+
+	close(blocker)
+	if _, err := coordinator.Wait(context.Background(), firstID); err != nil {
+		t.Fatalf("Wait first task after release failed: %v", err)
+	}
+
+	thirdID, err := coordinator.Spawn(context.Background(), TaskSpec{
+		Name: "third",
+		Metadata: map[string]string{
+			"quota_key": "shared",
+		},
+	})
+	if err != nil {
+		t.Fatalf("third Spawn failed after first task completion: %v", err)
+	}
+	if _, err := coordinator.Wait(context.Background(), thirdID); err != nil {
+		t.Fatalf("Wait third task failed: %v", err)
 	}
 }
 

--- a/internal/runtime/subagent_test.go
+++ b/internal/runtime/subagent_test.go
@@ -1,0 +1,164 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corepkg "bytemind/internal/core"
+)
+
+func TestInMemorySubAgentCoordinatorSpawnAndWaitSync(t *testing.T) {
+	manager := NewInMemoryTaskManager(
+		WithTaskExecutor(func(_ context.Context, task Task) ([]byte, error) {
+			return []byte("child:" + task.Spec.Name), nil
+		}),
+	)
+	quota := NewInMemoryQuotaManager(1, nil)
+	coordinator := NewInMemorySubAgentCoordinator(manager, quota)
+
+	taskID, err := coordinator.Spawn(context.Background(), TaskSpec{
+		SessionID: "sess-1",
+		Name:      "demo-child",
+		Metadata: map[string]string{
+			"quota_key": "subagent",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Spawn failed: %v", err)
+	}
+
+	result, err := coordinator.Wait(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if result.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected completed status, got %s", result.Status)
+	}
+	if string(result.Output) != "child:demo-child" {
+		t.Fatalf("expected output %q, got %q", "child:demo-child", string(result.Output))
+	}
+}
+
+func TestInMemorySubAgentCoordinatorQuotaExceededDoesNotSubmitTask(t *testing.T) {
+	blocker := make(chan struct{})
+	manager := NewInMemoryTaskManager(
+		WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+			select {
+			case <-blocker:
+				return []byte("released"), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}),
+	)
+	quota := NewInMemoryQuotaManager(1, map[string]int{"shared": 1})
+	coordinator := NewInMemorySubAgentCoordinator(manager, quota)
+
+	firstID, err := coordinator.Spawn(context.Background(), TaskSpec{
+		Name: "first",
+		Metadata: map[string]string{
+			"quota_key": "shared",
+		},
+	})
+	if err != nil {
+		t.Fatalf("first Spawn failed: %v", err)
+	}
+
+	// Ensure the first task has started and holds quota.
+	waitUntilTaskStatus(t, manager, firstID, corepkg.TaskRunning, 2*time.Second)
+
+	_, err = coordinator.Spawn(context.Background(), TaskSpec{
+		Name: "second",
+		Metadata: map[string]string{
+			"quota_key": "shared",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected quota exceeded error for second spawn")
+	}
+	if !hasErrorCode(err, ErrorCodeQuotaExceeded) {
+		t.Fatalf("expected error code %q, got %q", ErrorCodeQuotaExceeded, errorCode(err))
+	}
+
+	manager.mu.RLock()
+	taskCount := len(manager.tasks)
+	manager.mu.RUnlock()
+	if taskCount != 1 {
+		t.Fatalf("expected only one submitted task, got %d", taskCount)
+	}
+
+	close(blocker)
+	_, err = coordinator.Wait(context.Background(), firstID)
+	if err != nil {
+		t.Fatalf("Wait first task failed: %v", err)
+	}
+}
+
+func TestInMemoryTaskManagerParentCancelPropagatesToChild(t *testing.T) {
+	manager := NewInMemoryTaskManager(
+		WithTaskExecutor(func(ctx context.Context, task Task) ([]byte, error) {
+			_ = task
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}),
+	)
+
+	parentID, err := manager.Submit(context.Background(), TaskSpec{
+		Name: "parent",
+	})
+	if err != nil {
+		t.Fatalf("Submit parent failed: %v", err)
+	}
+	childID, err := manager.Submit(context.Background(), TaskSpec{
+		Name:         "child",
+		ParentTaskID: parentID,
+	})
+	if err != nil {
+		t.Fatalf("Submit child failed: %v", err)
+	}
+
+	waitUntilTaskStatus(t, manager, parentID, corepkg.TaskRunning, 2*time.Second)
+	waitUntilTaskStatus(t, manager, childID, corepkg.TaskRunning, 2*time.Second)
+
+	if err := manager.Cancel(context.Background(), parentID, "cancel parent"); err != nil {
+		t.Fatalf("Cancel parent failed: %v", err)
+	}
+
+	parentResult, err := manager.Wait(context.Background(), parentID)
+	if err != nil {
+		t.Fatalf("Wait parent failed: %v", err)
+	}
+	childResult, err := manager.Wait(context.Background(), childID)
+	if err != nil {
+		t.Fatalf("Wait child failed: %v", err)
+	}
+
+	if parentResult.Status != corepkg.TaskKilled {
+		t.Fatalf("expected parent killed, got %s", parentResult.Status)
+	}
+	if childResult.Status != corepkg.TaskKilled {
+		t.Fatalf("expected child killed, got %s", childResult.Status)
+	}
+	if childResult.ErrorCode != ErrorCodeTaskCancelled {
+		t.Fatalf("expected child cancel error code %q, got %q", ErrorCodeTaskCancelled, childResult.ErrorCode)
+	}
+}
+
+func waitUntilTaskStatus(t *testing.T, manager *InMemoryTaskManager, id corepkg.TaskID, expected corepkg.TaskStatus, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		task, err := manager.Get(context.Background(), id)
+		if err != nil {
+			t.Fatalf("Get task %q failed: %v", id, err)
+		}
+		if task.Status == expected {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task %q did not reach status %s (current=%s)", id, expected, task.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## 背景
推进 #203：在 runtime 侧落地同步子代理 `Spawn + Wait` 与基础配额控制，并补齐父任务取消向子任务传播。

> 说明：本 PR 依赖 #208（#202）先合并；#208 依赖 #206（#201）。当前基线未包含前置 PR 时，GitHub 会显示前置差异，前置合并后会自动收敛为 #203 增量。

## 主要变更
1. 子代理协调器（同步 MVP）
- 新增 `InMemorySubAgentCoordinator`：
  - `Spawn(ctx, spec)`：创建子任务。
  - `Wait(ctx, taskID)`：同步等待子任务终态并返回结果。

2. 基础配额控制
- 新增 `InMemoryQuotaManager`（按 key 的 `Acquire/Release`）。
- `Spawn` 时先 `Acquire`，超限立即返回 `quota_exceeded`，不提交任务（因此不会进入 running）。
- `Wait` 结束后自动 `Release`。

3. 父子任务关系与取消传播
- `InMemoryTaskManager` 新增父子任务索引（`parentChildren` / `childParent`）。
- 子任务通过 `TaskSpec.ParentTaskID` 建立链路。
- 取消父任务时，自动级联取消子任务；父子任务均收敛到终态。

## 测试
新增并通过：
- `TestInMemorySubAgentCoordinatorSpawnAndWaitSync`：同步 Spawn+Wait 闭环。
- `TestInMemorySubAgentCoordinatorQuotaExceededDoesNotSubmitTask`：并发争用下超配额返回且不会提交第二个任务。
- `TestInMemoryTaskManagerParentCancelPropagatesToChild`：父取消向子传播，父子任务终态一致。

并执行：
- `go test ./internal/runtime -v`
- `go test ./internal/agent ./internal/tools ./internal/app`
- `go test ./internal/storage`

Closes #203