### PR TITLE
Provider丨Step 6建立统一流式事件规范化层

### DIFF
--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -208,18 +208,44 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 		}) {
 			return
 		}
-		message, err := a.client.StreamMessage(ctx, req.ChatRequest, func(delta string) {
-			if strings.TrimSpace(delta) == "" {
-				return
+
+		deltas := make(chan string, 16)
+		deltaDone := make(chan struct{})
+		go func() {
+			defer close(deltaDone)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case delta, ok := <-deltas:
+					if !ok {
+						return
+					}
+					if strings.TrimSpace(delta) == "" {
+						continue
+					}
+					if !normalizeEvent(ctx, normalizer, stream, Event{
+						Type:       EventDelta,
+						TraceID:    req.TraceID,
+						ProviderID: a.providerID,
+						ModelID:    modelID,
+						Delta:      delta,
+					}) {
+						return
+					}
+				}
 			}
-			_ = normalizeEvent(ctx, normalizer, stream, Event{
-				Type:       EventDelta,
-				TraceID:    req.TraceID,
-				ProviderID: a.providerID,
-				ModelID:    modelID,
-				Delta:      delta,
-			})
+		}()
+
+		message, err := a.client.StreamMessage(ctx, req.ChatRequest, func(delta string) {
+			select {
+			case <-ctx.Done():
+				return
+			case deltas <- delta:
+			}
 		})
+		close(deltas)
+		<-deltaDone
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
 				return

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -199,7 +199,8 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 		if modelID == "" {
 			modelID = a.defaultModel
 		}
-		if !emit(ctx, stream, Event{
+		normalizer := newStreamNormalizer(req.TraceID, a.providerID, modelID)
+		if !normalizeEvent(ctx, normalizer, stream, Event{
 			Type:       EventStart,
 			TraceID:    req.TraceID,
 			ProviderID: a.providerID,
@@ -211,7 +212,7 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 			if strings.TrimSpace(delta) == "" {
 				return
 			}
-			_ = emit(ctx, stream, Event{
+			_ = normalizeEvent(ctx, normalizer, stream, Event{
 				Type:       EventDelta,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
@@ -227,7 +228,7 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 			if mapped == nil {
 				return
 			}
-			_ = emit(ctx, stream, Event{
+			_ = normalizeEvent(ctx, normalizer, stream, Event{
 				Type:       EventError,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
@@ -237,7 +238,7 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 			return
 		}
 		if message.Usage != nil {
-			if !emit(ctx, stream, Event{
+			if !normalizeEvent(ctx, normalizer, stream, Event{
 				Type:       EventUsage,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
@@ -254,7 +255,7 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 		message.Normalize()
 		for _, toolCall := range message.ToolCalls {
 			call := toolCall
-			if !emit(ctx, stream, Event{
+			if !normalizeEvent(ctx, normalizer, stream, Event{
 				Type:       EventToolCall,
 				TraceID:    req.TraceID,
 				ProviderID: a.providerID,
@@ -264,7 +265,7 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 				return
 			}
 		}
-		_ = emit(ctx, stream, Event{
+		_ = normalizeEvent(ctx, normalizer, stream, Event{
 			Type:       EventResult,
 			TraceID:    req.TraceID,
 			ProviderID: a.providerID,

--- a/internal/provider/compat.go
+++ b/internal/provider/compat.go
@@ -211,16 +211,34 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 
 		deltas := make(chan string, 16)
 		deltaDone := make(chan struct{})
+		deltaInputClosed := make(chan struct{})
 		go func() {
 			defer close(deltaDone)
 			for {
 				select {
 				case <-ctx.Done():
 					return
-				case delta, ok := <-deltas:
-					if !ok {
-						return
+				case <-deltaInputClosed:
+					for {
+						select {
+						case delta := <-deltas:
+							if strings.TrimSpace(delta) == "" {
+								continue
+							}
+							if !normalizeEvent(ctx, normalizer, stream, Event{
+								Type:       EventDelta,
+								TraceID:    req.TraceID,
+								ProviderID: a.providerID,
+								ModelID:    modelID,
+								Delta:      delta,
+							}) {
+								return
+							}
+						default:
+							return
+						}
 					}
+				case delta := <-deltas:
 					if strings.TrimSpace(delta) == "" {
 						continue
 					}
@@ -241,10 +259,12 @@ func (a *clientAdapter) Stream(ctx context.Context, req Request) (<-chan Event, 
 			select {
 			case <-ctx.Done():
 				return
+			case <-deltaInputClosed:
+				return
 			case deltas <- delta:
 			}
 		})
-		close(deltas)
+		close(deltaInputClosed)
 		<-deltaDone
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -29,6 +29,53 @@ func (s stubCompatClient) StreamMessage(ctx context.Context, _ llm.ChatRequest, 
 	return s.message, nil
 }
 
+type asyncDeltaCompatClient struct {
+	message llm.Message
+}
+
+func (s asyncDeltaCompatClient) CreateMessage(context.Context, llm.ChatRequest) (llm.Message, error) {
+	return s.message, nil
+}
+
+func (s asyncDeltaCompatClient) StreamMessage(_ context.Context, _ llm.ChatRequest, onDelta func(string)) (llm.Message, error) {
+	if onDelta == nil {
+		return s.message, nil
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		onDelta("hello")
+		close(started)
+		<-release
+		onDelta(" late")
+	}()
+	<-started
+	return s.message, nil
+}
+
+func TestWrapClientStreamIgnoresAsyncDeltaAfterTerminal(t *testing.T) {
+	adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), asyncDeltaCompatClient{message: llm.Message{Role: llm.RoleAssistant, Content: "hello"}})
+	stream, err := adapter.Stream(context.Background(), Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}, TraceID: "trace-async"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	var events []Event
+	for event := range stream {
+		events = append(events, event)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected start, delta, result only, got %#v", events)
+	}
+	if events[0].Type != EventStart || events[1].Type != EventDelta || events[2].Type != EventResult {
+		t.Fatalf("unexpected event order %#v", events)
+	}
+	if events[1].Delta != "hello" {
+		t.Fatalf("unexpected delta %#v", events[1])
+	}
+}
+
 func TestWrapClientStreamEmitsNormalizedEvents(t *testing.T) {
 	adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), stubCompatClient{message: llm.Message{
 		Role:    llm.RoleAssistant,

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -57,6 +57,17 @@ func TestWrapClientStreamEmitsNormalizedEvents(t *testing.T) {
 	if events[0].Type != EventStart || events[0].TraceID != "trace-1" {
 		t.Fatalf("unexpected start event %#v", events[0])
 	}
+	for i, event := range events {
+		if event.ID == "" {
+			t.Fatalf("expected event %d to have id, got %#v", i, event)
+		}
+		if event.ProviderID != ProviderOpenAI {
+			t.Fatalf("expected provider normalization on event %d, got %#v", i, event)
+		}
+		if event.ModelID != "gpt-5.4" {
+			t.Fatalf("expected model normalization on event %d, got %#v", i, event)
+		}
+	}
 	if events[1].Type != EventDelta || events[1].Delta != "hello" {
 		t.Fatalf("unexpected first delta %#v", events[1])
 	}
@@ -193,6 +204,49 @@ func TestWrapClientStreamDoesNotEmitNilErrorOnContextCanceled(t *testing.T) {
 	}
 	if len(events) != 1 || events[0].Type != EventStart {
 		t.Fatalf("expected only start event before cancel shutdown, got %#v", events)
+	}
+}
+
+func TestNormalizeEventRejectsMissingStart(t *testing.T) {
+	ctx := context.Background()
+	ch := make(chan Event, 1)
+	normalizer := newStreamNormalizer("trace-x", ProviderOpenAI, ModelID("gpt-5.4"))
+	if !normalizeEvent(ctx, normalizer, ch, Event{Type: EventDelta, Delta: "oops"}) {
+		t.Fatal("expected normalized error event to be emitted")
+	}
+	close(ch)
+	events := make([]Event, 0, len(ch))
+	for event := range ch {
+		events = append(events, event)
+	}
+	if len(events) != 1 || events[0].Type != EventError || events[0].Error == nil {
+		t.Fatalf("expected single error event, got %#v", events)
+	}
+	if events[0].Error.Code != ErrCodeUnavailable {
+		t.Fatalf("expected unavailable normalization error, got %#v", events[0])
+	}
+}
+
+func TestNormalizeEventRejectsEventsAfterTerminal(t *testing.T) {
+	ctx := context.Background()
+	ch := make(chan Event, 3)
+	normalizer := newStreamNormalizer("trace-y", ProviderOpenAI, ModelID("gpt-5.4"))
+	if !normalizeEvent(ctx, normalizer, ch, Event{Type: EventStart}) {
+		t.Fatal("expected start event")
+	}
+	if !normalizeEvent(ctx, normalizer, ch, Event{Type: EventResult, Result: &llm.Message{Role: llm.RoleAssistant}}) {
+		t.Fatal("expected result event")
+	}
+	if normalizeEvent(ctx, normalizer, ch, Event{Type: EventDelta, Delta: "late"}) {
+		t.Fatal("expected event after terminal to be rejected")
+	}
+	close(ch)
+	var events []Event
+	for event := range ch {
+		events = append(events, event)
+	}
+	if len(events) != 2 || events[0].Type != EventStart || events[1].Type != EventResult {
+		t.Fatalf("unexpected normalized events %#v", events)
 	}
 }
 

--- a/internal/provider/compat_test.go
+++ b/internal/provider/compat_test.go
@@ -31,6 +31,8 @@ func (s stubCompatClient) StreamMessage(ctx context.Context, _ llm.ChatRequest, 
 
 type asyncDeltaCompatClient struct {
 	message llm.Message
+	release chan struct{}
+	done    chan struct{}
 }
 
 func (s asyncDeltaCompatClient) CreateMessage(context.Context, llm.ChatRequest) (llm.Message, error) {
@@ -41,22 +43,19 @@ func (s asyncDeltaCompatClient) StreamMessage(_ context.Context, _ llm.ChatReque
 	if onDelta == nil {
 		return s.message, nil
 	}
-	started := make(chan struct{})
-	release := make(chan struct{})
-	done := make(chan struct{})
+	onDelta("hello")
 	go func() {
-		defer close(done)
-		onDelta("hello")
-		close(started)
-		<-release
+		<-s.release
 		onDelta(" late")
+		close(s.done)
 	}()
-	<-started
 	return s.message, nil
 }
 
 func TestWrapClientStreamIgnoresAsyncDeltaAfterTerminal(t *testing.T) {
-	adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), asyncDeltaCompatClient{message: llm.Message{Role: llm.RoleAssistant, Content: "hello"}})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	adapter := WrapClient(ProviderOpenAI, ModelID("gpt-5.4"), asyncDeltaCompatClient{message: llm.Message{Role: llm.RoleAssistant, Content: "hello"}, release: release, done: done})
 	stream, err := adapter.Stream(context.Background(), Request{ChatRequest: llm.ChatRequest{Model: "gpt-5.4"}, TraceID: "trace-async"})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -64,6 +63,10 @@ func TestWrapClientStreamIgnoresAsyncDeltaAfterTerminal(t *testing.T) {
 	var events []Event
 	for event := range stream {
 		events = append(events, event)
+		if event.Type == EventResult {
+			close(release)
+			<-done
+		}
 	}
 	if len(events) != 3 {
 		t.Fatalf("expected start, delta, result only, got %#v", events)

--- a/internal/provider/normalize.go
+++ b/internal/provider/normalize.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 )
 
 var eventCounter uint64
 
 type streamNormalizer struct {
+	mu         sync.Mutex
 	traceID    string
 	providerID ProviderID
 	modelID    ModelID
@@ -29,17 +31,33 @@ func normalizeEvent(ctx context.Context, n *streamNormalizer, ch chan<- Event, e
 	if n == nil {
 		n = newStreamNormalizer(evt.TraceID, evt.ProviderID, evt.ModelID)
 	}
-	normalized, err := n.normalize(evt)
-	if err != nil {
-		if n.terminated {
-			return false
-		}
-		normalized = n.errorEvent(err)
+	normalized, drop := n.normalizeOrConvert(evt)
+	if drop {
+		return false
 	}
 	return emit(ctx, ch, normalized)
 }
 
-func (n *streamNormalizer) normalize(evt Event) (Event, error) {
+func (n *streamNormalizer) normalizeOrConvert(evt Event) (Event, bool) {
+	if n == nil {
+		mapped := unavailableRouteError("provider stream normalizer unavailable")
+		return Event{Type: EventError, Error: mapped}, false
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	normalized, err := n.normalizeLocked(evt)
+	if err == nil {
+		return normalized, false
+	}
+	if n.terminated {
+		return Event{}, true
+	}
+	return n.errorEventLocked(err), false
+}
+
+func (n *streamNormalizer) normalizeLocked(evt Event) (Event, error) {
 	if n == nil {
 		return Event{}, fmt.Errorf("provider stream normalizer unavailable")
 	}
@@ -99,7 +117,7 @@ func (n *streamNormalizer) enrich(evt Event) Event {
 	return evt
 }
 
-func (n *streamNormalizer) errorEvent(err error) Event {
+func (n *streamNormalizer) errorEventLocked(err error) Event {
 	n.terminated = true
 	mapped := mapError(n.providerID, err)
 	if mapped == nil {

--- a/internal/provider/normalize.go
+++ b/internal/provider/normalize.go
@@ -1,0 +1,113 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+)
+
+var eventCounter uint64
+
+type streamNormalizer struct {
+	traceID    string
+	providerID ProviderID
+	modelID    ModelID
+	emitted    bool
+	terminated bool
+}
+
+func newStreamNormalizer(traceID string, providerID ProviderID, modelID ModelID) *streamNormalizer {
+	return &streamNormalizer{
+		traceID:    strings.TrimSpace(traceID),
+		providerID: normalizeRouteProviderID(providerID),
+		modelID:    normalizeRouteModelID(modelID),
+	}
+}
+
+func normalizeEvent(ctx context.Context, n *streamNormalizer, ch chan<- Event, evt Event) bool {
+	if n == nil {
+		n = newStreamNormalizer(evt.TraceID, evt.ProviderID, evt.ModelID)
+	}
+	normalized, err := n.normalize(evt)
+	if err != nil {
+		if n.terminated {
+			return false
+		}
+		normalized = n.errorEvent(err)
+	}
+	return emit(ctx, ch, normalized)
+}
+
+func (n *streamNormalizer) normalize(evt Event) (Event, error) {
+	if n == nil {
+		return Event{}, fmt.Errorf("provider stream normalizer unavailable")
+	}
+	if n.terminated {
+		return Event{}, fmt.Errorf("provider stream emitted event after terminal event")
+	}
+	if !n.emitted {
+		if evt.Type != EventStart {
+			return Event{}, fmt.Errorf("provider stream missing start event")
+		}
+		n.emitted = true
+	} else if evt.Type == EventStart {
+		return Event{}, fmt.Errorf("provider stream emitted duplicate start event")
+	}
+	evt = n.enrich(evt)
+	switch evt.Type {
+	case EventStart:
+	case EventDelta:
+	case EventToolCall:
+	case EventUsage:
+	case EventResult:
+		n.terminated = true
+	case EventError:
+		if evt.Error == nil {
+			return Event{}, fmt.Errorf("provider stream emitted error event without error payload")
+		}
+		n.terminated = true
+	default:
+		return Event{}, fmt.Errorf("provider stream emitted unknown event type %q", evt.Type)
+	}
+	return evt, nil
+}
+
+func (n *streamNormalizer) enrich(evt Event) Event {
+	evt.Type = EventType(strings.TrimSpace(string(evt.Type)))
+	if strings.TrimSpace(evt.ID) == "" {
+		evt.ID = nextEventID()
+	}
+	if strings.TrimSpace(evt.TraceID) == "" {
+		evt.TraceID = n.traceID
+	}
+	if evt.ProviderID == "" {
+		evt.ProviderID = n.providerID
+	}
+	evt.ProviderID = normalizeRouteProviderID(evt.ProviderID)
+	if evt.ModelID == "" {
+		evt.ModelID = n.modelID
+	}
+	evt.ModelID = normalizeRouteModelID(evt.ModelID)
+	if evt.Error != nil {
+		if evt.Error.Provider == "" {
+			evt.Error.Provider = evt.ProviderID
+		}
+		evt.Error.Retryable = isRetryableCode(evt.Error.Code)
+
+	}
+	return evt
+}
+
+func (n *streamNormalizer) errorEvent(err error) Event {
+	n.terminated = true
+	mapped := mapError(n.providerID, err)
+	if mapped == nil {
+		mapped = unavailableRouteError(err.Error())
+	}
+	return n.enrich(Event{Type: EventError, Error: mapped})
+}
+
+func nextEventID() string {
+	return fmt.Sprintf("evt-%d", atomic.AddUint64(&eventCounter, 1))
+}


### PR DESCRIPTION
Summary
在 internal/provider/normalize.go:1 新增统一流式事件规范化层，强制 provider 流满足 start -> ... -> result|error 时序约束，并自动补全 event_id/trace_id/provider_id/model_id
将兼容流出口接入规范化器：internal/provider/compat.go:198，把非法事件序列统一转为 provider 层 EventError，不把分支泄漏到上层
补充覆盖规范化行为的测试：internal/provider/compat_test.go:32，验证事件 ID 注入、缺失 start、终态后继续发事件等场景