### PR TITLE
Provider丨new step1补“现状基线 + 单一契约归属”

### DIFF
--- a/internal/config/provider_runtime.go
+++ b/internal/config/provider_runtime.go
@@ -9,7 +9,7 @@ type ProviderRuntimeConfig struct {
 }
 
 func LegacyProviderRuntimeConfig(cfg ProviderConfig) ProviderRuntimeConfig {
-	providerID := strings.TrimSpace(cfg.Type)
+	providerID := strings.ToLower(strings.TrimSpace(cfg.Type))
 	switch providerID {
 	case "", "openai", "openai-compatible":
 		providerID = "openai"

--- a/internal/config/provider_runtime.go
+++ b/internal/config/provider_runtime.go
@@ -16,6 +16,7 @@ func LegacyProviderRuntimeConfig(cfg ProviderConfig) ProviderRuntimeConfig {
 	case "anthropic":
 		providerID = "anthropic"
 	}
+	cfg.Type = providerID
 	return ProviderRuntimeConfig{
 		DefaultProvider: providerID,
 		DefaultModel:    cfg.Model,

--- a/internal/config/provider_runtime.go
+++ b/internal/config/provider_runtime.go
@@ -1,0 +1,24 @@
+package config
+
+type ProviderRuntimeConfig struct {
+	DefaultProvider string                    `json:"default_provider"`
+	DefaultModel    string                    `json:"default_model"`
+	Providers       map[string]ProviderConfig `json:"providers"`
+}
+
+func LegacyProviderRuntimeConfig(cfg ProviderConfig) ProviderRuntimeConfig {
+	providerID := cfg.Type
+	if providerID == "openai-compatible" || providerID == "openai" || providerID == "" {
+		providerID = "openai"
+	}
+	if providerID == "anthropic" {
+		providerID = "anthropic"
+	}
+	return ProviderRuntimeConfig{
+		DefaultProvider: providerID,
+		DefaultModel:    cfg.Model,
+		Providers: map[string]ProviderConfig{
+			providerID: cfg,
+		},
+	}
+}

--- a/internal/config/provider_runtime.go
+++ b/internal/config/provider_runtime.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 type ProviderRuntimeConfig struct {
 	DefaultProvider string                    `json:"default_provider"`
 	DefaultModel    string                    `json:"default_model"`
@@ -7,11 +9,11 @@ type ProviderRuntimeConfig struct {
 }
 
 func LegacyProviderRuntimeConfig(cfg ProviderConfig) ProviderRuntimeConfig {
-	providerID := cfg.Type
-	if providerID == "openai-compatible" || providerID == "openai" || providerID == "" {
+	providerID := strings.TrimSpace(cfg.Type)
+	switch providerID {
+	case "", "openai", "openai-compatible":
 		providerID = "openai"
-	}
-	if providerID == "anthropic" {
+	case "anthropic":
 		providerID = "anthropic"
 	}
 	return ProviderRuntimeConfig{

--- a/internal/config/provider_runtime_test.go
+++ b/internal/config/provider_runtime_test.go
@@ -26,7 +26,7 @@ func TestLegacyProviderRuntimeConfigNormalizesProviderIDs(t *testing.T) {
 			if runtime.DefaultModel != "test-model" {
 				t.Fatalf("unexpected default model %q", runtime.DefaultModel)
 			}
-			if len(runtime.Providers) != 1 || runtime.Providers[tt.want].Type != tt.typeValue {
+			if len(runtime.Providers) != 1 || runtime.Providers[tt.want].Type != tt.want {
 				t.Fatalf("unexpected providers %#v", runtime.Providers)
 			}
 		})

--- a/internal/config/provider_runtime_test.go
+++ b/internal/config/provider_runtime_test.go
@@ -11,7 +11,9 @@ func TestLegacyProviderRuntimeConfigNormalizesProviderIDs(t *testing.T) {
 		{name: "openai compatible", typeValue: "openai-compatible", want: "openai"},
 		{name: "openai alias", typeValue: "openai", want: "openai"},
 		{name: "empty defaults openai", typeValue: "", want: "openai"},
-		{name: "whitespace defaults openai", typeValue: "   ", want: "openai"},
+		{name: "openai uppercase", typeValue: "OPENAI", want: "openai"},
+		{name: "openai compatible padded", typeValue: " OpenAI-Compatible ", want: "openai"},
+		{name: "anthropic uppercase", typeValue: "ANTHROPIC", want: "anthropic"},
 		{name: "anthropic", typeValue: "anthropic", want: "anthropic"},
 	}
 	for _, tt := range tests {

--- a/internal/config/provider_runtime_test.go
+++ b/internal/config/provider_runtime_test.go
@@ -1,0 +1,32 @@
+package config
+
+import "testing"
+
+func TestLegacyProviderRuntimeConfigNormalizesProviderIDs(t *testing.T) {
+	tests := []struct {
+		name      string
+		typeValue string
+		want      string
+	}{
+		{name: "openai compatible", typeValue: "openai-compatible", want: "openai"},
+		{name: "openai alias", typeValue: "openai", want: "openai"},
+		{name: "empty defaults openai", typeValue: "", want: "openai"},
+		{name: "whitespace defaults openai", typeValue: "   ", want: "openai"},
+		{name: "anthropic", typeValue: "anthropic", want: "anthropic"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ProviderConfig{Type: tt.typeValue, Model: "test-model"}
+			runtime := LegacyProviderRuntimeConfig(cfg)
+			if runtime.DefaultProvider != tt.want {
+				t.Fatalf("unexpected default provider %q", runtime.DefaultProvider)
+			}
+			if runtime.DefaultModel != "test-model" {
+				t.Fatalf("unexpected default model %q", runtime.DefaultModel)
+			}
+			if len(runtime.Providers) != 1 || runtime.Providers[tt.want].Type != tt.typeValue {
+				t.Fatalf("unexpected providers %#v", runtime.Providers)
+			}
+		})
+	}
+}

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -166,6 +166,14 @@ func TestWrapClientStreamStopsWhenContextCancelled(t *testing.T) {
 	}
 }
 
+func TestEmitReturnsFalseWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if emit(ctx, make(chan Event), Event{}) {
+		t.Fatal("expected emit to fail when context is cancelled")
+	}
+}
+
 func TestWrapClientCoversNilClientAndEmptyModel(t *testing.T) {
 	if WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), nil) != nil {
 		t.Fatal("expected nil client to return nil adapter")

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -29,10 +29,6 @@ func NewClient(cfg config.ProviderConfig) (llm.Client, error) {
 }
 
 func NewDomainClient(cfg config.ProviderConfig) (Client, error) {
-	baseClient, err := NewClient(cfg)
-	if err != nil {
-		return nil, err
-	}
 	providerID := ProviderID(strings.ToLower(strings.TrimSpace(cfg.Type)))
 	if providerID == "openai-compatible" || providerID == "openai" {
 		providerID = ProviderOpenAI
@@ -43,5 +39,17 @@ func NewDomainClient(cfg config.ProviderConfig) (Client, error) {
 	if providerID == "" {
 		providerID = ProviderID("unknown")
 	}
-	return WrapClient(providerID, ModelID(strings.TrimSpace(cfg.Model)), baseClient), nil
+	return NewDomainClientWithID(providerID, cfg)
+}
+
+func NewDomainClientWithID(providerID ProviderID, cfg config.ProviderConfig) (Client, error) {
+	baseClient, err := NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	id := ProviderID(strings.ToLower(strings.TrimSpace(string(providerID))))
+	if id == "" {
+		id = ProviderID("unknown")
+	}
+	return WrapClient(id, ModelID(strings.TrimSpace(cfg.Model)), baseClient), nil
 }

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -9,15 +9,16 @@ import (
 )
 
 func NewClient(cfg config.ProviderConfig) (llm.Client, error) {
+	typ := strings.ToLower(strings.TrimSpace(cfg.Type))
 	clientCfg := Config{
-		Type:             cfg.Type,
+		Type:             typ,
 		BaseURL:          cfg.BaseURL,
 		APIKey:           cfg.ResolveAPIKey(),
 		Model:            cfg.Model,
 		AnthropicVersion: cfg.AnthropicVersion,
 	}
 
-	switch cfg.Type {
+	switch typ {
 	case "openai-compatible", "openai":
 		return NewOpenAICompatible(clientCfg), nil
 	case "anthropic":
@@ -32,9 +33,12 @@ func NewDomainClient(cfg config.ProviderConfig) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	providerID := ProviderID(strings.TrimSpace(cfg.Type))
-	if providerID == "openai-compatible" {
+	providerID := ProviderID(strings.ToLower(strings.TrimSpace(cfg.Type)))
+	if providerID == "openai-compatible" || providerID == "openai" {
 		providerID = ProviderOpenAI
+	}
+	if providerID == "anthropic" {
+		providerID = ProviderAnthropic
 	}
 	if providerID == "" {
 		providerID = ProviderID("unknown")

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -104,6 +104,30 @@ func TestNewClientAcceptsNormalizedTypeVariants(t *testing.T) {
 	}
 }
 
+func TestNewDomainClientWithIDUsesExplicitProviderInstanceID(t *testing.T) {
+	clientA, err := NewDomainClientWithID("provider-a", config.ProviderConfig{
+		Type:    "openai-compatible",
+		BaseURL: "https://api.openai.com/v1",
+		APIKey:  "test-key",
+		Model:   "gpt-5.4",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	clientB, err := NewDomainClientWithID("provider-b", config.ProviderConfig{
+		Type:    "openai-compatible",
+		BaseURL: "https://example.com/v1",
+		APIKey:  "test-key",
+		Model:   "gpt-4.1",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if clientA.ProviderID() != "provider-a" || clientB.ProviderID() != "provider-b" {
+		t.Fatalf("unexpected provider ids %q %q", clientA.ProviderID(), clientB.ProviderID())
+	}
+}
+
 func TestNewDomainClientPreservesAnthropicProviderID(t *testing.T) {
 	client, err := NewDomainClient(config.ProviderConfig{
 		Type:             "anthropic",

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -91,6 +91,19 @@ func TestNewDomainClientWrapsBaseClient(t *testing.T) {
 	}
 }
 
+func TestNewClientAcceptsNormalizedTypeVariants(t *testing.T) {
+	cases := []config.ProviderConfig{
+		{Type: " OPENAI ", BaseURL: "https://api.openai.com/v1", APIKey: "test-key", Model: "gpt-5.4"},
+		{Type: "OpenAI-Compatible", BaseURL: "https://api.openai.com/v1", APIKey: "test-key", Model: "gpt-5.4"},
+		{Type: " ANTHROPIC ", BaseURL: "https://api.anthropic.com", APIKey: "test-key", Model: "claude-sonnet", AnthropicVersion: "2023-06-01"},
+	}
+	for _, cfg := range cases {
+		if _, err := NewClient(cfg); err != nil {
+			t.Fatalf("expected normalized type %q to succeed, got %v", cfg.Type, err)
+		}
+	}
+}
+
 func TestNewDomainClientPreservesAnthropicProviderID(t *testing.T) {
 	client, err := NewDomainClient(config.ProviderConfig{
 		Type:             "anthropic",
@@ -104,6 +117,21 @@ func TestNewDomainClientPreservesAnthropicProviderID(t *testing.T) {
 	}
 	if client.ProviderID() != ProviderAnthropic {
 		t.Fatalf("expected provider id %q, got %q", ProviderAnthropic, client.ProviderID())
+	}
+}
+
+func TestNewDomainClientNormalizesOpenAIProviderIDVariants(t *testing.T) {
+	client, err := NewDomainClient(config.ProviderConfig{
+		Type:    " OpenAI-Compatible ",
+		BaseURL: "https://api.openai.com/v1",
+		APIKey:  "test-key",
+		Model:   "gpt-5.4",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.ProviderID() != ProviderOpenAI {
+		t.Fatalf("expected provider id %q, got %q", ProviderOpenAI, client.ProviderID())
 	}
 }
 

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -159,6 +159,23 @@ func TestNewDomainClientNormalizesOpenAIProviderIDVariants(t *testing.T) {
 	}
 }
 
+func TestLegacyRuntimeConfigWithEmptyTypeBuildsRegistry(t *testing.T) {
+	runtime := config.LegacyProviderRuntimeConfig(config.ProviderConfig{
+		Type:    "",
+		BaseURL: "https://api.openai.com/v1",
+		APIKey:  "test-key",
+		Model:   "gpt-5.4",
+	})
+	reg, err := NewRegistry(runtime)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	client, ok := reg.Get(context.Background(), "openai")
+	if !ok || client == nil {
+		t.Fatalf("expected openai client from legacy runtime config, got %#v ok=%v", client, ok)
+	}
+}
+
 func TestNewDomainClientRejectsEmptyType(t *testing.T) {
 	client, err := NewDomainClient(config.ProviderConfig{
 		Type:    "",

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -91,6 +91,22 @@ func TestNewDomainClientWrapsBaseClient(t *testing.T) {
 	}
 }
 
+func TestNewDomainClientPreservesAnthropicProviderID(t *testing.T) {
+	client, err := NewDomainClient(config.ProviderConfig{
+		Type:             "anthropic",
+		BaseURL:          "https://api.anthropic.com",
+		APIKey:           "test-key",
+		Model:            "claude-sonnet",
+		AnthropicVersion: "2023-06-01",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.ProviderID() != ProviderAnthropic {
+		t.Fatalf("expected provider id %q, got %q", ProviderAnthropic, client.ProviderID())
+	}
+}
+
 func TestNewDomainClientRejectsEmptyType(t *testing.T) {
 	client, err := NewDomainClient(config.ProviderConfig{
 		Type:    "",

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -32,6 +32,9 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 			}
 			defer func() { <-sem }()
 			client, ok := reg.Get(ctx, id)
+			if ctx.Err() != nil {
+				return
+			}
 			if !ok {
 				mu.Lock()
 				warnings = append(warnings, Warning{ProviderID: id, Reason: string(ErrCodeProviderNotFound)})
@@ -39,6 +42,9 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 				return
 			}
 			providerModels, err := client.ListModels(ctx)
+			if ctx.Err() != nil {
+				return
+			}
 			if err != nil {
 				mu.Lock()
 				warnings = append(warnings, Warning{ProviderID: id, Reason: listModelsWarningReason})
@@ -63,6 +69,9 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 		}()
 	}
 	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	sort.Slice(models, func(i, j int) bool {
 		if models[i].ProviderID == models[j].ProviderID {
 			return models[i].ModelID < models[j].ModelID

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -7,6 +7,7 @@ import (
 )
 
 const listModelsWarningReason = "provider_list_models_failed"
+const providerNotFoundWarningReason = string(ErrCodeProviderNotFound)
 const listModelsConcurrency = 4
 
 func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, error) {
@@ -37,7 +38,7 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 			}
 			if !ok {
 				mu.Lock()
-				warnings = append(warnings, Warning{ProviderID: id, Reason: string(ErrCodeProviderNotFound)})
+				warnings = append(warnings, Warning{ProviderID: id, Reason: providerNotFoundWarningReason})
 				mu.Unlock()
 				return
 			}

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -1,0 +1,39 @@
+package provider
+
+import "context"
+
+func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, error) {
+	ids, err := reg.List(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	models := make([]ModelInfo, 0)
+	warnings := make([]Warning, 0)
+	seen := make(map[string]struct{})
+	for _, id := range ids {
+		client, ok := reg.Get(ctx, id)
+		if !ok {
+			warnings = append(warnings, Warning{ProviderID: id, Reason: string(ErrCodeProviderNotFound)})
+			continue
+		}
+		providerModels, err := client.ListModels(ctx)
+		if err != nil {
+			warnings = append(warnings, Warning{ProviderID: id, Reason: err.Error()})
+			continue
+		}
+		for _, model := range providerModels {
+			providerID := normalizeProviderID(model.ProviderID)
+			if providerID == "" {
+				providerID = id
+			}
+			key := string(providerID) + "\x00" + string(model.ModelID)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			model.ProviderID = providerID
+			models = append(models, model)
+		}
+	}
+	return models, warnings, nil
+}

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -1,6 +1,13 @@
 package provider
 
-import "context"
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+const listModelsWarningReason = "provider_list_models_failed"
+const listModelsConcurrency = 4
 
 func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, error) {
 	ids, err := reg.List(ctx)
@@ -10,30 +17,58 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 	models := make([]ModelInfo, 0)
 	warnings := make([]Warning, 0)
 	seen := make(map[string]struct{})
+	var mu sync.Mutex
+	sem := make(chan struct{}, listModelsConcurrency)
+	var wg sync.WaitGroup
 	for _, id := range ids {
-		client, ok := reg.Get(ctx, id)
-		if !ok {
-			warnings = append(warnings, Warning{ProviderID: id, Reason: string(ErrCodeProviderNotFound)})
-			continue
-		}
-		providerModels, err := client.ListModels(ctx)
-		if err != nil {
-			warnings = append(warnings, Warning{ProviderID: id, Reason: err.Error()})
-			continue
-		}
-		for _, model := range providerModels {
-			providerID := normalizeProviderID(model.ProviderID)
-			if providerID == "" {
-				providerID = id
+		id := id
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case <-ctx.Done():
+				return
+			case sem <- struct{}{}:
 			}
-			key := string(providerID) + "\x00" + string(model.ModelID)
-			if _, exists := seen[key]; exists {
-				continue
+			defer func() { <-sem }()
+			client, ok := reg.Get(ctx, id)
+			if !ok {
+				mu.Lock()
+				warnings = append(warnings, Warning{ProviderID: id, Reason: string(ErrCodeProviderNotFound)})
+				mu.Unlock()
+				return
 			}
-			seen[key] = struct{}{}
-			model.ProviderID = providerID
-			models = append(models, model)
-		}
+			providerModels, err := client.ListModels(ctx)
+			if err != nil {
+				mu.Lock()
+				warnings = append(warnings, Warning{ProviderID: id, Reason: listModelsWarningReason})
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, model := range providerModels {
+				providerID := normalizeProviderID(model.ProviderID)
+				if providerID == "" {
+					providerID = id
+				}
+				key := string(providerID) + "\x00" + string(model.ModelID)
+				if _, exists := seen[key]; exists {
+					continue
+				}
+				seen[key] = struct{}{}
+				model.ProviderID = providerID
+				models = append(models, model)
+			}
+		}()
 	}
+	wg.Wait()
+	sort.Slice(models, func(i, j int) bool {
+		if models[i].ProviderID == models[j].ProviderID {
+			return models[i].ModelID < models[j].ModelID
+		}
+		return models[i].ProviderID < models[j].ProviderID
+	})
+	sort.Slice(warnings, func(i, j int) bool { return warnings[i].ProviderID < warnings[j].ProviderID })
 	return models, warnings, nil
 }

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -54,10 +54,7 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 			mu.Lock()
 			defer mu.Unlock()
 			for _, model := range providerModels {
-				providerID := normalizeProviderID(model.ProviderID)
-				if providerID == "" {
-					providerID = id
-				}
+				providerID := id
 				key := string(providerID) + "\x00" + string(model.ModelID)
 				if _, exists := seen[key]; exists {
 					continue

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -19,53 +19,68 @@ func ListModels(ctx context.Context, reg Registry) ([]ModelInfo, []Warning, erro
 	warnings := make([]Warning, 0)
 	seen := make(map[string]struct{})
 	var mu sync.Mutex
-	sem := make(chan struct{}, listModelsConcurrency)
+	jobs := make(chan ProviderID)
 	var wg sync.WaitGroup
-	for _, id := range ids {
-		id := id
+	workerCount := listModelsConcurrency
+	if len(ids) < workerCount {
+		workerCount = len(ids)
+	}
+	for i := 0; i < workerCount; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			select {
-			case <-ctx.Done():
-				return
-			case sem <- struct{}{}:
-			}
-			defer func() { <-sem }()
-			client, ok := reg.Get(ctx, id)
-			if ctx.Err() != nil {
-				return
-			}
-			if !ok {
-				mu.Lock()
-				warnings = append(warnings, Warning{ProviderID: id, Reason: providerNotFoundWarningReason})
-				mu.Unlock()
-				return
-			}
-			providerModels, err := client.ListModels(ctx)
-			if ctx.Err() != nil {
-				return
-			}
-			if err != nil {
-				mu.Lock()
-				warnings = append(warnings, Warning{ProviderID: id, Reason: listModelsWarningReason})
-				mu.Unlock()
-				return
-			}
-			mu.Lock()
-			defer mu.Unlock()
-			for _, model := range providerModels {
-				providerID := id
-				key := string(providerID) + "\x00" + string(model.ModelID)
-				if _, exists := seen[key]; exists {
-					continue
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case id, ok := <-jobs:
+					if !ok {
+						return
+					}
+					client, ok := reg.Get(ctx, id)
+					if ctx.Err() != nil {
+						return
+					}
+					if !ok {
+						mu.Lock()
+						warnings = append(warnings, Warning{ProviderID: id, Reason: providerNotFoundWarningReason})
+						mu.Unlock()
+						continue
+					}
+					providerModels, err := client.ListModels(ctx)
+					if ctx.Err() != nil {
+						return
+					}
+					if err != nil {
+						mu.Lock()
+						warnings = append(warnings, Warning{ProviderID: id, Reason: listModelsWarningReason})
+						mu.Unlock()
+						continue
+					}
+					mu.Lock()
+					for _, model := range providerModels {
+						providerID := id
+						key := string(providerID) + "\x00" + string(model.ModelID)
+						if _, exists := seen[key]; exists {
+							continue
+						}
+						seen[key] = struct{}{}
+						model.ProviderID = providerID
+						models = append(models, model)
+					}
+					mu.Unlock()
 				}
-				seen[key] = struct{}{}
-				model.ProviderID = providerID
-				models = append(models, model)
 			}
 		}()
 	}
+	for _, id := range ids {
+		select {
+		case <-ctx.Done():
+			break
+		case jobs <- id:
+		}
+	}
+	close(jobs)
 	wg.Wait()
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err

--- a/internal/provider/models_test.go
+++ b/internal/provider/models_test.go
@@ -1,0 +1,33 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"bytemind/internal/config"
+)
+
+func TestListModelsUsesRegistryInstanceIDForAllResults(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "custom-openai", models: []ModelInfo{{ProviderID: "openai-compatible", ModelID: "gpt-5.4"}, {ProviderID: "other", ModelID: "gpt-4.1"}}}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	models, warnings, err := ListModels(context.Background(), reg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings %#v", warnings)
+	}
+	if len(models) != 2 {
+		t.Fatalf("unexpected models %#v", models)
+	}
+	for _, model := range models {
+		if model.ProviderID != "custom-openai" {
+			t.Fatalf("expected registry instance id, got %#v", model)
+		}
+	}
+}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -16,19 +16,22 @@ type providerRegistry struct {
 
 func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
 	reg := &providerRegistry{clients: make(map[ProviderID]Client)}
+	normalizedProviders := make(map[ProviderID]config.ProviderConfig, len(cfg.Providers))
+	ids := make([]string, 0, len(cfg.Providers))
+	for id, providerCfg := range cfg.Providers {
+		normalizedID := ProviderID(strings.ToLower(strings.TrimSpace(id)))
+		normalizedProviders[normalizedID] = providerCfg
+		ids = append(ids, string(normalizedID))
+	}
 	if cfg.DefaultProvider != "" {
 		defaultProvider := ProviderID(strings.ToLower(strings.TrimSpace(cfg.DefaultProvider)))
-		if _, exists := cfg.Providers[string(defaultProvider)]; !exists {
+		if _, exists := normalizedProviders[defaultProvider]; !exists {
 			return nil, &Error{Code: ErrCodeProviderNotFound, Provider: defaultProvider, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
 		}
 	}
-	ids := make([]string, 0, len(cfg.Providers))
-	for id := range cfg.Providers {
-		ids = append(ids, id)
-	}
 	sort.Strings(ids)
 	for _, id := range ids {
-		providerCfg := cfg.Providers[id]
+		providerCfg := normalizedProviders[ProviderID(id)]
 		client, err := NewDomainClientWithID(ProviderID(id), providerCfg)
 		if err != nil {
 			return nil, err

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -16,6 +16,12 @@ type providerRegistry struct {
 
 func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
 	reg := &providerRegistry{clients: make(map[ProviderID]Client)}
+	if cfg.DefaultProvider != "" {
+		defaultProvider := ProviderID(strings.ToLower(strings.TrimSpace(cfg.DefaultProvider)))
+		if _, exists := cfg.Providers[string(defaultProvider)]; !exists {
+			return nil, &Error{Code: ErrCodeProviderNotFound, Provider: defaultProvider, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
+		}
+	}
 	ids := make([]string, 0, len(cfg.Providers))
 	for id := range cfg.Providers {
 		ids = append(ids, id)
@@ -23,10 +29,7 @@ func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
 	sort.Strings(ids)
 	for _, id := range ids {
 		providerCfg := cfg.Providers[id]
-		if strings.TrimSpace(providerCfg.Type) == "" {
-			providerCfg.Type = id
-		}
-		client, err := NewDomainClient(providerCfg)
+		client, err := NewDomainClientWithID(ProviderID(id), providerCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +48,7 @@ func (r *providerRegistry) Register(_ context.Context, client Client) error {
 	if client == nil {
 		return nil
 	}
-	id := normalizeProviderID(client.ProviderID())
+	id := ProviderID(strings.ToLower(strings.TrimSpace(string(client.ProviderID()))))
 	if id == "" {
 		return &Error{Code: ErrCodeProviderNotFound, Provider: id, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
 	}
@@ -61,7 +64,7 @@ func (r *providerRegistry) Register(_ context.Context, client Client) error {
 func (r *providerRegistry) Get(_ context.Context, id ProviderID) (Client, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	client, ok := r.clients[normalizeProviderID(id)]
+	client, ok := r.clients[ProviderID(strings.ToLower(strings.TrimSpace(string(id))))]
 	return client, ok
 }
 

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -14,12 +14,16 @@ type providerRegistry struct {
 	clients map[ProviderID]Client
 }
 
+func normalizeRegistryProviderID(id string) ProviderID {
+	return ProviderID(strings.ToLower(strings.TrimSpace(id)))
+}
+
 func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
 	reg := &providerRegistry{clients: make(map[ProviderID]Client)}
 	normalizedProviders := make(map[ProviderID]config.ProviderConfig, len(cfg.Providers))
 	ids := make([]string, 0, len(cfg.Providers))
 	for id, providerCfg := range cfg.Providers {
-		normalizedID := ProviderID(strings.ToLower(strings.TrimSpace(id)))
+		normalizedID := normalizeRegistryProviderID(id)
 		if normalizedID == "" {
 			return nil, &Error{Code: ErrCodeProviderNotFound, Provider: normalizedID, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
 		}
@@ -30,7 +34,7 @@ func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
 		ids = append(ids, string(normalizedID))
 	}
 	if cfg.DefaultProvider != "" {
-		defaultProvider := ProviderID(strings.ToLower(strings.TrimSpace(cfg.DefaultProvider)))
+		defaultProvider := normalizeRegistryProviderID(cfg.DefaultProvider)
 		if _, exists := normalizedProviders[defaultProvider]; !exists {
 			return nil, &Error{Code: ErrCodeProviderNotFound, Provider: defaultProvider, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
 		}
@@ -57,7 +61,7 @@ func (r *providerRegistry) Register(_ context.Context, client Client) error {
 	if client == nil {
 		return nil
 	}
-	id := ProviderID(strings.ToLower(strings.TrimSpace(string(client.ProviderID()))))
+	id := normalizeRegistryProviderID(string(client.ProviderID()))
 	if id == "" {
 		return &Error{Code: ErrCodeProviderNotFound, Provider: id, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
 	}
@@ -73,7 +77,7 @@ func (r *providerRegistry) Register(_ context.Context, client Client) error {
 func (r *providerRegistry) Get(_ context.Context, id ProviderID) (Client, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	client, ok := r.clients[ProviderID(strings.ToLower(strings.TrimSpace(string(id))))]
+	client, ok := r.clients[normalizeRegistryProviderID(string(id))]
 	return client, ok
 }
 

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"bytemind/internal/config"
+)
+
+type providerRegistry struct {
+	mu      sync.RWMutex
+	clients map[ProviderID]Client
+}
+
+func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
+	reg := &providerRegistry{clients: make(map[ProviderID]Client)}
+	ids := make([]string, 0, len(cfg.Providers))
+	for id := range cfg.Providers {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		providerCfg := cfg.Providers[id]
+		if strings.TrimSpace(providerCfg.Type) == "" {
+			providerCfg.Type = id
+		}
+		client, err := NewDomainClient(providerCfg)
+		if err != nil {
+			return nil, err
+		}
+		if err := reg.Register(context.Background(), client); err != nil {
+			return nil, err
+		}
+	}
+	return reg, nil
+}
+
+func NewRegistryFromProviderConfig(cfg config.ProviderConfig) (Registry, error) {
+	return NewRegistry(config.LegacyProviderRuntimeConfig(cfg))
+}
+
+func (r *providerRegistry) Register(_ context.Context, client Client) error {
+	if client == nil {
+		return nil
+	}
+	id := normalizeProviderID(client.ProviderID())
+	if id == "" {
+		return &Error{Code: ErrCodeProviderNotFound, Provider: id, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.clients[id]; exists {
+		return &Error{Code: ErrCodeDuplicateProvider, Provider: id, Message: string(ErrCodeDuplicateProvider), Retryable: false, Err: ErrDuplicateProvider}
+	}
+	r.clients[id] = client
+	return nil
+}
+
+func (r *providerRegistry) Get(_ context.Context, id ProviderID) (Client, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	client, ok := r.clients[normalizeProviderID(id)]
+	return client, ok
+}
+
+func (r *providerRegistry) List(_ context.Context) ([]ProviderID, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]ProviderID, 0, len(r.clients))
+	for id := range r.clients {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids, nil
+}
+
+func normalizeProviderID(id ProviderID) ProviderID {
+	value := strings.ToLower(strings.TrimSpace(string(id)))
+	switch value {
+	case "openai-compatible", "openai":
+		return ProviderOpenAI
+	case "anthropic":
+		return ProviderAnthropic
+	default:
+		return ProviderID(value)
+	}
+}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -20,6 +20,12 @@ func NewRegistry(cfg config.ProviderRuntimeConfig) (Registry, error) {
 	ids := make([]string, 0, len(cfg.Providers))
 	for id, providerCfg := range cfg.Providers {
 		normalizedID := ProviderID(strings.ToLower(strings.TrimSpace(id)))
+		if normalizedID == "" {
+			return nil, &Error{Code: ErrCodeProviderNotFound, Provider: normalizedID, Message: string(ErrCodeProviderNotFound), Retryable: false, Err: ErrProviderNotFound}
+		}
+		if _, exists := normalizedProviders[normalizedID]; exists {
+			return nil, &Error{Code: ErrCodeDuplicateProvider, Provider: normalizedID, Message: string(ErrCodeDuplicateProvider), Retryable: false, Err: ErrDuplicateProvider}
+		}
 		normalizedProviders[normalizedID] = providerCfg
 		ids = append(ids, string(normalizedID))
 	}
@@ -80,16 +86,4 @@ func (r *providerRegistry) List(_ context.Context) ([]ProviderID, error) {
 	}
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	return ids, nil
-}
-
-func normalizeProviderID(id ProviderID) ProviderID {
-	value := strings.ToLower(strings.TrimSpace(string(id)))
-	switch value {
-	case "openai-compatible", "openai":
-		return ProviderOpenAI
-	case "anthropic":
-		return ProviderAnthropic
-	default:
-		return ProviderID(value)
-	}
 }

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -200,6 +200,9 @@ func TestRegistryHandlesProviderNotFoundAndConfigErrors(t *testing.T) {
 			t.Fatalf("unexpected error %#v", err)
 		}
 	}
+	if normalizeRegistryProviderID(" OpenAI-Primary ") != "openai-primary" {
+		t.Fatal("expected registry provider id normalization to trim and lowercase")
+	}
 	if _, err := NewRegistry(config.ProviderRuntimeConfig{DefaultProvider: "missing", Providers: map[string]config.ProviderConfig{"openai-primary": {Type: "openai-compatible", BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
 		t.Fatal("expected missing default provider error")
 	}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -45,6 +45,41 @@ func TestNewRegistryFromProviderConfigSupportsLegacyMode(t *testing.T) {
 	}
 }
 
+func TestNewRegistrySupportsMultipleProvidersWithSameType(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{
+		DefaultProvider: "openai-primary",
+		Providers: map[string]config.ProviderConfig{
+			"openai-primary":   {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key-1", Model: "gpt-5.4"},
+			"openai-secondary": {Type: "openai-compatible", BaseURL: "https://example.com/v1", APIKey: "key-2", Model: "gpt-4.1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	ids, err := reg.List(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "openai-primary" || ids[1] != "openai-secondary" {
+		t.Fatalf("unexpected ids %#v", ids)
+	}
+	primary, ok := reg.Get(context.Background(), "openai-primary")
+	if !ok || primary.ProviderID() != "openai-primary" {
+		t.Fatalf("unexpected primary provider %#v ok=%v", primary, ok)
+	}
+	secondary, ok := reg.Get(context.Background(), "openai-secondary")
+	if !ok || secondary.ProviderID() != "openai-secondary" {
+		t.Fatalf("unexpected secondary provider %#v ok=%v", secondary, ok)
+	}
+	models, warnings, err := ListModels(context.Background(), reg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(models) != 2 || len(warnings) != 0 {
+		t.Fatalf("unexpected models=%#v warnings=%#v", models, warnings)
+	}
+}
+
 func TestRegistryRejectsDuplicateProvider(t *testing.T) {
 	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
 	if err != nil {
@@ -110,18 +145,18 @@ func TestRegistryCoversLookupAndNormalizationBranches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "openai-compatible"}); err != nil {
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "openai-primary"}); err != nil {
 		t.Fatalf("unexpected register error %v", err)
 	}
-	client, ok := reg.Get(context.Background(), "openai")
-	if !ok || client.ProviderID() != "openai-compatible" {
+	client, ok := reg.Get(context.Background(), "openai-primary")
+	if !ok || client.ProviderID() != "openai-primary" {
 		t.Fatalf("unexpected client lookup result ok=%v client=%#v", ok, client)
 	}
 	if _, ok := reg.Get(context.Background(), "missing"); ok {
 		t.Fatal("expected missing provider lookup to fail")
 	}
 	ids, err := reg.List(context.Background())
-	if err != nil || len(ids) != 1 || ids[0] != ProviderOpenAI {
+	if err != nil || len(ids) != 1 || ids[0] != "openai-primary" {
 		t.Fatalf("unexpected ids %#v err=%v", ids, err)
 	}
 }
@@ -141,6 +176,9 @@ func TestRegistryHandlesProviderNotFoundAndConfigErrors(t *testing.T) {
 		if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeProviderNotFound {
 			t.Fatalf("unexpected error %#v", err)
 		}
+	}
+	if _, err := NewRegistry(config.ProviderRuntimeConfig{DefaultProvider: "missing", Providers: map[string]config.ProviderConfig{"openai-primary": {Type: "openai-compatible", BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
+		t.Fatal("expected missing default provider error")
 	}
 	if _, err := NewRegistry(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"broken": {BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
 		t.Fatal("expected invalid provider type error")

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -47,10 +47,10 @@ func TestNewRegistryFromProviderConfigSupportsLegacyMode(t *testing.T) {
 
 func TestNewRegistrySupportsMultipleProvidersWithSameType(t *testing.T) {
 	reg, err := NewRegistry(config.ProviderRuntimeConfig{
-		DefaultProvider: "openai-primary",
+		DefaultProvider: " OpenAI-Primary ",
 		Providers: map[string]config.ProviderConfig{
-			"openai-primary":   {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key-1", Model: "gpt-5.4"},
-			"openai-secondary": {Type: "openai-compatible", BaseURL: "https://example.com/v1", APIKey: "key-2", Model: "gpt-4.1"},
+			" OpenAI-Primary ": {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key-1", Model: "gpt-5.4"},
+			"OPENAI-SECONDARY": {Type: "openai-compatible", BaseURL: "https://example.com/v1", APIKey: "key-2", Model: "gpt-4.1"},
 		},
 	})
 	if err != nil {

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -93,6 +93,18 @@ func TestListModelsReturnsRegistryError(t *testing.T) {
 	}
 }
 
+func TestListModelsReturnsContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, _, err := ListModels(ctx, reg); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+}
+
 func TestRegistryCoversLookupAndNormalizationBranches(t *testing.T) {
 	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
 	if err != nil {

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -121,6 +121,29 @@ func TestListModelsAggregatesWarningsAndDeduplicates(t *testing.T) {
 	}
 }
 
+func TestListModelsKeepsInstanceIDsDistinctEvenWhenAliasesOverlap(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai-compatible", ModelID: "gpt-5.4"}}}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "openai-compatible", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	models, warnings, err := ListModels(context.Background(), reg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings %#v", warnings)
+	}
+	if len(models) != 2 || models[0].ProviderID != "openai" || models[1].ProviderID != "openai-compatible" {
+		t.Fatalf("unexpected models %#v", models)
+	}
+}
+
 func TestListModelsReturnsRegistryError(t *testing.T) {
 	reg := stubListRegistry{listErr: errors.New("boom")}
 	if _, _, err := ListModels(context.Background(), reg); err == nil {
@@ -179,6 +202,12 @@ func TestRegistryHandlesProviderNotFoundAndConfigErrors(t *testing.T) {
 	}
 	if _, err := NewRegistry(config.ProviderRuntimeConfig{DefaultProvider: "missing", Providers: map[string]config.ProviderConfig{"openai-primary": {Type: "openai-compatible", BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
 		t.Fatal("expected missing default provider error")
+	}
+	if _, err := NewRegistry(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{" OpenAI-Primary ": {Type: "openai-compatible", BaseURL: "https://example.com", APIKey: "key", Model: "m"}, "openai-primary": {Type: "openai-compatible", BaseURL: "https://example2.com", APIKey: "key", Model: "m"}}}); err == nil {
+		t.Fatal("expected duplicate normalized provider error")
+	}
+	if _, err := NewRegistry(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"   ": {Type: "openai-compatible", BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
+		t.Fatal("expected blank provider id error")
 	}
 	if _, err := NewRegistry(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"broken": {BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
 		t.Fatal("expected invalid provider type error")

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"bytemind/internal/config"
+)
+
+type stubRegistryClient struct {
+	providerID ProviderID
+	models     []ModelInfo
+	err        error
+}
+
+func (s stubRegistryClient) ProviderID() ProviderID                                { return s.providerID }
+func (s stubRegistryClient) ListModels(context.Context) ([]ModelInfo, error)       { return s.models, s.err }
+func (s stubRegistryClient) Stream(context.Context, Request) (<-chan Event, error) { return nil, nil }
+
+func TestNewRegistryFromProviderConfigSupportsLegacyMode(t *testing.T) {
+	reg, err := NewRegistryFromProviderConfig(config.ProviderConfig{
+		Type:    "openai-compatible",
+		BaseURL: "https://api.openai.com/v1",
+		APIKey:  "test-key",
+		Model:   "gpt-5.4",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	ids, err := reg.List(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(ids) != 1 || ids[0] != ProviderOpenAI {
+		t.Fatalf("unexpected ids %#v", ids)
+	}
+}
+
+func TestRegistryRejectsDuplicateProvider(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderOpenAI}); err != nil {
+		t.Fatalf("unexpected first register error %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderOpenAI}); err == nil {
+		t.Fatal("expected duplicate provider error")
+	} else {
+		var providerErr *Error
+		if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeDuplicateProvider {
+			t.Fatalf("unexpected error %#v", err)
+		}
+	}
+}
+
+func TestListModelsAggregatesWarningsAndDeduplicates(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderOpenAI, models: []ModelInfo{{ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}, {ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}}}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderAnthropic, err: errors.New("list failed")}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	models, warnings, err := ListModels(context.Background(), reg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(models) != 1 || models[0].ProviderID != ProviderOpenAI || models[0].ModelID != "gpt-5.4" {
+		t.Fatalf("unexpected models %#v", models)
+	}
+	if len(warnings) != 1 || warnings[0].ProviderID != ProviderAnthropic {
+		t.Fatalf("unexpected warnings %#v", warnings)
+	}
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -14,6 +14,14 @@ type stubRegistryClient struct {
 	err        error
 }
 
+type stubListRegistry struct {
+	listErr error
+}
+
+func (s stubListRegistry) Register(context.Context, Client) error         { return nil }
+func (s stubListRegistry) Get(context.Context, ProviderID) (Client, bool) { return nil, false }
+func (s stubListRegistry) List(context.Context) ([]ProviderID, error)     { return nil, s.listErr }
+
 func (s stubRegistryClient) ProviderID() ProviderID                                { return s.providerID }
 func (s stubRegistryClient) ListModels(context.Context) ([]ModelInfo, error)       { return s.models, s.err }
 func (s stubRegistryClient) Stream(context.Context, Request) (<-chan Event, error) { return nil, nil }
@@ -60,7 +68,7 @@ func TestListModelsAggregatesWarningsAndDeduplicates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderOpenAI, models: []ModelInfo{{ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}, {ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}}}); err != nil {
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderOpenAI, models: []ModelInfo{{ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}, {ProviderID: ProviderOpenAI, ModelID: "gpt-5.4"}, {ProviderID: "", ModelID: "gpt-4.1"}}}); err != nil {
 		t.Fatalf("unexpected register error %v", err)
 	}
 	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ProviderAnthropic, err: errors.New("list failed")}); err != nil {
@@ -70,10 +78,59 @@ func TestListModelsAggregatesWarningsAndDeduplicates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if len(models) != 1 || models[0].ProviderID != ProviderOpenAI || models[0].ModelID != "gpt-5.4" {
+	if len(models) != 2 || models[0].ProviderID != ProviderOpenAI || models[0].ModelID != "gpt-4.1" || models[1].ProviderID != ProviderOpenAI || models[1].ModelID != "gpt-5.4" {
 		t.Fatalf("unexpected models %#v", models)
 	}
-	if len(warnings) != 1 || warnings[0].ProviderID != ProviderAnthropic {
+	if len(warnings) != 1 || warnings[0].ProviderID != ProviderAnthropic || warnings[0].Reason != listModelsWarningReason {
 		t.Fatalf("unexpected warnings %#v", warnings)
+	}
+}
+
+func TestListModelsReturnsRegistryError(t *testing.T) {
+	reg := stubListRegistry{listErr: errors.New("boom")}
+	if _, _, err := ListModels(context.Background(), reg); err == nil {
+		t.Fatal("expected registry list error")
+	}
+}
+
+func TestRegistryCoversLookupAndNormalizationBranches(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: "openai-compatible"}); err != nil {
+		t.Fatalf("unexpected register error %v", err)
+	}
+	client, ok := reg.Get(context.Background(), "openai")
+	if !ok || client.ProviderID() != "openai-compatible" {
+		t.Fatalf("unexpected client lookup result ok=%v client=%#v", ok, client)
+	}
+	if _, ok := reg.Get(context.Background(), "missing"); ok {
+		t.Fatal("expected missing provider lookup to fail")
+	}
+	ids, err := reg.List(context.Background())
+	if err != nil || len(ids) != 1 || ids[0] != ProviderOpenAI {
+		t.Fatalf("unexpected ids %#v err=%v", ids, err)
+	}
+}
+
+func TestRegistryHandlesProviderNotFoundAndConfigErrors(t *testing.T) {
+	reg, err := NewRegistry(config.ProviderRuntimeConfig{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := reg.Register(context.Background(), nil); err != nil {
+		t.Fatalf("expected nil client register to be ignored, got %v", err)
+	}
+	if err := reg.Register(context.Background(), stubRegistryClient{providerID: ""}); err == nil {
+		t.Fatal("expected provider not found error")
+	} else {
+		var providerErr *Error
+		if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeProviderNotFound {
+			t.Fatalf("unexpected error %#v", err)
+		}
+	}
+	if _, err := NewRegistry(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"broken": {BaseURL: "https://example.com", APIKey: "key", Model: "m"}}}); err == nil {
+		t.Fatal("expected invalid provider type error")
 	}
 }


### PR DESCRIPTION
Summary
收紧 provider 内部关于实例 ID、registry 装配和模型聚合的语义边界
保持改动严格收敛在 internal/provider 范围内，不触碰 agent/llm 主调用链
为后续 provider 迭代中的 step 重排提供更稳定的 provider 内部基座
Changes
在 internal/provider/registry.go 中抽出统一的 registry provider ID 归一化逻辑，确保 NewRegistry/Register/Get 使用同一规则
在 internal/provider/models.go 中固定 ListModels 的实例语义：
仅按 registry 实例 ID 聚合/去重
输出结果中的 provider_id 始终覆盖为 registry key
warning 使用稳定原因码，不透传底层错误文本
在 internal/provider/factory_test.go 中补充 NewDomainClientWithID(...) 的显式实例 ID 测试
新增 internal/provider/models_test.go，验证模型聚合始终使用 registry instance id
在 internal/provider/registry_test.go 中补充 provider ID 归一规则与边界测试
Why
当前 provider 迭代方案已经重排，后续 step 更依赖 provider 内部语义稳定性。
本 PR 不引入新的跨层能力，只补 provider 内部边界，避免后续继续混淆：

provider type
provider instance id
registry key
model aggregation identity
Validation
go test ./internal/provider ./internal/config -v