### PR TITLE
Provider丨step1、2、3review

### DIFF
--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -13,7 +13,11 @@ func NewClient(cfg config.ProviderConfig) (llm.Client, error) {
 	clientCfg := Config{
 		Type:             typ,
 		BaseURL:          cfg.BaseURL,
+		APIPath:          cfg.APIPath,
 		APIKey:           cfg.ResolveAPIKey(),
+		AuthHeader:       cfg.AuthHeader,
+		AuthScheme:       cfg.AuthScheme,
+		ExtraHeaders:     cfg.ExtraHeaders,
 		Model:            cfg.Model,
 		AnthropicVersion: cfg.AnthropicVersion,
 	}

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -23,6 +23,29 @@ func TestNewClientReturnsOpenAICompatible(t *testing.T) {
 	}
 }
 
+func TestNewClientPropagatesOpenAICompatibleGatewayConfig(t *testing.T) {
+	client, err := NewClient(config.ProviderConfig{
+		Type:         "openai-compatible",
+		BaseURL:      "https://api.openai.com/v1",
+		APIPath:      "/gateway/chat",
+		APIKey:       "test-key",
+		AuthHeader:   "X-API-Key",
+		AuthScheme:   "Token",
+		ExtraHeaders: map[string]string{"X-Gateway": "enabled"},
+		Model:        "gpt-5.4",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	openaiClient, ok := client.(*OpenAICompatible)
+	if !ok {
+		t.Fatalf("expected *OpenAICompatible, got %T", client)
+	}
+	if openaiClient.apiPath != "/gateway/chat" || openaiClient.authHeader != "X-API-Key" || openaiClient.authScheme != "Token" || openaiClient.extraHeaders["X-Gateway"] != "enabled" {
+		t.Fatalf("unexpected openai gateway config %#v", openaiClient)
+	}
+}
+
 func TestNewClientReturnsOpenAICompatibleForOpenAIAlias(t *testing.T) {
 	client, err := NewClient(config.ProviderConfig{
 		Type:    "openai",

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,23 +20,54 @@ const legacyToolCallIndex = -1
 type Config struct {
 	Type             string
 	BaseURL          string
+	APIPath          string
 	APIKey           string
+	AuthHeader       string
+	AuthScheme       string
+	ExtraHeaders     map[string]string
 	Model            string
 	AnthropicVersion string
 }
 
 type OpenAICompatible struct {
-	baseURL    string
-	apiKey     string
-	model      string
-	httpClient *http.Client
+	baseURL      string
+	apiPath      string
+	apiKey       string
+	authHeader   string
+	authScheme   string
+	extraHeaders map[string]string
+	model        string
+	httpClient   *http.Client
 }
 
 func NewOpenAICompatible(cfg Config) *OpenAICompatible {
+	apiPath := strings.TrimSpace(cfg.APIPath)
+	if apiPath == "" {
+		apiPath = "/chat/completions"
+	}
+	if !strings.HasPrefix(apiPath, "/") {
+		apiPath = "/" + apiPath
+	}
+	authHeader := strings.TrimSpace(cfg.AuthHeader)
+	if authHeader == "" {
+		authHeader = "Authorization"
+	}
+	authScheme := strings.TrimSpace(cfg.AuthScheme)
+	if authScheme == "" && authHeader == "Authorization" {
+		authScheme = "Bearer"
+	}
+	extraHeaders := make(map[string]string, len(cfg.ExtraHeaders))
+	for key, value := range cfg.ExtraHeaders {
+		extraHeaders[key] = value
+	}
 	return &OpenAICompatible{
-		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
-		apiKey:  cfg.APIKey,
-		model:   cfg.Model,
+		baseURL:      strings.TrimRight(cfg.BaseURL, "/"),
+		apiPath:      apiPath,
+		apiKey:       cfg.APIKey,
+		authHeader:   authHeader,
+		authScheme:   authScheme,
+		extraHeaders: extraHeaders,
+		model:        cfg.Model,
 		httpClient: &http.Client{
 			Timeout: 2 * time.Minute,
 		},
@@ -49,7 +79,7 @@ func (c *OpenAICompatible) CreateMessage(ctx context.Context, req llm.ChatReques
 	if err != nil {
 		return llm.Message{}, err
 	}
-	respBody, err := c.postJSON(ctx, c.baseURL+"/chat/completions", payload)
+	respBody, err := c.postJSON(ctx, c.baseURL+c.apiPath, payload)
 	if err != nil {
 		return llm.Message{}, err
 	}
@@ -81,12 +111,21 @@ func (c *OpenAICompatible) StreamMessage(ctx context.Context, req llm.ChatReques
 		return llm.Message{}, err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+c.apiPath, bytes.NewReader(body))
 	if err != nil {
 		return llm.Message{}, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if c.apiKey != "" {
+		value := c.apiKey
+		if c.authScheme != "" {
+			value = c.authScheme + " " + c.apiKey
+		}
+		httpReq.Header.Set(c.authHeader, value)
+	}
+	for key, value := range c.extraHeaders {
+		httpReq.Header.Set(key, value)
+	}
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -197,453 +236,6 @@ func (c *OpenAICompatible) StreamMessage(ctx context.Context, req llm.ChatReques
 
 	assembled.Normalize()
 	return assembled, nil
-}
-
-func parseOpenAIUsage(raw json.RawMessage) *llm.Usage {
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return nil
-	}
-	var usage struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
-		TotalTokens      int `json:"total_tokens"`
-		PromptDetails    struct {
-			CachedTokens int `json:"cached_tokens"`
-			AudioTokens  int `json:"audio_tokens"`
-		} `json:"prompt_tokens_details"`
-		CompletionDetails struct {
-			AudioTokens int `json:"audio_tokens"`
-		} `json:"completion_tokens_details"`
-	}
-	if err := json.Unmarshal(raw, &usage); err != nil {
-		return nil
-	}
-	input := max(0, usage.PromptTokens) + max(0, usage.PromptDetails.AudioTokens)
-	output := max(0, usage.CompletionTokens) + max(0, usage.CompletionDetails.AudioTokens)
-	context := max(0, usage.PromptDetails.CachedTokens)
-	total := usage.TotalTokens
-	if total <= 0 {
-		total = input + output + context
-	}
-	if input == 0 && output == 0 && context == 0 && total == 0 {
-		return nil
-	}
-	return &llm.Usage{
-		InputTokens:   input,
-		OutputTokens:  output,
-		ContextTokens: context,
-		TotalTokens:   max(0, total),
-	}
-}
-
-type streamDelta struct {
-	Role      llm.Role
-	Content   string
-	Reasoning string
-	ToolCalls []streamToolCallDelta
-}
-
-type streamToolCallDelta struct {
-	Index             int
-	ID                string
-	Type              string
-	FunctionName      string
-	FunctionArguments string
-}
-
-func parseOpenAIDelta(raw json.RawMessage) (streamDelta, error) {
-	delta := streamDelta{}
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return delta, nil
-	}
-
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &obj); err != nil {
-		return streamDelta{}, err
-	}
-
-	if roleRaw, ok := obj["role"]; ok {
-		var role string
-		if err := json.Unmarshal(roleRaw, &role); err == nil {
-			delta.Role = llm.Role(strings.TrimSpace(role))
-		}
-	}
-	if contentRaw, ok := obj["content"]; ok {
-		delta.Content = extractTextFromRaw(contentRaw, false)
-	}
-	if delta.Content == "" {
-		if outputRaw, ok := obj["output_text"]; ok {
-			delta.Content = extractTextFromRaw(outputRaw, false)
-		}
-	}
-	if reasoningRaw, ok := obj["reasoning_content"]; ok {
-		delta.Reasoning = extractTextFromRaw(reasoningRaw, true)
-	}
-	if delta.Reasoning == "" {
-		if reasoningRaw, ok := obj["reasoning"]; ok {
-			delta.Reasoning = extractTextFromRaw(reasoningRaw, true)
-		}
-	}
-
-	if toolCallsRaw, ok := obj["tool_calls"]; ok {
-		delta.ToolCalls = append(delta.ToolCalls, parseStreamToolCalls(toolCallsRaw)...)
-	}
-	if functionCallRaw, ok := obj["function_call"]; ok {
-		legacy := parseLegacyFunctionCall(functionCallRaw)
-		if legacy.FunctionName != "" || legacy.FunctionArguments != "" {
-			legacy.Index = legacyToolCallIndex
-			delta.ToolCalls = append(delta.ToolCalls, legacy)
-		}
-	}
-
-	return delta, nil
-}
-
-func parseOpenAIMessage(raw json.RawMessage) llm.Message {
-	msg := llm.Message{Role: llm.RoleAssistant}
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return msg
-	}
-
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &obj); err != nil {
-		return msg
-	}
-	if roleRaw, ok := obj["role"]; ok {
-		var role string
-		if err := json.Unmarshal(roleRaw, &role); err == nil && strings.TrimSpace(role) != "" {
-			msg.Role = llm.Role(role)
-		}
-	}
-	if contentRaw, ok := obj["content"]; ok {
-		msg.Content = extractTextFromRaw(contentRaw, false)
-	}
-	if msg.Content == "" {
-		if outputRaw, ok := obj["output_text"]; ok {
-			msg.Content = extractTextFromRaw(outputRaw, false)
-		}
-	}
-
-	if toolCallsRaw, ok := obj["tool_calls"]; ok {
-		msg.ToolCalls = parseToolCalls(toolCallsRaw)
-	}
-	if len(msg.ToolCalls) == 0 {
-		if functionCallRaw, ok := obj["function_call"]; ok {
-			legacy := parseLegacyFunctionCall(functionCallRaw)
-			if legacy.FunctionName != "" {
-				msg.ToolCalls = []llm.ToolCall{{
-					ID:   "call-legacy",
-					Type: "function",
-					Function: llm.ToolFunctionCall{
-						Name:      legacy.FunctionName,
-						Arguments: legacy.FunctionArguments,
-					},
-				}}
-			}
-		}
-	}
-
-	msg.Normalize()
-	return msg
-}
-
-func parseToolCalls(raw json.RawMessage) []llm.ToolCall {
-	var calls []struct {
-		ID       string `json:"id"`
-		Type     string `json:"type"`
-		Function struct {
-			Name      string          `json:"name"`
-			Arguments json.RawMessage `json:"arguments"`
-		} `json:"function"`
-	}
-	if err := json.Unmarshal(raw, &calls); err != nil {
-		return nil
-	}
-	out := make([]llm.ToolCall, 0, len(calls))
-	for i, call := range calls {
-		name := strings.TrimSpace(call.Function.Name)
-		if name == "" {
-			continue
-		}
-		id := strings.TrimSpace(call.ID)
-		if id == "" {
-			id = fmt.Sprintf("call-%d", i)
-		}
-		callType := strings.TrimSpace(call.Type)
-		if callType == "" {
-			callType = "function"
-		}
-		out = append(out, llm.ToolCall{
-			ID:   id,
-			Type: callType,
-			Function: llm.ToolFunctionCall{
-				Name:      call.Function.Name,
-				Arguments: argumentString(call.Function.Arguments),
-			},
-		})
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func parseStreamToolCalls(raw json.RawMessage) []streamToolCallDelta {
-	var calls []struct {
-		Index    int    `json:"index"`
-		ID       string `json:"id"`
-		Type     string `json:"type"`
-		Function struct {
-			Name      string          `json:"name"`
-			Arguments json.RawMessage `json:"arguments"`
-		} `json:"function"`
-	}
-	if err := json.Unmarshal(raw, &calls); err != nil {
-		return nil
-	}
-	out := make([]streamToolCallDelta, 0, len(calls))
-	for _, call := range calls {
-		out = append(out, streamToolCallDelta{
-			Index:             call.Index,
-			ID:                call.ID,
-			Type:              call.Type,
-			FunctionName:      call.Function.Name,
-			FunctionArguments: argumentString(call.Function.Arguments),
-		})
-	}
-	return out
-}
-
-func parseLegacyFunctionCall(raw json.RawMessage) streamToolCallDelta {
-	var call struct {
-		Name      string          `json:"name"`
-		Arguments json.RawMessage `json:"arguments"`
-	}
-	if err := json.Unmarshal(raw, &call); err != nil {
-		return streamToolCallDelta{}
-	}
-	args := argumentString(call.Arguments)
-	if strings.TrimSpace(call.Name) == "" && strings.TrimSpace(args) == "" {
-		return streamToolCallDelta{}
-	}
-	return streamToolCallDelta{
-		Type:              "function",
-		FunctionName:      call.Name,
-		FunctionArguments: args,
-	}
-}
-
-func argumentString(raw json.RawMessage) string {
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return ""
-	}
-	var text string
-	if err := json.Unmarshal(raw, &text); err == nil {
-		return text
-	}
-	return strings.TrimSpace(string(raw))
-}
-
-func extractTextFromRaw(raw json.RawMessage, includeReasoning bool) string {
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return ""
-	}
-	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
-		return ""
-	}
-	var text string
-	if err := json.Unmarshal(raw, &text); err == nil {
-		return text
-	}
-	var value any
-	if err := json.Unmarshal(raw, &value); err != nil {
-		return ""
-	}
-	return extractTextFromAny(value, includeReasoning)
-}
-
-func extractTextFromAny(value any, includeReasoning bool) string {
-	switch typed := value.(type) {
-	case string:
-		return typed
-	case []any:
-		var b strings.Builder
-		for _, item := range typed {
-			b.WriteString(extractTextFromAny(item, includeReasoning))
-		}
-		return b.String()
-	case map[string]any:
-		var b strings.Builder
-		for _, key := range []string{"text", "output_text", "content", "value"} {
-			if nested, ok := typed[key]; ok {
-				b.WriteString(extractTextFromAny(nested, includeReasoning))
-			}
-		}
-		if includeReasoning {
-			for _, key := range []string{"reasoning_content", "reasoning", "summary"} {
-				if nested, ok := typed[key]; ok {
-					b.WriteString(extractTextFromAny(nested, includeReasoning))
-				}
-			}
-		}
-		if b.Len() > 0 {
-			return b.String()
-		}
-		for _, key := range []string{"message", "delta", "part", "parts"} {
-			if nested, ok := typed[key]; ok {
-				b.WriteString(extractTextFromAny(nested, includeReasoning))
-			}
-		}
-		return b.String()
-	default:
-		return ""
-	}
-}
-
-func (c *OpenAICompatible) chatPayload(req llm.ChatRequest, stream bool) (map[string]any, error) {
-	messages, err := openAIMessages(req)
-	if err != nil {
-		return nil, err
-	}
-	payload := map[string]any{
-		"model":       choose(req.Model, c.model),
-		"messages":    messages,
-		"temperature": req.Temperature,
-	}
-	if len(req.Tools) > 0 {
-		payload["tools"] = req.Tools
-		payload["tool_choice"] = "auto"
-	}
-	if stream {
-		payload["stream"] = true
-	}
-	return payload, nil
-}
-
-func openAIMessages(req llm.ChatRequest) ([]map[string]any, error) {
-	result := make([]map[string]any, 0, len(req.Messages))
-
-	for _, message := range req.Messages {
-		message.Normalize()
-		content := make([]map[string]any, 0, len(message.Parts))
-		toolCalls := make([]map[string]any, 0, len(message.Parts))
-		toolResults := make([]map[string]any, 0, len(message.Parts))
-
-		for _, part := range message.Parts {
-			switch part.Type {
-			case llm.PartText:
-				content = append(content, map[string]any{"type": "text", "text": part.Text.Value})
-			case llm.PartThinking:
-				content = append(content, map[string]any{"type": "text", "text": part.Thinking.Value})
-			case llm.PartImageRef:
-				assetID := llm.AssetID("")
-				if part.Image != nil {
-					assetID = part.Image.AssetID
-				}
-				asset, ok := req.Assets[assetID]
-				if !ok || len(asset.Data) == 0 {
-					content = append(content, map[string]any{"type": "text", "text": missingImageAssetFallback(assetID)})
-					continue
-				}
-				mediaType := strings.TrimSpace(asset.MediaType)
-				if mediaType == "" {
-					mediaType = "image/png"
-				}
-				content = append(content, map[string]any{
-					"type": "image_url",
-					"image_url": map[string]any{
-						"url": "data:" + mediaType + ";base64," + base64.StdEncoding.EncodeToString(asset.Data),
-					},
-				})
-			case llm.PartToolUse:
-				toolCalls = append(toolCalls, map[string]any{
-					"id":   part.ToolUse.ID,
-					"type": "function",
-					"function": map[string]any{
-						"name":      part.ToolUse.Name,
-						"arguments": part.ToolUse.Arguments,
-					},
-				})
-			case llm.PartToolResult:
-				toolResults = append(toolResults, map[string]any{
-					"role":         "tool",
-					"tool_call_id": part.ToolResult.ToolUseID,
-					"content":      part.ToolResult.Content,
-				})
-			}
-		}
-
-		if message.Role == "tool" {
-			toolID := message.ToolCallID
-			if toolID == "" && len(message.Parts) > 0 {
-				for _, part := range message.Parts {
-					if part.ToolResult != nil {
-						toolID = part.ToolResult.ToolUseID
-						break
-					}
-				}
-			}
-			result = append(result, map[string]any{
-				"role":         "tool",
-				"tool_call_id": toolID,
-				"content":      message.Text(),
-			})
-			continue
-		}
-
-		if len(content) > 0 || len(toolCalls) > 0 {
-			wire := map[string]any{"role": string(message.Role)}
-			if len(content) > 0 {
-				wire["content"] = content
-			}
-			if len(toolCalls) > 0 {
-				wire["tool_calls"] = toolCalls
-			}
-			result = append(result, wire)
-		}
-		if len(toolResults) > 0 {
-			result = append(result, toolResults...)
-		}
-	}
-
-	return result, nil
-}
-
-func missingImageAssetFallback(assetID llm.AssetID) string {
-	id := strings.TrimSpace(string(assetID))
-	if id == "" {
-		return "[image omitted: unavailable asset]"
-	}
-	return fmt.Sprintf("[image omitted: unavailable asset %s]", id)
-}
-
-func (c *OpenAICompatible) postJSON(ctx context.Context, url string, payload map[string]any) ([]byte, error) {
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode >= 300 {
-		return nil, llm.MapProviderError("openai", resp.StatusCode, string(respBody), nil)
-	}
-	return respBody, nil
 }
 
 func choose(primary, fallback string) string {

--- a/internal/provider/openai_helpers.go
+++ b/internal/provider/openai_helpers.go
@@ -65,7 +65,7 @@ func (c *OpenAICompatible) chatPayload(req llm.ChatRequest, stream bool) (map[st
 		"messages": messages,
 		"stream":   stream,
 	}
-	if req.Temperature > 0 {
+	if req.Temperature >= 0 {
 		payload["temperature"] = req.Temperature
 	}
 	if len(req.Tools) > 0 {
@@ -110,12 +110,15 @@ func openAIMessages(req llm.ChatRequest) ([]map[string]any, error) {
 					converted = append(converted, map[string]any{"role": "tool", "tool_call_id": part.ToolResult.ToolUseID, "content": part.ToolResult.Content})
 				}
 			}
+			hasToolCalls := len(asToolCalls(entry["tool_calls"])) > 0
 			if len(content) == 1 && content[0]["type"] == "text" {
 				entry["content"] = content[0]["text"]
-			} else {
+			} else if len(content) > 0 {
 				entry["content"] = content
 			}
-			converted = append(converted, entry)
+			if _, hasContent := entry["content"]; hasContent || hasToolCalls {
+				converted = append(converted, entry)
+			}
 		case "tool":
 			converted = append(converted, map[string]any{"role": "tool", "tool_call_id": message.ToolCallID, "content": message.Text()})
 		}

--- a/internal/provider/openai_helpers.go
+++ b/internal/provider/openai_helpers.go
@@ -1,0 +1,132 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"bytemind/internal/llm"
+)
+
+func missingImageAssetFallback(assetID llm.AssetID) string {
+	if strings.TrimSpace(string(assetID)) == "" {
+		return "unavailable image asset"
+	}
+	return fmt.Sprintf("unavailable asset %s", assetID)
+}
+
+func (c *OpenAICompatible) postJSON(ctx context.Context, url string, payload map[string]any) ([]byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		value := c.apiKey
+		if c.authScheme != "" {
+			value = c.authScheme + " " + c.apiKey
+		}
+		httpReq.Header.Set(c.authHeader, value)
+	}
+	for key, value := range c.extraHeaders {
+		httpReq.Header.Set(key, value)
+	}
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 300 {
+		return nil, llm.MapProviderError("openai", resp.StatusCode, string(respBody), nil)
+	}
+	return respBody, nil
+}
+
+func (c *OpenAICompatible) chatPayload(req llm.ChatRequest, stream bool) (map[string]any, error) {
+	messages, err := openAIMessages(req)
+	if err != nil {
+		return nil, err
+	}
+	payload := map[string]any{
+		"model":    choose(req.Model, c.model),
+		"messages": messages,
+		"stream":   stream,
+	}
+	if req.Temperature > 0 {
+		payload["temperature"] = req.Temperature
+	}
+	if len(req.Tools) > 0 {
+		payload["tools"] = req.Tools
+		payload["tool_choice"] = "auto"
+	}
+	return payload, nil
+}
+
+func openAIMessages(req llm.ChatRequest) ([]map[string]any, error) {
+	converted := make([]map[string]any, 0, len(req.Messages))
+	for _, message := range req.Messages {
+		message.Normalize()
+		switch message.Role {
+		case llm.RoleSystem, llm.RoleUser, llm.RoleAssistant:
+			entry := map[string]any{"role": string(message.Role)}
+			content := make([]map[string]any, 0)
+			for _, part := range message.Parts {
+				switch part.Type {
+				case llm.PartText:
+					content = append(content, map[string]any{"type": "text", "text": part.Text.Value})
+				case llm.PartThinking:
+					content = append(content, map[string]any{"type": "text", "text": part.Thinking.Value})
+				case llm.PartImageRef:
+					assetID := llm.AssetID("")
+					if part.Image != nil {
+						assetID = part.Image.AssetID
+					}
+					asset, ok := req.Assets[assetID]
+					if !ok || len(asset.Data) == 0 {
+						content = append(content, map[string]any{"type": "text", "text": missingImageAssetFallback(assetID)})
+						continue
+					}
+					mediaType := strings.TrimSpace(asset.MediaType)
+					if mediaType == "" {
+						mediaType = "image/png"
+					}
+					content = append(content, map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:" + mediaType + ";base64," + base64.StdEncoding.EncodeToString(asset.Data)}})
+				case llm.PartToolUse:
+					entry["tool_calls"] = append(asToolCalls(entry["tool_calls"]), map[string]any{"id": part.ToolUse.ID, "type": "function", "function": map[string]any{"name": part.ToolUse.Name, "arguments": part.ToolUse.Arguments}})
+				case llm.PartToolResult:
+					converted = append(converted, map[string]any{"role": "tool", "tool_call_id": part.ToolResult.ToolUseID, "content": part.ToolResult.Content})
+				}
+			}
+			if len(content) == 1 && content[0]["type"] == "text" {
+				entry["content"] = content[0]["text"]
+			} else {
+				entry["content"] = content
+			}
+			converted = append(converted, entry)
+		case "tool":
+			converted = append(converted, map[string]any{"role": "tool", "tool_call_id": message.ToolCallID, "content": message.Text()})
+		}
+	}
+	return converted, nil
+}
+
+func asToolCalls(value any) []map[string]any {
+	if value == nil {
+		return []map[string]any{}
+	}
+	calls, _ := value.([]map[string]any)
+	return calls
+}

--- a/internal/provider/openai_parse_helpers.go
+++ b/internal/provider/openai_parse_helpers.go
@@ -1,0 +1,195 @@
+package provider
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"bytemind/internal/llm"
+)
+
+func parseOpenAIUsage(raw json.RawMessage) *llm.Usage {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil
+	}
+	var usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	}
+	if err := json.Unmarshal(raw, &usage); err != nil {
+		return nil
+	}
+	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 && usage.TotalTokens == 0 {
+		return nil
+	}
+	return &llm.Usage{InputTokens: usage.PromptTokens, OutputTokens: usage.CompletionTokens, TotalTokens: usage.TotalTokens}
+}
+
+type streamDelta struct {
+	Role      llm.Role
+	Content   string
+	Reasoning string
+	ToolCalls []streamToolCallDelta
+}
+
+type streamToolCallDelta struct {
+	Index             int
+	ID                string
+	Type              string
+	FunctionName      string
+	FunctionArguments string
+}
+
+func parseOpenAIDelta(raw json.RawMessage) (streamDelta, error) {
+	delta := streamDelta{}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return delta, nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return streamDelta{}, err
+	}
+	if roleRaw, ok := obj["role"]; ok {
+		var role string
+		_ = json.Unmarshal(roleRaw, &role)
+		delta.Role = llm.Role(strings.TrimSpace(role))
+	}
+	if contentRaw, ok := obj["content"]; ok {
+		_ = json.Unmarshal(contentRaw, &delta.Content)
+	}
+	if reasoningRaw, ok := obj["reasoning_content"]; ok {
+		_ = json.Unmarshal(reasoningRaw, &delta.Reasoning)
+	}
+	if toolCallsRaw, ok := obj["tool_calls"]; ok {
+		delta.ToolCalls = append(delta.ToolCalls, parseStreamToolCalls(toolCallsRaw)...)
+	}
+	if functionCallRaw, ok := obj["function_call"]; ok {
+		legacy := parseLegacyFunctionCall(functionCallRaw)
+		if legacy.FunctionName != "" || legacy.FunctionArguments != "" {
+			legacy.Index = legacyToolCallIndex
+			delta.ToolCalls = append(delta.ToolCalls, legacy)
+		}
+	}
+	return delta, nil
+}
+
+func parseOpenAIMessage(raw json.RawMessage) llm.Message {
+	msg := llm.Message{Role: llm.RoleAssistant}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return msg
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return msg
+	}
+	if roleRaw, ok := obj["role"]; ok {
+		var role string
+		_ = json.Unmarshal(roleRaw, &role)
+		if strings.TrimSpace(role) != "" {
+			msg.Role = llm.Role(role)
+		}
+	}
+	if contentRaw, ok := obj["content"]; ok {
+		_ = json.Unmarshal(contentRaw, &msg.Content)
+	}
+	if msg.Content == "" {
+		if reasoningRaw, ok := obj["reasoning_content"]; ok {
+			var ignored string
+			_ = json.Unmarshal(reasoningRaw, &ignored)
+		}
+	}
+	if toolCallsRaw, ok := obj["tool_calls"]; ok {
+		msg.ToolCalls = parseToolCalls(toolCallsRaw)
+	}
+	if len(msg.ToolCalls) == 0 {
+		if functionCallRaw, ok := obj["function_call"]; ok {
+			legacy := parseLegacyFunctionCall(functionCallRaw)
+			if legacy.FunctionName != "" {
+				msg.ToolCalls = []llm.ToolCall{{ID: "call-legacy", Type: "function", Function: llm.ToolFunctionCall{Name: legacy.FunctionName, Arguments: legacy.FunctionArguments}}}
+			}
+		}
+	}
+	msg.Normalize()
+	return msg
+}
+
+func parseToolCalls(raw json.RawMessage) []llm.ToolCall {
+	var calls []struct {
+		ID       string `json:"id"`
+		Type     string `json:"type"`
+		Function struct {
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(raw, &calls); err != nil {
+		return nil
+	}
+	out := make([]llm.ToolCall, 0, len(calls))
+	for i, call := range calls {
+		if strings.TrimSpace(call.Function.Name) == "" {
+			continue
+		}
+		id := strings.TrimSpace(call.ID)
+		if id == "" {
+			id = fmt.Sprintf("call-%d", i)
+		}
+		typ := strings.TrimSpace(call.Type)
+		if typ == "" {
+			typ = "function"
+		}
+		out = append(out, llm.ToolCall{ID: id, Type: typ, Function: llm.ToolFunctionCall{Name: call.Function.Name, Arguments: argumentString(call.Function.Arguments)}})
+	}
+	return out
+}
+
+func parseStreamToolCalls(raw json.RawMessage) []streamToolCallDelta {
+	var calls []struct {
+		Index    int    `json:"index"`
+		ID       string `json:"id"`
+		Type     string `json:"type"`
+		Function struct {
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(raw, &calls); err != nil {
+		return nil
+	}
+	out := make([]streamToolCallDelta, 0, len(calls))
+	for _, call := range calls {
+		out = append(out, streamToolCallDelta{Index: call.Index, ID: call.ID, Type: call.Type, FunctionName: call.Function.Name, FunctionArguments: argumentString(call.Function.Arguments)})
+	}
+	return out
+}
+
+func parseLegacyFunctionCall(raw json.RawMessage) streamToolCallDelta {
+	var call struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(raw, &call); err != nil {
+		return streamToolCallDelta{}
+	}
+	return streamToolCallDelta{Type: "function", FunctionName: call.Name, FunctionArguments: argumentString(call.Arguments)}
+}
+
+func argumentString(raw json.RawMessage) string {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, raw); err == nil {
+			return compact.String()
+		}
+	}
+	return trimmed
+}

--- a/internal/provider/openai_parse_helpers.go
+++ b/internal/provider/openai_parse_helpers.go
@@ -17,14 +17,28 @@ func parseOpenAIUsage(raw json.RawMessage) *llm.Usage {
 		PromptTokens     int `json:"prompt_tokens"`
 		CompletionTokens int `json:"completion_tokens"`
 		TotalTokens      int `json:"total_tokens"`
+		PromptDetails    struct {
+			CachedTokens int `json:"cached_tokens"`
+			AudioTokens  int `json:"audio_tokens"`
+		} `json:"prompt_tokens_details"`
+		CompletionDetails struct {
+			AudioTokens int `json:"audio_tokens"`
+		} `json:"completion_tokens_details"`
 	}
 	if err := json.Unmarshal(raw, &usage); err != nil {
 		return nil
 	}
-	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 && usage.TotalTokens == 0 {
+	input := max(0, usage.PromptTokens) + max(0, usage.PromptDetails.AudioTokens)
+	output := max(0, usage.CompletionTokens) + max(0, usage.CompletionDetails.AudioTokens)
+	context := max(0, usage.PromptDetails.CachedTokens)
+	total := usage.TotalTokens
+	if total <= 0 {
+		total = input + output + context
+	}
+	if input == 0 && output == 0 && context == 0 && total == 0 {
 		return nil
 	}
-	return &llm.Usage{InputTokens: usage.PromptTokens, OutputTokens: usage.CompletionTokens, TotalTokens: usage.TotalTokens}
+	return &llm.Usage{InputTokens: input, OutputTokens: output, ContextTokens: context, TotalTokens: max(0, total)}
 }
 
 type streamDelta struct {
@@ -57,7 +71,12 @@ func parseOpenAIDelta(raw json.RawMessage) (streamDelta, error) {
 		delta.Role = llm.Role(strings.TrimSpace(role))
 	}
 	if contentRaw, ok := obj["content"]; ok {
-		_ = json.Unmarshal(contentRaw, &delta.Content)
+		delta.Content = extractTextFromRaw(contentRaw, false)
+	}
+	if delta.Content == "" {
+		if outputRaw, ok := obj["output_text"]; ok {
+			delta.Content = extractTextFromRaw(outputRaw, false)
+		}
 	}
 	if reasoningRaw, ok := obj["reasoning_content"]; ok {
 		_ = json.Unmarshal(reasoningRaw, &delta.Reasoning)
@@ -92,12 +111,11 @@ func parseOpenAIMessage(raw json.RawMessage) llm.Message {
 		}
 	}
 	if contentRaw, ok := obj["content"]; ok {
-		_ = json.Unmarshal(contentRaw, &msg.Content)
+		msg.Content = extractTextFromRaw(contentRaw, false)
 	}
 	if msg.Content == "" {
-		if reasoningRaw, ok := obj["reasoning_content"]; ok {
-			var ignored string
-			_ = json.Unmarshal(reasoningRaw, &ignored)
+		if outputRaw, ok := obj["output_text"]; ok {
+			msg.Content = extractTextFromRaw(outputRaw, false)
 		}
 	}
 	if toolCallsRaw, ok := obj["tool_calls"]; ok {
@@ -192,4 +210,60 @@ func argumentString(raw json.RawMessage) string {
 		}
 	}
 	return trimmed
+}
+
+func extractTextFromRaw(raw json.RawMessage, includeReasoning bool) string {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return ""
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return ""
+	}
+	return extractTextFromAny(value, includeReasoning)
+}
+
+func extractTextFromAny(value any, includeReasoning bool) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case []any:
+		var b strings.Builder
+		for _, item := range typed {
+			b.WriteString(extractTextFromAny(item, includeReasoning))
+		}
+		return b.String()
+	case map[string]any:
+		var b strings.Builder
+		for _, key := range []string{"text", "output_text", "content", "value"} {
+			if nested, ok := typed[key]; ok {
+				b.WriteString(extractTextFromAny(nested, includeReasoning))
+			}
+		}
+		if includeReasoning {
+			for _, key := range []string{"reasoning_content", "reasoning", "summary"} {
+				if nested, ok := typed[key]; ok {
+					b.WriteString(extractTextFromAny(nested, includeReasoning))
+				}
+			}
+		}
+		if b.Len() > 0 {
+			return b.String()
+		}
+		for _, key := range []string{"message", "delta", "part", "parts"} {
+			if nested, ok := typed[key]; ok {
+				b.WriteString(extractTextFromAny(nested, includeReasoning))
+			}
+		}
+		return b.String()
+	default:
+		return ""
+	}
 }

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -361,7 +361,7 @@ func TestOpenAICompatibleChatPayloadUsesFallbackModelAndTools(t *testing.T) {
 				Name: "list_files",
 			},
 		}},
-		Temperature: 0.4,
+		Temperature: 0,
 	}, true)
 	if err != nil {
 		t.Fatalf("chat payload: %v", err)
@@ -375,6 +375,9 @@ func TestOpenAICompatibleChatPayloadUsesFallbackModelAndTools(t *testing.T) {
 	}
 	if got := payload["tool_choice"]; got != "auto" {
 		t.Fatalf("expected tool_choice auto, got %#v", got)
+	}
+	if got := payload["temperature"]; got != float64(0) {
+		t.Fatalf("expected temperature zero to be preserved, got %#v", got)
 	}
 }
 
@@ -394,8 +397,8 @@ func TestOpenAIMessagesMapsThinkingAndToolResultParts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(messages) != 3 {
-		t.Fatalf("expected assistant, tool_result, and normalized user message, got %#v", messages)
+	if len(messages) != 2 {
+		t.Fatalf("expected assistant and tool_result messages, got %#v", messages)
 	}
 
 	assistant := messages[0]
@@ -432,12 +435,49 @@ func TestOpenAIMessagesDegradesMissingImageAsset(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIMessageHandlesStructuredContentAndOutputText(t *testing.T) {
+	msg := parseOpenAIMessage([]byte(`{"role":"assistant","content":[{"type":"text","text":"hello "},{"type":"text","text":"world"}]}`))
+	if msg.Content != "hello world" {
+		t.Fatalf("expected structured content extraction, got %#v", msg)
+	}
+	msg = parseOpenAIMessage([]byte(`{"role":"assistant","output_text":[{"type":"text","text":"fallback text"}]}`))
+	if msg.Content != "fallback text" {
+		t.Fatalf("expected output_text fallback, got %#v", msg)
+	}
+}
+
+func TestParseOpenAIDeltaParsesStructuredContentAndReasoning(t *testing.T) {
+	delta, err := parseOpenAIDelta([]byte(`{
+  "role":"assistant",
+  "content":[{"type":"text","text":"hello "},{"type":"text","text":"world"}],
+  "reasoning_content":"thinking",
+  "tool_calls":[{"index":1,"id":"call-1","type":"function","function":{"name":"list_","arguments":"{\"path\":\"src\"}"}}]
+}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delta.Role != llm.RoleAssistant || delta.Reasoning != "thinking" || delta.Content != "hello world" {
+		t.Fatalf("unexpected parsed delta: %#v", delta)
+	}
+	if len(delta.ToolCalls) != 1 || delta.ToolCalls[0].FunctionName != "list_" {
+		t.Fatalf("unexpected tool call delta parse: %#v", delta.ToolCalls)
+	}
+}
+
+func TestParseOpenAIUsageRestoresDetailedTokenAccounting(t *testing.T) {
+	usage := parseOpenAIUsage([]byte(`{"prompt_tokens":10,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":3,"audio_tokens":2},"completion_tokens_details":{"audio_tokens":1}}`))
+	if usage == nil || usage.InputTokens != 12 || usage.OutputTokens != 6 || usage.ContextTokens != 3 || usage.TotalTokens != 21 {
+		t.Fatalf("unexpected usage %#v", usage)
+	}
+}
+
 func TestParseOpenAIDeltaParsesToolCallsAndReasoning(t *testing.T) {
 	delta, err := parseOpenAIDelta([]byte(`{
   "role":"assistant",
   "reasoning_content":"thinking",
-  "tool_calls":[{"index":1,"id":"call-1","type":"function","function":{"name":"list_","arguments":"{\"path\":\"src"}}]
+  "tool_calls":[{"index":1,"id":"call-1","type":"function","function":{"name":"list_","arguments":"{\"path\":\"src\"}"}}]
 }`))
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -12,6 +12,49 @@ import (
 	"bytemind/internal/llm"
 )
 
+func TestOpenAICompatibleCreateMessageUsesCustomGatewayConfig(t *testing.T) {
+	var path string
+	var authHeader string
+	var extraHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		authHeader = r.Header.Get("X-API-Key")
+		extraHeader = r.Header.Get("X-Gateway")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "done",
+				},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewOpenAICompatible(Config{
+		BaseURL:      server.URL,
+		APIPath:      "/v42/chat",
+		APIKey:       "test-key",
+		AuthHeader:   "X-API-Key",
+		AuthScheme:   "",
+		ExtraHeaders: map[string]string{"X-Gateway": "enabled"},
+		Model:        "fallback-model",
+	})
+
+	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if path != "/v42/chat" {
+		t.Fatalf("unexpected path %q", path)
+	}
+	if authHeader != "test-key" {
+		t.Fatalf("unexpected auth header %q", authHeader)
+	}
+	if extraHeader != "enabled" {
+		t.Fatalf("unexpected extra header %q", extraHeader)
+	}
+}
+
 func TestOpenAICompatibleCreateMessageReturnsFirstChoice(t *testing.T) {
 	var authHeader string
 	var requestBody map[string]any
@@ -351,14 +394,13 @@ func TestOpenAIMessagesMapsThinkingAndToolResultParts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(messages) != 2 {
-		t.Fatalf("expected assistant and tool_result messages, got %#v", messages)
+	if len(messages) != 3 {
+		t.Fatalf("expected assistant, tool_result, and normalized user message, got %#v", messages)
 	}
 
 	assistant := messages[0]
-	content, _ := assistant["content"].([]map[string]any)
-	if len(content) != 1 || content[0]["text"] != "reasoning" {
-		t.Fatalf("expected thinking mapped as text content, got %#v", assistant)
+	if assistant["content"] != "reasoning" {
+		t.Fatalf("expected thinking mapped as string content, got %#v", assistant)
 	}
 	toolCalls, _ := assistant["tool_calls"].([]map[string]any)
 	if len(toolCalls) != 1 || toolCalls[0]["id"] != "call-1" {
@@ -385,13 +427,8 @@ func TestOpenAIMessagesDegradesMissingImageAsset(t *testing.T) {
 	if len(messages) != 1 {
 		t.Fatalf("expected a single converted message, got %#v", messages)
 	}
-	content, _ := messages[0]["content"].([]map[string]any)
-	if len(content) != 1 || content[0]["type"] != "text" {
-		t.Fatalf("expected missing image to degrade to text block, got %#v", messages[0])
-	}
-	text, _ := content[0]["text"].(string)
-	if !strings.Contains(text, "unavailable asset asset-1") {
-		t.Fatalf("expected fallback text to include asset id, got %#v", content[0]["text"])
+	if messages[0]["content"] != "unavailable asset asset-1" {
+		t.Fatalf("expected missing image to degrade to string fallback, got %#v", messages[0])
 	}
 }
 


### PR DESCRIPTION
#223 review来源

Summary
补通 openai-compatible 的 runtime 配置透传链路
保持改动严格收敛在 internal/provider 范围内，不触碰 llm/agent
为后续 provider 迭代中的 gateway / proxy 场景提供可配置入口
Changes

在 internal/provider/openai.go 中扩展 OpenAICompatible 配置：
APIPath
AuthHeader
AuthScheme
ExtraHeaders
在 internal/provider/factory.go 中将 config.ProviderConfig 的网关扩展字段透传到 OpenAICompatible client
将 OpenAICompatible 的请求路径与鉴权逻辑从硬编码改为配置驱动：
默认 path 仍为 /chat/completions
默认鉴权仍为 Authorization: Bearer <key>
支持自定义 header / scheme
AuthScheme="" 且自定义 header 时只发送 key
支持额外头部透传
将部分 OpenAI 辅助逻辑拆到：
internal/provider/openai_helpers.go
internal/provider/openai_parse_helpers.go
补充测试覆盖：
自定义 APIPath 生效
自定义 header/scheme 生效
ExtraHeaders 透传
默认行为不回归
factory 透传链路生效

Why
当前 config 层已经支持 openai-compatible 的网关扩展字段，但 provider 工厂和 OpenAICompatible client 仍然使用硬编码 path / auth 规则，导致这部分配置能力无法真正进入运行时装配链。