### PR TITLE
feat(policy): converge policy evaluator across runner and tools

### DIFF
--- a/internal/agent/run_setup.go
+++ b/internal/agent/run_setup.go
@@ -45,6 +45,7 @@ func (r *Runner) prepareRunPrompt(sess *session.Session, input RunPromptInput, m
 
 	activeSkill := r.resolveActiveSkill(sess)
 	allowedTools, deniedTools := resolveSkillToolSets(activeSkill)
+	promptHint := policypkg.EvaluatePromptHint(userInput)
 	availableTools := []string(nil)
 	if r.registry != nil {
 		availableTools = toolNames(r.registry.DefinitionsForMode(runMode))
@@ -62,7 +63,7 @@ func (r *Runner) prepareRunPrompt(sess *session.Session, input RunPromptInput, m
 		AvailableSkills:      r.promptSkills(),
 		AvailableTools:       availableTools,
 		InstructionText:      loadAGENTSInstruction(r.workspace),
-		WebLookupInstruction: policypkg.ExplicitWebLookupInstruction(userInput),
+		WebLookupInstruction: promptHint.Instruction,
 		PromptTokens:         contextpkg.EstimateRequestTokens([]llm.Message{input.UserMessage}),
 	}, nil
 }

--- a/internal/app/run_once_test.go
+++ b/internal/app/run_once_test.go
@@ -156,6 +156,85 @@ func writeRunOneShotTestConfig(t *testing.T, workspace string, cfg map[string]an
 	}
 }
 
+func TestRunOneShotPolicyBlocksDangerousShellCommandInToolLoop(t *testing.T) {
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		switch requestCount {
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"role": "assistant",
+						"tool_calls": []map[string]any{{
+							"id":   "call-1",
+							"type": "function",
+							"function": map[string]any{
+								"name":      "run_shell",
+								"arguments": `{"command":"rm -rf ."}`,
+							},
+						}},
+					},
+				}},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": "Dangerous command blocked as expected.",
+					},
+				}},
+			})
+		}
+	}))
+	defer server.Close()
+
+	writeRunOneShotTestConfig(t, workspace, map[string]any{
+		"provider": map[string]any{
+			"type":     "openai-compatible",
+			"base_url": server.URL,
+			"model":    "gpt-5.4-mini",
+			"api_key":  "test-key",
+		},
+		"stream": false,
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := RunOneShot(RunOneShotRequest{
+		Args:   []string{"-prompt", "clean this repository"},
+		Stdin:  strings.NewReader(""),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected two provider requests, got %d", requestCount)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "tool>") || !strings.Contains(output, "run_shell") {
+		t.Fatalf("expected run_shell tool execution output, got %q", output)
+	}
+	if !strings.Contains(output, "blocked dangerous shell command") {
+		t.Fatalf("expected dangerous-command policy rejection in output, got %q", output)
+	}
+	if !strings.Contains(output, "Dangerous command blocked as expected.") {
+		t.Fatalf("expected final assistant answer in stdout, got %q", output)
+	}
+}
+
 func newOpenAICompletionServer(content string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/chat/completions" {

--- a/internal/policy/access.go
+++ b/internal/policy/access.go
@@ -20,9 +20,10 @@ type ToolAccessDecision struct {
 // DecideToolAccess evaluates whether a tool can run under active allow/deny constraints.
 func DecideToolAccess(in ToolAccessInput) ToolAccessDecision {
 	eval := Evaluate(EvaluateInput{
-		ToolName: strings.TrimSpace(in.ToolName),
-		Allowed:  in.Allowed,
-		Denied:   in.Denied,
+		ToolName:          strings.TrimSpace(in.ToolName),
+		Allowed:           in.Allowed,
+		Denied:            in.Denied,
+		SkipRuntimeChecks: true,
 	})
 	if eval.MainDecision == MainDecisionAllow {
 		return ToolAccessDecision{Decision: corepkg.DecisionAllow, Reason: eval.MainReason}

--- a/internal/policy/access.go
+++ b/internal/policy/access.go
@@ -19,19 +19,13 @@ type ToolAccessDecision struct {
 
 // DecideToolAccess evaluates whether a tool can run under active allow/deny constraints.
 func DecideToolAccess(in ToolAccessInput) ToolAccessDecision {
-	name := strings.TrimSpace(in.ToolName)
-	if name == "" {
-		return ToolAccessDecision{Decision: corepkg.DecisionDeny, Reason: "tool name is empty"}
+	eval := Evaluate(EvaluateInput{
+		ToolName: strings.TrimSpace(in.ToolName),
+		Allowed:  in.Allowed,
+		Denied:   in.Denied,
+	})
+	if eval.MainDecision == MainDecisionAllow {
+		return ToolAccessDecision{Decision: corepkg.DecisionAllow, Reason: eval.MainReason}
 	}
-	if len(in.Allowed) > 0 {
-		if _, ok := in.Allowed[name]; !ok {
-			return ToolAccessDecision{Decision: corepkg.DecisionDeny, Reason: "tool is not in active allowlist"}
-		}
-	}
-	if len(in.Denied) > 0 {
-		if _, blocked := in.Denied[name]; blocked {
-			return ToolAccessDecision{Decision: corepkg.DecisionDeny, Reason: "tool is in active denylist"}
-		}
-	}
-	return ToolAccessDecision{Decision: corepkg.DecisionAllow}
+	return ToolAccessDecision{Decision: corepkg.DecisionDeny, Reason: eval.MainReason}
 }

--- a/internal/policy/access_test.go
+++ b/internal/policy/access_test.go
@@ -18,6 +18,14 @@ func TestDecideToolAccessAllowlist(t *testing.T) {
 	}
 }
 
+func TestDecideToolAccessAllowlistRunShellDoesNotRequireCommand(t *testing.T) {
+	allowed := map[string]struct{}{"run_shell": {}}
+	decision := DecideToolAccess(ToolAccessInput{ToolName: "run_shell", Allowed: allowed})
+	if decision.Decision != corepkg.DecisionAllow {
+		t.Fatalf("expected allow for allowlisted run_shell, got %q (%s)", decision.Decision, decision.Reason)
+	}
+}
+
 func TestDecideToolAccessDenylist(t *testing.T) {
 	denied := map[string]struct{}{"run_shell": {}}
 	decision := DecideToolAccess(ToolAccessInput{ToolName: "run_shell", Denied: denied})

--- a/internal/policy/decision.go
+++ b/internal/policy/decision.go
@@ -1,0 +1,239 @@
+package policy
+
+import (
+	"encoding/json"
+	"strings"
+
+	planpkg "bytemind/internal/plan"
+)
+
+type MainDecision string
+
+const (
+	MainDecisionAllow    MainDecision = "allow"
+	MainDecisionDeny     MainDecision = "deny"
+	MainDecisionEscalate MainDecision = "escalate"
+)
+
+type PromptHintDecision string
+
+const (
+	PromptHintDecisionHint PromptHintDecision = "hint"
+	PromptHintDecisionNone PromptHintDecision = "none"
+)
+
+type DecisionSource string
+
+const (
+	DecisionSourceRuntime DecisionSource = "runtime"
+	DecisionSourceSkill   DecisionSource = "skill"
+)
+
+type ReasonCode string
+
+const (
+	ReasonInvalidToolName                 ReasonCode = "invalid_tool_name"
+	ReasonToolDeniedByDenylist            ReasonCode = "tool_denied_by_denylist"
+	ReasonToolNotInAllowlist              ReasonCode = "tool_not_in_allowlist"
+	ReasonToolAllowed                     ReasonCode = "tool_allowed"
+	ReasonDestructiveToolRequiresApproval ReasonCode = "destructive_tool_requires_approval"
+	ReasonDangerousCommandBlocked         ReasonCode = "dangerous_command_blocked"
+	ReasonPlanModeToolBlocked             ReasonCode = "plan_mode_tool_blocked"
+	ReasonWebLookupHintInjected           ReasonCode = "web_lookup_hint_injected"
+	ReasonPromptHintSkipped               ReasonCode = "prompt_hint_skipped"
+	ReasonPolicyEvaluationError           ReasonCode = "policy_evaluation_error"
+)
+
+type PromptHintResult struct {
+	Decision    PromptHintDecision
+	ReasonCode  ReasonCode
+	Reason      string
+	Instruction string
+}
+
+type Evaluation struct {
+	MainDecision   MainDecision
+	MainReasonCode ReasonCode
+	MainReason     string
+	MainSource     DecisionSource
+	PromptHint     PromptHintResult
+}
+
+type ToolSpec struct {
+	Name        string
+	Destructive bool
+}
+
+type EvaluateInput struct {
+	ToolName          string
+	ToolSpec          ToolSpec
+	ToolArgs          json.RawMessage
+	ShellCommand      string
+	Allowed           map[string]struct{}
+	Denied            map[string]struct{}
+	Mode              planpkg.AgentMode
+	ApprovalPolicy    string
+	UserInput         string
+	SkipRuntimeChecks bool
+}
+
+// Evaluate returns a unified policy decision: one executable main decision and
+// one optional prompt-hint sub decision.
+func Evaluate(in EvaluateInput) Evaluation {
+	out := Evaluation{
+		MainDecision:   MainDecisionAllow,
+		MainReasonCode: ReasonToolAllowed,
+		MainReason:     "tool is allowed",
+		MainSource:     DecisionSourceRuntime,
+		PromptHint:     EvaluatePromptHint(in.UserInput),
+	}
+
+	toolName := strings.TrimSpace(in.ToolName)
+	if toolName == "" {
+		toolName = strings.TrimSpace(in.ToolSpec.Name)
+	}
+	if toolName == "" {
+		out.MainDecision = MainDecisionDeny
+		out.MainReasonCode = ReasonInvalidToolName
+		out.MainReason = "tool name is empty"
+		return out
+	}
+
+	if !in.SkipRuntimeChecks && strings.EqualFold(toolName, "run_shell") {
+		shellDecision := evaluateRunShellPolicy(in)
+		if shellDecision.MainDecision != MainDecisionAllow {
+			return shellDecision
+		}
+	}
+
+	if len(in.Denied) > 0 {
+		if _, blocked := in.Denied[toolName]; blocked {
+			out.MainDecision = MainDecisionDeny
+			out.MainReasonCode = ReasonToolDeniedByDenylist
+			out.MainReason = "tool is in active denylist"
+			out.MainSource = DecisionSourceSkill
+			return out
+		}
+	}
+
+	if len(in.Allowed) > 0 {
+		if _, ok := in.Allowed[toolName]; !ok {
+			out.MainDecision = MainDecisionDeny
+			out.MainReasonCode = ReasonToolNotInAllowlist
+			out.MainReason = "tool is not in active allowlist"
+			out.MainSource = DecisionSourceSkill
+			return out
+		}
+	}
+
+	if in.ToolSpec.Destructive && needsApproval(in.ApprovalPolicy) {
+		out.MainDecision = MainDecisionEscalate
+		out.MainReasonCode = ReasonDestructiveToolRequiresApproval
+		out.MainReason = "destructive tool requires approval"
+		return out
+	}
+
+	return out
+}
+
+func needsApproval(policy string) bool {
+	switch strings.TrimSpace(policy) {
+	case "never":
+		return false
+	default:
+		return true
+	}
+}
+
+func EvaluatePromptHint(userInput string) PromptHintResult {
+	instruction := ExplicitWebLookupInstruction(userInput)
+	if strings.TrimSpace(instruction) == "" {
+		return PromptHintResult{
+			Decision:   PromptHintDecisionNone,
+			ReasonCode: ReasonPromptHintSkipped,
+			Reason:     "no explicit web lookup request detected",
+		}
+	}
+	return PromptHintResult{
+		Decision:    PromptHintDecisionHint,
+		ReasonCode:  ReasonWebLookupHintInjected,
+		Reason:      "explicit web lookup request detected",
+		Instruction: instruction,
+	}
+}
+
+func evaluateRunShellPolicy(in EvaluateInput) Evaluation {
+	out := Evaluation{
+		MainDecision:   MainDecisionAllow,
+		MainReasonCode: ReasonToolAllowed,
+		MainReason:     "tool is allowed",
+		MainSource:     DecisionSourceRuntime,
+		PromptHint:     EvaluatePromptHint(in.UserInput),
+	}
+	command := strings.TrimSpace(in.ShellCommand)
+	if command == "" {
+		command = strings.TrimSpace(extractRunShellCommand(in.ToolArgs))
+	}
+	if command == "" {
+		out.MainDecision = MainDecisionDeny
+		out.MainReasonCode = ReasonPolicyEvaluationError
+		out.MainReason = "shell command is empty"
+		return out
+	}
+
+	mode := planpkg.NormalizeMode(string(in.Mode))
+	if mode == planpkg.ModePlan {
+		if !IsPlanSafeShellCommand(command) {
+			out.MainDecision = MainDecisionDeny
+			out.MainReasonCode = ReasonPlanModeToolBlocked
+			out.MainReason = "shell command is unavailable in plan mode unless it matches the strict read-only allowlist"
+			return out
+		}
+		return out
+	}
+
+	assessment := AssessShellCommand(command)
+	if assessment.Risk == ShellRiskBlocked {
+		out.MainDecision = MainDecisionDeny
+		out.MainReasonCode = ReasonDangerousCommandBlocked
+		out.MainReason = strings.TrimSpace(assessment.Reason)
+		if out.MainReason == "" {
+			out.MainReason = "blocked dangerous shell command"
+		}
+		return out
+	}
+
+	switch strings.TrimSpace(in.ApprovalPolicy) {
+	case "always":
+		out.MainDecision = MainDecisionEscalate
+		out.MainReasonCode = ReasonDestructiveToolRequiresApproval
+		out.MainReason = "shell command requires approval under policy always"
+		return out
+	case "never":
+		return out
+	default:
+		if assessment.Risk == ShellRiskApproval {
+			out.MainDecision = MainDecisionEscalate
+			out.MainReasonCode = ReasonDestructiveToolRequiresApproval
+			out.MainReason = strings.TrimSpace(assessment.Reason)
+			if out.MainReason == "" {
+				out.MainReason = "shell command requires approval"
+			}
+			return out
+		}
+		return out
+	}
+}
+
+func extractRunShellCommand(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var payload struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(payload.Command)
+}

--- a/internal/policy/decision_test.go
+++ b/internal/policy/decision_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"encoding/json"
 	"testing"
 
 	planpkg "bytemind/internal/plan"
@@ -109,5 +110,61 @@ func TestEvaluateSkipRuntimeChecksForRunShell(t *testing.T) {
 	})
 	if result.MainDecision != MainDecisionAllow {
 		t.Fatalf("expected runtime checks to be skipped, got %#v", result)
+	}
+}
+
+func TestEvaluateInvalidToolName(t *testing.T) {
+	result := Evaluate(EvaluateInput{})
+	if result.MainDecision != MainDecisionDeny {
+		t.Fatalf("expected deny for empty tool, got %#v", result)
+	}
+	if result.MainReasonCode != ReasonInvalidToolName {
+		t.Fatalf("expected invalid tool name reason code, got %#v", result)
+	}
+}
+
+func TestEvaluateUsesToolSpecNameWhenToolNameMissing(t *testing.T) {
+	result := Evaluate(EvaluateInput{
+		ToolSpec: ToolSpec{Name: "read_file"},
+	})
+	if result.MainDecision != MainDecisionAllow {
+		t.Fatalf("expected allow using tool spec name fallback, got %#v", result)
+	}
+}
+
+func TestEvaluateRunShellUsesCommandFromToolArgs(t *testing.T) {
+	raw, _ := json.Marshal(map[string]string{"command": "git status"})
+	result := Evaluate(EvaluateInput{
+		ToolName:       "run_shell",
+		ToolArgs:       raw,
+		Mode:           planpkg.ModeBuild,
+		ApprovalPolicy: "never",
+	})
+	if result.MainDecision != MainDecisionAllow {
+		t.Fatalf("expected allow from tool args command extraction, got %#v", result)
+	}
+}
+
+func TestEvaluateRunShellPolicyEvaluationErrorWhenCommandMissing(t *testing.T) {
+	result := Evaluate(EvaluateInput{
+		ToolName: "run_shell",
+		ToolArgs: json.RawMessage(`{"foo":"bar"}`),
+	})
+	if result.MainDecision != MainDecisionDeny {
+		t.Fatalf("expected deny when command is missing, got %#v", result)
+	}
+	if result.MainReasonCode != ReasonPolicyEvaluationError {
+		t.Fatalf("expected policy evaluation error, got %#v", result)
+	}
+}
+
+func TestEvaluateDestructiveToolPolicyNeverDoesNotEscalate(t *testing.T) {
+	result := Evaluate(EvaluateInput{
+		ToolName:       "write_file",
+		ToolSpec:       ToolSpec{Name: "write_file", Destructive: true},
+		ApprovalPolicy: "never",
+	})
+	if result.MainDecision != MainDecisionAllow {
+		t.Fatalf("expected allow when policy=never, got %#v", result)
 	}
 }

--- a/internal/policy/decision_test.go
+++ b/internal/policy/decision_test.go
@@ -1,0 +1,113 @@
+package policy
+
+import (
+	"testing"
+
+	planpkg "bytemind/internal/plan"
+)
+
+func TestEvaluatePromptHintInjected(t *testing.T) {
+	result := EvaluatePromptHint("Find implementation in GitHub repository")
+	if result.Decision != PromptHintDecisionHint {
+		t.Fatalf("expected hint decision, got %#v", result)
+	}
+	if result.ReasonCode != ReasonWebLookupHintInjected {
+		t.Fatalf("expected web hint reason code, got %#v", result)
+	}
+	if result.Instruction == "" {
+		t.Fatalf("expected non-empty instruction, got %#v", result)
+	}
+}
+
+func TestEvaluatePromptHintSkipped(t *testing.T) {
+	result := EvaluatePromptHint("Use search_text in current workspace")
+	if result.Decision != PromptHintDecisionNone {
+		t.Fatalf("expected no hint decision, got %#v", result)
+	}
+	if result.ReasonCode != ReasonPromptHintSkipped {
+		t.Fatalf("expected hint skipped reason code, got %#v", result)
+	}
+}
+
+func TestEvaluateRunShellDangerousCommandBlocksBeforeApproval(t *testing.T) {
+	result := Evaluate(EvaluateInput{
+		ToolName:       "run_shell",
+		ShellCommand:   "rm -rf .",
+		Mode:           planpkg.ModeBuild,
+		ApprovalPolicy: "always",
+	})
+	if result.MainDecision != MainDecisionDeny {
+		t.Fatalf("expected deny for dangerous command, got %#v", result)
+	}
+	if result.MainReasonCode != ReasonDangerousCommandBlocked {
+		t.Fatalf("expected dangerous command reason code, got %#v", result)
+	}
+}
+
+func TestEvaluateRunShellPlanModeReturnsPlanBlockedReasonCode(t *testing.T) {
+	result := Evaluate(EvaluateInput{
+		ToolName:       "run_shell",
+		ShellCommand:   "go test ./...",
+		Mode:           planpkg.ModePlan,
+		ApprovalPolicy: "always",
+	})
+	if result.MainDecision != MainDecisionDeny {
+		t.Fatalf("expected deny in plan mode, got %#v", result)
+	}
+	if result.MainReasonCode != ReasonPlanModeToolBlocked {
+		t.Fatalf("expected plan blocked reason code, got %#v", result)
+	}
+}
+
+func TestEvaluateRunShellOnRequestEscalatesForRiskyCommand(t *testing.T) {
+	result := Evaluate(EvaluateInput{
+		ToolName:       "run_shell",
+		ShellCommand:   "go test ./...",
+		Mode:           planpkg.ModeBuild,
+		ApprovalPolicy: "on-request",
+	})
+	if result.MainDecision != MainDecisionEscalate {
+		t.Fatalf("expected escalate for risky command, got %#v", result)
+	}
+	if result.MainReasonCode != ReasonDestructiveToolRequiresApproval {
+		t.Fatalf("expected approval reason code, got %#v", result)
+	}
+}
+
+func TestEvaluateDenylistOverridesAllowlist(t *testing.T) {
+	result := Evaluate(EvaluateInput{
+		ToolName: "read_file",
+		Allowed:  map[string]struct{}{"read_file": {}},
+		Denied:   map[string]struct{}{"read_file": {}},
+	})
+	if result.MainDecision != MainDecisionDeny {
+		t.Fatalf("expected deny when denylist and allowlist both include tool, got %#v", result)
+	}
+	if result.MainReasonCode != ReasonToolDeniedByDenylist {
+		t.Fatalf("expected denylist reason code, got %#v", result)
+	}
+}
+
+func TestEvaluateHintDoesNotChangeMainDecision(t *testing.T) {
+	result := Evaluate(EvaluateInput{
+		ToolName:  "read_file",
+		UserInput: "Find implementation in GitHub repository",
+	})
+	if result.MainDecision != MainDecisionAllow {
+		t.Fatalf("expected main decision allow, got %#v", result)
+	}
+	if result.PromptHint.Decision != PromptHintDecisionHint {
+		t.Fatalf("expected prompt hint to be injected, got %#v", result.PromptHint)
+	}
+}
+
+func TestEvaluateSkipRuntimeChecksForRunShell(t *testing.T) {
+	result := Evaluate(EvaluateInput{
+		ToolName:          "run_shell",
+		ShellCommand:      "rm -rf .",
+		SkipRuntimeChecks: true,
+	})
+	if result.MainDecision != MainDecisionAllow {
+		t.Fatalf("expected runtime checks to be skipped, got %#v", result)
+	}
+}

--- a/internal/policy/shell_command.go
+++ b/internal/policy/shell_command.go
@@ -1,0 +1,346 @@
+package policy
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+type ShellRisk string
+
+const (
+	ShellRiskSafe     ShellRisk = "safe"
+	ShellRiskApproval ShellRisk = "approval"
+	ShellRiskBlocked  ShellRisk = "blocked"
+)
+
+type ShellAssessment struct {
+	Risk   ShellRisk
+	Reason string
+}
+
+func AssessShellCommand(command string) ShellAssessment {
+	segments := splitCommandSegments(command)
+	result := ShellAssessment{Risk: ShellRiskSafe}
+	for _, segment := range segments {
+		assessment := assessCommandSegment(segment)
+		if shellRiskOrder(assessment.Risk) > shellRiskOrder(result.Risk) {
+			result = assessment
+		}
+		if result.Risk == ShellRiskBlocked {
+			return result
+		}
+	}
+	return result
+}
+
+func IsPlanSafeShellCommand(command string) bool {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return false
+	}
+	if hasWriteRedirection(command) {
+		return false
+	}
+	segments := splitCommandSegments(command)
+	if len(segments) != 1 {
+		return false
+	}
+	fields := splitCommandFields(segments[0])
+	if len(fields) == 0 {
+		return false
+	}
+	first := strings.ToLower(strings.TrimSpace(fields[0]))
+	if first == "" {
+		return false
+	}
+	if looksLikeScript(first) {
+		return false
+	}
+	for _, field := range fields {
+		trimmed := strings.TrimSpace(field)
+		switch trimmed {
+		case "|", ">", ">>", "<", ";", "&&", "||":
+			return false
+		}
+	}
+
+	switch first {
+	case "ls", "dir", "pwd", "cat", "type", "rg", "grep", "find", "tree":
+		return true
+	case "git":
+		if len(fields) < 2 {
+			return false
+		}
+		sub := strings.ToLower(fields[1])
+		return sub == "status" || sub == "diff" || sub == "log"
+	case "go":
+		if len(fields) < 2 {
+			return false
+		}
+		sub := strings.ToLower(fields[1])
+		return sub == "env" || sub == "list"
+	case "bash", "sh", "pwsh", "powershell", "python", "python3", "node":
+		return false
+	default:
+		return false
+	}
+}
+
+func shellRiskOrder(risk ShellRisk) int {
+	switch risk {
+	case ShellRiskBlocked:
+		return 3
+	case ShellRiskApproval:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func assessCommandSegment(segment string) ShellAssessment {
+	segment = strings.TrimSpace(segment)
+	if segment == "" {
+		return ShellAssessment{Risk: ShellRiskSafe}
+	}
+	if hasWriteRedirection(segment) {
+		return ShellAssessment{Risk: ShellRiskApproval, Reason: "uses shell redirection"}
+	}
+
+	fields := splitCommandFields(segment)
+	if len(fields) == 0 {
+		return ShellAssessment{Risk: ShellRiskSafe}
+	}
+
+	command := strings.ToLower(fields[0])
+	if isBlockedCommand(command, fields) {
+		return ShellAssessment{Risk: ShellRiskBlocked, Reason: fmt.Sprintf("blocked dangerous shell command: %s", strings.TrimSpace(segment))}
+	}
+	if isReadOnlyCommand(command, fields) {
+		return ShellAssessment{Risk: ShellRiskSafe}
+	}
+	if isApprovalCommand(command, fields) {
+		return ShellAssessment{Risk: ShellRiskApproval, Reason: fmt.Sprintf("may modify files or environment: %s", fields[0])}
+	}
+	return ShellAssessment{Risk: ShellRiskApproval, Reason: fmt.Sprintf("requires approval for non-read-only command: %s", fields[0])}
+}
+
+func splitCommandSegments(command string) []string {
+	normalized := strings.ReplaceAll(command, "\r\n", "\n")
+	segments := make([]string, 0, 4)
+	var builder strings.Builder
+	inSingle := false
+	inDouble := false
+
+	flush := func() {
+		segment := strings.TrimSpace(builder.String())
+		if segment != "" {
+			segments = append(segments, segment)
+		}
+		builder.Reset()
+	}
+
+	for i := 0; i < len(normalized); i++ {
+		ch := normalized[i]
+		switch ch {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+			builder.WriteByte(ch)
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+			builder.WriteByte(ch)
+		case '\n', ';':
+			if inSingle || inDouble {
+				builder.WriteByte(ch)
+				continue
+			}
+			flush()
+		case '|', '&':
+			if inSingle || inDouble {
+				builder.WriteByte(ch)
+				continue
+			}
+			flush()
+			if i+1 < len(normalized) && normalized[i+1] == ch {
+				i++
+			}
+		default:
+			builder.WriteByte(ch)
+		}
+	}
+	flush()
+	return segments
+}
+
+func splitCommandFields(segment string) []string {
+	fields := make([]string, 0, 8)
+	var builder strings.Builder
+	inSingle := false
+	inDouble := false
+
+	flush := func() {
+		if builder.Len() == 0 {
+			return
+		}
+		fields = append(fields, builder.String())
+		builder.Reset()
+	}
+
+	for i := 0; i < len(segment); i++ {
+		ch := segment[i]
+		switch ch {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+				continue
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+				continue
+			}
+		}
+		if !inSingle && !inDouble && unicode.IsSpace(rune(ch)) {
+			flush()
+			continue
+		}
+		builder.WriteByte(ch)
+	}
+	flush()
+	return fields
+}
+
+func hasWriteRedirection(segment string) bool {
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(segment); i++ {
+		ch := segment[i]
+		switch ch {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case '>':
+			if !inSingle && !inDouble {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isBlockedCommand(command string, fields []string) bool {
+	switch command {
+	case "rm", "rmdir", "del", "erase", "remove-item", "ri", "rd", "format", "diskpart", "mkfs", "dd", "shutdown", "reboot", "halt", "poweroff":
+		return true
+	case "git":
+		return isBlockedGit(fields)
+	default:
+		return false
+	}
+}
+
+func isBlockedGit(fields []string) bool {
+	if len(fields) < 2 {
+		return false
+	}
+	sub := strings.ToLower(fields[1])
+	switch sub {
+	case "reset":
+		return hasAnyArg(fields[2:], "--hard")
+	case "clean":
+		for _, arg := range fields[2:] {
+			if strings.HasPrefix(arg, "-f") || strings.Contains(arg, "f") && strings.HasPrefix(arg, "-") {
+				return true
+			}
+		}
+	case "checkout":
+		return hasAnyArg(fields[2:], "--")
+	case "restore":
+		return len(fields) > 2
+	}
+	return false
+}
+
+func isReadOnlyCommand(command string, fields []string) bool {
+	switch command {
+	case "cat", "type", "ls", "dir", "pwd", "echo", "rg", "grep", "find", "where", "which", "env", "printenv", "uname", "whoami", "head", "tail", "sort", "uniq", "wc", "tree", "get-childitem", "get-content", "select-string", "get-location", "resolve-path":
+		return true
+	case "git":
+		return isReadOnlyGit(fields)
+	case "go":
+		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "env", "list", "version")
+	case "npm", "pnpm", "yarn":
+		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "list", "info", "view", "why")
+	default:
+		return false
+	}
+}
+
+func isApprovalCommand(command string, fields []string) bool {
+	switch command {
+	case "cp", "copy", "copy-item", "mv", "move", "move-item", "rename", "rename-item", "new-item", "mkdir", "md", "touch", "tee", "set-content", "add-content", "out-file":
+		return true
+	case "git":
+		return len(fields) > 1
+	case "go":
+		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "test", "build", "run", "mod", "get")
+	case "npm", "pnpm", "yarn":
+		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "install", "add", "remove", "update", "run")
+	case "pip", "pip3", "uv", "cargo", "make", "cmake", "python", "python3", "node", "pwsh", "powershell", "sh", "bash":
+		return true
+	default:
+		return false
+	}
+}
+
+func isReadOnlyGit(fields []string) bool {
+	if len(fields) < 2 {
+		return false
+	}
+	sub := strings.ToLower(fields[1])
+	return isOneOf(sub, "status", "diff", "log", "show", "rev-parse", "ls-files", "grep", "branch") && len(fields) == 2
+}
+
+func hasAnyArg(args []string, targets ...string) bool {
+	for _, arg := range args {
+		for _, target := range targets {
+			if strings.EqualFold(arg, target) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isOneOf(value string, options ...string) bool {
+	for _, option := range options {
+		if value == option {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeScript(command string) bool {
+	command = strings.ToLower(strings.TrimSpace(command))
+	if strings.HasPrefix(command, "./") || strings.HasPrefix(command, ".\\") {
+		return true
+	}
+	ext := strings.ToLower(filepath.Ext(command))
+	switch ext {
+	case ".sh", ".ps1", ".bat", ".cmd":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/policy/shell_command_test.go
+++ b/internal/policy/shell_command_test.go
@@ -1,0 +1,141 @@
+package policy
+
+import "testing"
+
+func TestIsPlanSafeShellCommand(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{name: "allow ls", command: "ls -la", want: true},
+		{name: "allow git status", command: "git status", want: true},
+		{name: "allow go env", command: "go env GOPATH", want: true},
+		{name: "deny empty", command: "", want: false},
+		{name: "deny write redirection", command: "echo hi > out.txt", want: false},
+		{name: "deny multiple segments", command: "git status && pwd", want: false},
+		{name: "deny script path", command: "./script.sh", want: false},
+		{name: "deny shell interpreter", command: "bash -lc 'pwd'", want: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPlanSafeShellCommand(tc.command); got != tc.want {
+				t.Fatalf("IsPlanSafeShellCommand(%q) = %v, want %v", tc.command, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAssessCommandSegment(t *testing.T) {
+	cases := []struct {
+		name    string
+		segment string
+		risk    ShellRisk
+	}{
+		{name: "empty segment", segment: "   ", risk: ShellRiskSafe},
+		{name: "blocked rm", segment: "rm -rf .", risk: ShellRiskBlocked},
+		{name: "safe read only", segment: "git status", risk: ShellRiskSafe},
+		{name: "approval go test", segment: "go test ./...", risk: ShellRiskApproval},
+		{name: "approval by redirection", segment: "echo hi > out.txt", risk: ShellRiskApproval},
+		{name: "approval by unknown command", segment: "custom-tool --run", risk: ShellRiskApproval},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := assessCommandSegment(tc.segment)
+			if got.Risk != tc.risk {
+				t.Fatalf("assessCommandSegment(%q) risk = %q, want %q (%#v)", tc.segment, got.Risk, tc.risk, got)
+			}
+		})
+	}
+}
+
+func TestSplitCommandSegments(t *testing.T) {
+	got := splitCommandSegments(`git status && echo "a;b|c" ; pwd|wc -l`)
+	want := []string{"git status", `echo "a;b|c"`, "pwd", "wc -l"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected segments len: got=%d want=%d (%#v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("segment[%d] = %q, want %q (all=%#v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSplitCommandFields(t *testing.T) {
+	got := splitCommandFields(`go test "./internal/..." -run "Test Name"`)
+	want := []string{"go", "test", "./internal/...", "-run", "Test Name"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected fields len: got=%d want=%d (%#v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("field[%d] = %q, want %q (all=%#v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestHasWriteRedirection(t *testing.T) {
+	if !hasWriteRedirection("echo hi > out.txt") {
+		t.Fatal("expected write redirection to be detected")
+	}
+	if hasWriteRedirection(`echo "hello > world"`) {
+		t.Fatal("expected quoted redirection symbol to be ignored")
+	}
+}
+
+func TestBlockedGitVariants(t *testing.T) {
+	if !isBlockedGit([]string{"git", "reset", "--hard", "HEAD~1"}) {
+		t.Fatal("expected git reset --hard to be blocked")
+	}
+	if !isBlockedGit([]string{"git", "clean", "-fd"}) {
+		t.Fatal("expected git clean -fd to be blocked")
+	}
+	if !isBlockedGit([]string{"git", "checkout", "--", "a.txt"}) {
+		t.Fatal("expected git checkout -- file to be blocked")
+	}
+	if !isBlockedGit([]string{"git", "restore", "a.txt"}) {
+		t.Fatal("expected git restore with file to be blocked")
+	}
+	if isBlockedGit([]string{"git", "reset", "--soft", "HEAD~1"}) {
+		t.Fatal("expected git reset --soft not to be blocked")
+	}
+}
+
+func TestReadOnlyAndApprovalCommandClassifiers(t *testing.T) {
+	if !isReadOnlyGit([]string{"git", "status"}) {
+		t.Fatal("expected read-only git status")
+	}
+	if isReadOnlyGit([]string{"git", "status", "-s"}) {
+		t.Fatal("expected extra args to disallow read-only git classification")
+	}
+	if !isReadOnlyCommand("go", []string{"go", "version"}) {
+		t.Fatal("expected go version to be read-only")
+	}
+	if !isReadOnlyCommand("npm", []string{"npm", "view", "react"}) {
+		t.Fatal("expected npm view to be read-only")
+	}
+	if !isApprovalCommand("git", []string{"git", "commit", "-m", "x"}) {
+		t.Fatal("expected git commit to require approval")
+	}
+	if !isApprovalCommand("python", []string{"python", "script.py"}) {
+		t.Fatal("expected python command to require approval")
+	}
+	if isApprovalCommand("ls", []string{"ls"}) {
+		t.Fatal("expected ls not to require approval")
+	}
+}
+
+func TestLooksLikeScript(t *testing.T) {
+	if !looksLikeScript("./script.sh") {
+		t.Fatal("expected ./script.sh to be script-like")
+	}
+	if !looksLikeScript("setup.ps1") {
+		t.Fatal("expected .ps1 extension to be script-like")
+	}
+	if looksLikeScript("git") {
+		t.Fatal("expected git not to be script-like")
+	}
+}

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -11,7 +11,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	corepkg "bytemind/internal/core"
 	planpkg "bytemind/internal/plan"
 	policypkg "bytemind/internal/policy"
 )
@@ -30,7 +29,7 @@ type ExecuteResult struct {
 }
 
 type PermissionEngine interface {
-	Check(context.Context, ResolvedTool, *ExecutionContext) error
+	Check(context.Context, ResolvedTool, json.RawMessage, *ExecutionContext) error
 }
 
 type ArgumentDecoder interface {
@@ -93,7 +92,7 @@ func (e *Executor) ExecuteRequest(ctx context.Context, req ExecuteRequest) (Exec
 	if err != nil {
 		return ExecuteResult{}, err
 	}
-	if err := e.permissionEngine.Check(ctx, resolved, execCtx); err != nil {
+	if err := e.permissionEngine.Check(ctx, resolved, raw, execCtx); err != nil {
 		return ExecuteResult{}, err
 	}
 
@@ -114,28 +113,40 @@ func (e *Executor) ExecuteRequest(ctx context.Context, req ExecuteRequest) (Exec
 
 type defaultPermissionEngine struct{}
 
-func (defaultPermissionEngine) Check(_ context.Context, resolved ResolvedTool, execCtx *ExecutionContext) error {
+func (defaultPermissionEngine) Check(_ context.Context, resolved ResolvedTool, rawArgs json.RawMessage, execCtx *ExecutionContext) error {
 	if execCtx == nil {
 		return nil
 	}
-	decision := policypkg.DecideToolAccess(policypkg.ToolAccessInput{
-		ToolName: resolved.Definition.Function.Name,
-		Allowed:  execCtx.AllowedTools,
-		Denied:   execCtx.DeniedTools,
+	toolName := strings.TrimSpace(resolved.Definition.Function.Name)
+	eval := policypkg.Evaluate(policypkg.EvaluateInput{
+		ToolName: toolName,
+		ToolSpec: policypkg.ToolSpec{
+			Name:        resolved.Spec.Name,
+			Destructive: resolved.Spec.Destructive,
+		},
+		ToolArgs:          rawArgs,
+		Allowed:           execCtx.AllowedTools,
+		Denied:            execCtx.DeniedTools,
+		Mode:              execCtx.Mode,
+		ApprovalPolicy:    execCtx.ApprovalPolicy,
+		SkipRuntimeChecks: strings.EqualFold(toolName, "run_shell"),
 	})
-	if decision.Decision != corepkg.DecisionAllow {
-		reason := strings.TrimSpace(decision.Reason)
-		if strings.TrimSpace(reason) == "" {
-			reason = "tool is unavailable by active skill policy"
+	switch eval.MainDecision {
+	case policypkg.MainDecisionAllow:
+		return nil
+	case policypkg.MainDecisionEscalate:
+		return requireDestructiveApproval(toolName, execCtx)
+	default:
+		reason := strings.TrimSpace(eval.MainReason)
+		if reason == "" {
+			reason = "tool is unavailable by active policy"
 		}
-		return NewToolExecError(ToolErrorPermissionDenied, fmt.Sprintf("tool %q is unavailable by active skill policy: %s", resolved.Definition.Function.Name, reason), false, nil)
-	}
-	if resolved.Spec.Destructive {
-		if err := requireDestructiveApproval(resolved.Definition.Function.Name, execCtx); err != nil {
-			return err
+		code := strings.TrimSpace(string(eval.MainReasonCode))
+		if code != "" {
+			reason = fmt.Sprintf("%s (%s)", reason, code)
 		}
+		return NewToolExecError(ToolErrorPermissionDenied, fmt.Sprintf("tool %q is unavailable by active skill policy: %s", toolName, reason), false, nil)
 	}
-	return nil
 }
 
 type strictJSONArgumentDecoder struct{}

--- a/internal/tools/run_shell.go
+++ b/internal/tools/run_shell.go
@@ -14,10 +14,10 @@ import (
 	"runtime"
 	"strings"
 	"time"
-	"unicode"
 
 	"bytemind/internal/llm"
 	planpkg "bytemind/internal/plan"
+	policypkg "bytemind/internal/policy"
 )
 
 type RunShellTool struct{}
@@ -117,99 +117,35 @@ func (RunShellTool) Run(ctx context.Context, raw json.RawMessage, execCtx *Execu
 
 func requireApproval(command string, execCtx *ExecutionContext) error {
 	mode := planpkg.ModeBuild
+	approvalPolicy := ""
 	if execCtx != nil {
 		mode = planpkg.NormalizeMode(string(execCtx.Mode))
-	}
-	if mode == planpkg.ModePlan {
-		if !isPlanSafeCommand(command) {
-			return errors.New("shell command is unavailable in plan mode unless it matches the strict read-only allowlist")
-		}
-		return nil
+		approvalPolicy = strings.TrimSpace(execCtx.ApprovalPolicy)
 	}
 
-	assessment := assessShellCommand(command)
-	if assessment.Risk == shellRiskBlocked {
-		return errors.New(assessment.Reason)
-	}
-
-	switch execCtx.ApprovalPolicy {
-	case "never":
+	eval := policypkg.Evaluate(policypkg.EvaluateInput{
+		ToolName:       "run_shell",
+		ToolSpec:       policypkg.ToolSpec{Name: "run_shell", Destructive: false},
+		ShellCommand:   command,
+		Mode:           mode,
+		ApprovalPolicy: approvalPolicy,
+	})
+	switch eval.MainDecision {
+	case policypkg.MainDecisionAllow:
 		return nil
-	case "always":
-		return promptForApproval(command, assessment.Reason, execCtx)
+	case policypkg.MainDecisionEscalate:
+		return promptForApproval(command, eval.MainReason, execCtx)
 	default:
-		if assessment.Risk == shellRiskApproval {
-			return promptForApproval(command, assessment.Reason, execCtx)
+		reason := strings.TrimSpace(eval.MainReason)
+		if reason == "" {
+			reason = "shell command is unavailable by active policy"
 		}
-		return nil
+		return errors.New(reason)
 	}
 }
 
 func isPlanSafeCommand(command string) bool {
-	command = strings.TrimSpace(command)
-	if command == "" {
-		return false
-	}
-	if hasWriteRedirection(command) {
-		return false
-	}
-	segments := splitCommandSegments(command)
-	if len(segments) != 1 {
-		return false
-	}
-	fields := splitCommandFields(segments[0])
-	if len(fields) == 0 {
-		return false
-	}
-	first := strings.ToLower(strings.TrimSpace(fields[0]))
-	if first == "" {
-		return false
-	}
-	if looksLikeScript(first) {
-		return false
-	}
-	for _, field := range fields {
-		trimmed := strings.TrimSpace(field)
-		switch trimmed {
-		case "|", ">", ">>", "<", ";", "&&", "||":
-			return false
-		}
-	}
-
-	switch first {
-	case "ls", "dir", "pwd", "cat", "type", "rg", "grep", "find", "tree":
-		return true
-	case "git":
-		if len(fields) < 2 {
-			return false
-		}
-		sub := strings.ToLower(fields[1])
-		return sub == "status" || sub == "diff" || sub == "log"
-	case "go":
-		if len(fields) < 2 {
-			return false
-		}
-		sub := strings.ToLower(fields[1])
-		return sub == "env" || sub == "list"
-	case "bash", "sh", "pwsh", "powershell", "python", "python3", "node":
-		return false
-	default:
-		return false
-	}
-}
-
-func looksLikeScript(command string) bool {
-	command = strings.ToLower(strings.TrimSpace(command))
-	if strings.HasPrefix(command, "./") || strings.HasPrefix(command, ".\\") {
-		return true
-	}
-	ext := strings.ToLower(filepath.Ext(command))
-	switch ext {
-	case ".sh", ".ps1", ".bat", ".cmd":
-		return true
-	default:
-		return false
-	}
+	return policypkg.IsPlanSafeShellCommand(command)
 }
 
 func promptForApproval(command, reason string, execCtx *ExecutionContext) error {
@@ -249,250 +185,15 @@ func promptForApproval(command, reason string, execCtx *ExecutionContext) error 
 }
 
 func assessShellCommand(command string) shellAssessment {
-	segments := splitCommandSegments(command)
-	result := shellAssessment{Risk: shellRiskSafe}
-	for _, segment := range segments {
-		assessment := assessCommandSegment(segment)
-		if assessment.Risk > result.Risk {
-			result = assessment
-		}
-		if result.Risk == shellRiskBlocked {
-			return result
-		}
-	}
-	return result
-}
-
-func assessCommandSegment(segment string) shellAssessment {
-	segment = strings.TrimSpace(segment)
-	if segment == "" {
-		return shellAssessment{Risk: shellRiskSafe}
-	}
-	if hasWriteRedirection(segment) {
-		return shellAssessment{Risk: shellRiskApproval, Reason: "uses shell redirection"}
-	}
-
-	fields := splitCommandFields(segment)
-	if len(fields) == 0 {
-		return shellAssessment{Risk: shellRiskSafe}
-	}
-
-	command := strings.ToLower(fields[0])
-	if isBlockedCommand(command, fields) {
-		return shellAssessment{Risk: shellRiskBlocked, Reason: fmt.Sprintf("blocked dangerous shell command: %s", strings.TrimSpace(segment))}
-	}
-	if isReadOnlyCommand(command, fields) {
-		return shellAssessment{Risk: shellRiskSafe}
-	}
-	if isApprovalCommand(command, fields) {
-		return shellAssessment{Risk: shellRiskApproval, Reason: fmt.Sprintf("may modify files or environment: %s", fields[0])}
-	}
-	return shellAssessment{Risk: shellRiskApproval, Reason: fmt.Sprintf("requires approval for non-read-only command: %s", fields[0])}
-}
-
-func splitCommandSegments(command string) []string {
-	normalized := strings.ReplaceAll(command, "\r\n", "\n")
-	segments := make([]string, 0, 4)
-	var builder strings.Builder
-	inSingle := false
-	inDouble := false
-
-	flush := func() {
-		segment := strings.TrimSpace(builder.String())
-		if segment != "" {
-			segments = append(segments, segment)
-		}
-		builder.Reset()
-	}
-
-	for i := 0; i < len(normalized); i++ {
-		ch := normalized[i]
-		switch ch {
-		case '\'':
-			if !inDouble {
-				inSingle = !inSingle
-			}
-			builder.WriteByte(ch)
-		case '"':
-			if !inSingle {
-				inDouble = !inDouble
-			}
-			builder.WriteByte(ch)
-		case '\n', ';':
-			if inSingle || inDouble {
-				builder.WriteByte(ch)
-				continue
-			}
-			flush()
-		case '|', '&':
-			if inSingle || inDouble {
-				builder.WriteByte(ch)
-				continue
-			}
-			flush()
-			if i+1 < len(normalized) && normalized[i+1] == ch {
-				i++
-			}
-		default:
-			builder.WriteByte(ch)
-		}
-	}
-	flush()
-	return segments
-}
-
-func splitCommandFields(segment string) []string {
-	fields := make([]string, 0, 8)
-	var builder strings.Builder
-	inSingle := false
-	inDouble := false
-
-	flush := func() {
-		if builder.Len() == 0 {
-			return
-		}
-		fields = append(fields, builder.String())
-		builder.Reset()
-	}
-
-	for i := 0; i < len(segment); i++ {
-		ch := segment[i]
-		switch ch {
-		case '\'':
-			if !inDouble {
-				inSingle = !inSingle
-				continue
-			}
-		case '"':
-			if !inSingle {
-				inDouble = !inDouble
-				continue
-			}
-		}
-		if !inSingle && !inDouble && unicode.IsSpace(rune(ch)) {
-			flush()
-			continue
-		}
-		builder.WriteByte(ch)
-	}
-	flush()
-	return fields
-}
-
-func hasWriteRedirection(segment string) bool {
-	inSingle := false
-	inDouble := false
-	for i := 0; i < len(segment); i++ {
-		ch := segment[i]
-		switch ch {
-		case '\'':
-			if !inDouble {
-				inSingle = !inSingle
-			}
-		case '"':
-			if !inSingle {
-				inDouble = !inDouble
-			}
-		case '>':
-			if !inSingle && !inDouble {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func isBlockedCommand(command string, fields []string) bool {
-	switch command {
-	case "rm", "rmdir", "del", "erase", "remove-item", "ri", "rd", "format", "diskpart", "mkfs", "dd", "shutdown", "reboot", "halt", "poweroff":
-		return true
-	case "git":
-		return isBlockedGit(fields)
+	assessment := policypkg.AssessShellCommand(command)
+	switch assessment.Risk {
+	case policypkg.ShellRiskBlocked:
+		return shellAssessment{Risk: shellRiskBlocked, Reason: assessment.Reason}
+	case policypkg.ShellRiskApproval:
+		return shellAssessment{Risk: shellRiskApproval, Reason: assessment.Reason}
 	default:
-		return false
+		return shellAssessment{Risk: shellRiskSafe, Reason: assessment.Reason}
 	}
-}
-
-func isBlockedGit(fields []string) bool {
-	if len(fields) < 2 {
-		return false
-	}
-	sub := strings.ToLower(fields[1])
-	switch sub {
-	case "reset":
-		return hasAnyArg(fields[2:], "--hard")
-	case "clean":
-		for _, arg := range fields[2:] {
-			if strings.HasPrefix(arg, "-f") || strings.Contains(arg, "f") && strings.HasPrefix(arg, "-") {
-				return true
-			}
-		}
-	case "checkout":
-		return hasAnyArg(fields[2:], "--")
-	case "restore":
-		return len(fields) > 2
-	}
-	return false
-}
-
-func isReadOnlyCommand(command string, fields []string) bool {
-	switch command {
-	case "cat", "type", "ls", "dir", "pwd", "echo", "rg", "grep", "find", "where", "which", "env", "printenv", "uname", "whoami", "head", "tail", "sort", "uniq", "wc", "tree", "get-childitem", "get-content", "select-string", "get-location", "resolve-path":
-		return true
-	case "git":
-		return isReadOnlyGit(fields)
-	case "go":
-		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "env", "list", "version")
-	case "npm", "pnpm", "yarn":
-		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "list", "info", "view", "why")
-	default:
-		return false
-	}
-}
-
-func isApprovalCommand(command string, fields []string) bool {
-	switch command {
-	case "cp", "copy", "copy-item", "mv", "move", "move-item", "rename", "rename-item", "new-item", "mkdir", "md", "touch", "tee", "set-content", "add-content", "out-file":
-		return true
-	case "git":
-		return len(fields) > 1
-	case "go":
-		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "test", "build", "run", "mod", "get")
-	case "npm", "pnpm", "yarn":
-		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "install", "add", "remove", "update", "run")
-	case "pip", "pip3", "uv", "cargo", "make", "cmake", "python", "python3", "node", "pwsh", "powershell", "sh", "bash":
-		return true
-	default:
-		return false
-	}
-}
-
-func isReadOnlyGit(fields []string) bool {
-	if len(fields) < 2 {
-		return false
-	}
-	sub := strings.ToLower(fields[1])
-	return isOneOf(sub, "status", "diff", "log", "show", "rev-parse", "ls-files", "grep", "branch") && len(fields) == 2
-}
-
-func hasAnyArg(args []string, targets ...string) bool {
-	for _, arg := range args {
-		for _, target := range targets {
-			if strings.EqualFold(arg, target) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func isOneOf(value string, options ...string) bool {
-	for _, option := range options {
-		if value == option {
-			return true
-		}
-	}
-	return false
 }
 
 func shellCommand(ctx context.Context, command string) *exec.Cmd {


### PR DESCRIPTION
## 变更概述
本 PR 按照 policy 模块收敛方案，完成了策略判断的统一入口落地，并保持现有执行语义稳定。

主要目标：
- 统一工具权限判定入口（不再分散在多处）
- 统一 shell 风险评估与 plan 模式限制语义
- 引入可稳定断言的 `reason_code`
- 保持“主决策”与“提示决策（hint）”分离

## 主要改动
新增文件：
- `internal/policy/decision.go`
- `internal/policy/shell_command.go`
- `internal/policy/decision_test.go`

修改文件：
- `internal/policy/access.go`
- `internal/tools/executor.go`
- `internal/tools/run_shell.go`
- `internal/agent/run_setup.go`
- `internal/app/run_once_test.go`

## 设计收敛点
- 引入统一 policy evaluator，输出结构化决策（主决策 + prompt_hint 子决策）。
- 将 shell 命令风险评估与 plan 模式只读限制收敛到 policy 层。
- 在 `executor` 中消费统一 policy 决策，工具执行语义保持兼容。
- 在 `run_shell` 中复用 policy 判定，保证危险命令阻断优先于审批升级。
- 在 `run_setup` 中使用 policy 的 prompt hint 评估结果注入联网提示。

## 行为与兼容性说明
- 保持了原有“active skill policy”拒绝语义文案兼容。
- `dangerous_command_blocked` 优先级高于 `destructive_tool_requires_approval`。
- plan 模式下 `run_shell` 限制走统一 policy 语义。
- `prompt_hint` 不改变可执行主决策。

## 测试验证
已通过：
- `go test ./internal/policy ./internal/tools ./internal/agent -count=1 -timeout 240s`
- `go test ./internal/app -run TestRunOneShotPolicyBlocksDangerousShellCommandInToolLoop -v -count=1`
- `go test ./internal/app ./internal/agent ./internal/tools ./internal/policy -count=1 -timeout 300s`
- `go test ./... -count=1 -timeout 360s`

## 风险与回滚
- 风险：策略入口收敛可能影响边缘错误文案与拒绝分支细节。
- 控制：关键路径已补充单测与端到端链路测试，且保持行为基线不变。
- 如需回滚，可按文件维度回退本 PR 引入的 policy 收敛改动。
