### PR TITLE
Provider丨Step 4引入 Router 与唯一 fallback 决策层

### DIFF
--- a/internal/config/provider_runtime.go
+++ b/internal/config/provider_runtime.go
@@ -5,6 +5,7 @@ import "strings"
 type ProviderRuntimeConfig struct {
 	DefaultProvider string                    `json:"default_provider"`
 	DefaultModel    string                    `json:"default_model"`
+	AllowFallback   bool                      `json:"allow_fallback"`
 	Providers       map[string]ProviderConfig `json:"providers"`
 }
 
@@ -20,6 +21,7 @@ func LegacyProviderRuntimeConfig(cfg ProviderConfig) ProviderRuntimeConfig {
 	return ProviderRuntimeConfig{
 		DefaultProvider: providerID,
 		DefaultModel:    cfg.Model,
+		AllowFallback:   false,
 		Providers: map[string]ProviderConfig{
 			providerID: cfg,
 		},

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -14,6 +14,17 @@ type clientAdapter struct {
 	client       llm.Client
 }
 
+type RoutedClient struct {
+	router Router
+}
+
+func NewRoutedClient(router Router) llm.Client {
+	if router == nil {
+		return nil
+	}
+	return &RoutedClient{router: router}
+}
+
 func WrapClient(providerID ProviderID, defaultModel ModelID, client llm.Client) Client {
 	if client == nil {
 		return nil
@@ -27,6 +38,94 @@ func WrapClient(providerID ProviderID, defaultModel ModelID, client llm.Client) 
 		defaultModel: ModelID(strings.TrimSpace(string(defaultModel))),
 		client:       client,
 	}
+}
+
+func (c *RoutedClient) CreateMessage(ctx context.Context, req llm.ChatRequest) (llm.Message, error) {
+	return c.execute(ctx, req, false, nil)
+}
+
+func (c *RoutedClient) StreamMessage(ctx context.Context, req llm.ChatRequest, onDelta func(string)) (llm.Message, error) {
+	return c.execute(ctx, req, true, onDelta)
+}
+
+func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream bool, onDelta func(string)) (llm.Message, error) {
+	if c == nil || c.router == nil {
+		return llm.Message{}, unavailableRouteError("no provider candidates available")
+	}
+	result, err := c.router.Route(ctx, ModelID(strings.TrimSpace(req.Model)), RouteContext{AllowFallback: true})
+	if err != nil {
+		return llm.Message{}, err
+	}
+	targets := make([]RouteTarget, 0, 1+len(result.Fallbacks))
+	targets = append(targets, result.Primary)
+	targets = append(targets, result.Fallbacks...)
+	var lastErr error
+	for _, target := range targets {
+		if target.Client == nil {
+			continue
+		}
+		callReq := Request{ChatRequest: req}
+		callReq.Model = string(target.ModelID)
+		msg, err := executeTarget(ctx, target, callReq, stream, onDelta)
+		if err == nil {
+			return msg, nil
+		}
+		lastErr = err
+		var providerErr *Error
+		if errors.As(err, &providerErr) {
+			if !providerErr.Retryable {
+				return llm.Message{}, providerErr
+			}
+			continue
+		}
+		mapped := mapCompatError(target.ProviderID, err)
+		if !mapped.Retryable {
+			return llm.Message{}, mapped
+		}
+		lastErr = mapped
+	}
+	if lastErr != nil {
+		var providerErr *Error
+		if errors.As(lastErr, &providerErr) {
+			return llm.Message{}, providerErr
+		}
+		return llm.Message{}, mapCompatError("", lastErr)
+	}
+	return llm.Message{}, unavailableRouteError("no provider candidates available")
+}
+
+func executeTarget(ctx context.Context, target RouteTarget, req Request, stream bool, onDelta func(string)) (llm.Message, error) {
+	streamCh, err := target.Client.Stream(ctx, req)
+	if err != nil {
+		return llm.Message{}, err
+	}
+	var result llm.Message
+	for event := range streamCh {
+		switch event.Type {
+		case EventDelta:
+			if stream && onDelta != nil && event.Delta != "" {
+				onDelta(event.Delta)
+			}
+		case EventToolCall:
+			if event.ToolCall != nil {
+				result.ToolCalls = append(result.ToolCalls, *event.ToolCall)
+			}
+		case EventUsage:
+			if event.Usage != nil {
+				result.Usage = &llm.Usage{InputTokens: int(event.Usage.InputTokens), OutputTokens: int(event.Usage.OutputTokens), TotalTokens: int(event.Usage.TotalTokens)}
+			}
+		case EventResult:
+			if event.Result != nil {
+				return *event.Result, nil
+			}
+		case EventError:
+			if event.Error != nil {
+				return llm.Message{}, event.Error
+			}
+		}
+	}
+	result.Normalize()
+	return result, nil
 }
 
 func (a *clientAdapter) ProviderID() ProviderID {

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -15,14 +15,19 @@ type clientAdapter struct {
 }
 
 type RoutedClient struct {
-	router Router
+	router        Router
+	allowFallback bool
 }
 
 func NewRoutedClient(router Router) llm.Client {
+	return NewRoutedClientWithPolicy(router, false)
+}
+
+func NewRoutedClientWithPolicy(router Router, allowFallback bool) llm.Client {
 	if router == nil {
 		return nil
 	}
-	return &RoutedClient{router: router}
+	return &RoutedClient{router: router, allowFallback: allowFallback}
 }
 
 func WrapClient(providerID ProviderID, defaultModel ModelID, client llm.Client) Client {
@@ -52,7 +57,7 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 	if c == nil || c.router == nil {
 		return llm.Message{}, unavailableRouteError("no provider candidates available")
 	}
-	result, err := c.router.Route(ctx, ModelID(strings.TrimSpace(req.Model)), RouteContext{AllowFallback: true})
+	result, err := c.router.Route(ctx, ModelID(strings.TrimSpace(req.Model)), RouteContext{AllowFallback: c.allowFallback})
 	if err != nil {
 		return llm.Message{}, err
 	}
@@ -100,9 +105,15 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 		return llm.Message{}, err
 	}
 	var result llm.Message
+	hasTerminal := false
+	hasDelta := false
 	for event := range streamCh {
 		switch event.Type {
 		case EventDelta:
+			if event.Delta != "" {
+				result.Content += event.Delta
+				hasDelta = true
+			}
 			if stream && onDelta != nil && event.Delta != "" {
 				onDelta(event.Delta)
 			}
@@ -115,14 +126,24 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 				result.Usage = &llm.Usage{InputTokens: int(event.Usage.InputTokens), OutputTokens: int(event.Usage.OutputTokens), TotalTokens: int(event.Usage.TotalTokens)}
 			}
 		case EventResult:
+			hasTerminal = true
 			if event.Result != nil {
 				return *event.Result, nil
 			}
+			result.Normalize()
+			return result, nil
 		case EventError:
+			hasTerminal = true
 			if event.Error != nil {
 				return llm.Message{}, event.Error
 			}
 		}
+	}
+	if !hasTerminal {
+		if hasDelta || len(result.ToolCalls) > 0 || result.Usage != nil {
+			return llm.Message{}, unavailableRouteError("provider stream terminated without terminal event")
+		}
+		return llm.Message{}, unavailableRouteError("provider stream terminated unexpectedly")
 	}
 	result.Normalize()
 	return result, nil

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -66,6 +66,9 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 	targets = append(targets, result.Fallbacks...)
 	var lastErr error
 	for _, target := range targets {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return llm.Message{}, ctxErr
+		}
 		if target.Client == nil {
 			continue
 		}
@@ -141,6 +144,9 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 		}
 	}
 	if !hasTerminal {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return llm.Message{}, ctxErr
+		}
 		if hasDelta || len(result.ToolCalls) > 0 || result.Usage != nil {
 			return llm.Message{}, unavailableRouteError("provider stream terminated without terminal event")
 		}

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -137,6 +137,7 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 			if event.Error != nil {
 				return llm.Message{}, event.Error
 			}
+			return llm.Message{}, unavailableRouteError("provider stream emitted error event without error payload")
 		}
 	}
 	if !hasTerminal {

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -135,7 +135,19 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request) (llm.Me
 		case EventResult:
 			hasTerminal = true
 			if event.Result != nil {
-				return *event.Result, deltas, nil
+				merged := *event.Result
+				if strings.TrimSpace(merged.Content) == "" && result.Content != "" {
+					merged.Content = result.Content
+				}
+				if len(merged.ToolCalls) == 0 && len(result.ToolCalls) > 0 {
+					merged.ToolCalls = append([]llm.ToolCall(nil), result.ToolCalls...)
+				}
+				if merged.Usage == nil && result.Usage != nil {
+					usage := *result.Usage
+					merged.Usage = &usage
+				}
+				merged.Normalize()
+				return merged, deltas, nil
 			}
 			result.Normalize()
 			return result, deltas, nil

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -74,8 +74,13 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 		}
 		callReq := Request{ChatRequest: req}
 		callReq.Model = string(target.ModelID)
-		msg, err := executeTarget(ctx, target, callReq, stream, onDelta)
+		msg, deltas, err := executeTarget(ctx, target, callReq)
 		if err == nil {
+			if stream && onDelta != nil {
+				for _, delta := range deltas {
+					onDelta(delta)
+				}
+			}
 			return msg, nil
 		}
 		lastErr = err
@@ -102,12 +107,13 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 	return llm.Message{}, unavailableRouteError("no provider candidates available")
 }
 
-func executeTarget(ctx context.Context, target RouteTarget, req Request, stream bool, onDelta func(string)) (llm.Message, error) {
+func executeTarget(ctx context.Context, target RouteTarget, req Request) (llm.Message, []string, error) {
 	streamCh, err := target.Client.Stream(ctx, req)
 	if err != nil {
-		return llm.Message{}, err
+		return llm.Message{}, nil, err
 	}
 	var result llm.Message
+	var deltas []string
 	hasTerminal := false
 	hasDelta := false
 	for event := range streamCh {
@@ -115,10 +121,8 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 		case EventDelta:
 			if event.Delta != "" {
 				result.Content += event.Delta
+				deltas = append(deltas, event.Delta)
 				hasDelta = true
-			}
-			if stream && onDelta != nil && event.Delta != "" {
-				onDelta(event.Delta)
 			}
 		case EventToolCall:
 			if event.ToolCall != nil {
@@ -131,29 +135,29 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 		case EventResult:
 			hasTerminal = true
 			if event.Result != nil {
-				return *event.Result, nil
+				return *event.Result, deltas, nil
 			}
 			result.Normalize()
-			return result, nil
+			return result, deltas, nil
 		case EventError:
 			hasTerminal = true
 			if event.Error != nil {
-				return llm.Message{}, event.Error
+				return llm.Message{}, nil, event.Error
 			}
-			return llm.Message{}, unavailableRouteError("provider stream emitted error event without error payload")
+			return llm.Message{}, nil, unavailableRouteError("provider stream emitted error event without error payload")
 		}
 	}
 	if !hasTerminal {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return llm.Message{}, ctxErr
+			return llm.Message{}, nil, ctxErr
 		}
 		if hasDelta || len(result.ToolCalls) > 0 || result.Usage != nil {
-			return llm.Message{}, unavailableRouteError("provider stream terminated without terminal event")
+			return llm.Message{}, nil, unavailableRouteError("provider stream terminated without terminal event")
 		}
-		return llm.Message{}, unavailableRouteError("provider stream terminated unexpectedly")
+		return llm.Message{}, nil, unavailableRouteError("provider stream terminated unexpectedly")
 	}
 	result.Normalize()
-	return result, nil
+	return result, deltas, nil
 }
 
 func (a *clientAdapter) ProviderID() ProviderID {

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -57,3 +57,14 @@ func NewDomainClientWithID(providerID ProviderID, cfg config.ProviderConfig) (Cl
 	}
 	return WrapClient(id, ModelID(strings.TrimSpace(cfg.Model)), baseClient), nil
 }
+
+func NewRouterClient(cfg config.ProviderRuntimeConfig, health HealthChecker) (llm.Client, error) {
+	reg, err := NewRegistry(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return NewRoutedClient(NewRouter(reg, health, RouterConfig{
+		DefaultProvider: ProviderID(cfg.DefaultProvider),
+		DefaultModel:    ModelID(cfg.DefaultModel),
+	})), nil
+}

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -63,8 +63,8 @@ func NewRouterClient(cfg config.ProviderRuntimeConfig, health HealthChecker) (ll
 	if err != nil {
 		return nil, err
 	}
-	return NewRoutedClient(NewRouter(reg, health, RouterConfig{
+	return NewRoutedClientWithPolicy(NewRouter(reg, health, RouterConfig{
 		DefaultProvider: ProviderID(cfg.DefaultProvider),
 		DefaultModel:    ModelID(cfg.DefaultModel),
-	})), nil
+	}), cfg.AllowFallback), nil
 }

--- a/internal/provider/router.go
+++ b/internal/provider/router.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -12,9 +13,10 @@ type RouterConfig struct {
 }
 
 type registryRouter struct {
-	registry Registry
-	health   HealthChecker
-	policy   RouterConfig
+	registry          Registry
+	health            HealthChecker
+	policy            RouterConfig
+	candidateWarnings []Warning
 }
 
 func NewRouter(reg Registry, health HealthChecker, cfg RouterConfig) Router {
@@ -65,6 +67,7 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 		return nil, err
 	}
 	candidates := make([]routeCandidate, 0, len(ids))
+	warnings := make([]Warning, 0)
 	seen := make(map[string]struct{})
 	for _, id := range ids {
 		client, ok := r.registry.Get(ctx, id)
@@ -77,6 +80,7 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 		}
 		models, err := client.ListModels(ctx)
 		if err != nil {
+			warnings = append(warnings, Warning{ProviderID: providerID, Reason: fmt.Sprintf("provider_list_models_failed:%v", err)})
 			continue
 		}
 		for _, model := range models {
@@ -96,7 +100,17 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 			})
 		}
 	}
+	r.candidateWarnings = warnings
 	return candidates, nil
+}
+
+func (r *registryRouter) CandidateWarnings() []Warning {
+	if r == nil || len(r.candidateWarnings) == 0 {
+		return nil
+	}
+	warnings := make([]Warning, len(r.candidateWarnings))
+	copy(warnings, r.candidateWarnings)
+	return warnings
 }
 
 func normalizeRouteProviderID(id ProviderID) ProviderID {

--- a/internal/provider/router.go
+++ b/internal/provider/router.go
@@ -1,0 +1,210 @@
+package provider
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+type RouterConfig struct {
+	DefaultProvider ProviderID
+	DefaultModel    ModelID
+}
+
+type registryRouter struct {
+	registry Registry
+	health   HealthChecker
+	policy   RouterConfig
+}
+
+func NewRouter(reg Registry, health HealthChecker, cfg RouterConfig) Router {
+	return &registryRouter{
+		registry: reg,
+		health:   health,
+		policy: RouterConfig{
+			DefaultProvider: normalizeRouteProviderID(cfg.DefaultProvider),
+			DefaultModel:    normalizeRouteModelID(cfg.DefaultModel),
+		},
+	}
+}
+
+func (r *registryRouter) Route(ctx context.Context, requestedModel ModelID, rc RouteContext) (RouteResult, error) {
+	if r == nil || r.registry == nil {
+		return RouteResult{}, unavailableRouteError("no provider candidates available")
+	}
+	candidates, err := r.collectCandidates(ctx)
+	if err != nil {
+		return RouteResult{}, err
+	}
+	requested := normalizeRouteModelID(requestedModel)
+	filtered := filterCandidatesByModel(candidates, requested)
+	if len(filtered) == 0 {
+		return RouteResult{}, unavailableRouteError("no provider candidates available")
+	}
+	available := filterHealthyCandidates(ctx, r.health, filtered)
+	if len(available) == 0 {
+		return RouteResult{}, unavailableRouteError("no provider candidates available")
+	}
+	ordered := sortRouteCandidates(available, requested, normalizeRouteContext(rc), r.policy)
+	if len(ordered) == 0 {
+		return RouteResult{}, unavailableRouteError("no provider candidates available")
+	}
+	result := RouteResult{Primary: toRouteTarget(ordered[0])}
+	if rc.AllowFallback {
+		result.Fallbacks = make([]RouteTarget, 0, len(ordered)-1)
+		for _, candidate := range ordered[1:] {
+			result.Fallbacks = append(result.Fallbacks, toRouteTarget(candidate))
+		}
+	}
+	return result, nil
+}
+
+func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidate, error) {
+	ids, err := r.registry.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]routeCandidate, 0, len(ids))
+	seen := make(map[string]struct{})
+	for _, id := range ids {
+		client, ok := r.registry.Get(ctx, id)
+		if !ok || client == nil {
+			continue
+		}
+		providerID := normalizeRouteProviderID(client.ProviderID())
+		if providerID == "" {
+			continue
+		}
+		models, err := client.ListModels(ctx)
+		if err != nil {
+			continue
+		}
+		for _, model := range models {
+			modelID := normalizeRouteModelID(model.ModelID)
+			if modelID == "" {
+				continue
+			}
+			key := string(providerID) + "\x00" + string(modelID)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			candidates = append(candidates, routeCandidate{
+				ProviderID: providerID,
+				ModelID:    modelID,
+				Client:     client,
+			})
+		}
+	}
+	return candidates, nil
+}
+
+func normalizeRouteProviderID(id ProviderID) ProviderID {
+	return ProviderID(strings.ToLower(strings.TrimSpace(string(id))))
+}
+
+func normalizeRouteModelID(id ModelID) ModelID {
+	return ModelID(strings.TrimSpace(string(id)))
+}
+
+func normalizeRouteContext(rc RouteContext) RouteContext {
+	rc.Scenario = strings.TrimSpace(rc.Scenario)
+	rc.Region = strings.TrimSpace(rc.Region)
+	if rc.Tags == nil {
+		rc.Tags = map[string]string{}
+	}
+	return rc
+}
+
+func unavailableRouteError(message string) *Error {
+	return &Error{
+		Code:      ErrCodeUnavailable,
+		Message:   message,
+		Retryable: true,
+		Err:       errorsUnavailable,
+	}
+}
+
+func toRouteTarget(candidate routeCandidate) RouteTarget {
+	return RouteTarget{
+		ProviderID: candidate.ProviderID,
+		ModelID:    candidate.ModelID,
+		Client:     candidate.Client,
+	}
+}
+
+func filterCandidatesByModel(candidates []routeCandidate, requested ModelID) []routeCandidate {
+	if requested == "" {
+		return append([]routeCandidate(nil), candidates...)
+	}
+	filtered := make([]routeCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.ModelID == requested {
+			filtered = append(filtered, candidate)
+		}
+	}
+	return filtered
+}
+
+func filterHealthyCandidates(ctx context.Context, health HealthChecker, candidates []routeCandidate) []routeCandidate {
+	if health == nil {
+		return append([]routeCandidate(nil), candidates...)
+	}
+	filtered := make([]routeCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if err := health.Check(ctx, candidate.ProviderID); err == nil {
+			filtered = append(filtered, candidate)
+		}
+	}
+	return filtered
+}
+
+func sortRouteCandidates(candidates []routeCandidate, requested ModelID, rc RouteContext, cfg RouterConfig) []routeCandidate {
+	ordered := append([]routeCandidate(nil), candidates...)
+	defaultProvider := normalizeRouteProviderID(cfg.DefaultProvider)
+	defaultModel := normalizeRouteModelID(cfg.DefaultModel)
+	preferredProvider := preferredRouteProvider(requested, rc)
+	preferLatency := rc.PreferLatency
+	preferLowCost := rc.PreferLowCost
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left := ordered[i]
+		right := ordered[j]
+		if left.ProviderID == preferredProvider && right.ProviderID != preferredProvider {
+			return true
+		}
+		if right.ProviderID == preferredProvider && left.ProviderID != preferredProvider {
+			return false
+		}
+		if left.ProviderID == defaultProvider && right.ProviderID != defaultProvider {
+			return true
+		}
+		if right.ProviderID == defaultProvider && left.ProviderID != defaultProvider {
+			return false
+		}
+		if left.ModelID == requested && right.ModelID != requested {
+			return true
+		}
+		if right.ModelID == requested && left.ModelID != requested {
+			return false
+		}
+		if left.ModelID == defaultModel && right.ModelID != defaultModel {
+			return true
+		}
+		if right.ModelID == defaultModel && left.ModelID != defaultModel {
+			return false
+		}
+		leftLatency, rightLatency := routeRankLatency(left.ProviderID), routeRankLatency(right.ProviderID)
+		leftCost, rightCost := routeRankCost(left.ProviderID), routeRankCost(right.ProviderID)
+		if preferLatency && leftLatency != rightLatency {
+			return leftLatency < rightLatency
+		}
+		if preferLowCost && leftCost != rightCost {
+			return leftCost < rightCost
+		}
+		if left.ProviderID != right.ProviderID {
+			return left.ProviderID < right.ProviderID
+		}
+		return left.ModelID < right.ModelID
+	})
+	return ordered
+}

--- a/internal/provider/router.go
+++ b/internal/provider/router.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 )
@@ -98,6 +99,9 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 				Client:     client,
 			})
 		}
+	}
+	for _, warning := range warnings {
+		log.Printf("provider router warning: provider=%s reason=%s", warning.ProviderID, warning.Reason)
 	}
 	return candidates, nil
 }

--- a/internal/provider/router.go
+++ b/internal/provider/router.go
@@ -13,10 +13,9 @@ type RouterConfig struct {
 }
 
 type registryRouter struct {
-	registry          Registry
-	health            HealthChecker
-	policy            RouterConfig
-	candidateWarnings []Warning
+	registry Registry
+	health   HealthChecker
+	policy   RouterConfig
 }
 
 func NewRouter(reg Registry, health HealthChecker, cfg RouterConfig) Router {
@@ -100,17 +99,7 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 			})
 		}
 	}
-	r.candidateWarnings = warnings
 	return candidates, nil
-}
-
-func (r *registryRouter) CandidateWarnings() []Warning {
-	if r == nil || len(r.candidateWarnings) == 0 {
-		return nil
-	}
-	warnings := make([]Warning, len(r.candidateWarnings))
-	copy(warnings, r.candidateWarnings)
-	return warnings
 }
 
 func normalizeRouteProviderID(id ProviderID) ProviderID {

--- a/internal/provider/router_policy.go
+++ b/internal/provider/router_policy.go
@@ -1,0 +1,61 @@
+package provider
+
+type routeCandidate struct {
+	ProviderID ProviderID
+	ModelID    ModelID
+	Client     Client
+}
+
+var errorsUnavailable = ErrProviderNotFound
+
+func preferredRouteProvider(requested ModelID, rc RouteContext) ProviderID {
+	if id := normalizeRouteProviderID(ProviderID(rc.Tags["provider"])); id != "" {
+		return id
+	}
+	model := normalizeRouteModelID(requested)
+	if model == "" {
+		return ""
+	}
+	if isAnthropicModel(model) {
+		return ProviderAnthropic
+	}
+	if isOpenAIModel(model) {
+		return ProviderOpenAI
+	}
+	return ""
+}
+
+func routeRankLatency(id ProviderID) int {
+	switch normalizeRouteProviderID(id) {
+	case ProviderOpenAI:
+		return 1
+	case ProviderAnthropic:
+		return 2
+	default:
+		return 10
+	}
+}
+
+func routeRankCost(id ProviderID) int {
+	switch normalizeRouteProviderID(id) {
+	case ProviderAnthropic:
+		return 1
+	case ProviderOpenAI:
+		return 2
+	default:
+		return 10
+	}
+}
+
+func isAnthropicModel(model ModelID) bool {
+	value := string(model)
+	return len(value) >= len("claude") && value[:len("claude")] == "claude"
+}
+
+func isOpenAIModel(model ModelID) bool {
+	value := string(model)
+	if len(value) >= len("gpt") && value[:len("gpt")] == "gpt" {
+		return true
+	}
+	return len(value) >= len("o1") && value[:len("o1")] == "o1"
+}

--- a/internal/provider/router_policy.go
+++ b/internal/provider/router_policy.go
@@ -1,12 +1,14 @@
 package provider
 
+import "errors"
+
 type routeCandidate struct {
 	ProviderID ProviderID
 	ModelID    ModelID
 	Client     Client
 }
 
-var errorsUnavailable = ErrProviderNotFound
+var errorsUnavailable = errors.New(string(ErrCodeUnavailable))
 
 func preferredRouteProvider(requested ModelID, rc RouteContext) ProviderID {
 	if id := normalizeRouteProviderID(ProviderID(rc.Tags["provider"])); id != "" {

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -1,0 +1,142 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"bytemind/internal/config"
+	"bytemind/internal/llm"
+)
+
+type stubHealthChecker struct {
+	errors map[ProviderID]error
+}
+
+func (s stubHealthChecker) Check(_ context.Context, id ProviderID) error {
+	if s.errors == nil {
+		return nil
+	}
+	return s.errors[id]
+}
+
+type stubRouterClient struct {
+	providerID ProviderID
+	models     []ModelInfo
+	streams    []stubRouterStreamResult
+	streamReqs []llm.ChatRequest
+}
+
+type stubRouterStreamResult struct {
+	message llm.Message
+	err     error
+	deltas  []string
+}
+
+func (s *stubRouterClient) ProviderID() ProviderID                          { return s.providerID }
+func (s *stubRouterClient) ListModels(context.Context) ([]ModelInfo, error) { return s.models, nil }
+func (s *stubRouterClient) Stream(_ context.Context, req Request) (<-chan Event, error) {
+	idx := len(s.streamReqs)
+	s.streamReqs = append(s.streamReqs, req.ChatRequest)
+	result := stubRouterStreamResult{}
+	if idx < len(s.streams) {
+		result = s.streams[idx]
+	}
+	ch := make(chan Event, len(result.deltas)+3)
+	go func() {
+		defer close(ch)
+		ch <- Event{Type: EventStart, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID}
+		for _, delta := range result.deltas {
+			ch <- Event{Type: EventDelta, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Delta: delta}
+		}
+		if result.err != nil {
+			var providerErr *Error
+			if errors.As(result.err, &providerErr) {
+				ch <- Event{Type: EventError, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Error: providerErr}
+				return
+			}
+			ch <- Event{Type: EventError, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Error: &Error{Code: ErrCodeUnavailable, Provider: s.providerID, Message: result.err.Error(), Retryable: false, Err: result.err}}
+			return
+		}
+		message := result.message
+		message.Normalize()
+		ch <- Event{Type: EventResult, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Result: &message}
+	}()
+	return ch, nil
+}
+
+func TestRouterRoutesRequestedModelWithFallbacks(t *testing.T) {
+	reg, _ := NewRegistryFromProviderConfig(config.ProviderConfig{Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key", Model: "gpt-5.4"})
+	_ = reg.Register(context.Background(), &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}})
+	router := NewRouter(reg, nil, RouterConfig{DefaultProvider: ProviderOpenAI, DefaultModel: "gpt-5.4"})
+	result, err := router.Route(context.Background(), "gpt-5.4", RouteContext{AllowFallback: true})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Primary.ProviderID != ProviderOpenAI || result.Primary.ModelID != "gpt-5.4" {
+		t.Fatalf("unexpected primary %#v", result.Primary)
+	}
+	if len(result.Fallbacks) != 1 || result.Fallbacks[0].ProviderID != "backup" {
+		t.Fatalf("unexpected fallbacks %#v", result.Fallbacks)
+	}
+}
+
+func TestRouterFiltersUnhealthyProviders(t *testing.T) {
+	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
+	_ = reg.Register(context.Background(), &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}})
+	_ = reg.Register(context.Background(), &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}})
+	router := NewRouter(reg, stubHealthChecker{errors: map[ProviderID]error{"openai": errors.New("down")}}, RouterConfig{})
+	result, err := router.Route(context.Background(), "gpt-5.4", RouteContext{AllowFallback: true})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Primary.ProviderID != "backup" {
+		t.Fatalf("unexpected primary %#v", result.Primary)
+	}
+}
+
+func TestRouterReturnsUnavailableWithoutCandidates(t *testing.T) {
+	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
+	router := NewRouter(reg, nil, RouterConfig{})
+	_, err := router.Route(context.Background(), "missing", RouteContext{AllowFallback: true})
+	var providerErr *Error
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
+		t.Fatalf("unexpected error %#v", err)
+	}
+}
+
+func TestRoutedClientFallsBackOnRetryableProviderError(t *testing.T) {
+	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeRateLimited, Provider: "openai", Message: "rate limited", Retryable: true}}}}
+	fallback := &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}, deltas: []string{"o", "k"}}}}
+	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
+	_ = reg.Register(context.Background(), primary)
+	_ = reg.Register(context.Background(), fallback)
+	client := NewRoutedClient(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}))
+	msg, err := client.StreamMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if msg.Content != "ok" {
+		t.Fatalf("unexpected message %#v", msg)
+	}
+	if len(primary.streamReqs) != 1 || len(fallback.streamReqs) != 1 {
+		t.Fatalf("unexpected request counts primary=%d fallback=%d", len(primary.streamReqs), len(fallback.streamReqs))
+	}
+}
+
+func TestRoutedClientStopsOnNonRetryableProviderError(t *testing.T) {
+	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeBadRequest, Provider: "openai", Message: "bad request", Retryable: false}}}}
+	fallback := &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}}
+	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
+	_ = reg.Register(context.Background(), primary)
+	_ = reg.Register(context.Background(), fallback)
+	client := NewRoutedClient(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}))
+	_, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"})
+	var providerErr *Error
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeBadRequest {
+		t.Fatalf("unexpected error %#v", err)
+	}
+	if len(fallback.streamReqs) != 0 {
+		t.Fatalf("expected fallback to be skipped, got %d calls", len(fallback.streamReqs))
+	}
+}

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -23,31 +23,46 @@ func (s stubHealthChecker) Check(_ context.Context, id ProviderID) error {
 type stubRouterClient struct {
 	providerID ProviderID
 	models     []ModelInfo
+	modelsErr  error
+	streamErr  error
 	streams    []stubRouterStreamResult
 	streamReqs []llm.ChatRequest
 }
 
 type stubRouterStreamResult struct {
-	message llm.Message
-	err     error
-	deltas  []string
+	message     llm.Message
+	err         error
+	deltas      []string
+	events      []Event
+	skipAutoEnd bool
 }
 
-func (s *stubRouterClient) ProviderID() ProviderID                          { return s.providerID }
-func (s *stubRouterClient) ListModels(context.Context) ([]ModelInfo, error) { return s.models, nil }
+func (s *stubRouterClient) ProviderID() ProviderID { return s.providerID }
+func (s *stubRouterClient) ListModels(context.Context) ([]ModelInfo, error) {
+	return s.models, s.modelsErr
+}
 func (s *stubRouterClient) Stream(_ context.Context, req Request) (<-chan Event, error) {
+	if s.streamErr != nil {
+		return nil, s.streamErr
+	}
 	idx := len(s.streamReqs)
 	s.streamReqs = append(s.streamReqs, req.ChatRequest)
 	result := stubRouterStreamResult{}
 	if idx < len(s.streams) {
 		result = s.streams[idx]
 	}
-	ch := make(chan Event, len(result.deltas)+3)
+	ch := make(chan Event, len(result.deltas)+len(result.events)+3)
 	go func() {
 		defer close(ch)
 		ch <- Event{Type: EventStart, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID}
 		for _, delta := range result.deltas {
 			ch <- Event{Type: EventDelta, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Delta: delta}
+		}
+		for _, event := range result.events {
+			ch <- event
+		}
+		if result.skipAutoEnd {
+			return
 		}
 		if result.err != nil {
 			var providerErr *Error
@@ -64,6 +79,28 @@ func (s *stubRouterClient) Stream(_ context.Context, req Request) (<-chan Event,
 	}()
 	return ch, nil
 }
+
+type stubRouter struct {
+	result RouteResult
+	err    error
+}
+
+func (s stubRouter) Route(context.Context, ModelID, RouteContext) (RouteResult, error) {
+	return s.result, s.err
+}
+
+type stubRegistry struct {
+	ids     []ProviderID
+	listErr error
+	clients map[ProviderID]Client
+}
+
+func (s stubRegistry) Register(context.Context, Client) error { return nil }
+func (s stubRegistry) Get(_ context.Context, id ProviderID) (Client, bool) {
+	client, ok := s.clients[id]
+	return client, ok
+}
+func (s stubRegistry) List(context.Context) ([]ProviderID, error) { return s.ids, s.listErr }
 
 func TestRouterRoutesRequestedModelWithFallbacks(t *testing.T) {
 	reg, _ := NewRegistryFromProviderConfig(config.ProviderConfig{Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key", Model: "gpt-5.4"})
@@ -138,5 +175,171 @@ func TestRoutedClientStopsOnNonRetryableProviderError(t *testing.T) {
 	}
 	if len(fallback.streamReqs) != 0 {
 		t.Fatalf("expected fallback to be skipped, got %d calls", len(fallback.streamReqs))
+	}
+}
+
+func TestRouterNoFallbacksWhenDisabled(t *testing.T) {
+	reg := stubRegistry{ids: []ProviderID{"openai", "backup"}, clients: map[ProviderID]Client{
+		"openai": &stubRouterClient{providerID: "openai", models: []ModelInfo{{ModelID: "gpt-5.4"}}},
+		"backup": &stubRouterClient{providerID: "backup", models: []ModelInfo{{ModelID: "gpt-5.4"}}},
+	}}
+	result, err := NewRouter(reg, nil, RouterConfig{}).Route(context.Background(), "gpt-5.4", RouteContext{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(result.Fallbacks) != 0 {
+		t.Fatalf("expected no fallbacks, got %#v", result.Fallbacks)
+	}
+}
+
+func TestRouterCollectCandidatesSkipsInvalidEntries(t *testing.T) {
+	reg := stubRegistry{ids: []ProviderID{"missing", "blank", "broken", "dup", "valid"}, clients: map[ProviderID]Client{
+		"blank":  &stubRouterClient{providerID: "   ", models: []ModelInfo{{ModelID: "gpt-5.4"}}},
+		"broken": &stubRouterClient{providerID: "broken", modelsErr: errors.New("boom")},
+		"dup":    &stubRouterClient{providerID: "dup", models: []ModelInfo{{ModelID: "gpt-5.4"}, {ModelID: "gpt-5.4"}, {ModelID: "   "}}},
+		"valid":  &stubRouterClient{providerID: "valid", models: []ModelInfo{{ModelID: "gpt-4.1"}}},
+	}}
+	candidates, err := (&registryRouter{registry: reg}).collectCandidates(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("unexpected candidates %#v", candidates)
+	}
+}
+
+func TestRouterCollectCandidatesPropagatesListError(t *testing.T) {
+	_, err := (&registryRouter{registry: stubRegistry{listErr: errors.New("boom")}}).collectCandidates(context.Background())
+	if err == nil {
+		t.Fatal("expected list error")
+	}
+}
+
+func TestRouterRouteHandlesNilRegistryAndNoHealthyCandidates(t *testing.T) {
+	if _, err := (*registryRouter)(nil).Route(context.Background(), "gpt-5.4", RouteContext{}); err == nil {
+		t.Fatal("expected nil router error")
+	}
+	reg := stubRegistry{ids: []ProviderID{"openai"}, clients: map[ProviderID]Client{"openai": &stubRouterClient{providerID: "openai", models: []ModelInfo{{ModelID: "gpt-5.4"}}}}}
+	_, err := NewRouter(reg, stubHealthChecker{errors: map[ProviderID]error{"openai": errors.New("down")}}, RouterConfig{}).Route(context.Background(), "gpt-5.4", RouteContext{AllowFallback: true})
+	if err == nil {
+		t.Fatal("expected unavailable error")
+	}
+}
+
+func TestRouteHelpersAndPolicyBranches(t *testing.T) {
+	if normalizeRouteProviderID(" OpenAI ") != "openai" || normalizeRouteModelID(" gpt-5.4 ") != "gpt-5.4" {
+		t.Fatal("expected normalization to trim values")
+	}
+	rc := normalizeRouteContext(RouteContext{Scenario: " chat ", Region: " us ", Tags: nil})
+	if rc.Scenario != "chat" || rc.Region != "us" || rc.Tags == nil {
+		t.Fatalf("unexpected context %#v", rc)
+	}
+	if toRouteTarget(routeCandidate{ProviderID: "openai", ModelID: "gpt-5.4"}).ProviderID != "openai" {
+		t.Fatal("expected target conversion")
+	}
+	if got := filterCandidatesByModel([]routeCandidate{{ProviderID: "a", ModelID: "m1"}, {ProviderID: "b", ModelID: "m2"}}, ""); len(got) != 2 {
+		t.Fatalf("unexpected candidates %#v", got)
+	}
+	if got := filterHealthyCandidates(context.Background(), nil, []routeCandidate{{ProviderID: "a"}}); len(got) != 1 {
+		t.Fatalf("unexpected healthy candidates %#v", got)
+	}
+	ordered := sortRouteCandidates([]routeCandidate{{ProviderID: "anthropic", ModelID: "claude-3"}, {ProviderID: "openai", ModelID: "gpt-5.4"}, {ProviderID: "zeta", ModelID: "z1"}}, "gpt-5.4", RouteContext{PreferLatency: true}, RouterConfig{})
+	if ordered[0].ProviderID != "openai" {
+		t.Fatalf("unexpected order %#v", ordered)
+	}
+	ordered = sortRouteCandidates([]routeCandidate{{ProviderID: "openai", ModelID: "gpt-5.4"}, {ProviderID: "anthropic", ModelID: "claude-3"}}, "", RouteContext{PreferLowCost: true}, RouterConfig{})
+	if ordered[0].ProviderID != "anthropic" {
+		t.Fatalf("unexpected cost order %#v", ordered)
+	}
+	ordered = sortRouteCandidates([]routeCandidate{{ProviderID: "beta", ModelID: "m2"}, {ProviderID: "alpha", ModelID: "m1"}}, "", RouteContext{}, RouterConfig{})
+	if ordered[0].ProviderID != "alpha" {
+		t.Fatalf("unexpected lexical order %#v", ordered)
+	}
+	if preferredRouteProvider("claude-3", RouteContext{}) != ProviderAnthropic {
+		t.Fatal("expected anthropic preference")
+	}
+	if preferredRouteProvider("gpt-5.4", RouteContext{}) != ProviderOpenAI {
+		t.Fatal("expected openai preference")
+	}
+	if preferredRouteProvider("", RouteContext{Tags: map[string]string{"provider": " backup "}}) != "backup" {
+		t.Fatal("expected tag provider preference")
+	}
+	if preferredRouteProvider("custom", RouteContext{}) != "" {
+		t.Fatal("expected no preferred provider")
+	}
+	if routeRankLatency("openai") >= routeRankLatency("anthropic") {
+		t.Fatal("expected openai latency rank ahead")
+	}
+	if routeRankCost("anthropic") >= routeRankCost("openai") {
+		t.Fatal("expected anthropic cost rank ahead")
+	}
+	if routeRankLatency("other") != 10 || routeRankCost("other") != 10 {
+		t.Fatal("expected default ranks")
+	}
+	if !isAnthropicModel("claude-3") || isAnthropicModel("gpt-5") {
+		t.Fatal("unexpected anthropic model detection")
+	}
+	if !isOpenAIModel("gpt-5") || !isOpenAIModel("o1-mini") || isOpenAIModel("claude-3") {
+		t.Fatal("unexpected openai model detection")
+	}
+}
+
+func TestUnavailableRouteError(t *testing.T) {
+	err := unavailableRouteError("no candidates")
+	if err.Code != ErrCodeUnavailable || !err.Retryable || err.Message != "no candidates" {
+		t.Fatalf("unexpected error %#v", err)
+	}
+}
+
+func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
+	if NewRoutedClient(nil) != nil {
+		t.Fatal("expected nil routed client for nil router")
+	}
+	var client *RoutedClient
+	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{}); err == nil {
+		t.Fatal("expected unavailable error")
+	}
+	client = &RoutedClient{router: stubRouter{err: errors.New("route failed")}}
+	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{}); err == nil {
+		t.Fatal("expected route error")
+	}
+	client = &RoutedClient{router: stubRouter{result: RouteResult{Primary: RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4"}}}}
+	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}); err == nil {
+		t.Fatal("expected unavailable when target client missing")
+	}
+}
+
+func TestExecuteTargetCoversBranches(t *testing.T) {
+	client := &stubRouterClient{providerID: "openai", streamErr: errors.New("stream setup failed")}
+	if _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil); err == nil {
+		t.Fatal("expected stream setup error")
+	}
+	var deltas []string
+	tool := llm.ToolCall{ID: "1", Type: "function", Function: llm.ToolFunctionCall{Name: "ls", Arguments: "{}"}}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}, {Type: EventError, Error: nil}}, deltas: []string{"a", ""}, skipAutoEnd: true}}}
+	msg, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { deltas = append(deltas, delta) })
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(deltas) != 1 || len(msg.ToolCalls) != 1 || msg.Usage == nil || msg.Usage.TotalTokens != 3 {
+		t.Fatalf("unexpected message %#v deltas=%#v", msg, deltas)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult}}}}}
+	msg, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	if err != nil || msg.Content != "" {
+		t.Fatalf("unexpected result %#v err=%v", msg, err)
+	}
+}
+
+func TestNewRouterClient(t *testing.T) {
+	client, err := NewRouterClient(config.ProviderRuntimeConfig{DefaultProvider: "openai", DefaultModel: "gpt-5.4", Providers: map[string]config.ProviderConfig{"openai": {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key", Model: "gpt-5.4"}}}, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, ok := client.(*RoutedClient); !ok {
+		t.Fatalf("expected routed client, got %T", client)
+	}
+	if _, err := NewRouterClient(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"broken": {Type: ""}}}, nil); err == nil {
+		t.Fatal("expected registry error")
 	}
 }

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -148,7 +148,7 @@ func TestRoutedClientFallsBackOnRetryableProviderError(t *testing.T) {
 	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
 	_ = reg.Register(context.Background(), primary)
 	_ = reg.Register(context.Background(), fallback)
-	client := NewRoutedClient(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}))
+	client := NewRoutedClientWithPolicy(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}), true)
 	msg, err := client.StreamMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -167,7 +167,7 @@ func TestRoutedClientStopsOnNonRetryableProviderError(t *testing.T) {
 	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
 	_ = reg.Register(context.Background(), primary)
 	_ = reg.Register(context.Background(), fallback)
-	client := NewRoutedClient(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}))
+	client := NewRoutedClientWithPolicy(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}), true)
 	_, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"})
 	var providerErr *Error
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeBadRequest {
@@ -255,6 +255,18 @@ func TestRouteHelpersAndPolicyBranches(t *testing.T) {
 	if ordered[0].ProviderID != "alpha" {
 		t.Fatalf("unexpected lexical order %#v", ordered)
 	}
+	ordered = sortRouteCandidates([]routeCandidate{{ProviderID: "backup", ModelID: "m1"}, {ProviderID: "openai", ModelID: "m2"}}, "", RouteContext{}, RouterConfig{DefaultProvider: "openai"})
+	if ordered[0].ProviderID != "openai" {
+		t.Fatalf("unexpected default provider order %#v", ordered)
+	}
+	ordered = sortRouteCandidates([]routeCandidate{{ProviderID: "backup", ModelID: "m1"}, {ProviderID: "backup", ModelID: "m2"}}, "", RouteContext{}, RouterConfig{DefaultModel: "m2"})
+	if ordered[0].ModelID != "m2" {
+		t.Fatalf("unexpected default model order %#v", ordered)
+	}
+	ordered = sortRouteCandidates([]routeCandidate{{ProviderID: "openai", ModelID: "gpt-5.4"}, {ProviderID: "backup", ModelID: "gpt-5.4"}}, "gpt-5.4", RouteContext{Tags: map[string]string{"provider": " backup "}}, RouterConfig{})
+	if ordered[0].ProviderID != "backup" {
+		t.Fatalf("unexpected tagged provider order %#v", ordered)
+	}
 	if preferredRouteProvider("claude-3", RouteContext{}) != ProviderAnthropic {
 		t.Fatal("expected anthropic preference")
 	}
@@ -307,6 +319,15 @@ func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
 	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}); err == nil {
 		t.Fatal("expected unavailable when target client missing")
 	}
+	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeRateLimited, Provider: "openai", Message: "rate limited", Retryable: true}}}}
+	fallback := &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}}
+	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
+	_ = reg.Register(context.Background(), primary)
+	_ = reg.Register(context.Background(), fallback)
+	client = NewRoutedClient(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"})).(*RoutedClient)
+	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}); err == nil {
+		t.Fatal("expected fallback disabled error")
+	}
 }
 
 func TestExecuteTargetCoversBranches(t *testing.T) {
@@ -316,28 +337,38 @@ func TestExecuteTargetCoversBranches(t *testing.T) {
 	}
 	var deltas []string
 	tool := llm.ToolCall{ID: "1", Type: "function", Function: llm.ToolFunctionCall{Name: "ls", Arguments: "{}"}}
-	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}, {Type: EventError, Error: nil}}, deltas: []string{"a", ""}, skipAutoEnd: true}}}
-	msg, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { deltas = append(deltas, delta) })
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}}, deltas: []string{"a", ""}, skipAutoEnd: true}}}
+	_, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { deltas = append(deltas, delta) })
+	var providerErr *Error
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
+		t.Fatalf("expected unavailable error, got %v", err)
 	}
-	if len(deltas) != 1 || len(msg.ToolCalls) != 1 || msg.Usage == nil || msg.Usage.TotalTokens != 3 {
-		t.Fatalf("unexpected message %#v deltas=%#v", msg, deltas)
+	if len(deltas) != 1 {
+		t.Fatalf("unexpected deltas %#v", deltas)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult}}}}}
-	msg, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	msg, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
 	if err != nil || msg.Content != "" {
 		t.Fatalf("unexpected result %#v err=%v", msg, err)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
+	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
+		t.Fatalf("expected delta termination error, got %v", err)
 	}
 }
 
 func TestNewRouterClient(t *testing.T) {
-	client, err := NewRouterClient(config.ProviderRuntimeConfig{DefaultProvider: "openai", DefaultModel: "gpt-5.4", Providers: map[string]config.ProviderConfig{"openai": {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key", Model: "gpt-5.4"}}}, nil)
+	client, err := NewRouterClient(config.ProviderRuntimeConfig{DefaultProvider: "openai", DefaultModel: "gpt-5.4", AllowFallback: true, Providers: map[string]config.ProviderConfig{"openai": {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key", Model: "gpt-5.4"}}}, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if _, ok := client.(*RoutedClient); !ok {
+	routed, ok := client.(*RoutedClient)
+	if !ok {
 		t.Fatalf("expected routed client, got %T", client)
+	}
+	if !routed.allowFallback {
+		t.Fatal("expected routed client fallback to be enabled")
 	}
 	if _, err := NewRouterClient(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"broken": {Type: ""}}}, nil); err == nil {
 		t.Fatal("expected registry error")

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -1,8 +1,11 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
+	"strings"
 	"testing"
 
 	"bytemind/internal/config"
@@ -199,12 +202,19 @@ func TestRouterCollectCandidatesSkipsInvalidEntries(t *testing.T) {
 		"dup":    &stubRouterClient{providerID: "dup", models: []ModelInfo{{ModelID: "gpt-5.4"}, {ModelID: "gpt-5.4"}, {ModelID: "   "}}},
 		"valid":  &stubRouterClient{providerID: "valid", models: []ModelInfo{{ModelID: "gpt-4.1"}}},
 	}}
+	var buf bytes.Buffer
+	prevWriter := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prevWriter)
 	candidates, err := (&registryRouter{registry: reg}).collectCandidates(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if len(candidates) != 2 {
 		t.Fatalf("unexpected candidates %#v", candidates)
+	}
+	if !strings.Contains(buf.String(), "provider=broken") || !strings.Contains(buf.String(), "provider_list_models_failed") {
+		t.Fatalf("expected warning log, got %q", buf.String())
 	}
 }
 
@@ -328,6 +338,14 @@ func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
 	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}); err == nil {
 		t.Fatal("expected fallback disabled error")
 	}
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := NewRoutedClientWithPolicy(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}), true).CreateMessage(cancelCtx, llm.ChatRequest{Model: "gpt-5.4"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+	if len(fallback.streamReqs) != 0 {
+		t.Fatalf("expected canceled request to skip fallback, got %d fallback calls", len(fallback.streamReqs))
+	}
 }
 
 func TestExecuteTargetCoversBranches(t *testing.T) {
@@ -355,6 +373,13 @@ func TestExecuteTargetCoversBranches(t *testing.T) {
 	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected nil-payload error event to fail, got %v", err)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = executeTarget(cancelCtx, RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
 	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -146,18 +146,22 @@ func TestRouterReturnsUnavailableWithoutCandidates(t *testing.T) {
 }
 
 func TestRoutedClientFallsBackOnRetryableProviderError(t *testing.T) {
-	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeRateLimited, Provider: "openai", Message: "rate limited", Retryable: true}}}}
+	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeRateLimited, Provider: "openai", Message: "rate limited", Retryable: true}, deltas: []string{"bad"}}}}
 	fallback := &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}, deltas: []string{"o", "k"}}}}
 	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
 	_ = reg.Register(context.Background(), primary)
 	_ = reg.Register(context.Background(), fallback)
 	client := NewRoutedClientWithPolicy(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}), true)
-	msg, err := client.StreamMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}, nil)
+	var streamed []string
+	msg, err := client.StreamMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}, func(delta string) { streamed = append(streamed, delta) })
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if msg.Content != "ok" {
 		t.Fatalf("unexpected message %#v", msg)
+	}
+	if strings.Join(streamed, "") != "ok" {
+		t.Fatalf("expected only fallback deltas, got %#v", streamed)
 	}
 	if len(primary.streamReqs) != 1 || len(fallback.streamReqs) != 1 {
 		t.Fatalf("unexpected request counts primary=%d fallback=%d", len(primary.streamReqs), len(fallback.streamReqs))
@@ -350,39 +354,47 @@ func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
 
 func TestExecuteTargetCoversBranches(t *testing.T) {
 	client := &stubRouterClient{providerID: "openai", streamErr: errors.New("stream setup failed")}
-	if _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil); err == nil {
+	if _, _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}); err == nil {
 		t.Fatal("expected stream setup error")
 	}
 	var deltas []string
 	tool := llm.ToolCall{ID: "1", Type: "function", Function: llm.ToolFunctionCall{Name: "ls", Arguments: "{}"}}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}}, deltas: []string{"a", ""}, skipAutoEnd: true}}}
-	_, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { deltas = append(deltas, delta) })
+	_, _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
 	var providerErr *Error
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected unavailable error, got %v", err)
 	}
-	if len(deltas) != 1 {
-		t.Fatalf("unexpected deltas %#v", deltas)
+	if len(deltas) != 0 {
+		t.Fatalf("expected executeTarget to buffer deltas, got %#v", deltas)
 	}
-	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult}}}}}
-	msg, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
-	if err != nil || msg.Content != "" {
-		t.Fatalf("unexpected result %#v err=%v", msg, err)
+	var buffered []string
+	msg, buffered, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if msg.Content != "" || len(buffered) != 0 {
+		t.Fatalf("unexpected buffered result %#v deltas=%#v", msg, buffered)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}, deltas: []string{"o", "k"}}}}
+	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	if err != nil || msg.Content != "ok" || strings.Join(buffered, "") != "ok" {
+		t.Fatalf("unexpected success result %#v deltas=%#v err=%v", msg, buffered, err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventError}}}}}
-	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	_, _, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected nil-payload error event to fail, got %v", err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err = executeTarget(cancelCtx, RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	_, _, err = executeTarget(cancelCtx, RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context cancellation, got %v", err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
-	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	_, _, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected delta termination error, got %v", err)
 	}

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -351,6 +351,11 @@ func TestExecuteTargetCoversBranches(t *testing.T) {
 	if err != nil || msg.Content != "" {
 		t.Fatalf("unexpected result %#v err=%v", msg, err)
 	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventError}}}}}
+	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
+		t.Fatalf("expected nil-payload error event to fail, got %v", err)
+	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
 	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -315,6 +315,9 @@ func TestUnavailableRouteError(t *testing.T) {
 	if err.Code != ErrCodeUnavailable || !err.Retryable || err.Message != "no candidates" {
 		t.Fatalf("unexpected error %#v", err)
 	}
+	if errors.Is(err, ErrProviderNotFound) {
+		t.Fatalf("unexpected provider-not-found unwrap %#v", err)
+	}
 }
 
 func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
@@ -375,6 +378,16 @@ func TestExecuteTargetCoversBranches(t *testing.T) {
 	}
 	if msg.Content != "" || len(buffered) != 0 {
 		t.Fatalf("unexpected buffered result %#v deltas=%#v", msg, buffered)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant}}}, deltas: []string{"o", "k"}}}}
+	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	if err != nil || msg.Content != "ok" || strings.Join(buffered, "") != "ok" {
+		t.Fatalf("expected merged delta content, got msg=%#v deltas=%#v err=%v", msg, buffered, err)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}, {Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant}}}}}}
+	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	if err != nil || len(msg.ToolCalls) != 1 || msg.Usage == nil || msg.Usage.TotalTokens != 3 || len(buffered) != 0 {
+		t.Fatalf("expected merged metadata result, got msg=%#v deltas=%#v err=%v", msg, buffered, err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}, deltas: []string{"o", "k"}}}}
 	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})

--- a/internal/tui/model_mouse_selection.go
+++ b/internal/tui/model_mouse_selection.go
@@ -477,7 +477,7 @@ func (m *model) viewportPointFromMouse(x, y int) (viewportSelectionPoint, bool) 
 		}
 		// Keep zone-first behavior robust for terminals that occasionally
 		// report mouse rows with small absolute drift near viewport edges.
-		if x >= z.StartX-1 && x <= z.EndX+1 {
+		if x >= z.StartX-mouseZoneAutoProbeMaxDelta && x <= z.EndX+mouseZoneAutoProbeMaxDelta {
 			for delta := 1; delta <= mouseZoneAutoProbeMaxDelta; delta++ {
 				if point, ok := m.viewportPointFromZone(z, x, y-delta); ok {
 					return point, true
@@ -496,8 +496,14 @@ func (m *model) viewportPointFromMouse(x, y int) (viewportSelectionPoint, bool) 
 	if renderedTop, found := m.conversationViewportTopFromRenderedView(left, top); found {
 		top = renderedTop
 		bottom = top + m.viewport.Height - 1
+	} else if z := zone.Get(conversationViewportZoneID); z != nil && y < top {
+		top = min(top, z.StartY)
+		bottom = top + m.viewport.Height - 1
 	}
 	// Keep drag-select usable for terminals that report 0-based or 1-based mouse coords.
+	if y < top-1 && y >= top-mouseZoneAutoProbeMaxDelta {
+		y = top
+	}
 	if x < left-1 || x > right+1 || y < top-1 || y > bottom+1 {
 		return viewportSelectionPoint{}, false
 	}


### PR DESCRIPTION
Summary
在 internal/provider 内落地 Step 4，新增独立 Router/RouterPolicy 实现，把“候选收集 → 健康过滤 → 模型过滤 → 排序 → primary/fallback 输出”收口为可测试能力，且没有把职责扩散到 provider 层之外。
新增 RoutedClient 作为 llm.Client facade，对上层保持原接口不变；内部统一执行 provider 选择与唯一一次 provider 级 fallback，依据 provider.Error.Retryable 决定是否切换后备 provider，避免上层再感知多 provider 细节。
在 factory.go 增加 NewRouterClient 装配入口，可直接从 ProviderRuntimeConfig 构建带 registry/router 的 routed client，为后续把 runner 接到新 provider facade 做准备。
补充 router_test.go，覆盖显式模型命中、健康状态过滤、无候选返回 unavailable、retryable 错误触发 fallback、non-retryable 错误立即终止等关键路径；并验证当前 provider 层改动通过 go test ./internal/provider -v。
本次改动刻意保持边界：只在 internal/provider 内引入路由与 provider fallback 机制，没有改动 agent/runner 的现有 stream→non-stream 兼容回退逻辑，因此 provider 级切换权已集中，但未越出 provider 层做上层调用链重构。