### PR TITLE
test(runtime): 推进 #205 并发一致性与边界固化

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -42,6 +42,7 @@ type Options struct {
 	Registry     ToolRegistry
 	Executor     ToolExecutor
 	TaskManager  runtimepkg.TaskManager
+	Runtime      RuntimeGateway
 	Extensions   extensionspkg.Manager
 	SkillManager *skills.Manager
 	TokenManager *tokenusage.TokenUsageManager
@@ -67,6 +68,7 @@ type Runner struct {
 	registry     ToolRegistry
 	executor     ToolExecutor
 	taskManager  runtimepkg.TaskManager
+	runtime      RuntimeGateway
 	extensions   extensionspkg.Manager
 	skillManager *skills.Manager
 	tokenManager *tokenusage.TokenUsageManager
@@ -105,6 +107,10 @@ func NewRunner(opts Options) *Runner {
 	if taskManager == nil {
 		taskManager = runtimepkg.NewInMemoryTaskManager()
 	}
+	runtimeGateway := opts.Runtime
+	if runtimeGateway == nil {
+		runtimeGateway = newDefaultRuntimeGateway(taskManager)
+	}
 	extensions := opts.Extensions
 	if extensions == nil {
 		extensions = extensionspkg.NopManager{}
@@ -117,6 +123,7 @@ func NewRunner(opts Options) *Runner {
 		registry:     registry,
 		executor:     executor,
 		taskManager:  taskManager,
+		runtime:      runtimeGateway,
 		extensions:   extensions,
 		skillManager: manager,
 		tokenManager: opts.TokenManager,

--- a/internal/agent/runtime_gateway.go
+++ b/internal/agent/runtime_gateway.go
@@ -91,15 +91,17 @@ func (g *defaultRuntimeGateway) RunSync(ctx context.Context, request RuntimeTask
 		Metadata:     copyTaskMetadata(request.Metadata),
 	}
 
-	if registry, ok := g.taskManager.(runtimepkg.TaskExecutionRegistry); ok {
-		token := g.buildExecutionToken(spec)
-		if spec.Metadata == nil {
-			spec.Metadata = make(map[string]string, 1)
-		}
-		spec.Metadata[runtimepkg.TaskExecutionTokenMetadataKey] = token
-		registry.RegisterExecution(token, executor)
-		defer registry.UnregisterExecution(token)
+	registry, ok := g.taskManager.(runtimepkg.TaskExecutionRegistry)
+	if !ok {
+		return RuntimeTaskExecution{}, fmt.Errorf("runtime task manager must implement TaskExecutionRegistry")
 	}
+	token := g.buildExecutionToken(spec)
+	if spec.Metadata == nil {
+		spec.Metadata = make(map[string]string, 1)
+	}
+	spec.Metadata[runtimepkg.TaskExecutionTokenMetadataKey] = token
+	registry.RegisterExecution(token, executor)
+	defer registry.UnregisterExecution(token)
 
 	taskID, submitErr := g.taskManager.Submit(ctx, spec)
 	if submitErr != nil {

--- a/internal/agent/runtime_gateway.go
+++ b/internal/agent/runtime_gateway.go
@@ -1,0 +1,220 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	corepkg "bytemind/internal/core"
+	runtimepkg "bytemind/internal/runtime"
+)
+
+const (
+	defaultPostCancelWait = 2 * time.Second
+)
+
+type RuntimeGateway interface {
+	RunSync(ctx context.Context, request RuntimeTaskRequest) (RuntimeTaskExecution, error)
+}
+
+type RuntimeTaskRequest struct {
+	SessionID          corepkg.SessionID
+	TraceID            corepkg.TraceID
+	Name               string
+	Kind               string
+	ParentTaskID       corepkg.TaskID
+	Timeout            time.Duration
+	Metadata           map[string]string
+	Execute            func(context.Context) ([]byte, error)
+	OnTaskStateChanged func(runtimepkg.Task)
+}
+
+type RuntimeTaskExecution struct {
+	TaskID         corepkg.TaskID
+	Result         runtimepkg.TaskResult
+	ExecutionError error
+}
+
+type defaultRuntimeGateway struct {
+	taskManager      runtimepkg.TaskManager
+	postCancelWait   time.Duration
+	tokenTimeFactory func() time.Time
+}
+
+func newDefaultRuntimeGateway(taskManager runtimepkg.TaskManager) RuntimeGateway {
+	return &defaultRuntimeGateway{
+		taskManager:      taskManager,
+		postCancelWait:   defaultPostCancelWait,
+		tokenTimeFactory: time.Now,
+	}
+}
+
+func (g *defaultRuntimeGateway) RunSync(ctx context.Context, request RuntimeTaskRequest) (RuntimeTaskExecution, error) {
+	if g == nil || g.taskManager == nil {
+		return RuntimeTaskExecution{}, fmt.Errorf("runtime task manager is unavailable")
+	}
+	if request.Execute == nil {
+		return RuntimeTaskExecution{}, fmt.Errorf("runtime task executor is unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var (
+		executionErr error
+		execErrMu    sync.Mutex
+	)
+
+	executor := func(execCtx context.Context, task runtimepkg.Task) ([]byte, error) {
+		if request.OnTaskStateChanged != nil {
+			request.OnTaskStateChanged(task)
+		}
+		output, err := request.Execute(execCtx)
+		if err != nil {
+			execErrMu.Lock()
+			executionErr = err
+			execErrMu.Unlock()
+		}
+		return output, err
+	}
+
+	spec := runtimepkg.TaskSpec{
+		SessionID:    request.SessionID,
+		TraceID:      request.TraceID,
+		Name:         request.Name,
+		Kind:         request.Kind,
+		ParentTaskID: request.ParentTaskID,
+		Timeout:      request.Timeout,
+		Metadata:     copyTaskMetadata(request.Metadata),
+	}
+
+	if registry, ok := g.taskManager.(runtimepkg.TaskExecutionRegistry); ok {
+		token := g.buildExecutionToken(spec)
+		if spec.Metadata == nil {
+			spec.Metadata = make(map[string]string, 1)
+		}
+		spec.Metadata[runtimepkg.TaskExecutionTokenMetadataKey] = token
+		registry.RegisterExecution(token, executor)
+		defer registry.UnregisterExecution(token)
+	}
+
+	taskID, submitErr := g.taskManager.Submit(ctx, spec)
+	if submitErr != nil {
+		return RuntimeTaskExecution{}, submitErr
+	}
+
+	if request.OnTaskStateChanged != nil {
+		if snapshot, err := g.taskManager.Get(context.Background(), taskID); err == nil {
+			request.OnTaskStateChanged(snapshot)
+		}
+	}
+
+	result, waitErr := g.taskManager.Wait(ctx, taskID)
+	if waitErr == nil {
+		execErrMu.Lock()
+		executionErrCopy := executionErr
+		execErrMu.Unlock()
+		if request.OnTaskStateChanged != nil {
+			if snapshot, err := g.taskManager.Get(context.Background(), taskID); err == nil {
+				request.OnTaskStateChanged(snapshot)
+			}
+		}
+		return RuntimeTaskExecution{
+			TaskID:         taskID,
+			Result:         result,
+			ExecutionError: executionErrCopy,
+		}, nil
+	}
+
+	execution := RuntimeTaskExecution{TaskID: taskID}
+	if !errors.Is(waitErr, context.Canceled) && !errors.Is(waitErr, context.DeadlineExceeded) {
+		return execution, waitErr
+	}
+	if ctx.Err() == nil {
+		return execution, waitErr
+	}
+
+	_ = g.taskManager.Cancel(context.Background(), taskID, "parent_context_cancelled")
+
+	settleWait := g.postCancelWait
+	if settleWait <= 0 {
+		settleWait = defaultPostCancelWait
+	}
+	settleCtx, settleCancel := context.WithTimeout(context.Background(), settleWait)
+	defer settleCancel()
+
+	settled, settleErr := g.taskManager.Wait(settleCtx, taskID)
+	if settleErr != nil {
+		return execution, waitErr
+	}
+
+	execErrMu.Lock()
+	executionErrCopy := executionErr
+	execErrMu.Unlock()
+	execution.Result = settled
+	execution.ExecutionError = executionErrCopy
+
+	if request.OnTaskStateChanged != nil {
+		if snapshot, err := g.taskManager.Get(context.Background(), taskID); err == nil {
+			request.OnTaskStateChanged(snapshot)
+		}
+	}
+
+	return execution, waitErr
+}
+
+func (g *defaultRuntimeGateway) buildExecutionToken(spec runtimepkg.TaskSpec) string {
+	nowFn := g.tokenTimeFactory
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	parts := []string{
+		strings.TrimSpace(string(spec.SessionID)),
+		strings.TrimSpace(string(spec.TraceID)),
+		strings.TrimSpace(spec.Name),
+	}
+	key := strings.Join(parts, ":")
+	if parts[0] == "" && parts[1] == "" && parts[2] == "" {
+		key = "task"
+	}
+	return fmt.Sprintf("%s:%d", key, nowFn().UTC().UnixNano())
+}
+
+type runtimeTaskResultError struct {
+	status    corepkg.TaskStatus
+	errorCode string
+}
+
+func (e runtimeTaskResultError) Error() string {
+	switch e.status {
+	case corepkg.TaskKilled:
+		if e.errorCode != "" {
+			return fmt.Sprintf("runtime task cancelled (%s)", e.errorCode)
+		}
+		return "runtime task cancelled"
+	case corepkg.TaskFailed:
+		if e.errorCode != "" {
+			return fmt.Sprintf("runtime task failed (%s)", e.errorCode)
+		}
+		return "runtime task failed"
+	default:
+		if e.errorCode != "" {
+			return fmt.Sprintf("runtime task ended with status %s (%s)", e.status, e.errorCode)
+		}
+		return fmt.Sprintf("runtime task ended with status %s", e.status)
+	}
+}
+
+func copyTaskMetadata(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(src))
+	for key, value := range src {
+		copied[key] = value
+	}
+	return copied
+}

--- a/internal/agent/runtime_gateway_test.go
+++ b/internal/agent/runtime_gateway_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -60,6 +61,9 @@ func TestDefaultRuntimeGatewayRunSyncCompletes(t *testing.T) {
 	}
 	if !containsTaskStatus(states, corepkg.TaskRunning) {
 		t.Fatalf("expected running status callback, got %v", states)
+	}
+	if err := assertMonotonicTaskProgress(states); err != nil {
+		t.Fatalf("expected monotonic state progression, got states=%v err=%v", states, err)
 	}
 }
 
@@ -153,4 +157,43 @@ func containsTaskStatus(states []corepkg.TaskStatus, expected corepkg.TaskStatus
 		}
 	}
 	return false
+}
+
+func assertMonotonicTaskProgress(states []corepkg.TaskStatus) error {
+	if len(states) == 0 {
+		return fmt.Errorf("empty states")
+	}
+	previousRank := -1
+	for _, status := range states {
+		rank, ok := taskStatusRank(status)
+		if !ok {
+			return fmt.Errorf("unknown status %q", status)
+		}
+		if previousRank > rank {
+			return fmt.Errorf("status regressed from rank %d to %d", previousRank, rank)
+		}
+		previousRank = rank
+	}
+	last := states[len(states)-1]
+	if !isTerminalStatus(last) {
+		return fmt.Errorf("final status %q is not terminal", last)
+	}
+	return nil
+}
+
+func taskStatusRank(status corepkg.TaskStatus) (int, bool) {
+	switch status {
+	case corepkg.TaskPending:
+		return 0, true
+	case corepkg.TaskRunning:
+		return 1, true
+	case corepkg.TaskCompleted, corepkg.TaskFailed, corepkg.TaskKilled:
+		return 2, true
+	default:
+		return 0, false
+	}
+}
+
+func isTerminalStatus(status corepkg.TaskStatus) bool {
+	return status == corepkg.TaskCompleted || status == corepkg.TaskFailed || status == corepkg.TaskKilled
 }

--- a/internal/agent/runtime_gateway_test.go
+++ b/internal/agent/runtime_gateway_test.go
@@ -53,8 +53,8 @@ func TestDefaultRuntimeGatewayRunSyncCompletes(t *testing.T) {
 	if len(states) < 3 {
 		t.Fatalf("expected at least 3 state callbacks, got %v", states)
 	}
-	if states[0] != corepkg.TaskPending {
-		t.Fatalf("expected first callback pending, got %v", states)
+	if states[0] != corepkg.TaskPending && states[0] != corepkg.TaskRunning {
+		t.Fatalf("expected first callback to be pending or running, got %v", states)
 	}
 	if states[len(states)-1] != corepkg.TaskCompleted {
 		t.Fatalf("expected final callback completed, got %v", states)
@@ -150,6 +150,26 @@ func TestDefaultRuntimeGatewayRunSyncCancelsTaskWhenParentContextCancelled(t *te
 	}
 }
 
+func TestDefaultRuntimeGatewayRunSyncFailsWhenRegistryUnavailable(t *testing.T) {
+	gateway := newDefaultRuntimeGateway(taskManagerWithoutRegistry{})
+
+	_, err := gateway.RunSync(context.Background(), RuntimeTaskRequest{
+		SessionID: "sess-1",
+		TraceID:   "trace-no-registry",
+		Name:      "tool_no_registry",
+		Kind:      "tool",
+		Execute: func(_ context.Context) ([]byte, error) {
+			return []byte("ok"), nil
+		},
+	})
+	if err == nil {
+		t.Fatal("expected RunSync to fail when registry is unavailable")
+	}
+	if got := err.Error(); got != "runtime task manager must implement TaskExecutionRegistry" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func containsTaskStatus(states []corepkg.TaskStatus, expected corepkg.TaskStatus) bool {
 	for _, status := range states {
 		if status == expected {
@@ -196,4 +216,30 @@ func taskStatusRank(status corepkg.TaskStatus) (int, bool) {
 
 func isTerminalStatus(status corepkg.TaskStatus) bool {
 	return status == corepkg.TaskCompleted || status == corepkg.TaskFailed || status == corepkg.TaskKilled
+}
+
+type taskManagerWithoutRegistry struct{}
+
+func (taskManagerWithoutRegistry) Submit(_ context.Context, _ runtimepkg.TaskSpec) (corepkg.TaskID, error) {
+	return "task-id", nil
+}
+
+func (taskManagerWithoutRegistry) Get(_ context.Context, _ corepkg.TaskID) (runtimepkg.Task, error) {
+	return runtimepkg.Task{}, nil
+}
+
+func (taskManagerWithoutRegistry) Cancel(_ context.Context, _ corepkg.TaskID, _ string) error {
+	return nil
+}
+
+func (taskManagerWithoutRegistry) Retry(_ context.Context, _ corepkg.TaskID) (corepkg.TaskID, error) {
+	return "", nil
+}
+
+func (taskManagerWithoutRegistry) Stream(_ context.Context, _ corepkg.TaskID) (<-chan runtimepkg.TaskEvent, error) {
+	return nil, nil
+}
+
+func (taskManagerWithoutRegistry) Wait(_ context.Context, _ corepkg.TaskID) (runtimepkg.TaskResult, error) {
+	return runtimepkg.TaskResult{}, nil
 }

--- a/internal/agent/runtime_gateway_test.go
+++ b/internal/agent/runtime_gateway_test.go
@@ -1,0 +1,156 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	corepkg "bytemind/internal/core"
+	runtimepkg "bytemind/internal/runtime"
+)
+
+func TestDefaultRuntimeGatewayRunSyncCompletes(t *testing.T) {
+	manager := runtimepkg.NewInMemoryTaskManager()
+	gateway := newDefaultRuntimeGateway(manager)
+
+	var (
+		mu     sync.Mutex
+		states []corepkg.TaskStatus
+	)
+
+	execution, err := gateway.RunSync(context.Background(), RuntimeTaskRequest{
+		SessionID: "sess-1",
+		TraceID:   "trace-1",
+		Name:      "tool_success",
+		Kind:      "tool",
+		Execute: func(_ context.Context) ([]byte, error) {
+			return []byte("ok"), nil
+		},
+		OnTaskStateChanged: func(task runtimepkg.Task) {
+			mu.Lock()
+			states = append(states, task.Status)
+			mu.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunSync failed: %v", err)
+	}
+	if execution.TaskID == "" {
+		t.Fatal("expected non-empty task id")
+	}
+	if execution.Result.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected completed status, got %s", execution.Result.Status)
+	}
+	if got := string(execution.Result.Output); got != "ok" {
+		t.Fatalf("expected output %q, got %q", "ok", got)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(states) < 3 {
+		t.Fatalf("expected at least 3 state callbacks, got %v", states)
+	}
+	if states[0] != corepkg.TaskPending {
+		t.Fatalf("expected first callback pending, got %v", states)
+	}
+	if states[len(states)-1] != corepkg.TaskCompleted {
+		t.Fatalf("expected final callback completed, got %v", states)
+	}
+	if !containsTaskStatus(states, corepkg.TaskRunning) {
+		t.Fatalf("expected running status callback, got %v", states)
+	}
+}
+
+func TestDefaultRuntimeGatewayRunSyncCapturesExecutionFailure(t *testing.T) {
+	manager := runtimepkg.NewInMemoryTaskManager()
+	gateway := newDefaultRuntimeGateway(manager)
+
+	execution, err := gateway.RunSync(context.Background(), RuntimeTaskRequest{
+		SessionID: "sess-1",
+		TraceID:   "trace-fail",
+		Name:      "tool_fail",
+		Kind:      "tool",
+		Execute: func(_ context.Context) ([]byte, error) {
+			return nil, errors.New("boom")
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunSync failed: %v", err)
+	}
+	if execution.Result.Status != corepkg.TaskFailed {
+		t.Fatalf("expected failed status, got %s", execution.Result.Status)
+	}
+	if execution.Result.ErrorCode != runtimepkg.ErrorCodeTaskExecutionFailed {
+		t.Fatalf("expected error code %q, got %q", runtimepkg.ErrorCodeTaskExecutionFailed, execution.Result.ErrorCode)
+	}
+	if execution.ExecutionError == nil || execution.ExecutionError.Error() != "boom" {
+		t.Fatalf("expected execution error boom, got %v", execution.ExecutionError)
+	}
+}
+
+func TestDefaultRuntimeGatewayRunSyncCancelsTaskWhenParentContextCancelled(t *testing.T) {
+	manager := runtimepkg.NewInMemoryTaskManager()
+	gateway := newDefaultRuntimeGateway(manager)
+
+	started := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resultCh := make(chan RuntimeTaskExecution, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		execution, err := gateway.RunSync(ctx, RuntimeTaskRequest{
+			SessionID: "sess-1",
+			TraceID:   "trace-cancel",
+			Name:      "tool_cancel",
+			Kind:      "tool",
+			Execute: func(execCtx context.Context) ([]byte, error) {
+				select {
+				case started <- struct{}{}:
+				default:
+				}
+				<-execCtx.Done()
+				return nil, execCtx.Err()
+			},
+		})
+		resultCh <- execution
+		errCh <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("task did not start")
+	}
+	cancel()
+
+	select {
+	case execution := <-resultCh:
+		err := <-errCh
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled error, got %v", err)
+		}
+		if execution.TaskID == "" {
+			t.Fatal("expected task id when cancelled")
+		}
+		if execution.Result.Status != corepkg.TaskKilled {
+			t.Fatalf("expected killed status, got %s", execution.Result.Status)
+		}
+		if execution.Result.ErrorCode != runtimepkg.ErrorCodeTaskCancelled {
+			t.Fatalf("expected cancel error code %q, got %q", runtimepkg.ErrorCodeTaskCancelled, execution.Result.ErrorCode)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("RunSync did not return after parent cancellation")
+	}
+}
+
+func containsTaskStatus(states []corepkg.TaskStatus, expected corepkg.TaskStatus) bool {
+	for _, status := range states {
+		if status == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/tool_execution.go
+++ b/internal/agent/tool_execution.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	corepkg "bytemind/internal/core"
 	"bytemind/internal/llm"
 	planpkg "bytemind/internal/plan"
+	runtimepkg "bytemind/internal/runtime"
 	"bytemind/internal/session"
 	storagepkg "bytemind/internal/storage"
 	"bytemind/internal/tools"
@@ -26,14 +28,18 @@ func (r *Runner) executeToolCall(
 	if r.executor == nil {
 		return fmt.Errorf("tool executor is unavailable")
 	}
+	traceID := buildToolTraceID(call)
+	sessionID := corepkg.SessionID(sess.ID)
+
 	r.emit(Event{
 		Type:          EventToolCallStarted,
-		SessionID:     corepkg.SessionID(sess.ID),
+		SessionID:     sessionID,
 		ToolName:      call.Function.Name,
 		ToolArguments: call.Function.Arguments,
 	})
 	r.appendAudit(ctx, storagepkg.AuditEvent{
-		SessionID: corepkg.SessionID(sess.ID),
+		SessionID: sessionID,
+		TraceID:   traceID,
 		Actor:     "agent",
 		Action:    "tool_execute_start",
 		Metadata: map[string]string{
@@ -45,19 +51,50 @@ func (r *Runner) executeToolCall(
 	}
 
 	execStartedAt := time.Now()
-	result, execErr := r.executor.ExecuteForMode(ctx, runMode, call.Function.Name, call.Function.Arguments, &tools.ExecutionContext{
-		Workspace:      r.workspace,
-		ApprovalPolicy: r.config.ApprovalPolicy,
-		Approval:       r.approval,
-		Session:        sess,
-		TaskManager:    r.taskManager,
-		Extensions:     r.extensions,
-		Mode:           runMode,
-		Stdin:          r.stdin,
-		Stdout:         r.stdout,
-		AllowedTools:   allowedTools,
-		DeniedTools:    deniedTools,
+	execution, runtimeErr := r.runtime.RunSync(ctx, RuntimeTaskRequest{
+		SessionID: sessionID,
+		TraceID:   traceID,
+		Name:      call.Function.Name,
+		Kind:      "tool",
+		Metadata: map[string]string{
+			"tool_name": call.Function.Name,
+		},
+		Execute: func(execCtx context.Context) ([]byte, error) {
+			output, err := r.executor.ExecuteForMode(execCtx, runMode, call.Function.Name, call.Function.Arguments, &tools.ExecutionContext{
+				Workspace:      r.workspace,
+				ApprovalPolicy: r.config.ApprovalPolicy,
+				Approval:       r.approval,
+				Session:        sess,
+				TaskManager:    r.taskManager,
+				Extensions:     r.extensions,
+				Mode:           runMode,
+				Stdin:          r.stdin,
+				Stdout:         r.stdout,
+				AllowedTools:   allowedTools,
+				DeniedTools:    deniedTools,
+			})
+			return []byte(output), err
+		},
+		OnTaskStateChanged: func(task runtimepkg.Task) {
+			r.appendTaskStateAudit(ctx, sessionID, traceID, call.Function.Name, task)
+		},
 	})
+
+	result := string(execution.Result.Output)
+	execErr := execution.ExecutionError
+	if runtimeErr != nil && execution.Result.TaskID == "" {
+		execErr = runtimeErr
+	}
+	if execErr == nil && execution.Result.TaskID != "" && execution.Result.Status != corepkg.TaskCompleted {
+		execErr = runtimeTaskResultError{
+			status:    execution.Result.Status,
+			errorCode: execution.Result.ErrorCode,
+		}
+	}
+	if execErr == nil && runtimeErr != nil {
+		execErr = runtimeErr
+	}
+
 	if execErr != nil {
 		result = marshalToolResult(map[string]any{
 			"ok":    false,
@@ -74,7 +111,7 @@ func (r *Runner) executeToolCall(
 	}
 	r.emit(Event{
 		Type:       EventToolCallCompleted,
-		SessionID:  corepkg.SessionID(sess.ID),
+		SessionID:  sessionID,
 		ToolName:   call.Function.Name,
 		ToolResult: result,
 		Error:      errText,
@@ -84,16 +121,22 @@ func (r *Runner) executeToolCall(
 	if execErr != nil {
 		auditResult = "error"
 	}
+	metadata := map[string]string{
+		"tool_name": call.Function.Name,
+		"error":     errText,
+	}
+	if execution.Result.ErrorCode != "" {
+		metadata["error_code"] = execution.Result.ErrorCode
+	}
 	r.appendAudit(ctx, storagepkg.AuditEvent{
-		SessionID: corepkg.SessionID(sess.ID),
+		SessionID: sessionID,
+		TaskID:    execution.TaskID,
+		TraceID:   traceID,
 		Actor:     "agent",
 		Action:    "tool_execute_result",
 		Result:    auditResult,
 		LatencyMS: time.Since(execStartedAt).Milliseconds(),
-		Metadata: map[string]string{
-			"tool_name": call.Function.Name,
-			"error":     errText,
-		},
+		Metadata:  metadata,
 	})
 
 	toolMessage := llm.NewToolResultMessage(call.ID, result)
@@ -109,9 +152,44 @@ func (r *Runner) executeToolCall(
 	if call.Function.Name == "update_plan" {
 		r.emit(Event{
 			Type:      EventPlanUpdated,
-			SessionID: corepkg.SessionID(sess.ID),
+			SessionID: sessionID,
 			Plan:      planpkg.CloneState(sess.Plan),
 		})
 	}
 	return nil
+}
+
+func buildToolTraceID(call llm.ToolCall) corepkg.TraceID {
+	if id := strings.TrimSpace(call.ID); id != "" {
+		return corepkg.TraceID(id)
+	}
+	return corepkg.TraceID(fmt.Sprintf("tool-%d", time.Now().UTC().UnixNano()))
+}
+
+func (r *Runner) appendTaskStateAudit(
+	ctx context.Context,
+	sessionID corepkg.SessionID,
+	traceID corepkg.TraceID,
+	toolName string,
+	task runtimepkg.Task,
+) {
+	if task.ID == "" {
+		return
+	}
+	metadata := map[string]string{
+		"tool_name": toolName,
+		"status":    string(task.Status),
+	}
+	if task.ErrorCode != "" {
+		metadata["error_code"] = task.ErrorCode
+	}
+	r.appendAudit(ctx, storagepkg.AuditEvent{
+		SessionID: sessionID,
+		TaskID:    task.ID,
+		TraceID:   traceID,
+		Actor:     "runtime",
+		Action:    "task_state_changed",
+		Result:    string(task.Status),
+		Metadata:  metadata,
+	})
 }

--- a/internal/agent/tool_execution_audit_test.go
+++ b/internal/agent/tool_execution_audit_test.go
@@ -10,6 +10,7 @@ import (
 	"bytemind/internal/config"
 	corepkg "bytemind/internal/core"
 	"bytemind/internal/llm"
+	runtimepkg "bytemind/internal/runtime"
 	"bytemind/internal/session"
 	storagepkg "bytemind/internal/storage"
 	"bytemind/internal/tools"
@@ -114,5 +115,97 @@ func TestRunPromptRecordsTaskStateChangedAuditWithSessionTaskTrace(t *testing.T)
 	}
 	if !seenTerminal {
 		t.Fatalf("expected at least one terminal task_state_changed event, got %+v", stateEvents)
+	}
+}
+
+type stubRuntimeGateway struct {
+	mu    sync.Mutex
+	calls []RuntimeTaskRequest
+}
+
+func (g *stubRuntimeGateway) RunSync(_ context.Context, request RuntimeTaskRequest) (RuntimeTaskExecution, error) {
+	g.mu.Lock()
+	g.calls = append(g.calls, request)
+	g.mu.Unlock()
+	return RuntimeTaskExecution{
+		TaskID: "runtime-task-1",
+		Result: runtimepkg.TaskResult{
+			TaskID: "runtime-task-1",
+			Status: corepkg.TaskCompleted,
+			Output: []byte(`{"ok":true,"via":"runtime_gateway"}`),
+		},
+	}, nil
+}
+
+func TestRunPromptExecutesToolThroughRuntimeGatewayBoundary(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "tool-via-runtime",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "list_files",
+					Arguments: `{}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "done",
+		},
+	}}
+	gateway := &stubRuntimeGateway{}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 4,
+			Stream:        false,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Runtime:  gateway,
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "run tool", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "done" {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+
+	gateway.mu.Lock()
+	callCount := len(gateway.calls)
+	var call RuntimeTaskRequest
+	if callCount > 0 {
+		call = gateway.calls[0]
+	}
+	gateway.mu.Unlock()
+	if callCount != 1 {
+		t.Fatalf("expected exactly 1 runtime gateway call, got %d", callCount)
+	}
+	if call.Name != "list_files" || call.Kind != "tool" {
+		t.Fatalf("expected runtime gateway tool request, got %+v", call)
+	}
+
+	if len(sess.Messages) < 3 {
+		t.Fatalf("expected tool result message to be persisted, got %#v", sess.Messages)
+	}
+	toolResult := sess.Messages[2].Content
+	if !strings.Contains(toolResult, `"via":"runtime_gateway"`) {
+		t.Fatalf("expected tool result from runtime gateway, got %q", toolResult)
 	}
 }

--- a/internal/agent/tool_execution_audit_test.go
+++ b/internal/agent/tool_execution_audit_test.go
@@ -1,0 +1,118 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"bytemind/internal/config"
+	corepkg "bytemind/internal/core"
+	"bytemind/internal/llm"
+	"bytemind/internal/session"
+	storagepkg "bytemind/internal/storage"
+	"bytemind/internal/tools"
+)
+
+type recordingAuditStore struct {
+	mu     sync.Mutex
+	events []storagepkg.AuditEvent
+}
+
+func (s *recordingAuditStore) Append(_ context.Context, event storagepkg.AuditEvent) error {
+	s.mu.Lock()
+	s.events = append(s.events, event)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *recordingAuditStore) snapshot() []storagepkg.AuditEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	copied := make([]storagepkg.AuditEvent, len(s.events))
+	copy(copied, s.events)
+	return copied
+}
+
+func TestRunPromptRecordsTaskStateChangedAuditWithSessionTaskTrace(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	auditStore := &recordingAuditStore{}
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "trace-tool-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "list_files",
+					Arguments: `{}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "done",
+		},
+	}}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 4,
+			Stream:        false,
+		},
+		Client:     client,
+		Store:      store,
+		Registry:   tools.DefaultRegistry(),
+		AuditStore: auditStore,
+		Stdin:      strings.NewReader(""),
+		Stdout:     io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "list files", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "done" {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+
+	events := auditStore.snapshot()
+	stateEvents := make([]storagepkg.AuditEvent, 0, 4)
+	for _, event := range events {
+		if event.Action == "task_state_changed" {
+			stateEvents = append(stateEvents, event)
+		}
+	}
+	if len(stateEvents) == 0 {
+		t.Fatalf("expected task_state_changed audit events, got %+v", events)
+	}
+
+	sessionID := corepkg.SessionID(sess.ID)
+	seenTerminal := false
+	for _, event := range stateEvents {
+		if event.SessionID != sessionID {
+			t.Fatalf("expected session id %q, got %q", sessionID, event.SessionID)
+		}
+		if event.TaskID == "" {
+			t.Fatalf("expected non-empty task id, got %+v", event)
+		}
+		if event.TraceID != corepkg.TraceID("trace-tool-1") {
+			t.Fatalf("expected trace id %q, got %q", "trace-tool-1", event.TraceID)
+		}
+		if event.Result == string(corepkg.TaskCompleted) || event.Result == string(corepkg.TaskFailed) || event.Result == string(corepkg.TaskKilled) {
+			seenTerminal = true
+		}
+	}
+	if !seenTerminal {
+		t.Fatalf("expected at least one terminal task_state_changed event, got %+v", stateEvents)
+	}
+}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -103,12 +104,45 @@ type QuotaManager interface {
 
 type TaskExecutorFunc func(ctx context.Context, task Task) ([]byte, error)
 
+const TaskExecutionTokenMetadataKey = "runtime_execution_token"
+
+type TaskExecutionRegistry interface {
+	RegisterExecution(token string, executor TaskExecutorFunc)
+	UnregisterExecution(token string)
+}
+
 type InMemoryTaskManagerOption func(*InMemoryTaskManager)
 
 func WithTaskExecutor(executor TaskExecutorFunc) InMemoryTaskManagerOption {
 	return func(m *InMemoryTaskManager) {
 		m.executor = executor
 	}
+}
+
+func (m *InMemoryTaskManager) RegisterExecution(token string, executor TaskExecutorFunc) {
+	if m == nil {
+		return
+	}
+	token = normalizeExecutionToken(token)
+	if token == "" || executor == nil {
+		return
+	}
+	m.mu.Lock()
+	m.executions[token] = executor
+	m.mu.Unlock()
+}
+
+func (m *InMemoryTaskManager) UnregisterExecution(token string) {
+	if m == nil {
+		return
+	}
+	token = normalizeExecutionToken(token)
+	if token == "" {
+		return
+	}
+	m.mu.Lock()
+	delete(m.executions, token)
+	m.mu.Unlock()
 }
 
 // InMemoryTaskManager is a safe placeholder until runtime orchestration is wired.
@@ -119,6 +153,7 @@ type InMemoryTaskManager struct {
 	runCancels     map[corepkg.TaskID]context.CancelFunc
 	parentChildren map[corepkg.TaskID]map[corepkg.TaskID]struct{}
 	childParent    map[corepkg.TaskID]corepkg.TaskID
+	executions     map[string]TaskExecutorFunc
 	executor       TaskExecutorFunc
 }
 
@@ -129,6 +164,7 @@ func NewInMemoryTaskManager(opts ...InMemoryTaskManagerOption) *InMemoryTaskMana
 		runCancels:     make(map[corepkg.TaskID]context.CancelFunc),
 		parentChildren: make(map[corepkg.TaskID]map[corepkg.TaskID]struct{}),
 		childParent:    make(map[corepkg.TaskID]corepkg.TaskID),
+		executions:     make(map[string]TaskExecutorFunc),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -331,7 +367,7 @@ func (m *InMemoryTaskManager) Wait(ctx context.Context, id corepkg.TaskID) (Task
 }
 
 func (m *InMemoryTaskManager) enqueueTask(parentCtx context.Context, id corepkg.TaskID) {
-	if m == nil || m.executor == nil {
+	if m == nil {
 		return
 	}
 	if parentCtx == nil {
@@ -341,7 +377,7 @@ func (m *InMemoryTaskManager) enqueueTask(parentCtx context.Context, id corepkg.
 }
 
 func (m *InMemoryTaskManager) runTaskAttempt(parentCtx context.Context, id corepkg.TaskID) {
-	if m == nil || m.executor == nil {
+	if m == nil {
 		return
 	}
 	if parentCtx == nil {
@@ -353,6 +389,11 @@ func (m *InMemoryTaskManager) runTaskAttempt(parentCtx context.Context, id corep
 	m.mu.Lock()
 	task, ok := m.tasks[id]
 	if !ok {
+		m.mu.Unlock()
+		return
+	}
+	executor := m.resolveExecutionLocked(task)
+	if executor == nil {
 		m.mu.Unlock()
 		return
 	}
@@ -379,7 +420,7 @@ func (m *InMemoryTaskManager) runTaskAttempt(parentCtx context.Context, id corep
 	if task.Spec.Timeout > 0 {
 		execCtx, timeoutCancel = context.WithTimeout(runCtx, task.Spec.Timeout)
 	}
-	output, execErr := m.executor(execCtx, task)
+	output, execErr := executor(execCtx, task)
 	timeoutCancel()
 	runCancel()
 
@@ -554,6 +595,25 @@ func cloneTaskSpec(spec TaskSpec) TaskSpec {
 		}
 	}
 	return cloned
+}
+
+func (m *InMemoryTaskManager) resolveExecutionLocked(task Task) TaskExecutorFunc {
+	if m == nil {
+		return nil
+	}
+	if len(task.Spec.Metadata) > 0 {
+		token := normalizeExecutionToken(task.Spec.Metadata[TaskExecutionTokenMetadataKey])
+		if token != "" {
+			if executor := m.executions[token]; executor != nil {
+				return executor
+			}
+		}
+	}
+	return m.executor
+}
+
+func normalizeExecutionToken(token string) string {
+	return strings.TrimSpace(token)
 }
 
 func detachContext(ctx context.Context) context.Context {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -564,3 +564,73 @@ func TestInMemoryTaskManagerTokenExecutionOverridesDefaultExecutor(t *testing.T)
 		t.Fatalf("expected dynamic executor output %q, got %q", "dynamic", got)
 	}
 }
+
+func TestInMemoryTaskManagerRetryCancelRaceConverges(t *testing.T) {
+	const iterations = 25
+
+	for i := 0; i < iterations; i++ {
+		var runs atomic.Int32
+		manager := NewInMemoryTaskManager(WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+			if runs.Add(1) == 1 {
+				return nil, errors.New("first failed")
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}))
+
+		id, err := manager.Submit(context.Background(), TaskSpec{
+			Name:       "race",
+			MaxRetries: 1,
+		})
+		if err != nil {
+			t.Fatalf("iteration %d: submit failed: %v", i, err)
+		}
+
+		first, err := manager.Wait(context.Background(), id)
+		if err != nil {
+			t.Fatalf("iteration %d: wait first attempt failed: %v", i, err)
+		}
+		if first.Status != corepkg.TaskFailed {
+			t.Fatalf("iteration %d: expected first attempt failed, got %s", i, first.Status)
+		}
+
+		start := make(chan struct{})
+		retryErrCh := make(chan error, 1)
+		cancelErrCh := make(chan error, 1)
+		go func() {
+			<-start
+			_, retryErr := manager.Retry(context.Background(), id)
+			retryErrCh <- retryErr
+		}()
+		go func() {
+			<-start
+			cancelErrCh <- manager.Cancel(context.Background(), id, "race")
+		}()
+		close(start)
+
+		retryErr := <-retryErrCh
+		cancelErr := <-cancelErrCh
+
+		if retryErr != nil && !hasErrorCode(retryErr, ErrorCodeInvalidTransition) {
+			t.Fatalf("iteration %d: retry returned unexpected error: %v", i, retryErr)
+		}
+		if cancelErr != nil && !hasErrorCode(cancelErr, ErrorCodeInvalidTransition) {
+			t.Fatalf("iteration %d: cancel returned unexpected error: %v", i, cancelErr)
+		}
+		if retryErr == nil && hasErrorCode(cancelErr, ErrorCodeInvalidTransition) {
+			if err := manager.Cancel(context.Background(), id, "post-race-converge"); err != nil && !hasErrorCode(err, ErrorCodeInvalidTransition) {
+				t.Fatalf("iteration %d: post-race cancel failed: %v", i, err)
+			}
+		}
+
+		finalCtx, finalCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		final, err := manager.Wait(finalCtx, id)
+		finalCancel()
+		if err != nil {
+			t.Fatalf("iteration %d: wait final failed: %v", i, err)
+		}
+		if !IsTerminalTaskStatus(final.Status) {
+			t.Fatalf("iteration %d: expected terminal status, got %s", i, final.Status)
+		}
+	}
+}

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -502,3 +502,65 @@ func TestInMemoryTaskManagerSubmitSnapshotsMutableTaskSpec(t *testing.T) {
 		t.Fatal("expected metadata not to include caller-side mutations")
 	}
 }
+
+func TestInMemoryTaskManagerRegisterExecutionRunsTokenExecutor(t *testing.T) {
+	mgr := NewInMemoryTaskManager()
+	mgr.RegisterExecution("token-1", func(_ context.Context, task Task) ([]byte, error) {
+		return []byte("token:" + task.Spec.Name), nil
+	})
+
+	id, err := mgr.Submit(context.Background(), TaskSpec{
+		Name: "dynamic",
+		Metadata: map[string]string{
+			TaskExecutionTokenMetadataKey: "token-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := mgr.Wait(waitCtx, id)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if result.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected completed status, got %s", result.Status)
+	}
+	if got := string(result.Output); got != "token:dynamic" {
+		t.Fatalf("expected token executor output %q, got %q", "token:dynamic", got)
+	}
+}
+
+func TestInMemoryTaskManagerTokenExecutionOverridesDefaultExecutor(t *testing.T) {
+	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(_ context.Context, _ Task) ([]byte, error) {
+		return []byte("default"), nil
+	}))
+	mgr.RegisterExecution("token-2", func(_ context.Context, _ Task) ([]byte, error) {
+		return []byte("dynamic"), nil
+	})
+
+	id, err := mgr.Submit(context.Background(), TaskSpec{
+		Name: "override",
+		Metadata: map[string]string{
+			TaskExecutionTokenMetadataKey: "token-2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := mgr.Wait(waitCtx, id)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if result.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected completed status, got %s", result.Status)
+	}
+	if got := string(result.Output); got != "dynamic" {
+		t.Fatalf("expected dynamic executor output %q, got %q", "dynamic", got)
+	}
+}

--- a/internal/runtime/subagent.go
+++ b/internal/runtime/subagent.go
@@ -50,6 +50,7 @@ func (c *InMemorySubAgentCoordinator) Spawn(ctx context.Context, spec TaskSpec) 
 		c.mu.Lock()
 		c.quotaKeys[taskID] = quotaKey
 		c.mu.Unlock()
+		go c.waitTerminalAndRelease(taskID)
 	}
 
 	return taskID, nil
@@ -60,8 +61,32 @@ func (c *InMemorySubAgentCoordinator) Wait(ctx context.Context, id corepkg.TaskI
 		return TaskResult{}, ErrTaskNotImplemented
 	}
 	result, err := c.taskManager.Wait(ctx, id)
-	c.releaseQuota(id)
+	if err == nil || c.isTaskTerminal(id) {
+		c.releaseQuota(id)
+	}
 	return result, err
+}
+
+func (c *InMemorySubAgentCoordinator) waitTerminalAndRelease(id corepkg.TaskID) {
+	if c == nil || c.taskManager == nil || c.quotaManager == nil {
+		return
+	}
+	_, err := c.taskManager.Wait(context.Background(), id)
+	if err != nil && !c.isTaskTerminal(id) {
+		return
+	}
+	c.releaseQuota(id)
+}
+
+func (c *InMemorySubAgentCoordinator) isTaskTerminal(id corepkg.TaskID) bool {
+	if c == nil || c.taskManager == nil {
+		return false
+	}
+	task, err := c.taskManager.Get(context.Background(), id)
+	if err != nil {
+		return false
+	}
+	return IsTerminalTaskStatus(task.Status)
 }
 
 func (c *InMemorySubAgentCoordinator) releaseQuota(id corepkg.TaskID) {

--- a/internal/runtime/subagent_test.go
+++ b/internal/runtime/subagent_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -142,6 +143,104 @@ func TestInMemoryTaskManagerParentCancelPropagatesToChild(t *testing.T) {
 	}
 	if childResult.ErrorCode != ErrorCodeTaskCancelled {
 		t.Fatalf("expected child cancel error code %q, got %q", ErrorCodeTaskCancelled, childResult.ErrorCode)
+	}
+}
+
+func TestInMemorySubAgentCoordinatorQuotaContentionConverges(t *testing.T) {
+	release := make(chan struct{})
+	manager := NewInMemoryTaskManager(
+		WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+			select {
+			case <-release:
+				return []byte("released"), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}),
+	)
+	quota := NewInMemoryQuotaManager(2, map[string]int{"shared": 2})
+	coordinator := NewInMemorySubAgentCoordinator(manager, quota)
+
+	const totalSpawns = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	type spawnResult struct {
+		id  corepkg.TaskID
+		err error
+	}
+	results := make(chan spawnResult, totalSpawns)
+
+	for i := 0; i < totalSpawns; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			id, err := coordinator.Spawn(context.Background(), TaskSpec{
+				Name: "contended-child",
+				Metadata: map[string]string{
+					"quota_key": "shared",
+				},
+			})
+			_ = index
+			results <- spawnResult{id: id, err: err}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	successIDs := make([]corepkg.TaskID, 0, 2)
+	quotaExceeded := 0
+	for result := range results {
+		if result.err == nil {
+			successIDs = append(successIDs, result.id)
+			continue
+		}
+		if !hasErrorCode(result.err, ErrorCodeQuotaExceeded) {
+			t.Fatalf("expected quota exceeded error, got %v", result.err)
+		}
+		quotaExceeded++
+	}
+
+	if len(successIDs) != 2 {
+		t.Fatalf("expected exactly 2 successful spawns under quota=2, got %d", len(successIDs))
+	}
+	if quotaExceeded != totalSpawns-len(successIDs) {
+		t.Fatalf("unexpected quota-exceeded count: got %d want %d", quotaExceeded, totalSpawns-len(successIDs))
+	}
+
+	for _, id := range successIDs {
+		waitUntilTaskStatus(t, manager, id, corepkg.TaskRunning, 2*time.Second)
+	}
+	close(release)
+
+	for _, id := range successIDs {
+		result, err := coordinator.Wait(context.Background(), id)
+		if err != nil {
+			t.Fatalf("wait task %q failed: %v", id, err)
+		}
+		if result.Status != corepkg.TaskCompleted {
+			t.Fatalf("expected completed status for %q, got %s", id, result.Status)
+		}
+	}
+
+	// Quota should be released after Wait and allow new spawn.
+	nextID, err := coordinator.Spawn(context.Background(), TaskSpec{
+		Name: "post-release-child",
+		Metadata: map[string]string{
+			"quota_key": "shared",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected spawn to recover after release, got %v", err)
+	}
+	nextResult, err := coordinator.Wait(context.Background(), nextID)
+	if err != nil {
+		t.Fatalf("expected post-release wait success, got %v", err)
+	}
+	if nextResult.Status != corepkg.TaskCompleted {
+		t.Fatalf("expected post-release completed status, got %s", nextResult.Status)
 	}
 }
 

--- a/internal/runtime/subagent_test.go
+++ b/internal/runtime/subagent_test.go
@@ -244,6 +244,110 @@ func TestInMemorySubAgentCoordinatorQuotaContentionConverges(t *testing.T) {
 	}
 }
 
+func TestInMemorySubAgentCoordinatorWaitCancellationDoesNotReleaseQuotaEarly(t *testing.T) {
+	release := make(chan struct{})
+	manager := NewInMemoryTaskManager(
+		WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+			select {
+			case <-release:
+				return []byte("released"), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}),
+	)
+	quota := NewInMemoryQuotaManager(1, map[string]int{"shared": 1})
+	coordinator := NewInMemorySubAgentCoordinator(manager, quota)
+
+	taskID, err := coordinator.Spawn(context.Background(), TaskSpec{
+		Name: "first",
+		Metadata: map[string]string{
+			"quota_key": "shared",
+		},
+	})
+	if err != nil {
+		t.Fatalf("spawn first failed: %v", err)
+	}
+	waitUntilTaskStatus(t, manager, taskID, corepkg.TaskRunning, 2*time.Second)
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer waitCancel()
+	_, err = coordinator.Wait(waitCtx, taskID)
+	if err == nil {
+		t.Fatal("expected wait timeout for running task")
+	}
+
+	_, err = coordinator.Spawn(context.Background(), TaskSpec{
+		Name: "second",
+		Metadata: map[string]string{
+			"quota_key": "shared",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected quota to remain occupied until first task reaches terminal state")
+	}
+	if !hasErrorCode(err, ErrorCodeQuotaExceeded) {
+		t.Fatalf("expected quota exceeded error, got %v", err)
+	}
+
+	close(release)
+	if _, err := manager.Wait(context.Background(), taskID); err != nil {
+		t.Fatalf("wait first task completion failed: %v", err)
+	}
+
+	waitUntilCondition(t, 2*time.Second, func() bool {
+		_, spawnErr := coordinator.Spawn(context.Background(), TaskSpec{
+			Name: "post-terminal",
+			Metadata: map[string]string{
+				"quota_key": "shared",
+			},
+		})
+		if spawnErr == nil {
+			return true
+		}
+		return false
+	})
+}
+
+func TestInMemorySubAgentCoordinatorReleasesQuotaWithoutCallerWait(t *testing.T) {
+	manager := NewInMemoryTaskManager(
+		WithTaskExecutor(func(_ context.Context, _ Task) ([]byte, error) {
+			time.Sleep(20 * time.Millisecond)
+			return []byte("done"), nil
+		}),
+	)
+	quota := NewInMemoryQuotaManager(1, map[string]int{"shared": 1})
+	coordinator := NewInMemorySubAgentCoordinator(manager, quota)
+
+	taskID, err := coordinator.Spawn(context.Background(), TaskSpec{
+		Name: "first-no-wait",
+		Metadata: map[string]string{
+			"quota_key": "shared",
+		},
+	})
+	if err != nil {
+		t.Fatalf("spawn first failed: %v", err)
+	}
+
+	waitUntilTaskStatus(t, manager, taskID, corepkg.TaskCompleted, 2*time.Second)
+
+	waitUntilCondition(t, 2*time.Second, func() bool {
+		nextID, spawnErr := coordinator.Spawn(context.Background(), TaskSpec{
+			Name: "second-after-auto-release",
+			Metadata: map[string]string{
+				"quota_key": "shared",
+			},
+		})
+		if spawnErr != nil {
+			return false
+		}
+		if _, waitErr := coordinator.Wait(context.Background(), nextID); waitErr != nil {
+			t.Fatalf("wait second task failed: %v", waitErr)
+		}
+		return true
+	})
+}
+
 func waitUntilTaskStatus(t *testing.T, manager *InMemoryTaskManager, id corepkg.TaskID, expected corepkg.TaskStatus, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -257,6 +361,20 @@ func waitUntilTaskStatus(t *testing.T, manager *InMemoryTaskManager, id corepkg.
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("task %q did not reach status %s (current=%s)", id, expected, task.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitUntilCondition(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if condition() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("condition was not satisfied before timeout")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}


### PR DESCRIPTION
## 关联
- 推进 #205
- 前置：#202 #203 #204(本 PR 为质量收口测试层，未引入大型新功能)

## 本次改动
1. 新增 runtime 并发竞争收敛测试：
   - `TestInMemoryTaskManagerRetryCancelRaceConverges`
   - 覆盖“重试与取消并发触发”下的终态收敛与无卡死。
2. 新增子代理配额争用收敛测试：
   - `TestInMemorySubAgentCoordinatorQuotaContentionConverges`
   - 验证并发争用下不超限，并在等待后配额可释放回收。
3. 新增 agent 边界固化测试：
   - `TestRunPromptExecutesToolThroughRuntimeGatewayBoundary`
   - 确保 tool 执行通过 RuntimeGateway 路径进行，固化“agent 仅通过 runtime 改变任务状态”约束。
4. 补充 gateway 任务状态进度一致性校验：
   - 在 `TestDefaultRuntimeGatewayRunSyncCompletes` 中新增状态单调性断言。

## 验证结果
已通过：
- `go test ./internal/runtime -v`
- `go test ./internal/agent -v`
- `go test ./internal/app -v`

尝试但当前环境受限：
- `go test ./internal/runtime -race -v`
- 失败原因：缺少 cgo 编译器（`gcc not found`）。
