### PR TITLE
Provider丨Step 5重构错误语义与 retryable 规则

### DIFF
--- a/internal/config/provider_runtime.go
+++ b/internal/config/provider_runtime.go
@@ -5,6 +5,7 @@ import "strings"
 type ProviderRuntimeConfig struct {
 	DefaultProvider string                    `json:"default_provider"`
 	DefaultModel    string                    `json:"default_model"`
+	AllowFallback   bool                      `json:"allow_fallback"`
 	Providers       map[string]ProviderConfig `json:"providers"`
 }
 
@@ -20,6 +21,7 @@ func LegacyProviderRuntimeConfig(cfg ProviderConfig) ProviderRuntimeConfig {
 	return ProviderRuntimeConfig{
 		DefaultProvider: providerID,
 		DefaultModel:    cfg.Model,
+		AllowFallback:   false,
 		Providers: map[string]ProviderConfig{
 			providerID: cfg,
 		},

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -273,27 +273,5 @@ func emit(ctx context.Context, ch chan<- Event, evt Event) bool {
 }
 
 func mapCompatError(providerID ProviderID, err error) *Error {
-	mapped := &Error{
-		Code:      ErrCodeUnavailable,
-		Provider:  providerID,
-		Message:   "provider request failed",
-		Retryable: false,
-		Err:       err,
-	}
-	var providerErr *llm.ProviderError
-	if !errors.As(err, &providerErr) || providerErr == nil {
-		return mapped
-	}
-	mapped.Retryable = providerErr.Retryable
-	switch providerErr.Code {
-	case llm.ErrorCodeRateLimited:
-		mapped.Code = ErrCodeRateLimited
-		mapped.Message = "provider rate limited"
-	case llm.ErrorCodeContextTooLong:
-		mapped.Code = ErrCodeBadRequest
-		mapped.Message = "request exceeds provider context limit"
-	default:
-		mapped.Message = "provider unavailable"
-	}
-	return mapped
+	return mapError(providerID, err)
 }

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -14,6 +14,17 @@ type clientAdapter struct {
 	client       llm.Client
 }
 
+type RoutedClient struct {
+	router Router
+}
+
+func NewRoutedClient(router Router) llm.Client {
+	if router == nil {
+		return nil
+	}
+	return &RoutedClient{router: router}
+}
+
 func WrapClient(providerID ProviderID, defaultModel ModelID, client llm.Client) Client {
 	if client == nil {
 		return nil
@@ -27,6 +38,94 @@ func WrapClient(providerID ProviderID, defaultModel ModelID, client llm.Client) 
 		defaultModel: ModelID(strings.TrimSpace(string(defaultModel))),
 		client:       client,
 	}
+}
+
+func (c *RoutedClient) CreateMessage(ctx context.Context, req llm.ChatRequest) (llm.Message, error) {
+	return c.execute(ctx, req, false, nil)
+}
+
+func (c *RoutedClient) StreamMessage(ctx context.Context, req llm.ChatRequest, onDelta func(string)) (llm.Message, error) {
+	return c.execute(ctx, req, true, onDelta)
+}
+
+func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream bool, onDelta func(string)) (llm.Message, error) {
+	if c == nil || c.router == nil {
+		return llm.Message{}, unavailableRouteError("no provider candidates available")
+	}
+	result, err := c.router.Route(ctx, ModelID(strings.TrimSpace(req.Model)), RouteContext{AllowFallback: true})
+	if err != nil {
+		return llm.Message{}, err
+	}
+	targets := make([]RouteTarget, 0, 1+len(result.Fallbacks))
+	targets = append(targets, result.Primary)
+	targets = append(targets, result.Fallbacks...)
+	var lastErr error
+	for _, target := range targets {
+		if target.Client == nil {
+			continue
+		}
+		callReq := Request{ChatRequest: req}
+		callReq.Model = string(target.ModelID)
+		msg, err := executeTarget(ctx, target, callReq, stream, onDelta)
+		if err == nil {
+			return msg, nil
+		}
+		lastErr = err
+		var providerErr *Error
+		if errors.As(err, &providerErr) {
+			if !providerErr.Retryable {
+				return llm.Message{}, providerErr
+			}
+			continue
+		}
+		mapped := mapCompatError(target.ProviderID, err)
+		if !mapped.Retryable {
+			return llm.Message{}, mapped
+		}
+		lastErr = mapped
+	}
+	if lastErr != nil {
+		var providerErr *Error
+		if errors.As(lastErr, &providerErr) {
+			return llm.Message{}, providerErr
+		}
+		return llm.Message{}, mapCompatError("", lastErr)
+	}
+	return llm.Message{}, unavailableRouteError("no provider candidates available")
+}
+
+func executeTarget(ctx context.Context, target RouteTarget, req Request, stream bool, onDelta func(string)) (llm.Message, error) {
+	streamCh, err := target.Client.Stream(ctx, req)
+	if err != nil {
+		return llm.Message{}, err
+	}
+	var result llm.Message
+	for event := range streamCh {
+		switch event.Type {
+		case EventDelta:
+			if stream && onDelta != nil && event.Delta != "" {
+				onDelta(event.Delta)
+			}
+		case EventToolCall:
+			if event.ToolCall != nil {
+				result.ToolCalls = append(result.ToolCalls, *event.ToolCall)
+			}
+		case EventUsage:
+			if event.Usage != nil {
+				result.Usage = &llm.Usage{InputTokens: int(event.Usage.InputTokens), OutputTokens: int(event.Usage.OutputTokens), TotalTokens: int(event.Usage.TotalTokens)}
+			}
+		case EventResult:
+			if event.Result != nil {
+				return *event.Result, nil
+			}
+		case EventError:
+			if event.Error != nil {
+				return llm.Message{}, event.Error
+			}
+		}
+	}
+	result.Normalize()
+	return result, nil
 }
 
 func (a *clientAdapter) ProviderID() ProviderID {

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -15,14 +15,19 @@ type clientAdapter struct {
 }
 
 type RoutedClient struct {
-	router Router
+	router        Router
+	allowFallback bool
 }
 
 func NewRoutedClient(router Router) llm.Client {
+	return NewRoutedClientWithPolicy(router, false)
+}
+
+func NewRoutedClientWithPolicy(router Router, allowFallback bool) llm.Client {
 	if router == nil {
 		return nil
 	}
-	return &RoutedClient{router: router}
+	return &RoutedClient{router: router, allowFallback: allowFallback}
 }
 
 func WrapClient(providerID ProviderID, defaultModel ModelID, client llm.Client) Client {
@@ -52,7 +57,7 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 	if c == nil || c.router == nil {
 		return llm.Message{}, unavailableRouteError("no provider candidates available")
 	}
-	result, err := c.router.Route(ctx, ModelID(strings.TrimSpace(req.Model)), RouteContext{AllowFallback: true})
+	result, err := c.router.Route(ctx, ModelID(strings.TrimSpace(req.Model)), RouteContext{AllowFallback: c.allowFallback})
 	if err != nil {
 		return llm.Message{}, err
 	}
@@ -100,9 +105,15 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 		return llm.Message{}, err
 	}
 	var result llm.Message
+	hasTerminal := false
+	hasDelta := false
 	for event := range streamCh {
 		switch event.Type {
 		case EventDelta:
+			if event.Delta != "" {
+				result.Content += event.Delta
+				hasDelta = true
+			}
 			if stream && onDelta != nil && event.Delta != "" {
 				onDelta(event.Delta)
 			}
@@ -115,14 +126,24 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 				result.Usage = &llm.Usage{InputTokens: int(event.Usage.InputTokens), OutputTokens: int(event.Usage.OutputTokens), TotalTokens: int(event.Usage.TotalTokens)}
 			}
 		case EventResult:
+			hasTerminal = true
 			if event.Result != nil {
 				return *event.Result, nil
 			}
+			result.Normalize()
+			return result, nil
 		case EventError:
+			hasTerminal = true
 			if event.Error != nil {
 				return llm.Message{}, event.Error
 			}
 		}
+	}
+	if !hasTerminal {
+		if hasDelta || len(result.ToolCalls) > 0 || result.Usage != nil {
+			return llm.Message{}, unavailableRouteError("provider stream terminated without terminal event")
+		}
+		return llm.Message{}, unavailableRouteError("provider stream terminated unexpectedly")
 	}
 	result.Normalize()
 	return result, nil

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -65,6 +65,14 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 	targets = append(targets, result.Primary)
 	targets = append(targets, result.Fallbacks...)
 	var lastErr error
+	hasStreamedDelta := false
+	forwardDelta := onDelta
+	if stream && onDelta != nil {
+		forwardDelta = func(delta string) {
+			hasStreamedDelta = true
+			onDelta(delta)
+		}
+	}
 	for _, target := range targets {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return llm.Message{}, ctxErr
@@ -74,7 +82,7 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 		}
 		callReq := Request{ChatRequest: req}
 		callReq.Model = string(target.ModelID)
-		msg, err := executeTarget(ctx, target, callReq, stream, onDelta)
+		msg, err := executeTarget(ctx, target, callReq, stream, forwardDelta)
 		if err == nil {
 			return msg, nil
 		}
@@ -86,7 +94,7 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 			return llm.Message{}, err
 		}
 		lastErr = mapped
-		if !mapped.Retryable {
+		if !mapped.Retryable || hasStreamedDelta {
 			return llm.Message{}, mapped
 		}
 	}
@@ -144,7 +152,14 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 		case EventError:
 			hasTerminal = true
 			if event.Error != nil {
-				return llm.Message{}, mapCompatError(target.ProviderID, event.Error)
+				mapped := mapCompatError(target.ProviderID, event.Error)
+				if mapped == nil && errors.Is(event.Error, context.Canceled) {
+					return llm.Message{}, context.Canceled
+				}
+				if mapped == nil {
+					return llm.Message{}, unavailableRouteError("provider stream emitted invalid error payload")
+				}
+				return llm.Message{}, mapped
 			}
 			return llm.Message{}, unavailableRouteError("provider stream emitted error event without error payload")
 		}

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -66,6 +66,9 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 	targets = append(targets, result.Fallbacks...)
 	var lastErr error
 	for _, target := range targets {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return llm.Message{}, ctxErr
+		}
 		if target.Client == nil {
 			continue
 		}
@@ -141,6 +144,9 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 		}
 	}
 	if !hasTerminal {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return llm.Message{}, ctxErr
+		}
 		if hasDelta || len(result.ToolCalls) > 0 || result.Usage != nil {
 			return llm.Message{}, unavailableRouteError("provider stream terminated without terminal event")
 		}

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -137,6 +137,7 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 			if event.Error != nil {
 				return llm.Message{}, event.Error
 			}
+			return llm.Message{}, unavailableRouteError("provider stream emitted error event without error payload")
 		}
 	}
 	if !hasTerminal {

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -205,12 +205,19 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 			})
 		})
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+				return
+			}
+			mapped := mapCompatError(a.providerID, err)
+			if mapped == nil {
+				return
+			}
 			_ = emit(ctx, stream, Event{
 				Type:       EventError,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
 				ModelID:    modelID,
-				Error:      mapCompatError(a.providerID, err),
+				Error:      mapped,
 			})
 			return
 		}

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -135,7 +135,19 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request) (llm.Me
 		case EventResult:
 			hasTerminal = true
 			if event.Result != nil {
-				return *event.Result, deltas, nil
+				merged := *event.Result
+				if strings.TrimSpace(merged.Content) == "" && result.Content != "" {
+					merged.Content = result.Content
+				}
+				if len(merged.ToolCalls) == 0 && len(result.ToolCalls) > 0 {
+					merged.ToolCalls = append([]llm.ToolCall(nil), result.ToolCalls...)
+				}
+				if merged.Usage == nil && result.Usage != nil {
+					usage := *result.Usage
+					merged.Usage = &usage
+				}
+				merged.Normalize()
+				return merged, deltas, nil
 			}
 			result.Normalize()
 			return result, deltas, nil

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -74,8 +74,13 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 		}
 		callReq := Request{ChatRequest: req}
 		callReq.Model = string(target.ModelID)
-		msg, err := executeTarget(ctx, target, callReq, stream, onDelta)
+		msg, deltas, err := executeTarget(ctx, target, callReq)
 		if err == nil {
+			if stream && onDelta != nil {
+				for _, delta := range deltas {
+					onDelta(delta)
+				}
+			}
 			return msg, nil
 		}
 		lastErr = err
@@ -102,12 +107,13 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 	return llm.Message{}, unavailableRouteError("no provider candidates available")
 }
 
-func executeTarget(ctx context.Context, target RouteTarget, req Request, stream bool, onDelta func(string)) (llm.Message, error) {
+func executeTarget(ctx context.Context, target RouteTarget, req Request) (llm.Message, []string, error) {
 	streamCh, err := target.Client.Stream(ctx, req)
 	if err != nil {
-		return llm.Message{}, err
+		return llm.Message{}, nil, err
 	}
 	var result llm.Message
+	var deltas []string
 	hasTerminal := false
 	hasDelta := false
 	for event := range streamCh {
@@ -115,10 +121,8 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 		case EventDelta:
 			if event.Delta != "" {
 				result.Content += event.Delta
+				deltas = append(deltas, event.Delta)
 				hasDelta = true
-			}
-			if stream && onDelta != nil && event.Delta != "" {
-				onDelta(event.Delta)
 			}
 		case EventToolCall:
 			if event.ToolCall != nil {
@@ -131,29 +135,29 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request, stream 
 		case EventResult:
 			hasTerminal = true
 			if event.Result != nil {
-				return *event.Result, nil
+				return *event.Result, deltas, nil
 			}
 			result.Normalize()
-			return result, nil
+			return result, deltas, nil
 		case EventError:
 			hasTerminal = true
 			if event.Error != nil {
-				return llm.Message{}, event.Error
+				return llm.Message{}, nil, event.Error
 			}
-			return llm.Message{}, unavailableRouteError("provider stream emitted error event without error payload")
+			return llm.Message{}, nil, unavailableRouteError("provider stream emitted error event without error payload")
 		}
 	}
 	if !hasTerminal {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return llm.Message{}, ctxErr
+			return llm.Message{}, nil, ctxErr
 		}
 		if hasDelta || len(result.ToolCalls) > 0 || result.Usage != nil {
-			return llm.Message{}, unavailableRouteError("provider stream terminated without terminal event")
+			return llm.Message{}, nil, unavailableRouteError("provider stream terminated without terminal event")
 		}
-		return llm.Message{}, unavailableRouteError("provider stream terminated unexpectedly")
+		return llm.Message{}, nil, unavailableRouteError("provider stream terminated unexpectedly")
 	}
 	result.Normalize()
-	return result, nil
+	return result, deltas, nil
 }
 
 func (a *clientAdapter) ProviderID() ProviderID {

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -74,46 +74,34 @@ func (c *RoutedClient) execute(ctx context.Context, req llm.ChatRequest, stream 
 		}
 		callReq := Request{ChatRequest: req}
 		callReq.Model = string(target.ModelID)
-		msg, deltas, err := executeTarget(ctx, target, callReq)
+		msg, err := executeTarget(ctx, target, callReq, stream, onDelta)
 		if err == nil {
-			if stream && onDelta != nil {
-				for _, delta := range deltas {
-					onDelta(delta)
-				}
-			}
 			return msg, nil
 		}
-		lastErr = err
-		var providerErr *Error
-		if errors.As(err, &providerErr) {
-			if !providerErr.Retryable {
-				return llm.Message{}, providerErr
-			}
-			continue
+		if errors.Is(err, context.Canceled) {
+			return llm.Message{}, err
 		}
 		mapped := mapCompatError(target.ProviderID, err)
+		if mapped == nil {
+			return llm.Message{}, err
+		}
+		lastErr = mapped
 		if !mapped.Retryable {
 			return llm.Message{}, mapped
 		}
-		lastErr = mapped
 	}
 	if lastErr != nil {
-		var providerErr *Error
-		if errors.As(lastErr, &providerErr) {
-			return llm.Message{}, providerErr
-		}
-		return llm.Message{}, mapCompatError("", lastErr)
+		return llm.Message{}, lastErr
 	}
 	return llm.Message{}, unavailableRouteError("no provider candidates available")
 }
 
-func executeTarget(ctx context.Context, target RouteTarget, req Request) (llm.Message, []string, error) {
+func executeTarget(ctx context.Context, target RouteTarget, req Request, stream bool, onDelta func(string)) (llm.Message, error) {
 	streamCh, err := target.Client.Stream(ctx, req)
 	if err != nil {
-		return llm.Message{}, nil, err
+		return llm.Message{}, err
 	}
 	var result llm.Message
-	var deltas []string
 	hasTerminal := false
 	hasDelta := false
 	for event := range streamCh {
@@ -121,8 +109,10 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request) (llm.Me
 		case EventDelta:
 			if event.Delta != "" {
 				result.Content += event.Delta
-				deltas = append(deltas, event.Delta)
 				hasDelta = true
+				if stream && onDelta != nil {
+					onDelta(event.Delta)
+				}
 			}
 		case EventToolCall:
 			if event.ToolCall != nil {
@@ -147,29 +137,29 @@ func executeTarget(ctx context.Context, target RouteTarget, req Request) (llm.Me
 					merged.Usage = &usage
 				}
 				merged.Normalize()
-				return merged, deltas, nil
+				return merged, nil
 			}
 			result.Normalize()
-			return result, deltas, nil
+			return result, nil
 		case EventError:
 			hasTerminal = true
 			if event.Error != nil {
-				return llm.Message{}, nil, event.Error
+				return llm.Message{}, mapCompatError(target.ProviderID, event.Error)
 			}
-			return llm.Message{}, nil, unavailableRouteError("provider stream emitted error event without error payload")
+			return llm.Message{}, unavailableRouteError("provider stream emitted error event without error payload")
 		}
 	}
 	if !hasTerminal {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return llm.Message{}, nil, ctxErr
+			return llm.Message{}, ctxErr
 		}
 		if hasDelta || len(result.ToolCalls) > 0 || result.Usage != nil {
-			return llm.Message{}, nil, unavailableRouteError("provider stream terminated without terminal event")
+			return llm.Message{}, unavailableRouteError("provider stream terminated without terminal event")
 		}
-		return llm.Message{}, nil, unavailableRouteError("provider stream terminated unexpectedly")
+		return llm.Message{}, unavailableRouteError("provider stream terminated unexpectedly")
 	}
 	result.Normalize()
-	return result, deltas, nil
+	return result, nil
 }
 
 func (a *clientAdapter) ProviderID() ProviderID {

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -112,14 +112,29 @@ func TestWrapClientStreamMapsProviderErrors(t *testing.T) {
 			code: ErrCodeRateLimited, retryable: true, message: "provider rate limited",
 		},
 		{
+			name: "unauthorized",
+			err:  &llm.ProviderError{Code: llm.ErrorCodeUnknown, Provider: "openai", Status: 401, Retryable: true, Message: "bad auth"},
+			code: ErrCodeUnauthorized, retryable: false, message: "provider unauthorized",
+		},
+		{
 			name: "context too long",
 			err:  &llm.ProviderError{Code: llm.ErrorCodeContextTooLong, Provider: "anthropic", Status: 413, Retryable: false, Message: "prompt is too long with raw details"},
 			code: ErrCodeBadRequest, retryable: false, message: "request exceeds provider context limit",
 		},
 		{
+			name: "bad request",
+			err:  &llm.ProviderError{Code: llm.ErrorCodeUnknown, Provider: "openai", Status: 400, Retryable: true, Message: "invalid payload"},
+			code: ErrCodeBadRequest, retryable: false, message: "provider rejected request",
+		},
+		{
+			name: "gateway timeout",
+			err:  &llm.ProviderError{Code: llm.ErrorCodeUnknown, Provider: "openai", Status: 504, Retryable: false, Message: "gateway timeout"},
+			code: ErrCodeTimeout, retryable: true, message: "provider request timed out",
+		},
+		{
 			name: "fallback unavailable",
 			err:  errors.New("sensitive raw body"),
-			code: ErrCodeUnavailable, retryable: false, message: "provider request failed",
+			code: ErrCodeUnavailable, retryable: true, message: "provider unavailable",
 		},
 	}
 
@@ -193,7 +208,7 @@ func TestWrapClientCoversNilClientAndEmptyModel(t *testing.T) {
 
 func TestMapCompatErrorDefaultProviderErrorBranch(t *testing.T) {
 	mapped := mapCompatError(ProviderAnthropic, &llm.ProviderError{Code: llm.ErrorCodeUnknown, Retryable: true, Message: "hidden upstream body"})
-	if mapped.Code != ErrCodeUnavailable || !mapped.Retryable || mapped.Message != "provider unavailable" || mapped.Provider != ProviderAnthropic {
+	if mapped.Code != ErrCodeUnavailable || !mapped.Retryable || mapped.Message != "provider unavailable" || mapped.Provider != ProviderAnthropic || mapped.Detail != "hidden upstream body" {
 		t.Fatalf("unexpected mapped error %#v", mapped)
 	}
 }

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -18,12 +18,15 @@ func (s stubCompatClient) CreateMessage(context.Context, llm.ChatRequest) (llm.M
 	return s.message, s.err
 }
 
-func (s stubCompatClient) StreamMessage(_ context.Context, _ llm.ChatRequest, onDelta func(string)) (llm.Message, error) {
+func (s stubCompatClient) StreamMessage(ctx context.Context, _ llm.ChatRequest, onDelta func(string)) (llm.Message, error) {
+	if s.err != nil {
+		return llm.Message{}, s.err
+	}
 	if onDelta != nil {
 		onDelta("hello")
 		onDelta(" world")
 	}
-	return s.message, s.err
+	return s.message, nil
 }
 
 func TestWrapClientStreamEmitsNormalizedEvents(t *testing.T) {
@@ -81,20 +84,17 @@ func TestWrapClientStreamEmitsErrorEvent(t *testing.T) {
 	for event := range stream {
 		events = append(events, event)
 	}
-	if len(events) != 4 {
-		t.Fatalf("expected 4 events, got %#v", events)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %#v", events)
 	}
 	if events[0].Type != EventStart {
 		t.Fatalf("expected start event, got %#v", events[0])
 	}
-	if events[1].Type != EventDelta || events[2].Type != EventDelta {
-		t.Fatalf("expected delta events before error, got %#v", events)
+	if events[1].Type != EventError || events[1].Error == nil {
+		t.Fatalf("expected error event, got %#v", events[1])
 	}
-	if events[3].Type != EventError || events[3].Error == nil {
-		t.Fatalf("expected error event, got %#v", events[3])
-	}
-	if events[3].Error.Code != ErrCodeUnavailable {
-		t.Fatalf("unexpected error code %#v", events[3].Error)
+	if events[1].Error.Code != ErrCodeUnavailable {
+		t.Fatalf("unexpected error code %#v", events[1].Error)
 	}
 }
 
@@ -178,6 +178,21 @@ func TestWrapClientStreamStopsWhenContextCancelled(t *testing.T) {
 			for range stream {
 			}
 		}
+	}
+}
+
+func TestWrapClientStreamDoesNotEmitNilErrorOnContextCanceled(t *testing.T) {
+	adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), stubCompatClient{err: context.Canceled})
+	stream, err := adapter.Stream(context.Background(), Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}, TraceID: "trace-cancel-err"})
+	if err != nil {
+		t.Fatalf("expected no setup error, got %v", err)
+	}
+	var events []Event
+	for event := range stream {
+		events = append(events, event)
+	}
+	if len(events) != 1 || events[0].Type != EventStart {
+		t.Fatalf("expected only start event before cancel shutdown, got %#v", events)
 	}
 }
 

--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -37,6 +37,10 @@ func mapError(providerID ProviderID, err error) *Error {
 	if errors.Is(err, context.Canceled) {
 		return nil
 	}
+	var upstream *llm.ProviderError
+	if errors.As(err, &upstream) && upstream != nil {
+		return mapLLMProviderError(providerID, upstream)
+	}
 	var providerErr *Error
 	if errors.As(err, &providerErr) && providerErr != nil {
 		providerErr.Retryable = isRetryableCode(providerErr.Code)
@@ -47,10 +51,6 @@ func mapError(providerID ProviderID, err error) *Error {
 			providerErr.Detail = providerErr.Err.Error()
 		}
 		return providerErr
-	}
-	var upstream *llm.ProviderError
-	if errors.As(err, &upstream) && upstream != nil {
-		return mapLLMProviderError(providerID, upstream)
 	}
 	if errors.Is(err, context.DeadlineExceeded) || isTimeoutError(err) {
 		return newError(ErrCodeTimeout, providerID, "provider request timed out", err, err.Error())

--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+
+	"bytemind/internal/llm"
+)
+
+func newError(code ErrorCode, providerID ProviderID, message string, err error, detail string) *Error {
+	return &Error{
+		Code:      code,
+		Provider:  providerID,
+		Message:   message,
+		Retryable: isRetryableCode(code),
+		Err:       err,
+		Detail:    strings.TrimSpace(detail),
+	}
+}
+
+func isRetryableCode(code ErrorCode) bool {
+	switch code {
+	case ErrCodeRateLimited, ErrCodeTimeout, ErrCodeUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+func mapError(providerID ProviderID, err error) *Error {
+	if err == nil {
+		return nil
+	}
+	var providerErr *Error
+	if errors.As(err, &providerErr) && providerErr != nil {
+		providerErr.Retryable = isRetryableCode(providerErr.Code)
+		if providerErr.Provider == "" {
+			providerErr.Provider = providerID
+		}
+		if providerErr.Detail == "" && providerErr.Err != nil {
+			providerErr.Detail = providerErr.Err.Error()
+		}
+		return providerErr
+	}
+	var upstream *llm.ProviderError
+	if errors.As(err, &upstream) && upstream != nil {
+		return mapLLMProviderError(providerID, upstream)
+	}
+	if errors.Is(err, context.DeadlineExceeded) || isTimeoutError(err) {
+		return newError(ErrCodeTimeout, providerID, "provider request timed out", err, err.Error())
+	}
+	if errors.Is(err, context.Canceled) {
+		return newError(ErrCodeUnavailable, providerID, "provider unavailable", err, err.Error())
+	}
+	return newError(ErrCodeUnavailable, providerID, "provider unavailable", err, err.Error())
+}
+
+func mapLLMProviderError(providerID ProviderID, err *llm.ProviderError) *Error {
+	if err == nil {
+		return nil
+	}
+	detail := strings.TrimSpace(err.Message)
+	switch {
+	case err.Status == http.StatusUnauthorized || err.Status == http.StatusForbidden:
+		return newError(ErrCodeUnauthorized, providerID, "provider unauthorized", err, detail)
+	case err.Code == llm.ErrorCodeContextTooLong || err.Status == http.StatusRequestEntityTooLarge:
+		return newError(ErrCodeBadRequest, providerID, "request exceeds provider context limit", err, detail)
+	case err.Status == http.StatusBadRequest:
+		return newError(ErrCodeBadRequest, providerID, "provider rejected request", err, detail)
+	case err.Code == llm.ErrorCodeRateLimited || err.Status == http.StatusTooManyRequests:
+		return newError(ErrCodeRateLimited, providerID, "provider rate limited", err, detail)
+	case err.Status == http.StatusRequestTimeout || err.Status == http.StatusGatewayTimeout:
+		return newError(ErrCodeTimeout, providerID, "provider request timed out", err, detail)
+	case err.Status >= http.StatusInternalServerError:
+		return newError(ErrCodeUnavailable, providerID, "provider unavailable", err, detail)
+	default:
+		return newError(ErrCodeUnavailable, providerID, "provider unavailable", err, detail)
+	}
+}
+
+func isTimeoutError(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}

--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -34,6 +34,9 @@ func mapError(providerID ProviderID, err error) *Error {
 	if err == nil {
 		return nil
 	}
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
 	var providerErr *Error
 	if errors.As(err, &providerErr) && providerErr != nil {
 		providerErr.Retryable = isRetryableCode(providerErr.Code)
@@ -51,9 +54,6 @@ func mapError(providerID ProviderID, err error) *Error {
 	}
 	if errors.Is(err, context.DeadlineExceeded) || isTimeoutError(err) {
 		return newError(ErrCodeTimeout, providerID, "provider request timed out", err, err.Error())
-	}
-	if errors.Is(err, context.Canceled) {
-		return newError(ErrCodeUnavailable, providerID, "provider unavailable", err, err.Error())
 	}
 	return newError(ErrCodeUnavailable, providerID, "provider unavailable", err, err.Error())
 }

--- a/internal/provider/errors_test.go
+++ b/internal/provider/errors_test.go
@@ -20,6 +20,10 @@ func TestMapErrorNormalizesRetryableByCode(t *testing.T) {
 	if mapped.Code != ErrCodeBadRequest || mapped.Retryable {
 		t.Fatalf("unexpected mapped error %#v", mapped)
 	}
+	mapped = mapError("openai", &Error{Code: ErrCodeUnavailable, Message: "wrapped", Retryable: true, Err: &llm.ProviderError{Status: 401, Message: "bad auth"}})
+	if mapped.Code != ErrCodeUnauthorized || mapped.Retryable || mapped.Provider != "openai" || mapped.Detail != "bad auth" {
+		t.Fatalf("expected wrapped provider error to normalize from upstream status, got %#v", mapped)
+	}
 }
 
 func TestMapErrorHandlesTimeoutSources(t *testing.T) {

--- a/internal/provider/errors_test.go
+++ b/internal/provider/errors_test.go
@@ -1,0 +1,67 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"bytemind/internal/llm"
+)
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+func TestMapErrorNormalizesRetryableByCode(t *testing.T) {
+	mapped := mapError("openai", &Error{Code: ErrCodeBadRequest, Provider: "openai", Message: "bad", Retryable: true, Err: errors.New("raw")})
+	if mapped.Code != ErrCodeBadRequest || mapped.Retryable {
+		t.Fatalf("unexpected mapped error %#v", mapped)
+	}
+}
+
+func TestMapErrorHandlesTimeoutSources(t *testing.T) {
+	mapped := mapError("openai", context.DeadlineExceeded)
+	if mapped.Code != ErrCodeTimeout || !mapped.Retryable {
+		t.Fatalf("unexpected deadline mapping %#v", mapped)
+	}
+	mapped = mapError("openai", timeoutError{})
+	if mapped.Code != ErrCodeTimeout || !mapped.Retryable {
+		t.Fatalf("unexpected net timeout mapping %#v", mapped)
+	}
+}
+
+func TestMapLLMProviderErrorStatusRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       *llm.ProviderError
+		code      ErrorCode
+		retryable bool
+		message   string
+	}{
+		{name: "unauthorized", err: &llm.ProviderError{Status: 401, Message: "bad auth"}, code: ErrCodeUnauthorized, retryable: false, message: "provider unauthorized"},
+		{name: "forbidden", err: &llm.ProviderError{Status: 403, Message: "forbidden"}, code: ErrCodeUnauthorized, retryable: false, message: "provider unauthorized"},
+		{name: "bad request", err: &llm.ProviderError{Status: 400, Message: "invalid"}, code: ErrCodeBadRequest, retryable: false, message: "provider rejected request"},
+		{name: "too long", err: &llm.ProviderError{Code: llm.ErrorCodeContextTooLong, Status: 413, Message: "too many tokens"}, code: ErrCodeBadRequest, retryable: false, message: "request exceeds provider context limit"},
+		{name: "rate limit", err: &llm.ProviderError{Status: 429, Message: "slow down"}, code: ErrCodeRateLimited, retryable: true, message: "provider rate limited"},
+		{name: "timeout", err: &llm.ProviderError{Status: 504, Message: "gateway timeout"}, code: ErrCodeTimeout, retryable: true, message: "provider request timed out"},
+		{name: "server error", err: &llm.ProviderError{Status: 500, Message: "boom"}, code: ErrCodeUnavailable, retryable: true, message: "provider unavailable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapped := mapLLMProviderError("anthropic", tt.err)
+			if mapped.Code != tt.code || mapped.Retryable != tt.retryable || mapped.Message != tt.message || mapped.Detail != tt.err.Message {
+				t.Fatalf("unexpected mapped error %#v", mapped)
+			}
+		})
+	}
+}
+
+func TestTimeoutErrorSatisfiesNetError(t *testing.T) {
+	var netErr net.Error = timeoutError{}
+	if !netErr.Timeout() {
+		t.Fatal("expected timeout net error")
+	}
+}

--- a/internal/provider/errors_test.go
+++ b/internal/provider/errors_test.go
@@ -31,6 +31,9 @@ func TestMapErrorHandlesTimeoutSources(t *testing.T) {
 	if mapped.Code != ErrCodeTimeout || !mapped.Retryable {
 		t.Fatalf("unexpected net timeout mapping %#v", mapped)
 	}
+	if mapped := mapError("openai", context.Canceled); mapped != nil {
+		t.Fatalf("expected context cancellation to bypass provider mapping, got %#v", mapped)
+	}
 }
 
 func TestMapLLMProviderErrorStatusRules(t *testing.T) {

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -57,3 +57,14 @@ func NewDomainClientWithID(providerID ProviderID, cfg config.ProviderConfig) (Cl
 	}
 	return WrapClient(id, ModelID(strings.TrimSpace(cfg.Model)), baseClient), nil
 }
+
+func NewRouterClient(cfg config.ProviderRuntimeConfig, health HealthChecker) (llm.Client, error) {
+	reg, err := NewRegistry(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return NewRoutedClient(NewRouter(reg, health, RouterConfig{
+		DefaultProvider: ProviderID(cfg.DefaultProvider),
+		DefaultModel:    ModelID(cfg.DefaultModel),
+	})), nil
+}

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -63,8 +63,8 @@ func NewRouterClient(cfg config.ProviderRuntimeConfig, health HealthChecker) (ll
 	if err != nil {
 		return nil, err
 	}
-	return NewRoutedClient(NewRouter(reg, health, RouterConfig{
+	return NewRoutedClientWithPolicy(NewRouter(reg, health, RouterConfig{
 		DefaultProvider: ProviderID(cfg.DefaultProvider),
 		DefaultModel:    ModelID(cfg.DefaultModel),
-	})), nil
+	}), cfg.AllowFallback), nil
 }

--- a/internal/provider/router.go
+++ b/internal/provider/router.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"sort"
 	"strings"
@@ -80,7 +79,7 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 		}
 		models, err := client.ListModels(ctx)
 		if err != nil {
-			warnings = append(warnings, Warning{ProviderID: providerID, Reason: fmt.Sprintf("provider_list_models_failed:%v", err)})
+			warnings = append(warnings, Warning{ProviderID: providerID, Reason: "provider_list_models_failed"})
 			continue
 		}
 		for _, model := range models {
@@ -158,8 +157,14 @@ func filterHealthyCandidates(ctx context.Context, health HealthChecker, candidat
 		return append([]routeCandidate(nil), candidates...)
 	}
 	filtered := make([]routeCandidate, 0, len(candidates))
+	checked := make(map[ProviderID]error, len(candidates))
 	for _, candidate := range candidates {
-		if err := health.Check(ctx, candidate.ProviderID); err == nil {
+		err, ok := checked[candidate.ProviderID]
+		if !ok {
+			err = health.Check(ctx, candidate.ProviderID)
+			checked[candidate.ProviderID] = err
+		}
+		if err == nil {
 			filtered = append(filtered, candidate)
 		}
 	}

--- a/internal/provider/router.go
+++ b/internal/provider/router.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"log"
 	"sort"
 	"strings"
@@ -42,7 +43,10 @@ func (r *registryRouter) Route(ctx context.Context, requestedModel ModelID, rc R
 	if len(filtered) == 0 {
 		return RouteResult{}, unavailableRouteError("no provider candidates available")
 	}
-	available := filterHealthyCandidates(ctx, r.health, filtered)
+	available, err := filterHealthyCandidates(ctx, r.health, filtered)
+	if err != nil {
+		return RouteResult{}, err
+	}
 	if len(available) == 0 {
 		return RouteResult{}, unavailableRouteError("no provider candidates available")
 	}
@@ -79,6 +83,9 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 		}
 		models, err := client.ListModels(ctx)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil, err
+			}
 			warnings = append(warnings, Warning{ProviderID: providerID, Reason: "provider_list_models_failed"})
 			continue
 		}
@@ -152,9 +159,9 @@ func filterCandidatesByModel(candidates []routeCandidate, requested ModelID) []r
 	return filtered
 }
 
-func filterHealthyCandidates(ctx context.Context, health HealthChecker, candidates []routeCandidate) []routeCandidate {
+func filterHealthyCandidates(ctx context.Context, health HealthChecker, candidates []routeCandidate) ([]routeCandidate, error) {
 	if health == nil {
-		return append([]routeCandidate(nil), candidates...)
+		return append([]routeCandidate(nil), candidates...), nil
 	}
 	filtered := make([]routeCandidate, 0, len(candidates))
 	checked := make(map[ProviderID]error, len(candidates))
@@ -162,13 +169,16 @@ func filterHealthyCandidates(ctx context.Context, health HealthChecker, candidat
 		err, ok := checked[candidate.ProviderID]
 		if !ok {
 			err = health.Check(ctx, candidate.ProviderID)
+			if errors.Is(err, context.Canceled) {
+				return nil, err
+			}
 			checked[candidate.ProviderID] = err
 		}
 		if err == nil {
 			filtered = append(filtered, candidate)
 		}
 	}
-	return filtered
+	return filtered, nil
 }
 
 func sortRouteCandidates(candidates []routeCandidate, requested ModelID, rc RouteContext, cfg RouterConfig) []routeCandidate {

--- a/internal/provider/router.go
+++ b/internal/provider/router.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -12,9 +13,10 @@ type RouterConfig struct {
 }
 
 type registryRouter struct {
-	registry Registry
-	health   HealthChecker
-	policy   RouterConfig
+	registry          Registry
+	health            HealthChecker
+	policy            RouterConfig
+	candidateWarnings []Warning
 }
 
 func NewRouter(reg Registry, health HealthChecker, cfg RouterConfig) Router {
@@ -65,6 +67,7 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 		return nil, err
 	}
 	candidates := make([]routeCandidate, 0, len(ids))
+	warnings := make([]Warning, 0)
 	seen := make(map[string]struct{})
 	for _, id := range ids {
 		client, ok := r.registry.Get(ctx, id)
@@ -77,6 +80,7 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 		}
 		models, err := client.ListModels(ctx)
 		if err != nil {
+			warnings = append(warnings, Warning{ProviderID: providerID, Reason: fmt.Sprintf("provider_list_models_failed:%v", err)})
 			continue
 		}
 		for _, model := range models {
@@ -96,7 +100,17 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 			})
 		}
 	}
+	r.candidateWarnings = warnings
 	return candidates, nil
+}
+
+func (r *registryRouter) CandidateWarnings() []Warning {
+	if r == nil || len(r.candidateWarnings) == 0 {
+		return nil
+	}
+	warnings := make([]Warning, len(r.candidateWarnings))
+	copy(warnings, r.candidateWarnings)
+	return warnings
 }
 
 func normalizeRouteProviderID(id ProviderID) ProviderID {

--- a/internal/provider/router.go
+++ b/internal/provider/router.go
@@ -1,0 +1,210 @@
+package provider
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+type RouterConfig struct {
+	DefaultProvider ProviderID
+	DefaultModel    ModelID
+}
+
+type registryRouter struct {
+	registry Registry
+	health   HealthChecker
+	policy   RouterConfig
+}
+
+func NewRouter(reg Registry, health HealthChecker, cfg RouterConfig) Router {
+	return &registryRouter{
+		registry: reg,
+		health:   health,
+		policy: RouterConfig{
+			DefaultProvider: normalizeRouteProviderID(cfg.DefaultProvider),
+			DefaultModel:    normalizeRouteModelID(cfg.DefaultModel),
+		},
+	}
+}
+
+func (r *registryRouter) Route(ctx context.Context, requestedModel ModelID, rc RouteContext) (RouteResult, error) {
+	if r == nil || r.registry == nil {
+		return RouteResult{}, unavailableRouteError("no provider candidates available")
+	}
+	candidates, err := r.collectCandidates(ctx)
+	if err != nil {
+		return RouteResult{}, err
+	}
+	requested := normalizeRouteModelID(requestedModel)
+	filtered := filterCandidatesByModel(candidates, requested)
+	if len(filtered) == 0 {
+		return RouteResult{}, unavailableRouteError("no provider candidates available")
+	}
+	available := filterHealthyCandidates(ctx, r.health, filtered)
+	if len(available) == 0 {
+		return RouteResult{}, unavailableRouteError("no provider candidates available")
+	}
+	ordered := sortRouteCandidates(available, requested, normalizeRouteContext(rc), r.policy)
+	if len(ordered) == 0 {
+		return RouteResult{}, unavailableRouteError("no provider candidates available")
+	}
+	result := RouteResult{Primary: toRouteTarget(ordered[0])}
+	if rc.AllowFallback {
+		result.Fallbacks = make([]RouteTarget, 0, len(ordered)-1)
+		for _, candidate := range ordered[1:] {
+			result.Fallbacks = append(result.Fallbacks, toRouteTarget(candidate))
+		}
+	}
+	return result, nil
+}
+
+func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidate, error) {
+	ids, err := r.registry.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]routeCandidate, 0, len(ids))
+	seen := make(map[string]struct{})
+	for _, id := range ids {
+		client, ok := r.registry.Get(ctx, id)
+		if !ok || client == nil {
+			continue
+		}
+		providerID := normalizeRouteProviderID(client.ProviderID())
+		if providerID == "" {
+			continue
+		}
+		models, err := client.ListModels(ctx)
+		if err != nil {
+			continue
+		}
+		for _, model := range models {
+			modelID := normalizeRouteModelID(model.ModelID)
+			if modelID == "" {
+				continue
+			}
+			key := string(providerID) + "\x00" + string(modelID)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			candidates = append(candidates, routeCandidate{
+				ProviderID: providerID,
+				ModelID:    modelID,
+				Client:     client,
+			})
+		}
+	}
+	return candidates, nil
+}
+
+func normalizeRouteProviderID(id ProviderID) ProviderID {
+	return ProviderID(strings.ToLower(strings.TrimSpace(string(id))))
+}
+
+func normalizeRouteModelID(id ModelID) ModelID {
+	return ModelID(strings.TrimSpace(string(id)))
+}
+
+func normalizeRouteContext(rc RouteContext) RouteContext {
+	rc.Scenario = strings.TrimSpace(rc.Scenario)
+	rc.Region = strings.TrimSpace(rc.Region)
+	if rc.Tags == nil {
+		rc.Tags = map[string]string{}
+	}
+	return rc
+}
+
+func unavailableRouteError(message string) *Error {
+	return &Error{
+		Code:      ErrCodeUnavailable,
+		Message:   message,
+		Retryable: true,
+		Err:       errorsUnavailable,
+	}
+}
+
+func toRouteTarget(candidate routeCandidate) RouteTarget {
+	return RouteTarget{
+		ProviderID: candidate.ProviderID,
+		ModelID:    candidate.ModelID,
+		Client:     candidate.Client,
+	}
+}
+
+func filterCandidatesByModel(candidates []routeCandidate, requested ModelID) []routeCandidate {
+	if requested == "" {
+		return append([]routeCandidate(nil), candidates...)
+	}
+	filtered := make([]routeCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.ModelID == requested {
+			filtered = append(filtered, candidate)
+		}
+	}
+	return filtered
+}
+
+func filterHealthyCandidates(ctx context.Context, health HealthChecker, candidates []routeCandidate) []routeCandidate {
+	if health == nil {
+		return append([]routeCandidate(nil), candidates...)
+	}
+	filtered := make([]routeCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if err := health.Check(ctx, candidate.ProviderID); err == nil {
+			filtered = append(filtered, candidate)
+		}
+	}
+	return filtered
+}
+
+func sortRouteCandidates(candidates []routeCandidate, requested ModelID, rc RouteContext, cfg RouterConfig) []routeCandidate {
+	ordered := append([]routeCandidate(nil), candidates...)
+	defaultProvider := normalizeRouteProviderID(cfg.DefaultProvider)
+	defaultModel := normalizeRouteModelID(cfg.DefaultModel)
+	preferredProvider := preferredRouteProvider(requested, rc)
+	preferLatency := rc.PreferLatency
+	preferLowCost := rc.PreferLowCost
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left := ordered[i]
+		right := ordered[j]
+		if left.ProviderID == preferredProvider && right.ProviderID != preferredProvider {
+			return true
+		}
+		if right.ProviderID == preferredProvider && left.ProviderID != preferredProvider {
+			return false
+		}
+		if left.ProviderID == defaultProvider && right.ProviderID != defaultProvider {
+			return true
+		}
+		if right.ProviderID == defaultProvider && left.ProviderID != defaultProvider {
+			return false
+		}
+		if left.ModelID == requested && right.ModelID != requested {
+			return true
+		}
+		if right.ModelID == requested && left.ModelID != requested {
+			return false
+		}
+		if left.ModelID == defaultModel && right.ModelID != defaultModel {
+			return true
+		}
+		if right.ModelID == defaultModel && left.ModelID != defaultModel {
+			return false
+		}
+		leftLatency, rightLatency := routeRankLatency(left.ProviderID), routeRankLatency(right.ProviderID)
+		leftCost, rightCost := routeRankCost(left.ProviderID), routeRankCost(right.ProviderID)
+		if preferLatency && leftLatency != rightLatency {
+			return leftLatency < rightLatency
+		}
+		if preferLowCost && leftCost != rightCost {
+			return leftCost < rightCost
+		}
+		if left.ProviderID != right.ProviderID {
+			return left.ProviderID < right.ProviderID
+		}
+		return left.ModelID < right.ModelID
+	})
+	return ordered
+}

--- a/internal/provider/router.go
+++ b/internal/provider/router.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 )
@@ -98,6 +99,9 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 				Client:     client,
 			})
 		}
+	}
+	for _, warning := range warnings {
+		log.Printf("provider router warning: provider=%s reason=%s", warning.ProviderID, warning.Reason)
 	}
 	return candidates, nil
 }

--- a/internal/provider/router.go
+++ b/internal/provider/router.go
@@ -13,10 +13,9 @@ type RouterConfig struct {
 }
 
 type registryRouter struct {
-	registry          Registry
-	health            HealthChecker
-	policy            RouterConfig
-	candidateWarnings []Warning
+	registry Registry
+	health   HealthChecker
+	policy   RouterConfig
 }
 
 func NewRouter(reg Registry, health HealthChecker, cfg RouterConfig) Router {
@@ -100,17 +99,7 @@ func (r *registryRouter) collectCandidates(ctx context.Context) ([]routeCandidat
 			})
 		}
 	}
-	r.candidateWarnings = warnings
 	return candidates, nil
-}
-
-func (r *registryRouter) CandidateWarnings() []Warning {
-	if r == nil || len(r.candidateWarnings) == 0 {
-		return nil
-	}
-	warnings := make([]Warning, len(r.candidateWarnings))
-	copy(warnings, r.candidateWarnings)
-	return warnings
 }
 
 func normalizeRouteProviderID(id ProviderID) ProviderID {

--- a/internal/provider/router_policy.go
+++ b/internal/provider/router_policy.go
@@ -1,0 +1,61 @@
+package provider
+
+type routeCandidate struct {
+	ProviderID ProviderID
+	ModelID    ModelID
+	Client     Client
+}
+
+var errorsUnavailable = ErrProviderNotFound
+
+func preferredRouteProvider(requested ModelID, rc RouteContext) ProviderID {
+	if id := normalizeRouteProviderID(ProviderID(rc.Tags["provider"])); id != "" {
+		return id
+	}
+	model := normalizeRouteModelID(requested)
+	if model == "" {
+		return ""
+	}
+	if isAnthropicModel(model) {
+		return ProviderAnthropic
+	}
+	if isOpenAIModel(model) {
+		return ProviderOpenAI
+	}
+	return ""
+}
+
+func routeRankLatency(id ProviderID) int {
+	switch normalizeRouteProviderID(id) {
+	case ProviderOpenAI:
+		return 1
+	case ProviderAnthropic:
+		return 2
+	default:
+		return 10
+	}
+}
+
+func routeRankCost(id ProviderID) int {
+	switch normalizeRouteProviderID(id) {
+	case ProviderAnthropic:
+		return 1
+	case ProviderOpenAI:
+		return 2
+	default:
+		return 10
+	}
+}
+
+func isAnthropicModel(model ModelID) bool {
+	value := string(model)
+	return len(value) >= len("claude") && value[:len("claude")] == "claude"
+}
+
+func isOpenAIModel(model ModelID) bool {
+	value := string(model)
+	if len(value) >= len("gpt") && value[:len("gpt")] == "gpt" {
+		return true
+	}
+	return len(value) >= len("o1") && value[:len("o1")] == "o1"
+}

--- a/internal/provider/router_policy.go
+++ b/internal/provider/router_policy.go
@@ -1,12 +1,14 @@
 package provider
 
+import "errors"
+
 type routeCandidate struct {
 	ProviderID ProviderID
 	ModelID    ModelID
 	Client     Client
 }
 
-var errorsUnavailable = ErrProviderNotFound
+var errorsUnavailable = errors.New(string(ErrCodeUnavailable))
 
 func preferredRouteProvider(requested ModelID, rc RouteContext) ProviderID {
 	if id := normalizeRouteProviderID(ProviderID(rc.Tags["provider"])); id != "" {

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -73,7 +73,7 @@ func (s *stubRouterClient) Stream(_ context.Context, req Request) (<-chan Event,
 				ch <- Event{Type: EventError, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Error: providerErr}
 				return
 			}
-			ch <- Event{Type: EventError, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Error: &Error{Code: ErrCodeUnavailable, Provider: s.providerID, Message: result.err.Error(), Retryable: false, Err: result.err}}
+			ch <- Event{Type: EventError, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Error: &Error{Code: ErrCodeUnavailable, Provider: s.providerID, Message: "provider unavailable", Retryable: true, Err: result.err, Detail: result.err.Error()}}
 			return
 		}
 		message := result.message

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -251,12 +251,25 @@ func TestRouterRouteHandlesNilRegistryAndNoHealthyCandidates(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unavailable error")
 	}
+	reg = stubRegistry{ids: []ProviderID{"openai"}, clients: map[ProviderID]Client{"openai": &stubRouterClient{providerID: "openai", modelsErr: context.Canceled}}}
+	_, err = NewRouter(reg, nil, RouterConfig{}).Route(context.Background(), "gpt-5.4", RouteContext{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected list models cancellation to propagate, got %v", err)
+	}
+	reg = stubRegistry{ids: []ProviderID{"openai"}, clients: map[ProviderID]Client{"openai": &stubRouterClient{providerID: "openai", models: []ModelInfo{{ModelID: "gpt-5.4"}}}}}
+	_, err = NewRouter(reg, stubHealthChecker{errors: map[ProviderID]error{"openai": context.Canceled}}, RouterConfig{}).Route(context.Background(), "gpt-5.4", RouteContext{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected health check cancellation to propagate, got %v", err)
+	}
 }
 
 func TestFilterHealthyCandidatesChecksEachProviderOnce(t *testing.T) {
 	health := stubHealthChecker{calls: map[ProviderID]int{}, errors: map[ProviderID]error{"backup": errors.New("down")}}
 	candidates := []routeCandidate{{ProviderID: "openai", ModelID: "gpt-5.4"}, {ProviderID: "openai", ModelID: "gpt-4.1"}, {ProviderID: "backup", ModelID: "gpt-5.4"}, {ProviderID: "backup", ModelID: "gpt-4.1"}}
-	filtered := filterHealthyCandidates(context.Background(), health, candidates)
+	filtered, err := filterHealthyCandidates(context.Background(), health, candidates)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	if len(filtered) != 2 {
 		t.Fatalf("unexpected filtered candidates %#v", filtered)
 	}
@@ -279,8 +292,8 @@ func TestRouteHelpersAndPolicyBranches(t *testing.T) {
 	if got := filterCandidatesByModel([]routeCandidate{{ProviderID: "a", ModelID: "m1"}, {ProviderID: "b", ModelID: "m2"}}, ""); len(got) != 2 {
 		t.Fatalf("unexpected candidates %#v", got)
 	}
-	if got := filterHealthyCandidates(context.Background(), nil, []routeCandidate{{ProviderID: "a"}}); len(got) != 1 {
-		t.Fatalf("unexpected healthy candidates %#v", got)
+	if got, err := filterHealthyCandidates(context.Background(), nil, []routeCandidate{{ProviderID: "a"}}); err != nil || len(got) != 1 {
+		t.Fatalf("unexpected healthy candidates %#v err=%v", got, err)
 	}
 	ordered := sortRouteCandidates([]routeCandidate{{ProviderID: "anthropic", ModelID: "claude-3"}, {ProviderID: "openai", ModelID: "gpt-5.4"}, {ProviderID: "zeta", ModelID: "z1"}}, "gpt-5.4", RouteContext{PreferLatency: true}, RouterConfig{})
 	if ordered[0].ProviderID != "openai" {

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -14,9 +14,13 @@ import (
 
 type stubHealthChecker struct {
 	errors map[ProviderID]error
+	calls  map[ProviderID]int
 }
 
 func (s stubHealthChecker) Check(_ context.Context, id ProviderID) error {
+	if s.calls != nil {
+		s.calls[id]++
+	}
 	if s.errors == nil {
 		return nil
 	}
@@ -217,8 +221,12 @@ func TestRouterCollectCandidatesSkipsInvalidEntries(t *testing.T) {
 	if len(candidates) != 2 {
 		t.Fatalf("unexpected candidates %#v", candidates)
 	}
-	if !strings.Contains(buf.String(), "provider=broken") || !strings.Contains(buf.String(), "provider_list_models_failed") {
-		t.Fatalf("expected warning log, got %q", buf.String())
+	logged := buf.String()
+	if !strings.Contains(logged, "provider=broken") || !strings.Contains(logged, "provider_list_models_failed") {
+		t.Fatalf("expected warning log, got %q", logged)
+	}
+	if strings.Contains(logged, "boom") {
+		t.Fatalf("expected warning log to omit raw upstream error, got %q", logged)
 	}
 }
 
@@ -237,6 +245,18 @@ func TestRouterRouteHandlesNilRegistryAndNoHealthyCandidates(t *testing.T) {
 	_, err := NewRouter(reg, stubHealthChecker{errors: map[ProviderID]error{"openai": errors.New("down")}}, RouterConfig{}).Route(context.Background(), "gpt-5.4", RouteContext{AllowFallback: true})
 	if err == nil {
 		t.Fatal("expected unavailable error")
+	}
+}
+
+func TestFilterHealthyCandidatesChecksEachProviderOnce(t *testing.T) {
+	health := stubHealthChecker{calls: map[ProviderID]int{}, errors: map[ProviderID]error{"backup": errors.New("down")}}
+	candidates := []routeCandidate{{ProviderID: "openai", ModelID: "gpt-5.4"}, {ProviderID: "openai", ModelID: "gpt-4.1"}, {ProviderID: "backup", ModelID: "gpt-5.4"}, {ProviderID: "backup", ModelID: "gpt-4.1"}}
+	filtered := filterHealthyCandidates(context.Background(), health, candidates)
+	if len(filtered) != 2 {
+		t.Fatalf("unexpected filtered candidates %#v", filtered)
+	}
+	if health.calls["openai"] != 1 || health.calls["backup"] != 1 {
+		t.Fatalf("expected one health check per provider, got %#v", health.calls)
 	}
 }
 

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -1,0 +1,142 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"bytemind/internal/config"
+	"bytemind/internal/llm"
+)
+
+type stubHealthChecker struct {
+	errors map[ProviderID]error
+}
+
+func (s stubHealthChecker) Check(_ context.Context, id ProviderID) error {
+	if s.errors == nil {
+		return nil
+	}
+	return s.errors[id]
+}
+
+type stubRouterClient struct {
+	providerID ProviderID
+	models     []ModelInfo
+	streams    []stubRouterStreamResult
+	streamReqs []llm.ChatRequest
+}
+
+type stubRouterStreamResult struct {
+	message llm.Message
+	err     error
+	deltas  []string
+}
+
+func (s *stubRouterClient) ProviderID() ProviderID                          { return s.providerID }
+func (s *stubRouterClient) ListModels(context.Context) ([]ModelInfo, error) { return s.models, nil }
+func (s *stubRouterClient) Stream(_ context.Context, req Request) (<-chan Event, error) {
+	idx := len(s.streamReqs)
+	s.streamReqs = append(s.streamReqs, req.ChatRequest)
+	result := stubRouterStreamResult{}
+	if idx < len(s.streams) {
+		result = s.streams[idx]
+	}
+	ch := make(chan Event, len(result.deltas)+3)
+	go func() {
+		defer close(ch)
+		ch <- Event{Type: EventStart, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID}
+		for _, delta := range result.deltas {
+			ch <- Event{Type: EventDelta, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Delta: delta}
+		}
+		if result.err != nil {
+			var providerErr *Error
+			if errors.As(result.err, &providerErr) {
+				ch <- Event{Type: EventError, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Error: providerErr}
+				return
+			}
+			ch <- Event{Type: EventError, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Error: &Error{Code: ErrCodeUnavailable, Provider: s.providerID, Message: result.err.Error(), Retryable: false, Err: result.err}}
+			return
+		}
+		message := result.message
+		message.Normalize()
+		ch <- Event{Type: EventResult, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Result: &message}
+	}()
+	return ch, nil
+}
+
+func TestRouterRoutesRequestedModelWithFallbacks(t *testing.T) {
+	reg, _ := NewRegistryFromProviderConfig(config.ProviderConfig{Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key", Model: "gpt-5.4"})
+	_ = reg.Register(context.Background(), &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}})
+	router := NewRouter(reg, nil, RouterConfig{DefaultProvider: ProviderOpenAI, DefaultModel: "gpt-5.4"})
+	result, err := router.Route(context.Background(), "gpt-5.4", RouteContext{AllowFallback: true})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Primary.ProviderID != ProviderOpenAI || result.Primary.ModelID != "gpt-5.4" {
+		t.Fatalf("unexpected primary %#v", result.Primary)
+	}
+	if len(result.Fallbacks) != 1 || result.Fallbacks[0].ProviderID != "backup" {
+		t.Fatalf("unexpected fallbacks %#v", result.Fallbacks)
+	}
+}
+
+func TestRouterFiltersUnhealthyProviders(t *testing.T) {
+	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
+	_ = reg.Register(context.Background(), &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}})
+	_ = reg.Register(context.Background(), &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}})
+	router := NewRouter(reg, stubHealthChecker{errors: map[ProviderID]error{"openai": errors.New("down")}}, RouterConfig{})
+	result, err := router.Route(context.Background(), "gpt-5.4", RouteContext{AllowFallback: true})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Primary.ProviderID != "backup" {
+		t.Fatalf("unexpected primary %#v", result.Primary)
+	}
+}
+
+func TestRouterReturnsUnavailableWithoutCandidates(t *testing.T) {
+	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
+	router := NewRouter(reg, nil, RouterConfig{})
+	_, err := router.Route(context.Background(), "missing", RouteContext{AllowFallback: true})
+	var providerErr *Error
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
+		t.Fatalf("unexpected error %#v", err)
+	}
+}
+
+func TestRoutedClientFallsBackOnRetryableProviderError(t *testing.T) {
+	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeRateLimited, Provider: "openai", Message: "rate limited", Retryable: true}}}}
+	fallback := &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}, deltas: []string{"o", "k"}}}}
+	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
+	_ = reg.Register(context.Background(), primary)
+	_ = reg.Register(context.Background(), fallback)
+	client := NewRoutedClient(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}))
+	msg, err := client.StreamMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if msg.Content != "ok" {
+		t.Fatalf("unexpected message %#v", msg)
+	}
+	if len(primary.streamReqs) != 1 || len(fallback.streamReqs) != 1 {
+		t.Fatalf("unexpected request counts primary=%d fallback=%d", len(primary.streamReqs), len(fallback.streamReqs))
+	}
+}
+
+func TestRoutedClientStopsOnNonRetryableProviderError(t *testing.T) {
+	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeBadRequest, Provider: "openai", Message: "bad request", Retryable: false}}}}
+	fallback := &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}}
+	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
+	_ = reg.Register(context.Background(), primary)
+	_ = reg.Register(context.Background(), fallback)
+	client := NewRoutedClient(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}))
+	_, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"})
+	var providerErr *Error
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeBadRequest {
+		t.Fatalf("unexpected error %#v", err)
+	}
+	if len(fallback.streamReqs) != 0 {
+		t.Fatalf("expected fallback to be skipped, got %d calls", len(fallback.streamReqs))
+	}
+}

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -150,24 +150,29 @@ func TestRouterReturnsUnavailableWithoutCandidates(t *testing.T) {
 }
 
 func TestRoutedClientFallsBackOnRetryableProviderError(t *testing.T) {
-	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeRateLimited, Provider: "openai", Message: "rate limited", Retryable: true}, deltas: []string{"bad"}}}}
+	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}}, {err: &Error{Code: ErrCodeRateLimited, Provider: "openai", Message: "rate limited", Retryable: true}, deltas: []string{"bad"}}}}
 	fallback := &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}, deltas: []string{"o", "k"}}}}
 	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
 	_ = reg.Register(context.Background(), primary)
 	_ = reg.Register(context.Background(), fallback)
 	client := NewRoutedClientWithPolicy(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}), true)
-	var streamed []string
-	msg, err := client.StreamMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}, func(delta string) { streamed = append(streamed, delta) })
+	msg, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if msg.Content != "ok" {
 		t.Fatalf("unexpected message %#v", msg)
 	}
-	if strings.Join(streamed, "") != "badok" {
-		t.Fatalf("expected realtime primary+fallback deltas, got %#v", streamed)
+	var streamed []string
+	_, err = client.StreamMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}, func(delta string) { streamed = append(streamed, delta) })
+	var providerErr *Error
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeRateLimited || !providerErr.Retryable {
+		t.Fatalf("expected streamed attempt to stop on retryable primary error after delta, got %#v", err)
 	}
-	if len(primary.streamReqs) != 1 || len(fallback.streamReqs) != 1 {
+	if strings.Join(streamed, "") != "bad" {
+		t.Fatalf("expected only primary streamed delta before stopping, got %#v", streamed)
+	}
+	if len(primary.streamReqs) != 2 || len(fallback.streamReqs) != 0 {
 		t.Fatalf("unexpected request counts primary=%d fallback=%d", len(primary.streamReqs), len(fallback.streamReqs))
 	}
 }
@@ -413,6 +418,11 @@ func TestExecuteTargetCoversBranches(t *testing.T) {
 	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeBadRequest || providerErr.Retryable || providerErr.Provider != "openai" || providerErr.Detail != "raw" {
 		t.Fatalf("expected normalized event error, got %#v", err)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventError, Error: &Error{Err: context.Canceled}}}}}}
+	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected event error cancellation, got %v", err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventError}}}}}
 	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -23,31 +23,46 @@ func (s stubHealthChecker) Check(_ context.Context, id ProviderID) error {
 type stubRouterClient struct {
 	providerID ProviderID
 	models     []ModelInfo
+	modelsErr  error
+	streamErr  error
 	streams    []stubRouterStreamResult
 	streamReqs []llm.ChatRequest
 }
 
 type stubRouterStreamResult struct {
-	message llm.Message
-	err     error
-	deltas  []string
+	message     llm.Message
+	err         error
+	deltas      []string
+	events      []Event
+	skipAutoEnd bool
 }
 
-func (s *stubRouterClient) ProviderID() ProviderID                          { return s.providerID }
-func (s *stubRouterClient) ListModels(context.Context) ([]ModelInfo, error) { return s.models, nil }
+func (s *stubRouterClient) ProviderID() ProviderID { return s.providerID }
+func (s *stubRouterClient) ListModels(context.Context) ([]ModelInfo, error) {
+	return s.models, s.modelsErr
+}
 func (s *stubRouterClient) Stream(_ context.Context, req Request) (<-chan Event, error) {
+	if s.streamErr != nil {
+		return nil, s.streamErr
+	}
 	idx := len(s.streamReqs)
 	s.streamReqs = append(s.streamReqs, req.ChatRequest)
 	result := stubRouterStreamResult{}
 	if idx < len(s.streams) {
 		result = s.streams[idx]
 	}
-	ch := make(chan Event, len(result.deltas)+3)
+	ch := make(chan Event, len(result.deltas)+len(result.events)+3)
 	go func() {
 		defer close(ch)
 		ch <- Event{Type: EventStart, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID}
 		for _, delta := range result.deltas {
 			ch <- Event{Type: EventDelta, ProviderID: s.providerID, ModelID: ModelID(req.Model), TraceID: req.TraceID, Delta: delta}
+		}
+		for _, event := range result.events {
+			ch <- event
+		}
+		if result.skipAutoEnd {
+			return
 		}
 		if result.err != nil {
 			var providerErr *Error
@@ -64,6 +79,28 @@ func (s *stubRouterClient) Stream(_ context.Context, req Request) (<-chan Event,
 	}()
 	return ch, nil
 }
+
+type stubRouter struct {
+	result RouteResult
+	err    error
+}
+
+func (s stubRouter) Route(context.Context, ModelID, RouteContext) (RouteResult, error) {
+	return s.result, s.err
+}
+
+type stubRegistry struct {
+	ids     []ProviderID
+	listErr error
+	clients map[ProviderID]Client
+}
+
+func (s stubRegistry) Register(context.Context, Client) error { return nil }
+func (s stubRegistry) Get(_ context.Context, id ProviderID) (Client, bool) {
+	client, ok := s.clients[id]
+	return client, ok
+}
+func (s stubRegistry) List(context.Context) ([]ProviderID, error) { return s.ids, s.listErr }
 
 func TestRouterRoutesRequestedModelWithFallbacks(t *testing.T) {
 	reg, _ := NewRegistryFromProviderConfig(config.ProviderConfig{Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key", Model: "gpt-5.4"})
@@ -138,5 +175,171 @@ func TestRoutedClientStopsOnNonRetryableProviderError(t *testing.T) {
 	}
 	if len(fallback.streamReqs) != 0 {
 		t.Fatalf("expected fallback to be skipped, got %d calls", len(fallback.streamReqs))
+	}
+}
+
+func TestRouterNoFallbacksWhenDisabled(t *testing.T) {
+	reg := stubRegistry{ids: []ProviderID{"openai", "backup"}, clients: map[ProviderID]Client{
+		"openai": &stubRouterClient{providerID: "openai", models: []ModelInfo{{ModelID: "gpt-5.4"}}},
+		"backup": &stubRouterClient{providerID: "backup", models: []ModelInfo{{ModelID: "gpt-5.4"}}},
+	}}
+	result, err := NewRouter(reg, nil, RouterConfig{}).Route(context.Background(), "gpt-5.4", RouteContext{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(result.Fallbacks) != 0 {
+		t.Fatalf("expected no fallbacks, got %#v", result.Fallbacks)
+	}
+}
+
+func TestRouterCollectCandidatesSkipsInvalidEntries(t *testing.T) {
+	reg := stubRegistry{ids: []ProviderID{"missing", "blank", "broken", "dup", "valid"}, clients: map[ProviderID]Client{
+		"blank":  &stubRouterClient{providerID: "   ", models: []ModelInfo{{ModelID: "gpt-5.4"}}},
+		"broken": &stubRouterClient{providerID: "broken", modelsErr: errors.New("boom")},
+		"dup":    &stubRouterClient{providerID: "dup", models: []ModelInfo{{ModelID: "gpt-5.4"}, {ModelID: "gpt-5.4"}, {ModelID: "   "}}},
+		"valid":  &stubRouterClient{providerID: "valid", models: []ModelInfo{{ModelID: "gpt-4.1"}}},
+	}}
+	candidates, err := (&registryRouter{registry: reg}).collectCandidates(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("unexpected candidates %#v", candidates)
+	}
+}
+
+func TestRouterCollectCandidatesPropagatesListError(t *testing.T) {
+	_, err := (&registryRouter{registry: stubRegistry{listErr: errors.New("boom")}}).collectCandidates(context.Background())
+	if err == nil {
+		t.Fatal("expected list error")
+	}
+}
+
+func TestRouterRouteHandlesNilRegistryAndNoHealthyCandidates(t *testing.T) {
+	if _, err := (*registryRouter)(nil).Route(context.Background(), "gpt-5.4", RouteContext{}); err == nil {
+		t.Fatal("expected nil router error")
+	}
+	reg := stubRegistry{ids: []ProviderID{"openai"}, clients: map[ProviderID]Client{"openai": &stubRouterClient{providerID: "openai", models: []ModelInfo{{ModelID: "gpt-5.4"}}}}}
+	_, err := NewRouter(reg, stubHealthChecker{errors: map[ProviderID]error{"openai": errors.New("down")}}, RouterConfig{}).Route(context.Background(), "gpt-5.4", RouteContext{AllowFallback: true})
+	if err == nil {
+		t.Fatal("expected unavailable error")
+	}
+}
+
+func TestRouteHelpersAndPolicyBranches(t *testing.T) {
+	if normalizeRouteProviderID(" OpenAI ") != "openai" || normalizeRouteModelID(" gpt-5.4 ") != "gpt-5.4" {
+		t.Fatal("expected normalization to trim values")
+	}
+	rc := normalizeRouteContext(RouteContext{Scenario: " chat ", Region: " us ", Tags: nil})
+	if rc.Scenario != "chat" || rc.Region != "us" || rc.Tags == nil {
+		t.Fatalf("unexpected context %#v", rc)
+	}
+	if toRouteTarget(routeCandidate{ProviderID: "openai", ModelID: "gpt-5.4"}).ProviderID != "openai" {
+		t.Fatal("expected target conversion")
+	}
+	if got := filterCandidatesByModel([]routeCandidate{{ProviderID: "a", ModelID: "m1"}, {ProviderID: "b", ModelID: "m2"}}, ""); len(got) != 2 {
+		t.Fatalf("unexpected candidates %#v", got)
+	}
+	if got := filterHealthyCandidates(context.Background(), nil, []routeCandidate{{ProviderID: "a"}}); len(got) != 1 {
+		t.Fatalf("unexpected healthy candidates %#v", got)
+	}
+	ordered := sortRouteCandidates([]routeCandidate{{ProviderID: "anthropic", ModelID: "claude-3"}, {ProviderID: "openai", ModelID: "gpt-5.4"}, {ProviderID: "zeta", ModelID: "z1"}}, "gpt-5.4", RouteContext{PreferLatency: true}, RouterConfig{})
+	if ordered[0].ProviderID != "openai" {
+		t.Fatalf("unexpected order %#v", ordered)
+	}
+	ordered = sortRouteCandidates([]routeCandidate{{ProviderID: "openai", ModelID: "gpt-5.4"}, {ProviderID: "anthropic", ModelID: "claude-3"}}, "", RouteContext{PreferLowCost: true}, RouterConfig{})
+	if ordered[0].ProviderID != "anthropic" {
+		t.Fatalf("unexpected cost order %#v", ordered)
+	}
+	ordered = sortRouteCandidates([]routeCandidate{{ProviderID: "beta", ModelID: "m2"}, {ProviderID: "alpha", ModelID: "m1"}}, "", RouteContext{}, RouterConfig{})
+	if ordered[0].ProviderID != "alpha" {
+		t.Fatalf("unexpected lexical order %#v", ordered)
+	}
+	if preferredRouteProvider("claude-3", RouteContext{}) != ProviderAnthropic {
+		t.Fatal("expected anthropic preference")
+	}
+	if preferredRouteProvider("gpt-5.4", RouteContext{}) != ProviderOpenAI {
+		t.Fatal("expected openai preference")
+	}
+	if preferredRouteProvider("", RouteContext{Tags: map[string]string{"provider": " backup "}}) != "backup" {
+		t.Fatal("expected tag provider preference")
+	}
+	if preferredRouteProvider("custom", RouteContext{}) != "" {
+		t.Fatal("expected no preferred provider")
+	}
+	if routeRankLatency("openai") >= routeRankLatency("anthropic") {
+		t.Fatal("expected openai latency rank ahead")
+	}
+	if routeRankCost("anthropic") >= routeRankCost("openai") {
+		t.Fatal("expected anthropic cost rank ahead")
+	}
+	if routeRankLatency("other") != 10 || routeRankCost("other") != 10 {
+		t.Fatal("expected default ranks")
+	}
+	if !isAnthropicModel("claude-3") || isAnthropicModel("gpt-5") {
+		t.Fatal("unexpected anthropic model detection")
+	}
+	if !isOpenAIModel("gpt-5") || !isOpenAIModel("o1-mini") || isOpenAIModel("claude-3") {
+		t.Fatal("unexpected openai model detection")
+	}
+}
+
+func TestUnavailableRouteError(t *testing.T) {
+	err := unavailableRouteError("no candidates")
+	if err.Code != ErrCodeUnavailable || !err.Retryable || err.Message != "no candidates" {
+		t.Fatalf("unexpected error %#v", err)
+	}
+}
+
+func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
+	if NewRoutedClient(nil) != nil {
+		t.Fatal("expected nil routed client for nil router")
+	}
+	var client *RoutedClient
+	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{}); err == nil {
+		t.Fatal("expected unavailable error")
+	}
+	client = &RoutedClient{router: stubRouter{err: errors.New("route failed")}}
+	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{}); err == nil {
+		t.Fatal("expected route error")
+	}
+	client = &RoutedClient{router: stubRouter{result: RouteResult{Primary: RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4"}}}}
+	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}); err == nil {
+		t.Fatal("expected unavailable when target client missing")
+	}
+}
+
+func TestExecuteTargetCoversBranches(t *testing.T) {
+	client := &stubRouterClient{providerID: "openai", streamErr: errors.New("stream setup failed")}
+	if _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil); err == nil {
+		t.Fatal("expected stream setup error")
+	}
+	var deltas []string
+	tool := llm.ToolCall{ID: "1", Type: "function", Function: llm.ToolFunctionCall{Name: "ls", Arguments: "{}"}}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}, {Type: EventError, Error: nil}}, deltas: []string{"a", ""}, skipAutoEnd: true}}}
+	msg, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { deltas = append(deltas, delta) })
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(deltas) != 1 || len(msg.ToolCalls) != 1 || msg.Usage == nil || msg.Usage.TotalTokens != 3 {
+		t.Fatalf("unexpected message %#v deltas=%#v", msg, deltas)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult}}}}}
+	msg, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	if err != nil || msg.Content != "" {
+		t.Fatalf("unexpected result %#v err=%v", msg, err)
+	}
+}
+
+func TestNewRouterClient(t *testing.T) {
+	client, err := NewRouterClient(config.ProviderRuntimeConfig{DefaultProvider: "openai", DefaultModel: "gpt-5.4", Providers: map[string]config.ProviderConfig{"openai": {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key", Model: "gpt-5.4"}}}, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, ok := client.(*RoutedClient); !ok {
+		t.Fatalf("expected routed client, got %T", client)
+	}
+	if _, err := NewRouterClient(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"broken": {Type: ""}}}, nil); err == nil {
+		t.Fatal("expected registry error")
 	}
 }

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -148,7 +148,7 @@ func TestRoutedClientFallsBackOnRetryableProviderError(t *testing.T) {
 	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
 	_ = reg.Register(context.Background(), primary)
 	_ = reg.Register(context.Background(), fallback)
-	client := NewRoutedClient(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}))
+	client := NewRoutedClientWithPolicy(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}), true)
 	msg, err := client.StreamMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -167,7 +167,7 @@ func TestRoutedClientStopsOnNonRetryableProviderError(t *testing.T) {
 	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
 	_ = reg.Register(context.Background(), primary)
 	_ = reg.Register(context.Background(), fallback)
-	client := NewRoutedClient(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}))
+	client := NewRoutedClientWithPolicy(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}), true)
 	_, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"})
 	var providerErr *Error
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeBadRequest {
@@ -255,6 +255,18 @@ func TestRouteHelpersAndPolicyBranches(t *testing.T) {
 	if ordered[0].ProviderID != "alpha" {
 		t.Fatalf("unexpected lexical order %#v", ordered)
 	}
+	ordered = sortRouteCandidates([]routeCandidate{{ProviderID: "backup", ModelID: "m1"}, {ProviderID: "openai", ModelID: "m2"}}, "", RouteContext{}, RouterConfig{DefaultProvider: "openai"})
+	if ordered[0].ProviderID != "openai" {
+		t.Fatalf("unexpected default provider order %#v", ordered)
+	}
+	ordered = sortRouteCandidates([]routeCandidate{{ProviderID: "backup", ModelID: "m1"}, {ProviderID: "backup", ModelID: "m2"}}, "", RouteContext{}, RouterConfig{DefaultModel: "m2"})
+	if ordered[0].ModelID != "m2" {
+		t.Fatalf("unexpected default model order %#v", ordered)
+	}
+	ordered = sortRouteCandidates([]routeCandidate{{ProviderID: "openai", ModelID: "gpt-5.4"}, {ProviderID: "backup", ModelID: "gpt-5.4"}}, "gpt-5.4", RouteContext{Tags: map[string]string{"provider": " backup "}}, RouterConfig{})
+	if ordered[0].ProviderID != "backup" {
+		t.Fatalf("unexpected tagged provider order %#v", ordered)
+	}
 	if preferredRouteProvider("claude-3", RouteContext{}) != ProviderAnthropic {
 		t.Fatal("expected anthropic preference")
 	}
@@ -307,6 +319,15 @@ func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
 	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}); err == nil {
 		t.Fatal("expected unavailable when target client missing")
 	}
+	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeRateLimited, Provider: "openai", Message: "rate limited", Retryable: true}}}}
+	fallback := &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}}
+	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
+	_ = reg.Register(context.Background(), primary)
+	_ = reg.Register(context.Background(), fallback)
+	client = NewRoutedClient(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"})).(*RoutedClient)
+	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}); err == nil {
+		t.Fatal("expected fallback disabled error")
+	}
 }
 
 func TestExecuteTargetCoversBranches(t *testing.T) {
@@ -316,28 +337,38 @@ func TestExecuteTargetCoversBranches(t *testing.T) {
 	}
 	var deltas []string
 	tool := llm.ToolCall{ID: "1", Type: "function", Function: llm.ToolFunctionCall{Name: "ls", Arguments: "{}"}}
-	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}, {Type: EventError, Error: nil}}, deltas: []string{"a", ""}, skipAutoEnd: true}}}
-	msg, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { deltas = append(deltas, delta) })
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}}, deltas: []string{"a", ""}, skipAutoEnd: true}}}
+	_, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { deltas = append(deltas, delta) })
+	var providerErr *Error
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
+		t.Fatalf("expected unavailable error, got %v", err)
 	}
-	if len(deltas) != 1 || len(msg.ToolCalls) != 1 || msg.Usage == nil || msg.Usage.TotalTokens != 3 {
-		t.Fatalf("unexpected message %#v deltas=%#v", msg, deltas)
+	if len(deltas) != 1 {
+		t.Fatalf("unexpected deltas %#v", deltas)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult}}}}}
-	msg, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	msg, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
 	if err != nil || msg.Content != "" {
 		t.Fatalf("unexpected result %#v err=%v", msg, err)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
+	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
+		t.Fatalf("expected delta termination error, got %v", err)
 	}
 }
 
 func TestNewRouterClient(t *testing.T) {
-	client, err := NewRouterClient(config.ProviderRuntimeConfig{DefaultProvider: "openai", DefaultModel: "gpt-5.4", Providers: map[string]config.ProviderConfig{"openai": {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key", Model: "gpt-5.4"}}}, nil)
+	client, err := NewRouterClient(config.ProviderRuntimeConfig{DefaultProvider: "openai", DefaultModel: "gpt-5.4", AllowFallback: true, Providers: map[string]config.ProviderConfig{"openai": {Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "key", Model: "gpt-5.4"}}}, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if _, ok := client.(*RoutedClient); !ok {
+	routed, ok := client.(*RoutedClient)
+	if !ok {
 		t.Fatalf("expected routed client, got %T", client)
+	}
+	if !routed.allowFallback {
+		t.Fatal("expected routed client fallback to be enabled")
 	}
 	if _, err := NewRouterClient(config.ProviderRuntimeConfig{Providers: map[string]config.ProviderConfig{"broken": {Type: ""}}}, nil); err == nil {
 		t.Fatal("expected registry error")

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -1,8 +1,11 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
+	"strings"
 	"testing"
 
 	"bytemind/internal/config"
@@ -199,12 +202,19 @@ func TestRouterCollectCandidatesSkipsInvalidEntries(t *testing.T) {
 		"dup":    &stubRouterClient{providerID: "dup", models: []ModelInfo{{ModelID: "gpt-5.4"}, {ModelID: "gpt-5.4"}, {ModelID: "   "}}},
 		"valid":  &stubRouterClient{providerID: "valid", models: []ModelInfo{{ModelID: "gpt-4.1"}}},
 	}}
+	var buf bytes.Buffer
+	prevWriter := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prevWriter)
 	candidates, err := (&registryRouter{registry: reg}).collectCandidates(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if len(candidates) != 2 {
 		t.Fatalf("unexpected candidates %#v", candidates)
+	}
+	if !strings.Contains(buf.String(), "provider=broken") || !strings.Contains(buf.String(), "provider_list_models_failed") {
+		t.Fatalf("expected warning log, got %q", buf.String())
 	}
 }
 
@@ -328,6 +338,14 @@ func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
 	if _, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}); err == nil {
 		t.Fatal("expected fallback disabled error")
 	}
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := NewRoutedClientWithPolicy(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}), true).CreateMessage(cancelCtx, llm.ChatRequest{Model: "gpt-5.4"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+	if len(fallback.streamReqs) != 0 {
+		t.Fatalf("expected canceled request to skip fallback, got %d fallback calls", len(fallback.streamReqs))
+	}
 }
 
 func TestExecuteTargetCoversBranches(t *testing.T) {
@@ -355,6 +373,13 @@ func TestExecuteTargetCoversBranches(t *testing.T) {
 	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected nil-payload error event to fail, got %v", err)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = executeTarget(cancelCtx, RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
 	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -146,18 +146,22 @@ func TestRouterReturnsUnavailableWithoutCandidates(t *testing.T) {
 }
 
 func TestRoutedClientFallsBackOnRetryableProviderError(t *testing.T) {
-	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeRateLimited, Provider: "openai", Message: "rate limited", Retryable: true}}}}
+	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeRateLimited, Provider: "openai", Message: "rate limited", Retryable: true}, deltas: []string{"bad"}}}}
 	fallback := &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}, deltas: []string{"o", "k"}}}}
 	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
 	_ = reg.Register(context.Background(), primary)
 	_ = reg.Register(context.Background(), fallback)
 	client := NewRoutedClientWithPolicy(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}), true)
-	msg, err := client.StreamMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}, nil)
+	var streamed []string
+	msg, err := client.StreamMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"}, func(delta string) { streamed = append(streamed, delta) })
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if msg.Content != "ok" {
 		t.Fatalf("unexpected message %#v", msg)
+	}
+	if strings.Join(streamed, "") != "ok" {
+		t.Fatalf("expected only fallback deltas, got %#v", streamed)
 	}
 	if len(primary.streamReqs) != 1 || len(fallback.streamReqs) != 1 {
 		t.Fatalf("unexpected request counts primary=%d fallback=%d", len(primary.streamReqs), len(fallback.streamReqs))
@@ -350,39 +354,47 @@ func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
 
 func TestExecuteTargetCoversBranches(t *testing.T) {
 	client := &stubRouterClient{providerID: "openai", streamErr: errors.New("stream setup failed")}
-	if _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil); err == nil {
+	if _, _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}); err == nil {
 		t.Fatal("expected stream setup error")
 	}
 	var deltas []string
 	tool := llm.ToolCall{ID: "1", Type: "function", Function: llm.ToolFunctionCall{Name: "ls", Arguments: "{}"}}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}}, deltas: []string{"a", ""}, skipAutoEnd: true}}}
-	_, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { deltas = append(deltas, delta) })
+	_, _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
 	var providerErr *Error
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected unavailable error, got %v", err)
 	}
-	if len(deltas) != 1 {
-		t.Fatalf("unexpected deltas %#v", deltas)
+	if len(deltas) != 0 {
+		t.Fatalf("expected executeTarget to buffer deltas, got %#v", deltas)
 	}
-	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult}}}}}
-	msg, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
-	if err != nil || msg.Content != "" {
-		t.Fatalf("unexpected result %#v err=%v", msg, err)
+	var buffered []string
+	msg, buffered, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if msg.Content != "" || len(buffered) != 0 {
+		t.Fatalf("unexpected buffered result %#v deltas=%#v", msg, buffered)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}, deltas: []string{"o", "k"}}}}
+	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	if err != nil || msg.Content != "ok" || strings.Join(buffered, "") != "ok" {
+		t.Fatalf("unexpected success result %#v deltas=%#v err=%v", msg, buffered, err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventError}}}}}
-	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	_, _, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected nil-payload error event to fail, got %v", err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err = executeTarget(cancelCtx, RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	_, _, err = executeTarget(cancelCtx, RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context cancellation, got %v", err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
-	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	_, _, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected delta termination error, got %v", err)
 	}

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -351,6 +351,11 @@ func TestExecuteTargetCoversBranches(t *testing.T) {
 	if err != nil || msg.Content != "" {
 		t.Fatalf("unexpected result %#v err=%v", msg, err)
 	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventError}}}}}
+	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
+		t.Fatalf("expected nil-payload error event to fail, got %v", err)
+	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
 	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -164,8 +164,8 @@ func TestRoutedClientFallsBackOnRetryableProviderError(t *testing.T) {
 	if msg.Content != "ok" {
 		t.Fatalf("unexpected message %#v", msg)
 	}
-	if strings.Join(streamed, "") != "ok" {
-		t.Fatalf("expected only fallback deltas, got %#v", streamed)
+	if strings.Join(streamed, "") != "badok" {
+		t.Fatalf("expected realtime primary+fallback deltas, got %#v", streamed)
 	}
 	if len(primary.streamReqs) != 1 || len(fallback.streamReqs) != 1 {
 		t.Fatalf("unexpected request counts primary=%d fallback=%d", len(primary.streamReqs), len(fallback.streamReqs))
@@ -173,7 +173,7 @@ func TestRoutedClientFallsBackOnRetryableProviderError(t *testing.T) {
 }
 
 func TestRoutedClientStopsOnNonRetryableProviderError(t *testing.T) {
-	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeBadRequest, Provider: "openai", Message: "bad request", Retryable: false}}}}
+	primary := &stubRouterClient{providerID: "openai", models: []ModelInfo{{ProviderID: "openai", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{err: &Error{Code: ErrCodeBadRequest, Provider: "openai", Message: "bad request", Retryable: true}}}}
 	fallback := &stubRouterClient{providerID: "backup", models: []ModelInfo{{ProviderID: "backup", ModelID: "gpt-5.4"}}, streams: []stubRouterStreamResult{{message: llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}}
 	reg, _ := NewRegistry(config.ProviderRuntimeConfig{})
 	_ = reg.Register(context.Background(), primary)
@@ -181,7 +181,7 @@ func TestRoutedClientStopsOnNonRetryableProviderError(t *testing.T) {
 	client := NewRoutedClientWithPolicy(NewRouter(reg, nil, RouterConfig{DefaultProvider: "openai"}), true)
 	_, err := client.CreateMessage(context.Background(), llm.ChatRequest{Model: "gpt-5.4"})
 	var providerErr *Error
-	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeBadRequest {
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeBadRequest || providerErr.Retryable {
 		t.Fatalf("unexpected error %#v", err)
 	}
 	if len(fallback.streamReqs) != 0 {
@@ -377,57 +377,57 @@ func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
 
 func TestExecuteTargetCoversBranches(t *testing.T) {
 	client := &stubRouterClient{providerID: "openai", streamErr: errors.New("stream setup failed")}
-	if _, _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}); err == nil {
+	if _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil); err == nil {
 		t.Fatal("expected stream setup error")
 	}
-	var deltas []string
+	var streamed []string
 	tool := llm.ToolCall{ID: "1", Type: "function", Function: llm.ToolFunctionCall{Name: "ls", Arguments: "{}"}}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant}}}, deltas: []string{"o", "k"}}}}
+	msg, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { streamed = append(streamed, delta) })
+	if err != nil || msg.Content != "ok" || strings.Join(streamed, "") != "ok" {
+		t.Fatalf("expected realtime merged delta content, got msg=%#v deltas=%#v err=%v", msg, streamed, err)
+	}
+	streamed = nil
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}, {Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant}}}}}}
+	msg, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { streamed = append(streamed, delta) })
+	if err != nil || len(msg.ToolCalls) != 1 || msg.Usage == nil || msg.Usage.TotalTokens != 3 || len(streamed) != 0 {
+		t.Fatalf("expected merged metadata result, got msg=%#v deltas=%#v err=%v", msg, streamed, err)
+	}
+	streamed = nil
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}, deltas: []string{"o", "k"}}}}
+	msg, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { streamed = append(streamed, delta) })
+	if err != nil || msg.Content != "ok" || strings.Join(streamed, "") != "ok" {
+		t.Fatalf("unexpected success result %#v deltas=%#v err=%v", msg, streamed, err)
+	}
+	streamed = nil
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}}, deltas: []string{"a", ""}, skipAutoEnd: true}}}
-	_, _, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, true, func(delta string) { streamed = append(streamed, delta) })
 	var providerErr *Error
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected unavailable error, got %v", err)
 	}
-	if len(deltas) != 0 {
-		t.Fatalf("expected executeTarget to buffer deltas, got %#v", deltas)
+	if strings.Join(streamed, "") != "a" {
+		t.Fatalf("expected immediate streamed delta before failure, got %#v", streamed)
 	}
-	var buffered []string
-	msg, buffered, err := executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if msg.Content != "" || len(buffered) != 0 {
-		t.Fatalf("unexpected buffered result %#v deltas=%#v", msg, buffered)
-	}
-	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant}}}, deltas: []string{"o", "k"}}}}
-	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
-	if err != nil || msg.Content != "ok" || strings.Join(buffered, "") != "ok" {
-		t.Fatalf("expected merged delta content, got msg=%#v deltas=%#v err=%v", msg, buffered, err)
-	}
-	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}, {Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant}}}}}}
-	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
-	if err != nil || len(msg.ToolCalls) != 1 || msg.Usage == nil || msg.Usage.TotalTokens != 3 || len(buffered) != 0 {
-		t.Fatalf("expected merged metadata result, got msg=%#v deltas=%#v err=%v", msg, buffered, err)
-	}
-	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}, deltas: []string{"o", "k"}}}}
-	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
-	if err != nil || msg.Content != "ok" || strings.Join(buffered, "") != "ok" {
-		t.Fatalf("unexpected success result %#v deltas=%#v err=%v", msg, buffered, err)
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventError, Error: &Error{Code: ErrCodeBadRequest, Provider: "", Message: "bad", Retryable: true, Err: errors.New("raw")}}}}}}
+	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
+	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeBadRequest || providerErr.Retryable || providerErr.Provider != "openai" || providerErr.Detail != "raw" {
+		t.Fatalf("expected normalized event error, got %#v", err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventError}}}}}
-	_, _, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected nil-payload error event to fail, got %v", err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, _, err = executeTarget(cancelCtx, RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	_, err = executeTarget(cancelCtx, RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context cancellation, got %v", err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{deltas: []string{"a", "b"}, skipAutoEnd: true}}}
-	_, _, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	_, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}}, false, nil)
 	if !errors.As(err, &providerErr) || providerErr.Code != ErrCodeUnavailable {
 		t.Fatalf("expected delta termination error, got %v", err)
 	}

--- a/internal/provider/router_test.go
+++ b/internal/provider/router_test.go
@@ -315,6 +315,9 @@ func TestUnavailableRouteError(t *testing.T) {
 	if err.Code != ErrCodeUnavailable || !err.Retryable || err.Message != "no candidates" {
 		t.Fatalf("unexpected error %#v", err)
 	}
+	if errors.Is(err, ErrProviderNotFound) {
+		t.Fatalf("unexpected provider-not-found unwrap %#v", err)
+	}
 }
 
 func TestNewRoutedClientAndExecuteBranches(t *testing.T) {
@@ -375,6 +378,16 @@ func TestExecuteTargetCoversBranches(t *testing.T) {
 	}
 	if msg.Content != "" || len(buffered) != 0 {
 		t.Fatalf("unexpected buffered result %#v deltas=%#v", msg, buffered)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant}}}, deltas: []string{"o", "k"}}}}
+	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	if err != nil || msg.Content != "ok" || strings.Join(buffered, "") != "ok" {
+		t.Fatalf("expected merged delta content, got msg=%#v deltas=%#v err=%v", msg, buffered, err)
+	}
+	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventToolCall, ToolCall: &tool}, {Type: EventUsage, Usage: &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}}, {Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant}}}}}}
+	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})
+	if err != nil || len(msg.ToolCalls) != 1 || msg.Usage == nil || msg.Usage.TotalTokens != 3 || len(buffered) != 0 {
+		t.Fatalf("expected merged metadata result, got msg=%#v deltas=%#v err=%v", msg, buffered, err)
 	}
 	client = &stubRouterClient{providerID: "openai", streams: []stubRouterStreamResult{{events: []Event{{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant, Content: "ok"}}}, deltas: []string{"o", "k"}}}}
 	msg, buffered, err = executeTarget(context.Background(), RouteTarget{ProviderID: "openai", ModelID: "gpt-5.4", Client: client}, Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}})

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -76,6 +76,7 @@ type Error struct {
 	Message   string
 	Retryable bool
 	Err       error
+	Detail    string
 }
 
 func (e *Error) Error() string {

--- a/internal/tui/model_mouse_selection.go
+++ b/internal/tui/model_mouse_selection.go
@@ -477,7 +477,7 @@ func (m *model) viewportPointFromMouse(x, y int) (viewportSelectionPoint, bool) 
 		}
 		// Keep zone-first behavior robust for terminals that occasionally
 		// report mouse rows with small absolute drift near viewport edges.
-		if x >= z.StartX-1 && x <= z.EndX+1 {
+		if x >= z.StartX-mouseZoneAutoProbeMaxDelta && x <= z.EndX+mouseZoneAutoProbeMaxDelta {
 			for delta := 1; delta <= mouseZoneAutoProbeMaxDelta; delta++ {
 				if point, ok := m.viewportPointFromZone(z, x, y-delta); ok {
 					return point, true
@@ -496,8 +496,14 @@ func (m *model) viewportPointFromMouse(x, y int) (viewportSelectionPoint, bool) 
 	if renderedTop, found := m.conversationViewportTopFromRenderedView(left, top); found {
 		top = renderedTop
 		bottom = top + m.viewport.Height - 1
+	} else if z := zone.Get(conversationViewportZoneID); z != nil && y < top {
+		top = min(top, z.StartY)
+		bottom = top + m.viewport.Height - 1
 	}
 	// Keep drag-select usable for terminals that report 0-based or 1-based mouse coords.
+	if y < top-1 && y >= top-mouseZoneAutoProbeMaxDelta {
+		y = top
+	}
 	if x < left-1 || x > right+1 || y < top-1 || y > bottom+1 {
 		return viewportSelectionPoint{}, false
 	}


### PR DESCRIPTION
## Summary
- 在 provider 层新增统一错误映射入口 `mapError`，收敛原本分散的错误语义与 retryable 判定逻辑。
- 按 PRD 固化 retryable 规则：`unauthorized` / `bad_request` 不可重试，`rate_limited` / `timeout` / `unavailable` 可重试，并保留上游原始错误到 `Detail` 便于诊断。
- 补充 provider 层测试，覆盖 401、400、413/context too long、429、timeout、5xx 以及 fallback unavailable 场景。