### PR TITLE
Provider丨Step 3将工厂升级为 Registry 装配入口

### DIFF
--- a/internal/config/provider_runtime.go
+++ b/internal/config/provider_runtime.go
@@ -9,7 +9,7 @@ type ProviderRuntimeConfig struct {
 }
 
 func LegacyProviderRuntimeConfig(cfg ProviderConfig) ProviderRuntimeConfig {
-	providerID := strings.TrimSpace(cfg.Type)
+	providerID := strings.ToLower(strings.TrimSpace(cfg.Type))
 	switch providerID {
 	case "", "openai", "openai-compatible":
 		providerID = "openai"

--- a/internal/config/provider_runtime.go
+++ b/internal/config/provider_runtime.go
@@ -1,0 +1,24 @@
+package config
+
+type ProviderRuntimeConfig struct {
+	DefaultProvider string                    `json:"default_provider"`
+	DefaultModel    string                    `json:"default_model"`
+	Providers       map[string]ProviderConfig `json:"providers"`
+}
+
+func LegacyProviderRuntimeConfig(cfg ProviderConfig) ProviderRuntimeConfig {
+	providerID := cfg.Type
+	if providerID == "openai-compatible" || providerID == "openai" || providerID == "" {
+		providerID = "openai"
+	}
+	if providerID == "anthropic" {
+		providerID = "anthropic"
+	}
+	return ProviderRuntimeConfig{
+		DefaultProvider: providerID,
+		DefaultModel:    cfg.Model,
+		Providers: map[string]ProviderConfig{
+			providerID: cfg,
+		},
+	}
+}

--- a/internal/config/provider_runtime.go
+++ b/internal/config/provider_runtime.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 type ProviderRuntimeConfig struct {
 	DefaultProvider string                    `json:"default_provider"`
 	DefaultModel    string                    `json:"default_model"`
@@ -7,11 +9,11 @@ type ProviderRuntimeConfig struct {
 }
 
 func LegacyProviderRuntimeConfig(cfg ProviderConfig) ProviderRuntimeConfig {
-	providerID := cfg.Type
-	if providerID == "openai-compatible" || providerID == "openai" || providerID == "" {
+	providerID := strings.TrimSpace(cfg.Type)
+	switch providerID {
+	case "", "openai", "openai-compatible":
 		providerID = "openai"
-	}
-	if providerID == "anthropic" {
+	case "anthropic":
 		providerID = "anthropic"
 	}
 	return ProviderRuntimeConfig{

--- a/internal/config/provider_runtime_test.go
+++ b/internal/config/provider_runtime_test.go
@@ -11,7 +11,9 @@ func TestLegacyProviderRuntimeConfigNormalizesProviderIDs(t *testing.T) {
 		{name: "openai compatible", typeValue: "openai-compatible", want: "openai"},
 		{name: "openai alias", typeValue: "openai", want: "openai"},
 		{name: "empty defaults openai", typeValue: "", want: "openai"},
-		{name: "whitespace defaults openai", typeValue: "   ", want: "openai"},
+		{name: "openai uppercase", typeValue: "OPENAI", want: "openai"},
+		{name: "openai compatible padded", typeValue: " OpenAI-Compatible ", want: "openai"},
+		{name: "anthropic uppercase", typeValue: "ANTHROPIC", want: "anthropic"},
 		{name: "anthropic", typeValue: "anthropic", want: "anthropic"},
 	}
 	for _, tt := range tests {

--- a/internal/config/provider_runtime_test.go
+++ b/internal/config/provider_runtime_test.go
@@ -1,0 +1,32 @@
+package config
+
+import "testing"
+
+func TestLegacyProviderRuntimeConfigNormalizesProviderIDs(t *testing.T) {
+	tests := []struct {
+		name      string
+		typeValue string
+		want      string
+	}{
+		{name: "openai compatible", typeValue: "openai-compatible", want: "openai"},
+		{name: "openai alias", typeValue: "openai", want: "openai"},
+		{name: "empty defaults openai", typeValue: "", want: "openai"},
+		{name: "whitespace defaults openai", typeValue: "   ", want: "openai"},
+		{name: "anthropic", typeValue: "anthropic", want: "anthropic"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ProviderConfig{Type: tt.typeValue, Model: "test-model"}
+			runtime := LegacyProviderRuntimeConfig(cfg)
+			if runtime.DefaultProvider != tt.want {
+				t.Fatalf("unexpected default provider %q", runtime.DefaultProvider)
+			}
+			if runtime.DefaultModel != "test-model" {
+				t.Fatalf("unexpected default model %q", runtime.DefaultModel)
+			}
+			if len(runtime.Providers) != 1 || runtime.Providers[tt.want].Type != tt.typeValue {
+				t.Fatalf("unexpected providers %#v", runtime.Providers)
+			}
+		})
+	}
+}

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"context"
+	"strings"
+
+	"bytemind/internal/llm"
+)
+
+type clientAdapter struct {
+	providerID   ProviderID
+	defaultModel ModelID
+	client       llm.Client
+}
+
+func WrapClient(providerID ProviderID, defaultModel ModelID, client llm.Client) Client {
+	if client == nil {
+		return nil
+	}
+	id := ProviderID(strings.TrimSpace(string(providerID)))
+	if id == "" {
+		id = ProviderID("unknown")
+	}
+	return &clientAdapter{
+		providerID:   id,
+		defaultModel: ModelID(strings.TrimSpace(string(defaultModel))),
+		client:       client,
+	}
+}
+
+func (a *clientAdapter) ProviderID() ProviderID {
+	return a.providerID
+}
+
+func (a *clientAdapter) ListModels(context.Context) ([]ModelInfo, error) {
+	if a.defaultModel == "" {
+		return nil, nil
+	}
+	return []ModelInfo{{
+		ProviderID: a.providerID,
+		ModelID:    a.defaultModel,
+	}}, nil
+}
+
+func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, error) {
+	stream := make(chan Event, 4)
+	go func() {
+		defer close(stream)
+		modelID := ModelID(strings.TrimSpace(req.Model))
+		if modelID == "" {
+			modelID = a.defaultModel
+		}
+		stream <- Event{
+			Type:       EventStart,
+			TraceID:    req.TraceID,
+			ProviderID: a.providerID,
+			ModelID:    modelID,
+		}
+		message, err := a.client.StreamMessage(ctx, req.ChatRequest, func(delta string) {
+			if strings.TrimSpace(delta) == "" {
+				return
+			}
+			stream <- Event{
+				Type:       EventDelta,
+				TraceID:    req.TraceID,
+				ProviderID: a.providerID,
+				ModelID:    modelID,
+				Delta:      delta,
+			}
+		})
+		if err != nil {
+			stream <- Event{
+				Type:       EventError,
+				TraceID:    req.TraceID,
+				ProviderID: a.providerID,
+				ModelID:    modelID,
+				Error: &Error{
+					Code:      ErrCodeUnavailable,
+					Provider:  a.providerID,
+					Message:   err.Error(),
+					Retryable: false,
+					Err:       err,
+				},
+			}
+			return
+		}
+		if message.Usage != nil {
+			stream <- Event{
+				Type:       EventUsage,
+				TraceID:    req.TraceID,
+				ProviderID: a.providerID,
+				ModelID:    modelID,
+				Usage: &Usage{
+					InputTokens:  int64(message.Usage.InputTokens),
+					OutputTokens: int64(message.Usage.OutputTokens),
+					TotalTokens:  int64(message.Usage.TotalTokens),
+				},
+			}
+		}
+		message.Normalize()
+		for _, toolCall := range message.ToolCalls {
+			call := toolCall
+			stream <- Event{
+				Type:       EventToolCall,
+				TraceID:    req.TraceID,
+				ProviderID: a.providerID,
+				ModelID:    modelID,
+				ToolCall:   &call,
+			}
+		}
+		stream <- Event{
+			Type:       EventResult,
+			TraceID:    req.TraceID,
+			ProviderID: a.providerID,
+			ModelID:    modelID,
+			Result:     &message,
+		}
+	}()
+	return stream, nil
+}

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"bytemind/internal/llm"
@@ -50,42 +51,38 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 		if modelID == "" {
 			modelID = a.defaultModel
 		}
-		stream <- Event{
+		if !emit(ctx, stream, Event{
 			Type:       EventStart,
 			TraceID:    req.TraceID,
 			ProviderID: a.providerID,
 			ModelID:    modelID,
+		}) {
+			return
 		}
 		message, err := a.client.StreamMessage(ctx, req.ChatRequest, func(delta string) {
 			if strings.TrimSpace(delta) == "" {
 				return
 			}
-			stream <- Event{
+			_ = emit(ctx, stream, Event{
 				Type:       EventDelta,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
 				ModelID:    modelID,
 				Delta:      delta,
-			}
+			})
 		})
 		if err != nil {
-			stream <- Event{
+			_ = emit(ctx, stream, Event{
 				Type:       EventError,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
 				ModelID:    modelID,
-				Error: &Error{
-					Code:      ErrCodeUnavailable,
-					Provider:  a.providerID,
-					Message:   err.Error(),
-					Retryable: false,
-					Err:       err,
-				},
-			}
+				Error:      mapCompatError(a.providerID, err),
+			})
 			return
 		}
 		if message.Usage != nil {
-			stream <- Event{
+			if !emit(ctx, stream, Event{
 				Type:       EventUsage,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
@@ -95,26 +92,65 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 					OutputTokens: int64(message.Usage.OutputTokens),
 					TotalTokens:  int64(message.Usage.TotalTokens),
 				},
+			}) {
+				return
 			}
 		}
 		message.Normalize()
 		for _, toolCall := range message.ToolCalls {
 			call := toolCall
-			stream <- Event{
+			if !emit(ctx, stream, Event{
 				Type:       EventToolCall,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
 				ModelID:    modelID,
 				ToolCall:   &call,
+			}) {
+				return
 			}
 		}
-		stream <- Event{
+		_ = emit(ctx, stream, Event{
 			Type:       EventResult,
 			TraceID:    req.TraceID,
 			ProviderID: a.providerID,
 			ModelID:    modelID,
 			Result:     &message,
-		}
+		})
 	}()
 	return stream, nil
+}
+
+func emit(ctx context.Context, ch chan<- Event, evt Event) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case ch <- evt:
+		return true
+	}
+}
+
+func mapCompatError(providerID ProviderID, err error) *Error {
+	mapped := &Error{
+		Code:      ErrCodeUnavailable,
+		Provider:  providerID,
+		Message:   "provider request failed",
+		Retryable: false,
+		Err:       err,
+	}
+	var providerErr *llm.ProviderError
+	if !errors.As(err, &providerErr) || providerErr == nil {
+		return mapped
+	}
+	mapped.Retryable = providerErr.Retryable
+	switch providerErr.Code {
+	case llm.ErrorCodeRateLimited:
+		mapped.Code = ErrCodeRateLimited
+		mapped.Message = "provider rate limited"
+	case llm.ErrorCodeContextTooLong:
+		mapped.Code = ErrCodeBadRequest
+		mapped.Message = "request exceeds provider context limit"
+	default:
+		mapped.Message = "provider unavailable"
+	}
+	return mapped
 }

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"bytemind/internal/llm"
+)
+
+type stubCompatClient struct {
+	message llm.Message
+	err     error
+}
+
+func (s stubCompatClient) CreateMessage(context.Context, llm.ChatRequest) (llm.Message, error) {
+	return s.message, s.err
+}
+
+func (s stubCompatClient) StreamMessage(_ context.Context, _ llm.ChatRequest, onDelta func(string)) (llm.Message, error) {
+	if onDelta != nil {
+		onDelta("hello")
+		onDelta(" world")
+	}
+	return s.message, s.err
+}
+
+func TestWrapClientStreamEmitsNormalizedEvents(t *testing.T) {
+	adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), stubCompatClient{message: llm.Message{
+		Role:    llm.RoleAssistant,
+		Content: "hello world",
+		ToolCalls: []llm.ToolCall{{
+			ID:   "call-1",
+			Type: "function",
+			Function: llm.ToolFunctionCall{
+				Name:      "list_files",
+				Arguments: "{}",
+			},
+		}},
+		Usage: &llm.Usage{InputTokens: 3, OutputTokens: 2, TotalTokens: 5},
+	}})
+	stream, err := adapter.Stream(context.Background(), Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}, TraceID: "trace-1"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	var events []Event
+	for event := range stream {
+		events = append(events, event)
+	}
+	if len(events) != 6 {
+		t.Fatalf("expected 6 events, got %#v", events)
+	}
+	if events[0].Type != EventStart || events[0].TraceID != "trace-1" {
+		t.Fatalf("unexpected start event %#v", events[0])
+	}
+	if events[1].Type != EventDelta || events[1].Delta != "hello" {
+		t.Fatalf("unexpected first delta %#v", events[1])
+	}
+	if events[2].Type != EventDelta || events[2].Delta != " world" {
+		t.Fatalf("unexpected second delta %#v", events[2])
+	}
+	if events[3].Type != EventUsage || events[3].Usage == nil || events[3].Usage.TotalTokens != 5 {
+		t.Fatalf("unexpected usage event %#v", events[3])
+	}
+	if events[4].Type != EventToolCall || events[4].ToolCall == nil || events[4].ToolCall.Function.Name != "list_files" {
+		t.Fatalf("unexpected tool call event %#v", events[4])
+	}
+	if events[5].Type != EventResult || events[5].Result == nil || events[5].Result.Content != "hello world" {
+		t.Fatalf("expected final result event, got %#v", events[5])
+	}
+}
+
+func TestWrapClientStreamEmitsErrorEvent(t *testing.T) {
+	adapter := WrapClient(ProviderAnthropic, ModelID("claude"), stubCompatClient{err: errors.New("boom")})
+	stream, err := adapter.Stream(context.Background(), Request{ChatRequest: llm.ChatRequest{}, TraceID: "trace-2"})
+	if err != nil {
+		t.Fatalf("expected no setup error, got %v", err)
+	}
+	var events []Event
+	for event := range stream {
+		events = append(events, event)
+	}
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %#v", events)
+	}
+	if events[0].Type != EventStart {
+		t.Fatalf("expected start event, got %#v", events[0])
+	}
+	if events[1].Type != EventDelta || events[2].Type != EventDelta {
+		t.Fatalf("expected delta events before error, got %#v", events)
+	}
+	if events[3].Type != EventError || events[3].Error == nil {
+		t.Fatalf("expected error event, got %#v", events[3])
+	}
+	if events[3].Error.Code != ErrCodeUnavailable {
+		t.Fatalf("unexpected error code %#v", events[3].Error)
+	}
+}

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -166,6 +166,14 @@ func TestWrapClientStreamStopsWhenContextCancelled(t *testing.T) {
 	}
 }
 
+func TestEmitReturnsFalseWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if emit(ctx, make(chan Event), Event{}) {
+		t.Fatal("expected emit to fail when context is cancelled")
+	}
+}
+
 func TestWrapClientCoversNilClientAndEmptyModel(t *testing.T) {
 	if WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), nil) != nil {
 		t.Fatal("expected nil client to return nil adapter")

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"bytemind/internal/llm"
 )
@@ -94,5 +95,97 @@ func TestWrapClientStreamEmitsErrorEvent(t *testing.T) {
 	}
 	if events[3].Error.Code != ErrCodeUnavailable {
 		t.Fatalf("unexpected error code %#v", events[3].Error)
+	}
+}
+
+func TestWrapClientStreamMapsProviderErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		code      ErrorCode
+		retryable bool
+		message   string
+	}{
+		{
+			name: "rate limited",
+			err:  &llm.ProviderError{Code: llm.ErrorCodeRateLimited, Provider: "openai", Status: 429, Retryable: true, Message: "429: raw upstream body"},
+			code: ErrCodeRateLimited, retryable: true, message: "provider rate limited",
+		},
+		{
+			name: "context too long",
+			err:  &llm.ProviderError{Code: llm.ErrorCodeContextTooLong, Provider: "anthropic", Status: 413, Retryable: false, Message: "prompt is too long with raw details"},
+			code: ErrCodeBadRequest, retryable: false, message: "request exceeds provider context limit",
+		},
+		{
+			name: "fallback unavailable",
+			err:  errors.New("sensitive raw body"),
+			code: ErrCodeUnavailable, retryable: false, message: "provider request failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), stubCompatClient{err: tt.err})
+			stream, err := adapter.Stream(context.Background(), Request{ChatRequest: llm.ChatRequest{}, TraceID: "trace-map"})
+			if err != nil {
+				t.Fatalf("expected no setup error, got %v", err)
+			}
+			var got *Error
+			for event := range stream {
+				if event.Type == EventError {
+					got = event.Error
+				}
+			}
+			if got == nil {
+				t.Fatal("expected error event")
+			}
+			if got.Code != tt.code || got.Retryable != tt.retryable || got.Provider != ProviderOpenAI || got.Message != tt.message {
+				t.Fatalf("unexpected mapped error %#v", got)
+			}
+		})
+	}
+}
+
+func TestWrapClientStreamStopsWhenContextCancelled(t *testing.T) {
+	adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), stubCompatClient{message: llm.Message{Role: llm.RoleAssistant, Content: "hello world"}})
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := adapter.Stream(ctx, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}, TraceID: "trace-cancel"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	<-stream
+	cancel()
+	select {
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected stream to stop after cancellation")
+	case _, ok := <-stream:
+		if ok {
+			for range stream {
+			}
+		}
+	}
+}
+
+func TestWrapClientCoversNilClientAndEmptyModel(t *testing.T) {
+	if WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), nil) != nil {
+		t.Fatal("expected nil client to return nil adapter")
+	}
+	adapter := WrapClient("", ModelID(""), stubCompatClient{})
+	if adapter.ProviderID() != ProviderID("unknown") {
+		t.Fatalf("unexpected provider id %q", adapter.ProviderID())
+	}
+	models, err := adapter.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if models != nil {
+		t.Fatalf("expected nil models, got %#v", models)
+	}
+}
+
+func TestMapCompatErrorDefaultProviderErrorBranch(t *testing.T) {
+	mapped := mapCompatError(ProviderAnthropic, &llm.ProviderError{Code: llm.ErrorCodeUnknown, Retryable: true, Message: "hidden upstream body"})
+	if mapped.Code != ErrCodeUnavailable || !mapped.Retryable || mapped.Message != "provider unavailable" || mapped.Provider != ProviderAnthropic {
+		t.Fatalf("unexpected mapped error %#v", mapped)
 	}
 }

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -29,10 +29,6 @@ func NewClient(cfg config.ProviderConfig) (llm.Client, error) {
 }
 
 func NewDomainClient(cfg config.ProviderConfig) (Client, error) {
-	baseClient, err := NewClient(cfg)
-	if err != nil {
-		return nil, err
-	}
 	providerID := ProviderID(strings.ToLower(strings.TrimSpace(cfg.Type)))
 	if providerID == "openai-compatible" || providerID == "openai" {
 		providerID = ProviderOpenAI
@@ -43,5 +39,17 @@ func NewDomainClient(cfg config.ProviderConfig) (Client, error) {
 	if providerID == "" {
 		providerID = ProviderID("unknown")
 	}
-	return WrapClient(providerID, ModelID(strings.TrimSpace(cfg.Model)), baseClient), nil
+	return NewDomainClientWithID(providerID, cfg)
+}
+
+func NewDomainClientWithID(providerID ProviderID, cfg config.ProviderConfig) (Client, error) {
+	baseClient, err := NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	id := ProviderID(strings.ToLower(strings.TrimSpace(string(providerID))))
+	if id == "" {
+		id = ProviderID("unknown")
+	}
+	return WrapClient(id, ModelID(strings.TrimSpace(cfg.Model)), baseClient), nil
 }

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 
 	"bytemind/internal/config"
 	"bytemind/internal/llm"
@@ -24,4 +25,19 @@ func NewClient(cfg config.ProviderConfig) (llm.Client, error) {
 	default:
 		return nil, fmt.Errorf("unsupported provider type %q", cfg.Type)
 	}
+}
+
+func NewDomainClient(cfg config.ProviderConfig) (Client, error) {
+	baseClient, err := NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	providerID := ProviderID(strings.TrimSpace(cfg.Type))
+	if providerID == "openai-compatible" {
+		providerID = ProviderOpenAI
+	}
+	if providerID == "" {
+		providerID = ProviderID("unknown")
+	}
+	return WrapClient(providerID, ModelID(strings.TrimSpace(cfg.Model)), baseClient), nil
 }

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -9,15 +9,16 @@ import (
 )
 
 func NewClient(cfg config.ProviderConfig) (llm.Client, error) {
+	typ := strings.ToLower(strings.TrimSpace(cfg.Type))
 	clientCfg := Config{
-		Type:             cfg.Type,
+		Type:             typ,
 		BaseURL:          cfg.BaseURL,
 		APIKey:           cfg.ResolveAPIKey(),
 		Model:            cfg.Model,
 		AnthropicVersion: cfg.AnthropicVersion,
 	}
 
-	switch cfg.Type {
+	switch typ {
 	case "openai-compatible", "openai":
 		return NewOpenAICompatible(clientCfg), nil
 	case "anthropic":
@@ -32,9 +33,12 @@ func NewDomainClient(cfg config.ProviderConfig) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	providerID := ProviderID(strings.TrimSpace(cfg.Type))
-	if providerID == "openai-compatible" {
+	providerID := ProviderID(strings.ToLower(strings.TrimSpace(cfg.Type)))
+	if providerID == "openai-compatible" || providerID == "openai" {
 		providerID = ProviderOpenAI
+	}
+	if providerID == "anthropic" {
+		providerID = ProviderAnthropic
 	}
 	if providerID == "" {
 		providerID = ProviderID("unknown")

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -65,5 +66,27 @@ func TestNewClientRejectsUnsupportedProviderType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported provider type") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewDomainClientWrapsBaseClient(t *testing.T) {
+	client, err := NewDomainClient(config.ProviderConfig{
+		Type:    "openai-compatible",
+		BaseURL: "https://api.openai.com/v1",
+		APIKey:  "test-key",
+		Model:   "gpt-5.4",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.ProviderID() != ProviderOpenAI {
+		t.Fatalf("expected provider id %q, got %q", ProviderOpenAI, client.ProviderID())
+	}
+	models, err := client.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error listing models, got %v", err)
+	}
+	if len(models) != 1 || models[0].ModelID != ModelID("gpt-5.4") {
+		t.Fatalf("unexpected models: %#v", models)
 	}
 }

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -91,6 +91,19 @@ func TestNewDomainClientWrapsBaseClient(t *testing.T) {
 	}
 }
 
+func TestNewClientAcceptsNormalizedTypeVariants(t *testing.T) {
+	cases := []config.ProviderConfig{
+		{Type: " OPENAI ", BaseURL: "https://api.openai.com/v1", APIKey: "test-key", Model: "gpt-5.4"},
+		{Type: "OpenAI-Compatible", BaseURL: "https://api.openai.com/v1", APIKey: "test-key", Model: "gpt-5.4"},
+		{Type: " ANTHROPIC ", BaseURL: "https://api.anthropic.com", APIKey: "test-key", Model: "claude-sonnet", AnthropicVersion: "2023-06-01"},
+	}
+	for _, cfg := range cases {
+		if _, err := NewClient(cfg); err != nil {
+			t.Fatalf("expected normalized type %q to succeed, got %v", cfg.Type, err)
+		}
+	}
+}
+
 func TestNewDomainClientPreservesAnthropicProviderID(t *testing.T) {
 	client, err := NewDomainClient(config.ProviderConfig{
 		Type:             "anthropic",
@@ -104,6 +117,21 @@ func TestNewDomainClientPreservesAnthropicProviderID(t *testing.T) {
 	}
 	if client.ProviderID() != ProviderAnthropic {
 		t.Fatalf("expected provider id %q, got %q", ProviderAnthropic, client.ProviderID())
+	}
+}
+
+func TestNewDomainClientNormalizesOpenAIProviderIDVariants(t *testing.T) {
+	client, err := NewDomainClient(config.ProviderConfig{
+		Type:    " OpenAI-Compatible ",
+		BaseURL: "https://api.openai.com/v1",
+		APIKey:  "test-key",
+		Model:   "gpt-5.4",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.ProviderID() != ProviderOpenAI {
+		t.Fatalf("expected provider id %q, got %q", ProviderOpenAI, client.ProviderID())
 	}
 }
 

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -91,6 +91,22 @@ func TestNewDomainClientWrapsBaseClient(t *testing.T) {
 	}
 }
 
+func TestNewDomainClientPreservesAnthropicProviderID(t *testing.T) {
+	client, err := NewDomainClient(config.ProviderConfig{
+		Type:             "anthropic",
+		BaseURL:          "https://api.anthropic.com",
+		APIKey:           "test-key",
+		Model:            "claude-sonnet",
+		AnthropicVersion: "2023-06-01",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.ProviderID() != ProviderAnthropic {
+		t.Fatalf("expected provider id %q, got %q", ProviderAnthropic, client.ProviderID())
+	}
+}
+
 func TestNewDomainClientRejectsEmptyType(t *testing.T) {
 	client, err := NewDomainClient(config.ProviderConfig{
 		Type:    "",

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -90,3 +90,18 @@ func TestNewDomainClientWrapsBaseClient(t *testing.T) {
 		t.Fatalf("unexpected models: %#v", models)
 	}
 }
+
+func TestNewDomainClientRejectsEmptyType(t *testing.T) {
+	client, err := NewDomainClient(config.ProviderConfig{
+		Type:    "",
+		BaseURL: "https://example.com",
+		APIKey:  "test-key",
+		Model:   "test-model",
+	})
+	if err == nil {
+		t.Fatal("expected unsupported provider type error")
+	}
+	if client != nil {
+		t.Fatalf("expected nil client, got %v", client)
+	}
+}

--- a/internal/provider/interfaces.go
+++ b/internal/provider/interfaces.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"context"
+
+	"bytemind/internal/llm"
+)
+
+type ProviderID string
+
+type ModelID string
+
+type Client interface {
+	ProviderID() ProviderID
+	ListModels(ctx context.Context) ([]ModelInfo, error)
+	Stream(ctx context.Context, req Request) (<-chan Event, error)
+}
+
+type Registry interface {
+	Register(ctx context.Context, client Client) error
+	Get(ctx context.Context, id ProviderID) (Client, bool)
+	List(ctx context.Context) ([]ProviderID, error)
+}
+
+type Router interface {
+	Route(ctx context.Context, requestedModel ModelID, rc RouteContext) (RouteResult, error)
+}
+
+type HealthChecker interface {
+	Check(ctx context.Context, id ProviderID) error
+}
+
+type Request struct {
+	llm.ChatRequest
+	TraceID string
+	Tags    map[string]string
+}
+
+type RouteContext struct {
+	Scenario      string
+	Region        string
+	PreferLatency bool
+	PreferLowCost bool
+	AllowFallback bool
+	Tags          map[string]string
+}
+
+type RouteResult struct {
+	Primary   RouteTarget
+	Fallbacks []RouteTarget
+}
+
+type RouteTarget struct {
+	ProviderID ProviderID
+	ModelID    ModelID
+	Client     Client
+}

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -32,6 +32,9 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 			}
 			defer func() { <-sem }()
 			client, ok := reg.Get(ctx, id)
+			if ctx.Err() != nil {
+				return
+			}
 			if !ok {
 				mu.Lock()
 				warnings = append(warnings, Warning{ProviderID: id, Reason: string(ErrCodeProviderNotFound)})
@@ -39,6 +42,9 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 				return
 			}
 			providerModels, err := client.ListModels(ctx)
+			if ctx.Err() != nil {
+				return
+			}
 			if err != nil {
 				mu.Lock()
 				warnings = append(warnings, Warning{ProviderID: id, Reason: listModelsWarningReason})
@@ -63,6 +69,9 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 		}()
 	}
 	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	sort.Slice(models, func(i, j int) bool {
 		if models[i].ProviderID == models[j].ProviderID {
 			return models[i].ModelID < models[j].ModelID

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -1,0 +1,39 @@
+package provider
+
+import "context"
+
+func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, error) {
+	ids, err := reg.List(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	models := make([]ModelInfo, 0)
+	warnings := make([]Warning, 0)
+	seen := make(map[string]struct{})
+	for _, id := range ids {
+		client, ok := reg.Get(ctx, id)
+		if !ok {
+			warnings = append(warnings, Warning{ProviderID: id, Reason: string(ErrCodeProviderNotFound)})
+			continue
+		}
+		providerModels, err := client.ListModels(ctx)
+		if err != nil {
+			warnings = append(warnings, Warning{ProviderID: id, Reason: err.Error()})
+			continue
+		}
+		for _, model := range providerModels {
+			providerID := normalizeProviderID(model.ProviderID)
+			if providerID == "" {
+				providerID = id
+			}
+			key := string(providerID) + "\x00" + string(model.ModelID)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			model.ProviderID = providerID
+			models = append(models, model)
+		}
+	}
+	return models, warnings, nil
+}

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -1,6 +1,13 @@
 package provider
 
-import "context"
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+const listModelsWarningReason = "provider_list_models_failed"
+const listModelsConcurrency = 4
 
 func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, error) {
 	ids, err := reg.List(ctx)
@@ -10,30 +17,58 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 	models := make([]ModelInfo, 0)
 	warnings := make([]Warning, 0)
 	seen := make(map[string]struct{})
+	var mu sync.Mutex
+	sem := make(chan struct{}, listModelsConcurrency)
+	var wg sync.WaitGroup
 	for _, id := range ids {
-		client, ok := reg.Get(ctx, id)
-		if !ok {
-			warnings = append(warnings, Warning{ProviderID: id, Reason: string(ErrCodeProviderNotFound)})
-			continue
-		}
-		providerModels, err := client.ListModels(ctx)
-		if err != nil {
-			warnings = append(warnings, Warning{ProviderID: id, Reason: err.Error()})
-			continue
-		}
-		for _, model := range providerModels {
-			providerID := normalizeProviderID(model.ProviderID)
-			if providerID == "" {
-				providerID = id
+		id := id
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case <-ctx.Done():
+				return
+			case sem <- struct{}{}:
 			}
-			key := string(providerID) + "\x00" + string(model.ModelID)
-			if _, exists := seen[key]; exists {
-				continue
+			defer func() { <-sem }()
+			client, ok := reg.Get(ctx, id)
+			if !ok {
+				mu.Lock()
+				warnings = append(warnings, Warning{ProviderID: id, Reason: string(ErrCodeProviderNotFound)})
+				mu.Unlock()
+				return
 			}
-			seen[key] = struct{}{}
-			model.ProviderID = providerID
-			models = append(models, model)
-		}
+			providerModels, err := client.ListModels(ctx)
+			if err != nil {
+				mu.Lock()
+				warnings = append(warnings, Warning{ProviderID: id, Reason: listModelsWarningReason})
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, model := range providerModels {
+				providerID := normalizeProviderID(model.ProviderID)
+				if providerID == "" {
+					providerID = id
+				}
+				key := string(providerID) + "\x00" + string(model.ModelID)
+				if _, exists := seen[key]; exists {
+					continue
+				}
+				seen[key] = struct{}{}
+				model.ProviderID = providerID
+				models = append(models, model)
+			}
+		}()
 	}
+	wg.Wait()
+	sort.Slice(models, func(i, j int) bool {
+		if models[i].ProviderID == models[j].ProviderID {
+			return models[i].ModelID < models[j].ModelID
+		}
+		return models[i].ProviderID < models[j].ProviderID
+	})
+	sort.Slice(warnings, func(i, j int) bool { return warnings[i].ProviderID < warnings[j].ProviderID })
 	return models, warnings, nil
 }

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -54,10 +54,7 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 			mu.Lock()
 			defer mu.Unlock()
 			for _, model := range providerModels {
-				providerID := normalizeProviderID(model.ProviderID)
-				if providerID == "" {
-					providerID = id
-				}
+				providerID := id
 				key := string(providerID) + "\x00" + string(model.ModelID)
 				if _, exists := seen[key]; exists {
 					continue

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -16,19 +16,22 @@ type providerRegistry struct {
 
 func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
 	reg := &providerRegistry{clients: make(map[ProviderID]Client)}
+	normalizedProviders := make(map[ProviderID]config.ProviderConfig, len(cfg.Providers))
+	ids := make([]string, 0, len(cfg.Providers))
+	for id, providerCfg := range cfg.Providers {
+		normalizedID := ProviderID(strings.ToLower(strings.TrimSpace(id)))
+		normalizedProviders[normalizedID] = providerCfg
+		ids = append(ids, string(normalizedID))
+	}
 	if cfg.DefaultProvider != "" {
 		defaultProvider := ProviderID(strings.ToLower(strings.TrimSpace(cfg.DefaultProvider)))
-		if _, exists := cfg.Providers[string(defaultProvider)]; !exists {
+		if _, exists := normalizedProviders[defaultProvider]; !exists {
 			return nil, &Error{Code: ErrCodeProviderNotFound, Provider: defaultProvider, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
 		}
 	}
-	ids := make([]string, 0, len(cfg.Providers))
-	for id := range cfg.Providers {
-		ids = append(ids, id)
-	}
 	sort.Strings(ids)
 	for _, id := range ids {
-		providerCfg := cfg.Providers[id]
+		providerCfg := normalizedProviders[ProviderID(id)]
 		client, err := NewDomainClientWithID(ProviderID(id), providerCfg)
 		if err != nil {
 			return nil, err

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -16,6 +16,12 @@ type providerRegistry struct {
 
 func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
 	reg := &providerRegistry{clients: make(map[ProviderID]Client)}
+	if cfg.DefaultProvider != "" {
+		defaultProvider := ProviderID(strings.ToLower(strings.TrimSpace(cfg.DefaultProvider)))
+		if _, exists := cfg.Providers[string(defaultProvider)]; !exists {
+			return nil, &Error{Code: ErrCodeProviderNotFound, Provider: defaultProvider, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
+		}
+	}
 	ids := make([]string, 0, len(cfg.Providers))
 	for id := range cfg.Providers {
 		ids = append(ids, id)
@@ -23,10 +29,7 @@ func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
 	sort.Strings(ids)
 	for _, id := range ids {
 		providerCfg := cfg.Providers[id]
-		if strings.TrimSpace(providerCfg.Type) == "" {
-			providerCfg.Type = id
-		}
-		client, err := NewDomainClient(providerCfg)
+		client, err := NewDomainClientWithID(ProviderID(id), providerCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +48,7 @@ func (r *providerRegistry) Register(_ context.Context, client Client) error {
 	if client == nil {
 		return nil
 	}
-	id := normalizeProviderID(client.ProviderID())
+	id := ProviderID(strings.ToLower(strings.TrimSpace(string(client.ProviderID()))))
 	if id == "" {
 		return &Error{Code: ErrCodeProviderNotFound, Provider: id, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
 	}
@@ -61,7 +64,7 @@ func (r *providerRegistry) Register(_ context.Context, client Client) error {
 func (r *providerRegistry) Get(_ context.Context, id ProviderID) (Client, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	client, ok := r.clients[normalizeProviderID(id)]
+	client, ok := r.clients[ProviderID(strings.ToLower(strings.TrimSpace(string(id))))]
 	return client, ok
 }
 

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"bytemind/internal/config"
+)
+
+type providerRegistry struct {
+	mu      sync.RWMutex
+	clients map[ProviderID]Client
+}
+
+func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
+	reg := &providerRegistry{clients: make(map[ProviderID]Client)}
+	ids := make([]string, 0, len(cfg.Providers))
+	for id := range cfg.Providers {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		providerCfg := cfg.Providers[id]
+		if strings.TrimSpace(providerCfg.Type) == "" {
+			providerCfg.Type = id
+		}
+		client, err := NewDomainClient(providerCfg)
+		if err != nil {
+			return nil, err
+		}
+		if err := reg.Register(context.Background(), client); err != nil {
+			return nil, err
+		}
+	}
+	return reg, nil
+}
+
+func NewRegistryFromProviderConfig(cfg config.ProviderConfig) (Registry, error) {
+	return NewRegistry(config.LegacyProviderRuntimeConfig(cfg))
+}
+
+func (r *providerRegistry) Register(_ context.Context, client Client) error {
+	if client == nil {
+		return nil
+	}
+	id := normalizeProviderID(client.ProviderID())
+	if id == "" {
+		return &Error{Code: ErrCodeProviderNotFound, Provider: id, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.clients[id]; exists {
+		return &Error{Code: ErrCodeDuplicateProvider, Provider: id, Message: string(ErrCodeDuplicateProvider), Retryable: false, Err: ErrDuplicateProvider}
+	}
+	r.clients[id] = client
+	return nil
+}
+
+func (r *providerRegistry) Get(_ context.Context, id ProviderID) (Client, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	client, ok := r.clients[normalizeProviderID(id)]
+	return client, ok
+}
+
+func (r *providerRegistry) List(_ context.Context) ([]ProviderID, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]ProviderID, 0, len(r.clients))
+	for id := range r.clients {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids, nil
+}
+
+func normalizeProviderID(id ProviderID) ProviderID {
+	value := strings.ToLower(strings.TrimSpace(string(id)))
+	switch value {
+	case "openai-compatible", "openai":
+		return ProviderOpenAI
+	case "anthropic":
+		return ProviderAnthropic
+	default:
+		return ProviderID(value)
+	}
+}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -20,6 +20,12 @@ func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
 	ids := make([]string, 0, len(cfg.Providers))
 	for id, providerCfg := range cfg.Providers {
 		normalizedID := ProviderID(strings.ToLower(strings.TrimSpace(id)))
+		if normalizedID == "" {
+			return nil, &Error{Code: ErrCodeProviderNotFound, Provider: normalizedID, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
+		}
+		if _, exists := normalizedProviders[normalizedID]; exists {
+			return nil, &Error{Code: ErrCodeDuplicateProvider, Provider: normalizedID, Message: string(ErrCodeDuplicateProvider), Retryable: false, Err: ErrDuplicateProvider}
+		}
 		normalizedProviders[normalizedID] = providerCfg
 		ids = append(ids, string(normalizedID))
 	}
@@ -80,16 +86,4 @@ func (r *providerRegistry) List(_ context.Context) ([]ProviderID, error) {
 	}
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	return ids, nil
-}
-
-func normalizeProviderID(id ProviderID) ProviderID {
-	value := strings.ToLower(strings.TrimSpace(string(id)))
-	switch value {
-	case "openai-compatible", "openai":
-		return ProviderOpenAI
-	case "anthropic":
-		return ProviderAnthropic
-	default:
-		return ProviderID(value)
-	}
 }

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -45,6 +45,41 @@ func TestNewRegistryFromProviderConfigSupportsLegacyMode(t *testing.T) {
 	}
 }
 
+func TestNewRegistrySupportsMultipleProvidersWithSameType(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{
+		DefaultProvider: "openai-primary",
+		Providers: map[string]config.ProviderConfig{
+			"openai-primary":   {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key-1", Model: "gpt-5.4"},
+			"openai-secondary": {Type: "openai-compatible", BaseURL: "https://example.com/v1", APIKey: "key-2", Model: "gpt-4.1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	ids, err := reg.List(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "openai-primary" || ids[1] != "openai-secondary" {
+		t.Fatalf("unexpected ids %#v", ids)
+	}
+	primary, ok := reg.Get(context.Background(), "openai-primary")
+	if !ok || primary.ProviderID() != "openai-primary" {
+		t.Fatalf("unexpected primary provider %#v ok=%v", primary, ok)
+	}
+	secondary, ok := reg.Get(context.Background(), "openai-secondary")
+	if !ok || secondary.ProviderID() != "openai-secondary" {
+		t.Fatalf("unexpected secondary provider %#v ok=%v", secondary, ok)
+	}
+	models, warnings, err := ListModels(context.Background(), reg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(models) != 2 || len(warnings) != 0 {
+		t.Fatalf("unexpected models=%#v warnings=%#v", models, warnings)
+	}
+}
+
 func TestRegistryRejectsDuplicateProvider(t *testing.T) {
 	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
 	if err != nil {
@@ -110,18 +145,18 @@ func TestRegistryCoversLookupAndNormalizationBranches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "openai-compatible"}); err != nil {
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "openai-primary"}); err != nil {
 		t.Fatalf("unexpected register error %v", err)
 	}
-	client, ok := reg.Get(context.Background(), "openai")
-	if !ok || client.ProviderID() != "openai-compatible" {
+	client, ok := reg.Get(context.Background(), "openai-primary")
+	if !ok || client.ProviderID() != "openai-primary" {
 		t.Fatalf("unexpected client lookup result ok=%v client=%#v", ok, client)
 	}
 	if _, ok := reg.Get(context.Background(), "missing"); ok {
 		t.Fatal("expected missing provider lookup to fail")
 	}
 	ids, err := reg.List(context.Background())
-	if err != nil || len(ids) != 1 || ids[0] != ProviderOpenAI {
+	if err != nil || len(ids) != 1 || ids[0] != "openai-primary" {
 		t.Fatalf("unexpected ids %#v err=%v", ids, err)
 	}
 }
@@ -141,6 +176,9 @@ func TestRegistryHandlesProviderNotFoundAndConfigErrors(t *testing.T) {
 		if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeProviderNotFound {
 			t.Fatalf("unexpected error %#v", err)
 		}
+	}
+	if _, err := NewRegistry(config.ProviderRuntimeConfig{DefaultProvider: "missing", Providers: map[string]config.ProviderConfig{"openai-primary": {Type: "openai-compatible", BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
+		t.Fatal("expected missing default provider error")
 	}
 	if _, err := NewRegistry(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"broken": {BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
 		t.Fatal("expected invalid provider type error")

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -47,10 +47,10 @@ func TestNewRegistryFromProviderConfigSupportsLegacyMode(t *testing.T) {
 
 func TestNewRegistrySupportsMultipleProvidersWithSameType(t *testing.T) {
 	reg, err := NewRegistry(config.ProviderRuntimeConfig{
-		DefaultProvider: "openai-primary",
+		DefaultProvider: " OpenAI-Primary ",
 		Providers: map[string]config.ProviderConfig{
-			"openai-primary":   {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key-1", Model: "gpt-5.4"},
-			"openai-secondary": {Type: "openai-compatible", BaseURL: "https://example.com/v1", APIKey: "key-2", Model: "gpt-4.1"},
+			" OpenAI-Primary ": {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key-1", Model: "gpt-5.4"},
+			"OPENAI-SECONDARY": {Type: "openai-compatible", BaseURL: "https://example.com/v1", APIKey: "key-2", Model: "gpt-4.1"},
 		},
 	})
 	if err != nil {

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -93,6 +93,18 @@ func TestListModelsReturnsRegistryError(t *testing.T) {
 	}
 }
 
+func TestListModelsReturnsContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, _, err := ListModels(ctx, reg); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+}
+
 func TestRegistryCoversLookupAndNormalizationBranches(t *testing.T) {
 	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
 	if err != nil {

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -121,6 +121,29 @@ func TestListModelsAggregatesWarningsAndDeduplicates(t *testing.T) {
 	}
 }
 
+func TestListModelsKeepsInstanceIDsDistinctEvenWhenAliasesOverlap(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai-compatible", ModelID: "gpt-5.4"}}}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "openai-compatible", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	models, warnings, err := ListModels(context.Background(), reg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings %#v", warnings)
+	}
+	if len(models) != 2 || models[0].ProviderID != "openai" || models[1].ProviderID != "openai-compatible" {
+		t.Fatalf("unexpected models %#v", models)
+	}
+}
+
 func TestListModelsReturnsRegistryError(t *testing.T) {
 	reg := stubListRegistry{listErr: errors.New("boom")}
 	if _, _, err := ListModels(context.Background(), reg); err == nil {
@@ -179,6 +202,12 @@ func TestRegistryHandlesProviderNotFoundAndConfigErrors(t *testing.T) {
 	}
 	if _, err := NewRegistry(config.ProviderRuntimeConfig{DefaultProvider: "missing", Providers: map[string]config.ProviderConfig{"openai-primary": {Type: "openai-compatible", BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
 		t.Fatal("expected missing default provider error")
+	}
+	if _, err := NewRegistry(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{" OpenAI-Primary ": {Type: "openai-compatible", BaseURL: "https://example.com", APIKey: "key", Model: "m"}, "openai-primary": {Type: "openai-compatible", BaseURL: "https://example2.com", APIKey: "key", Model: "m"}}}); err == nil {
+		t.Fatal("expected duplicate normalized provider error")
+	}
+	if _, err := NewRegistry(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"   ": {Type: "openai-compatible", BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
+		t.Fatal("expected blank provider id error")
 	}
 	if _, err := NewRegistry(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"broken": {BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
 		t.Fatal("expected invalid provider type error")

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"bytemind/internal/config"
+)
+
+type stubRegistryClient struct {
+	providerID ProviderID
+	models     []ModelInfo
+	err        error
+}
+
+func (s stubRegistryClient) ProviderID() ProviderID                                { return s.providerID }
+func (s stubRegistryClient) ListModels(context.Context) ([]ModelInfo, error)       { return s.models, s.err }
+func (s stubRegistryClient) Stream(context.Context, Request) (<-chan Event, error) { return nil, nil }
+
+func TestNewRegistryFromProviderConfigSupportsLegacyMode(t *testing.T) {
+	reg, err := NewRegistryFromProviderConfig(config.ProviderConfig{
+		Type:    "openai-compatible",
+		BaseURL: "https://api.openai.com/v1",
+		APIKey:  "test-key",
+		Model:   "gpt-5.4",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	ids, err := reg.List(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(ids) != 1 || ids[0] != ProviderOpenAI {
+		t.Fatalf("unexpected ids %#v", ids)
+	}
+}
+
+func TestRegistryRejectsDuplicateProvider(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderOpenAI}); err != nil {
+		t.Fatalf("unexpected first register error %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderOpenAI}); err == nil {
+		t.Fatal("expected duplicate provider error")
+	} else {
+		var providerErr *Error
+		if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeDuplicateProvider {
+			t.Fatalf("unexpected error %#v", err)
+		}
+	}
+}
+
+func TestListModelsAggregatesWarningsAndDeduplicates(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderOpenAI, models: []ModelInfo{{ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}, {ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}}}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderAnthropic, err: errors.New("list failed")}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	models, warnings, err := ListModels(context.Background(), reg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(models) != 1 || models[0].ProviderID != ProviderOpenAI || models[0].ModelID != "gpt-5.4" {
+		t.Fatalf("unexpected models %#v", models)
+	}
+	if len(warnings) != 1 || warnings[0].ProviderID != ProviderAnthropic {
+		t.Fatalf("unexpected warnings %#v", warnings)
+	}
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -14,6 +14,14 @@ type stubRegistryClient struct {
 	err        error
 }
 
+type stubListRegistry struct {
+	listErr error
+}
+
+func (s stubListRegistry) Register(context.Context, Client) error         { return nil }
+func (s stubListRegistry) Get(context.Context, ProviderID) (Client, bool) { return nil, false }
+func (s stubListRegistry) List(context.Context) ([]ProviderID, error)     { return nil, s.listErr }
+
 func (s stubRegistryClient) ProviderID() ProviderID                                { return s.providerID }
 func (s stubRegistryClient) ListModels(context.Context) ([]ModelInfo, error)       { return s.models, s.err }
 func (s stubRegistryClient) Stream(context.Context, Request) (<-chan Event, error) { return nil, nil }
@@ -60,7 +68,7 @@ func TestListModelsAggregatesWarningsAndDeduplicates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderOpenAI, models: []ModelInfo{{ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}, {ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}}}); err != nil {
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderOpenAI, models: []ModelInfo{{ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}, {ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}, {ProviderID: "", ModelID: "gpt-4.1"}}}); err != nil {
 		t.Fatalf("unexpected register error %v", err)
 	}
 	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderAnthropic, err: errors.New("list failed")}); err != nil {
@@ -70,10 +78,59 @@ func TestListModelsAggregatesWarningsAndDeduplicates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if len(models) != 1 || models[0].ProviderID != ProviderOpenAI || models[0].ModelID != "gpt-5.4" {
+	if len(models) != 2 || models[0].ProviderID != ProviderOpenAI || models[0].ModelID != "gpt-4.1" || models[1].ProviderID != ProviderOpenAI || models[1].ModelID != "gpt-5.4" {
 		t.Fatalf("unexpected models %#v", models)
 	}
-	if len(warnings) != 1 || warnings[0].ProviderID != ProviderAnthropic {
+	if len(warnings) != 1 || warnings[0].ProviderID != ProviderAnthropic || warnings[0].Reason != listModelsWarningReason {
 		t.Fatalf("unexpected warnings %#v", warnings)
+	}
+}
+
+func TestListModelsReturnsRegistryError(t *testing.T) {
+	reg := stubListRegistry{listErr: errors.New("boom")}
+	if _, _, err := ListModels(context.Background(), reg); err == nil {
+		t.Fatal("expected registry list error")
+	}
+}
+
+func TestRegistryCoversLookupAndNormalizationBranches(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "openai-compatible"}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	client, ok := reg.Get(context.Background(), "openai")
+	if !ok || client.ProviderID() != "openai-compatible" {
+		t.Fatalf("unexpected client lookup result ok=%v client=%#v", ok, client)
+	}
+	if _, ok := reg.Get(context.Background(), "missing"); ok {
+		t.Fatal("expected missing provider lookup to fail")
+	}
+	ids, err := reg.List(context.Background())
+	if err != nil || len(ids) != 1 || ids[0] != ProviderOpenAI {
+		t.Fatalf("unexpected ids %#v err=%v", ids, err)
+	}
+}
+
+func TestRegistryHandlesProviderNotFoundAndConfigErrors(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), nil); err != nil {
+		t.Fatalf("expected nil client register to be ignored, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ""}); err == nil {
+		t.Fatal("expected provider not found error")
+	} else {
+		var providerErr *Error
+		if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeProviderNotFound {
+			t.Fatalf("unexpected error %#v", err)
+		}
+	}
+	if _, err := NewRegistry(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"broken": {BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
+		t.Fatal("expected invalid provider type error")
 	}
 }

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -1,0 +1,112 @@
+package provider
+
+import (
+	"errors"
+	"strings"
+
+	"bytemind/internal/llm"
+)
+
+const (
+	ProviderOpenAI    ProviderID = "openai"
+	ProviderAnthropic ProviderID = "anthropic"
+)
+
+type ErrorCode string
+
+type EventType string
+
+type HealthStatus string
+
+const (
+	ErrCodeUnauthorized      ErrorCode = "unauthorized"
+	ErrCodeRateLimited       ErrorCode = "rate_limited"
+	ErrCodeTimeout           ErrorCode = "timeout"
+	ErrCodeUnavailable       ErrorCode = "unavailable"
+	ErrCodeBadRequest        ErrorCode = "bad_request"
+	ErrCodeProviderNotFound  ErrorCode = "provider_not_found"
+	ErrCodeDuplicateProvider ErrorCode = "duplicate_provider"
+)
+
+const (
+	EventStart    EventType = "start"
+	EventDelta    EventType = "delta"
+	EventToolCall EventType = "tool_call"
+	EventUsage    EventType = "usage"
+	EventResult   EventType = "result"
+	EventError    EventType = "error"
+)
+
+const (
+	HealthStatusHealthy     HealthStatus = "healthy"
+	HealthStatusDegraded    HealthStatus = "degraded"
+	HealthStatusUnavailable HealthStatus = "unavailable"
+	HealthStatusHalfOpen    HealthStatus = "half_open"
+)
+
+var (
+	ErrProviderNotFound  = errors.New(string(ErrCodeProviderNotFound))
+	ErrDuplicateProvider = errors.New(string(ErrCodeDuplicateProvider))
+)
+
+type ModelInfo struct {
+	ProviderID   ProviderID
+	ModelID      ModelID
+	DisplayAlias string
+	Metadata     map[string]string
+}
+
+type Warning struct {
+	ProviderID ProviderID
+	Reason     string
+}
+
+type Usage struct {
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+	Cost         float64
+	Currency     string
+	IsEstimated  bool
+}
+
+type Error struct {
+	Code      ErrorCode
+	Provider  ProviderID
+	Message   string
+	Retryable bool
+	Err       error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return string(e.Code)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+type Event struct {
+	ID         string
+	TraceID    string
+	ProviderID ProviderID
+	ModelID    ModelID
+	Type       EventType
+	Delta      string
+	ToolCall   *llm.ToolCall
+	Usage      *Usage
+	Result     *llm.Message
+	Error      *Error
+}

--- a/internal/provider/types_test.go
+++ b/internal/provider/types_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestProviderErrorStringAndUnwrap(t *testing.T) {
+	base := errors.New("base error")
+
+	if (*Error)(nil).Error() != "" {
+		t.Fatal("expected nil error string to be empty")
+	}
+	if (*Error)(nil).Unwrap() != nil {
+		t.Fatal("expected nil unwrap to be nil")
+	}
+
+	withMessage := &Error{Code: ErrCodeUnavailable, Message: "trimmed message", Err: base}
+	if withMessage.Error() != "trimmed message" {
+		t.Fatalf("unexpected message: %q", withMessage.Error())
+	}
+
+	withWrapped := &Error{Code: ErrCodeUnavailable, Err: base}
+	if withWrapped.Error() != "base error" {
+		t.Fatalf("unexpected wrapped message: %q", withWrapped.Error())
+	}
+	if !errors.Is(withWrapped, base) {
+		t.Fatal("expected unwrap to expose base error")
+	}
+
+	withCodeOnly := &Error{Code: ErrCodeBadRequest}
+	if withCodeOnly.Error() != string(ErrCodeBadRequest) {
+		t.Fatalf("unexpected code-only message: %q", withCodeOnly.Error())
+	}
+}


### PR DESCRIPTION
方案来源 #209  step3

> 把当前单 client 工厂升级为“多 provider 注册与查询中心”，同时兼容当前默认 provider 运行模式。

本次迭代内容

新增 internal/provider/registry.go
实现并发安全 Registry
支持 Register/Get/List
重复注册返回 duplicate_provider
提供 NewRegistry(cfg config.ProviderRuntimeConfig)
提供 legacy 兼容入口 NewRegistryFromProviderConfig(cfg config.ProviderConfig)
新增 internal/provider/models.go
聚合 registry 下所有 provider 的模型目录
按 (provider_id, model_id) 去重
支持部分成功，返回 models + warnings
新增 internal/provider/registry_test.go
覆盖 legacy 单 provider 装配
覆盖重复注册错误
覆盖模型聚合与 warnings
新增 internal/config/provider_runtime.go
新增 ProviderRuntimeConfig
保留 ProviderConfig
提供 legacy -> runtime config 映射
对齐 PRD / 方案

对齐 provider-iteration-plan.md:181-257
对齐 prd-provider.md:231-236
没越到 Router / fallback / health / 上层调用链