### PR TITLE
feat(agent): close out #237 engine orchestration + turn events

### DIFF
--- a/internal/agent/completion_runtime.go
+++ b/internal/agent/completion_runtime.go
@@ -11,15 +11,28 @@ import (
 	"bytemind/internal/session"
 )
 
-func (r *Runner) completeTurn(ctx context.Context, request llm.ChatRequest, out io.Writer, streamedText *bool) (llm.Message, error) {
-	if !r.config.Stream {
-		return r.client.CreateMessage(ctx, request)
+func (e *defaultEngine) completeTurn(ctx context.Context, request llm.ChatRequest, out io.Writer, streamedText *bool) (llm.Message, error) {
+	if e == nil || e.runner == nil {
+		return llm.Message{}, fmt.Errorf("agent engine is unavailable")
+	}
+	runner := e.runner
+
+	if !runner.config.Stream {
+		return runner.client.CreateMessage(ctx, request)
 	}
 
-	reply, err := r.client.StreamMessage(ctx, request, func(delta string) {
+	reply, err := runner.client.StreamMessage(ctx, request, func(delta string) {
+		if delta != "" {
+			emitTurnEvent(ctx, TurnEvent{
+				Type: TurnEventDelta,
+				Payload: map[string]any{
+					"content": delta,
+				},
+			})
+		}
 		if out == nil || delta == "" {
 			if delta != "" {
-				r.emit(Event{Type: EventAssistantDelta, Content: delta})
+				runner.emit(Event{Type: EventAssistantDelta, Content: delta})
 			}
 			return
 		}
@@ -28,7 +41,7 @@ func (r *Runner) completeTurn(ctx context.Context, request llm.ChatRequest, out 
 		}
 		*streamedText = true
 		fmt.Fprint(out, delta)
-		r.emit(Event{Type: EventAssistantDelta, Content: delta})
+		runner.emit(Event{Type: EventAssistantDelta, Content: delta})
 	})
 	if err != nil {
 		return llm.Message{}, err
@@ -39,16 +52,20 @@ func (r *Runner) completeTurn(ctx context.Context, request llm.ChatRequest, out 
 
 	// Some providers/models occasionally return empty streaming payloads while
 	// still producing a valid non-stream completion. Retry once without stream.
-	fallback, fallbackErr := r.client.CreateMessage(ctx, request)
+	fallback, fallbackErr := runner.client.CreateMessage(ctx, request)
 	if fallbackErr == nil {
 		return fallback, nil
 	}
 	return reply, nil
 }
 
-func (r *Runner) finishWithSummary(sess *session.Session, summary string, out io.Writer, streamedText bool) (string, error) {
+func (e *defaultEngine) finishWithSummary(sess *session.Session, summary string, out io.Writer, streamedText bool) (string, error) {
+	if e == nil || e.runner == nil {
+		return "", fmt.Errorf("agent engine is unavailable")
+	}
+
 	summaryMessage := llm.NewAssistantTextMessage(summary)
-	if err := r.persistAssistantReply(sess, summaryMessage); err != nil {
+	if err := e.persistAssistantReply(sess, summaryMessage); err != nil {
 		return "", err
 	}
 	if out != nil {
@@ -59,6 +76,16 @@ func (r *Runner) finishWithSummary(sess *session.Session, summary string, out io
 		fmt.Fprintln(out, summary)
 	}
 	return summary, nil
+}
+
+func (r *Runner) completeTurn(ctx context.Context, request llm.ChatRequest, out io.Writer, streamedText *bool) (llm.Message, error) {
+	engine := &defaultEngine{runner: r}
+	return engine.completeTurn(ctx, request, out, streamedText)
+}
+
+func (r *Runner) finishWithSummary(sess *session.Session, summary string, out io.Writer, streamedText bool) (string, error) {
+	engine := &defaultEngine{runner: r}
+	return engine.finishWithSummary(sess, summary, out, streamedText)
 }
 
 func marshalToolResult(v any) string {

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	corepkg "bytemind/internal/core"
 )
@@ -38,6 +39,20 @@ func (e *defaultEngine) HandleTurn(ctx context.Context, req TurnRequest) (<-chan
 	events := stream.Events()
 
 	go func() {
+		defer func() {
+			recovered := recover()
+			if recovered == nil {
+				return
+			}
+			if err := stream.Emit(TurnEvent{
+				Type:      TurnEventError,
+				Error:     formatTurnPanicError(recovered),
+				ErrorCode: "run_panicked",
+			}); err != nil {
+				stream.CloseWithoutTerminal()
+			}
+		}()
+
 		runCtx := withTurnEventSink(ctx, stream)
 
 		if err := stream.Emit(TurnEvent{Type: TurnEventStart}); err != nil {
@@ -81,4 +96,13 @@ func (e *defaultEngine) HandleTurn(ctx context.Context, req TurnRequest) (<-chan
 	}()
 
 	return events, nil
+}
+
+func formatTurnPanicError(recovered any) error {
+	switch v := recovered.(type) {
+	case error:
+		return fmt.Errorf("panic recovered in turn execution: %w", v)
+	default:
+		return fmt.Errorf("panic recovered in turn execution: %v", v)
+	}
 }

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -38,6 +38,8 @@ func (e *defaultEngine) HandleTurn(ctx context.Context, req TurnRequest) (<-chan
 	events := stream.Events()
 
 	go func() {
+		runCtx := withTurnEventSink(ctx, stream)
+
 		if err := stream.Emit(TurnEvent{Type: TurnEventStart}); err != nil {
 			stream.CloseWithoutTerminal()
 			return
@@ -52,7 +54,7 @@ func (e *defaultEngine) HandleTurn(ctx context.Context, req TurnRequest) (<-chan
 			return
 		}
 
-		setup, err := e.runner.prepareRunPrompt(req.Session, req.Input, req.Mode)
+		setup, err := e.prepareRunPrompt(req.Session, req.Input, req.Mode)
 		if err != nil {
 			_ = stream.Emit(TurnEvent{
 				Type:      TurnEventError,
@@ -62,7 +64,7 @@ func (e *defaultEngine) HandleTurn(ctx context.Context, req TurnRequest) (<-chan
 			return
 		}
 
-		answer, err := e.runner.runPromptTurns(ctx, req.Session, setup, req.Out)
+		answer, err := e.runPromptTurns(runCtx, req.Session, setup, req.Out)
 		if err != nil {
 			_ = stream.Emit(TurnEvent{
 				Type:      TurnEventError,

--- a/internal/agent/engine_run_loop.go
+++ b/internal/agent/engine_run_loop.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	contextpkg "bytemind/internal/context"
+	corepkg "bytemind/internal/core"
+	"bytemind/internal/llm"
+	runtimepkg "bytemind/internal/runtime"
+	"bytemind/internal/session"
+)
+
+func (e *defaultEngine) runPromptTurns(ctx context.Context, sess *session.Session, setup runPromptSetup, out io.Writer) (string, error) {
+	if e == nil || e.runner == nil {
+		return "", fmt.Errorf("agent engine is unavailable")
+	}
+
+	runner := e.runner
+	toolSequenceTracker := runtimepkg.NewToolSequenceTracker(runtimepkg.DefaultRepeatedToolSequenceThreshold)
+	executedToolNames := make([]string, 0, 16)
+
+	for step := 0; step < runner.config.MaxIterations; step++ {
+		messages, err := e.messagesForStep(ctx, sess, setup, step, out)
+		if err != nil {
+			return "", err
+		}
+		answer, finished, err := e.processTurnWithReactiveCompaction(ctx, setup, turnProcessParams{
+			Session:          sess,
+			RunMode:          setup.RunMode,
+			Messages:         messages,
+			Assets:           setup.Input.Assets,
+			AllowedToolNames: setup.AllowedToolNames,
+			DeniedToolNames:  setup.DeniedToolNames,
+			AllowedTools:     setup.AllowedTools,
+			DeniedTools:      setup.DeniedTools,
+			SequenceTracker:  toolSequenceTracker,
+			ExecutedTools:    &executedToolNames,
+			Out:              out,
+		})
+		if err != nil {
+			return "", err
+		}
+		if finished {
+			return answer, nil
+		}
+	}
+
+	summary := runtimepkg.BuildStopSummary(runtimepkg.StopSummaryInput{
+		SessionID:     corepkg.SessionID(sess.ID),
+		Reason:        fmt.Sprintf("I reached the current execution budget of %d turns before producing a final answer.", runner.config.MaxIterations),
+		ExecutedTools: executedToolNames,
+	})
+	return e.finishWithSummary(sess, summary, out, false)
+}
+
+func (e *defaultEngine) processTurnWithReactiveCompaction(ctx context.Context, setup runPromptSetup, params turnProcessParams) (string, bool, error) {
+	if e == nil || e.runner == nil {
+		return "", false, fmt.Errorf("agent engine is unavailable")
+	}
+
+	runner := e.runner
+	answer, finished, err := e.processTurn(ctx, params)
+	if err == nil || !isPromptTooLongError(err) {
+		return answer, finished, err
+	}
+
+	_, compacted, compactErr := runner.compactSession(ctx, params.Session, true, true, "reactive_prompt_too_long")
+	if compactErr != nil {
+		return "", false, compactErr
+	}
+	if !compacted {
+		return "", false, err
+	}
+	if params.Out != nil {
+		fmt.Fprintf(params.Out, "%scontext exceeded model window; compacted and retrying once%s\n", ansiDim, ansiReset)
+	}
+
+	retryMessages, buildErr := e.buildTurnMessages(params.Session, setup)
+	if buildErr != nil {
+		return "", false, buildErr
+	}
+	params.Messages = retryMessages
+	return e.processTurn(ctx, params)
+}
+
+func (e *defaultEngine) messagesForStep(ctx context.Context, sess *session.Session, setup runPromptSetup, step int, out io.Writer) ([]llm.Message, error) {
+	if e == nil || e.runner == nil {
+		return nil, fmt.Errorf("agent engine is unavailable")
+	}
+
+	runner := e.runner
+	messages, err := e.buildTurnMessages(sess, setup)
+	if err != nil {
+		return nil, err
+	}
+	if step != 0 {
+		return messages, nil
+	}
+
+	requestTokens := contextpkg.EstimateRequestTokens(messages)
+	compacted, compactErr := runner.maybeAutoCompactSession(ctx, sess, setup.PromptTokens, requestTokens)
+	if compactErr != nil {
+		return nil, compactErr
+	}
+	if !compacted {
+		return messages, nil
+	}
+	if out != nil {
+		fmt.Fprintf(out, "%scontext compacted to fit long-history budget%s\n", ansiDim, ansiReset)
+	}
+	return e.buildTurnMessages(sess, setup)
+}

--- a/internal/agent/engine_run_setup.go
+++ b/internal/agent/engine_run_setup.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"fmt"
+	"time"
+
+	contextpkg "bytemind/internal/context"
+	corepkg "bytemind/internal/core"
+	"bytemind/internal/llm"
+	planpkg "bytemind/internal/plan"
+	policypkg "bytemind/internal/policy"
+	"bytemind/internal/session"
+)
+
+func (e *defaultEngine) prepareRunPrompt(sess *session.Session, input RunPromptInput, mode string) (runPromptSetup, error) {
+	if e == nil || e.runner == nil {
+		return runPromptSetup{}, fmt.Errorf("agent engine is unavailable")
+	}
+	runner := e.runner
+
+	input = normalizeRunPromptInput(input)
+	userInput := input.DisplayText
+	runMode := resolveRunMode(sess, mode)
+	mode = string(runMode)
+	if sess.Mode != runMode {
+		sess.Mode = runMode
+	}
+	planpkg.SeedForRun(&sess.Plan, runMode, userInput, input.UserMessage.Text())
+
+	if err := e.beginRunSession(sess, input.UserMessage, userInput); err != nil {
+		return runPromptSetup{}, err
+	}
+
+	activeSkill := runner.resolveActiveSkill(sess)
+	allowedTools, deniedTools := resolveSkillToolSets(activeSkill)
+	promptHint := policypkg.EvaluatePromptHint(userInput)
+	availableTools := []string(nil)
+	if runner.registry != nil {
+		availableTools = toolNames(runner.registry.DefinitionsForMode(runMode))
+	}
+	return runPromptSetup{
+		Input:                input,
+		UserInput:            userInput,
+		RunMode:              runMode,
+		Mode:                 mode,
+		ActiveSkill:          activeSkill,
+		AllowedTools:         allowedTools,
+		DeniedTools:          deniedTools,
+		AllowedToolNames:     policypkg.SortedToolNames(allowedTools),
+		DeniedToolNames:      policypkg.SortedToolNames(deniedTools),
+		AvailableSkills:      runner.promptSkills(),
+		AvailableTools:       availableTools,
+		InstructionText:      loadAGENTSInstruction(runner.workspace),
+		WebLookupInstruction: promptHint.Instruction,
+		PromptTokens:         contextpkg.EstimateRequestTokens([]llm.Message{input.UserMessage}),
+	}, nil
+}
+
+func (e *defaultEngine) beginRunSession(sess *session.Session, userMessage llm.Message, userInput string) error {
+	if e == nil || e.runner == nil {
+		return fmt.Errorf("agent engine is unavailable")
+	}
+	runner := e.runner
+
+	if err := llm.ValidateMessage(userMessage); err != nil {
+		return err
+	}
+	sess.Messages = append(sess.Messages, userMessage)
+	if runner.store != nil {
+		if err := runner.store.Save(sess); err != nil {
+			return err
+		}
+	}
+	runner.appendPromptHistory(corepkg.SessionID(sess.ID), userInput, time.Now().UTC())
+	runner.emit(Event{
+		Type:      EventRunStarted,
+		SessionID: corepkg.SessionID(sess.ID),
+		UserInput: userInput,
+	})
+	return nil
+}
+
+func (e *defaultEngine) buildTurnMessages(sess *session.Session, setup runPromptSetup) ([]llm.Message, error) {
+	if e == nil || e.runner == nil {
+		return nil, fmt.Errorf("agent engine is unavailable")
+	}
+	runner := e.runner
+
+	return contextpkg.BuildTurnMessages(contextpkg.TurnMessagesRequest{
+		SystemPrompt: systemPrompt(PromptInput{
+			Workspace:      runner.workspace,
+			ApprovalPolicy: runner.config.ApprovalPolicy,
+			Model:          runner.config.Provider.Model,
+			Mode:           setup.Mode,
+			Skills:         setup.AvailableSkills,
+			Tools:          setup.AvailableTools,
+			ActiveSkill:    promptActiveSkill(setup.ActiveSkill),
+			Instruction:    setup.InstructionText,
+		}),
+		WebLookupInstruction: setup.WebLookupInstruction,
+		ConversationMessages: sess.Messages,
+	})
+}

--- a/internal/agent/final_reply.go
+++ b/internal/agent/final_reply.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
@@ -10,7 +11,11 @@ import (
 	"bytemind/internal/session"
 )
 
-func (r *Runner) finalizeTurnWithoutTools(runMode planpkg.AgentMode, sess *session.Session, reply llm.Message, out io.Writer, streamedText bool) (string, error) {
+func (e *defaultEngine) finalizeTurnWithoutTools(runMode planpkg.AgentMode, sess *session.Session, reply llm.Message, out io.Writer, streamedText bool) (string, error) {
+	if e == nil || e.runner == nil {
+		return "", fmt.Errorf("agent engine is unavailable")
+	}
+
 	answer := strings.TrimSpace(reply.Content)
 	if answer == "" {
 		reply.Content = emptyReplyFallback
@@ -23,7 +28,7 @@ func (r *Runner) finalizeTurnWithoutTools(runMode planpkg.AgentMode, sess *sessi
 		reply = llm.NewAssistantTextMessage(answer)
 	}
 
-	if err := r.persistAssistantReply(sess, reply); err != nil {
+	if err := e.persistAssistantReply(sess, reply); err != nil {
 		return "", err
 	}
 
@@ -35,25 +40,40 @@ func (r *Runner) finalizeTurnWithoutTools(runMode planpkg.AgentMode, sess *sessi
 	return answer, nil
 }
 
-func (r *Runner) persistAssistantReply(sess *session.Session, reply llm.Message) error {
+func (e *defaultEngine) persistAssistantReply(sess *session.Session, reply llm.Message) error {
+	if e == nil || e.runner == nil {
+		return fmt.Errorf("agent engine is unavailable")
+	}
+	runner := e.runner
+
 	if err := llm.ValidateMessage(reply); err != nil {
 		return err
 	}
 	sess.Messages = append(sess.Messages, reply)
-	if r.store != nil {
-		if err := r.store.Save(sess); err != nil {
+	if runner.store != nil {
+		if err := runner.store.Save(sess); err != nil {
 			return err
 		}
 	}
-	r.emit(Event{
+	runner.emit(Event{
 		Type:      EventAssistantMessage,
 		SessionID: corepkg.SessionID(sess.ID),
 		Content:   reply.Content,
 	})
-	r.emit(Event{
+	runner.emit(Event{
 		Type:      EventRunFinished,
 		SessionID: corepkg.SessionID(sess.ID),
 		Content:   reply.Content,
 	})
 	return nil
+}
+
+func (r *Runner) finalizeTurnWithoutTools(runMode planpkg.AgentMode, sess *session.Session, reply llm.Message, out io.Writer, streamedText bool) (string, error) {
+	engine := &defaultEngine{runner: r}
+	return engine.finalizeTurnWithoutTools(runMode, sess, reply, out, streamedText)
+}
+
+func (r *Runner) persistAssistantReply(sess *session.Session, reply llm.Message) error {
+	engine := &defaultEngine{runner: r}
+	return engine.persistAssistantReply(sess, reply)
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -2,98 +2,23 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"io"
 
-	contextpkg "bytemind/internal/context"
-	corepkg "bytemind/internal/core"
 	"bytemind/internal/llm"
-	runtimepkg "bytemind/internal/runtime"
 	"bytemind/internal/session"
 )
 
 func (r *Runner) runPromptTurns(ctx context.Context, sess *session.Session, setup runPromptSetup, out io.Writer) (string, error) {
-	toolSequenceTracker := runtimepkg.NewToolSequenceTracker(runtimepkg.DefaultRepeatedToolSequenceThreshold)
-	executedToolNames := make([]string, 0, 16)
-
-	for step := 0; step < r.config.MaxIterations; step++ {
-		messages, err := r.messagesForStep(ctx, sess, setup, step, out)
-		if err != nil {
-			return "", err
-		}
-		answer, finished, err := r.processTurnWithReactiveCompaction(ctx, setup, turnProcessParams{
-			Session:          sess,
-			RunMode:          setup.RunMode,
-			Messages:         messages,
-			Assets:           setup.Input.Assets,
-			AllowedToolNames: setup.AllowedToolNames,
-			DeniedToolNames:  setup.DeniedToolNames,
-			AllowedTools:     setup.AllowedTools,
-			DeniedTools:      setup.DeniedTools,
-			SequenceTracker:  toolSequenceTracker,
-			ExecutedTools:    &executedToolNames,
-			Out:              out,
-		})
-		if err != nil {
-			return "", err
-		}
-		if finished {
-			return answer, nil
-		}
-	}
-
-	summary := runtimepkg.BuildStopSummary(runtimepkg.StopSummaryInput{
-		SessionID:     corepkg.SessionID(sess.ID),
-		Reason:        fmt.Sprintf("I reached the current execution budget of %d turns before producing a final answer.", r.config.MaxIterations),
-		ExecutedTools: executedToolNames,
-	})
-	return r.finishWithSummary(sess, summary, out, false)
+	engine := &defaultEngine{runner: r}
+	return engine.runPromptTurns(ctx, sess, setup, out)
 }
 
 func (r *Runner) processTurnWithReactiveCompaction(ctx context.Context, setup runPromptSetup, params turnProcessParams) (string, bool, error) {
-	answer, finished, err := r.processTurn(ctx, params)
-	if err == nil || !isPromptTooLongError(err) {
-		return answer, finished, err
-	}
-
-	_, compacted, compactErr := r.compactSession(ctx, params.Session, true, true, "reactive_prompt_too_long")
-	if compactErr != nil {
-		return "", false, compactErr
-	}
-	if !compacted {
-		return "", false, err
-	}
-	if params.Out != nil {
-		fmt.Fprintf(params.Out, "%scontext exceeded model window; compacted and retrying once%s\n", ansiDim, ansiReset)
-	}
-
-	retryMessages, buildErr := r.buildTurnMessages(params.Session, setup)
-	if buildErr != nil {
-		return "", false, buildErr
-	}
-	params.Messages = retryMessages
-	return r.processTurn(ctx, params)
+	engine := &defaultEngine{runner: r}
+	return engine.processTurnWithReactiveCompaction(ctx, setup, params)
 }
 
 func (r *Runner) messagesForStep(ctx context.Context, sess *session.Session, setup runPromptSetup, step int, out io.Writer) ([]llm.Message, error) {
-	messages, err := r.buildTurnMessages(sess, setup)
-	if err != nil {
-		return nil, err
-	}
-	if step != 0 {
-		return messages, nil
-	}
-
-	requestTokens := contextpkg.EstimateRequestTokens(messages)
-	compacted, compactErr := r.maybeAutoCompactSession(ctx, sess, setup.PromptTokens, requestTokens)
-	if compactErr != nil {
-		return nil, compactErr
-	}
-	if !compacted {
-		return messages, nil
-	}
-	if out != nil {
-		fmt.Fprintf(out, "%scontext compacted to fit long-history budget%s\n", ansiDim, ansiReset)
-	}
-	return r.buildTurnMessages(sess, setup)
+	engine := &defaultEngine{runner: r}
+	return engine.messagesForStep(ctx, sess, setup, step, out)
 }

--- a/internal/agent/run_setup.go
+++ b/internal/agent/run_setup.go
@@ -2,13 +2,9 @@ package agent
 
 import (
 	"strings"
-	"time"
 
-	contextpkg "bytemind/internal/context"
-	corepkg "bytemind/internal/core"
 	"bytemind/internal/llm"
 	planpkg "bytemind/internal/plan"
-	policypkg "bytemind/internal/policy"
 	"bytemind/internal/session"
 )
 
@@ -30,42 +26,8 @@ type runPromptSetup struct {
 }
 
 func (r *Runner) prepareRunPrompt(sess *session.Session, input RunPromptInput, mode string) (runPromptSetup, error) {
-	input = normalizeRunPromptInput(input)
-	userInput := input.DisplayText
-	runMode := resolveRunMode(sess, mode)
-	mode = string(runMode)
-	if sess.Mode != runMode {
-		sess.Mode = runMode
-	}
-	planpkg.SeedForRun(&sess.Plan, runMode, userInput, input.UserMessage.Text())
-
-	if err := r.beginRunSession(sess, input.UserMessage, userInput); err != nil {
-		return runPromptSetup{}, err
-	}
-
-	activeSkill := r.resolveActiveSkill(sess)
-	allowedTools, deniedTools := resolveSkillToolSets(activeSkill)
-	promptHint := policypkg.EvaluatePromptHint(userInput)
-	availableTools := []string(nil)
-	if r.registry != nil {
-		availableTools = toolNames(r.registry.DefinitionsForMode(runMode))
-	}
-	return runPromptSetup{
-		Input:                input,
-		UserInput:            userInput,
-		RunMode:              runMode,
-		Mode:                 mode,
-		ActiveSkill:          activeSkill,
-		AllowedTools:         allowedTools,
-		DeniedTools:          deniedTools,
-		AllowedToolNames:     policypkg.SortedToolNames(allowedTools),
-		DeniedToolNames:      policypkg.SortedToolNames(deniedTools),
-		AvailableSkills:      r.promptSkills(),
-		AvailableTools:       availableTools,
-		InstructionText:      loadAGENTSInstruction(r.workspace),
-		WebLookupInstruction: promptHint.Instruction,
-		PromptTokens:         contextpkg.EstimateRequestTokens([]llm.Message{input.UserMessage}),
-	}, nil
+	engine := &defaultEngine{runner: r}
+	return engine.prepareRunPrompt(sess, input, mode)
 }
 
 func normalizeRunPromptInput(input RunPromptInput) RunPromptInput {
@@ -88,37 +50,11 @@ func resolveRunMode(sess *session.Session, mode string) planpkg.AgentMode {
 }
 
 func (r *Runner) beginRunSession(sess *session.Session, userMessage llm.Message, userInput string) error {
-	if err := llm.ValidateMessage(userMessage); err != nil {
-		return err
-	}
-	sess.Messages = append(sess.Messages, userMessage)
-	if r.store != nil {
-		if err := r.store.Save(sess); err != nil {
-			return err
-		}
-	}
-	r.appendPromptHistory(corepkg.SessionID(sess.ID), userInput, time.Now().UTC())
-	r.emit(Event{
-		Type:      EventRunStarted,
-		SessionID: corepkg.SessionID(sess.ID),
-		UserInput: userInput,
-	})
-	return nil
+	engine := &defaultEngine{runner: r}
+	return engine.beginRunSession(sess, userMessage, userInput)
 }
 
 func (r *Runner) buildTurnMessages(sess *session.Session, setup runPromptSetup) ([]llm.Message, error) {
-	return contextpkg.BuildTurnMessages(contextpkg.TurnMessagesRequest{
-		SystemPrompt: systemPrompt(PromptInput{
-			Workspace:      r.workspace,
-			ApprovalPolicy: r.config.ApprovalPolicy,
-			Model:          r.config.Provider.Model,
-			Mode:           setup.Mode,
-			Skills:         setup.AvailableSkills,
-			Tools:          setup.AvailableTools,
-			ActiveSkill:    promptActiveSkill(setup.ActiveSkill),
-			Instruction:    setup.InstructionText,
-		}),
-		WebLookupInstruction: setup.WebLookupInstruction,
-		ConversationMessages: sess.Messages,
-	})
+	engine := &defaultEngine{runner: r}
+	return engine.buildTurnMessages(sess, setup)
 }

--- a/internal/agent/tool_execution.go
+++ b/internal/agent/tool_execution.go
@@ -15,7 +15,7 @@ import (
 	"bytemind/internal/tools"
 )
 
-func (r *Runner) executeToolCall(
+func (e *defaultEngine) executeToolCall(
 	ctx context.Context,
 	sess *session.Session,
 	runMode planpkg.AgentMode,
@@ -24,30 +24,35 @@ func (r *Runner) executeToolCall(
 	allowedTools map[string]struct{},
 	deniedTools map[string]struct{},
 ) error {
-	if r.executor == nil {
+	if e == nil || e.runner == nil {
+		return fmt.Errorf("agent engine is unavailable")
+	}
+	runner := e.runner
+
+	if runner.executor == nil {
 		return fmt.Errorf("tool executor is unavailable")
 	}
-	if r.policyGateway == nil {
+	if runner.policyGateway == nil {
 		return fmt.Errorf("policy gateway is unavailable")
 	}
-	if r.runtime == nil {
+	if runner.runtime == nil {
 		return fmt.Errorf("runtime gateway is unavailable")
 	}
 
 	traceID := buildToolTraceID(call)
 	sessionID := corepkg.SessionID(sess.ID)
 
-	decision, err := r.policyGateway.DecideTool(ctx, ToolDecisionInput{
+	decision, err := runner.policyGateway.DecideTool(ctx, ToolDecisionInput{
 		ToolName:       call.Function.Name,
 		AllowedTools:   allowedTools,
 		DeniedTools:    deniedTools,
-		ApprovalPolicy: r.config.ApprovalPolicy,
-		SafetyClass:    r.toolSafetyClass(call.Function.Name),
+		ApprovalPolicy: runner.config.ApprovalPolicy,
+		SafetyClass:    e.toolSafetyClass(call.Function.Name),
 	})
 	if err != nil {
 		return err
 	}
-	r.appendAudit(ctx, storagepkg.AuditEvent{
+	runner.appendAudit(ctx, storagepkg.AuditEvent{
 		SessionID:  sessionID,
 		TraceID:    traceID,
 		Actor:      "agent",
@@ -62,16 +67,16 @@ func (r *Runner) executeToolCall(
 	})
 
 	if decision.Decision == corepkg.DecisionDeny {
-		return r.handleRejectedToolCall(ctx, sess, call, out, decision)
+		return e.handleRejectedToolCall(ctx, sess, call, out, decision)
 	}
 
-	r.emit(Event{
+	runner.emit(Event{
 		Type:          EventToolCallStarted,
 		SessionID:     sessionID,
 		ToolName:      call.Function.Name,
 		ToolArguments: call.Function.Arguments,
 	})
-	r.appendAudit(ctx, storagepkg.AuditEvent{
+	runner.appendAudit(ctx, storagepkg.AuditEvent{
 		SessionID: sessionID,
 		TraceID:   traceID,
 		Actor:     "agent",
@@ -85,7 +90,7 @@ func (r *Runner) executeToolCall(
 	}
 
 	execStartedAt := time.Now()
-	execution, runtimeErr := r.runtime.RunSync(ctx, RuntimeTaskRequest{
+	execution, runtimeErr := runner.runtime.RunSync(ctx, RuntimeTaskRequest{
 		SessionID: sessionID,
 		TraceID:   traceID,
 		Name:      call.Function.Name,
@@ -94,23 +99,23 @@ func (r *Runner) executeToolCall(
 			"tool_name": call.Function.Name,
 		},
 		Execute: func(execCtx context.Context) ([]byte, error) {
-			output, err := r.executor.ExecuteForMode(execCtx, runMode, call.Function.Name, call.Function.Arguments, &tools.ExecutionContext{
-				Workspace:      r.workspace,
-				ApprovalPolicy: r.config.ApprovalPolicy,
-				Approval:       r.approval,
+			output, err := runner.executor.ExecuteForMode(execCtx, runMode, call.Function.Name, call.Function.Arguments, &tools.ExecutionContext{
+				Workspace:      runner.workspace,
+				ApprovalPolicy: runner.config.ApprovalPolicy,
+				Approval:       runner.approval,
 				Session:        sess,
-				TaskManager:    r.taskManager,
-				Extensions:     r.extensions,
+				TaskManager:    runner.taskManager,
+				Extensions:     runner.extensions,
 				Mode:           runMode,
-				Stdin:          r.stdin,
-				Stdout:         r.stdout,
+				Stdin:          runner.stdin,
+				Stdout:         runner.stdout,
 				AllowedTools:   allowedTools,
 				DeniedTools:    deniedTools,
 			})
 			return []byte(output), err
 		},
 		OnTaskStateChanged: func(task runtimepkg.Task) {
-			r.appendTaskStateAudit(ctx, sessionID, traceID, call.Function.Name, task)
+			runner.appendTaskStateAudit(ctx, sessionID, traceID, call.Function.Name, task)
 		},
 	})
 
@@ -136,19 +141,28 @@ func (r *Runner) executeToolCall(
 		})
 	}
 	if out != nil {
-		r.renderToolFeedback(out, call.Function.Name, result)
+		runner.renderToolFeedback(out, call.Function.Name, result)
 	}
 
 	errText := ""
 	if execErr != nil {
 		errText = execErr.Error()
 	}
-	r.emit(Event{
+	runner.emit(Event{
 		Type:       EventToolCallCompleted,
 		SessionID:  sessionID,
 		ToolName:   call.Function.Name,
 		ToolResult: result,
 		Error:      errText,
+	})
+	emitTurnEvent(ctx, TurnEvent{
+		Type: TurnEventToolResult,
+		Payload: map[string]any{
+			"tool_name":    call.Function.Name,
+			"tool_call_id": call.ID,
+			"tool_result":  result,
+			"error":        errText,
+		},
 	})
 
 	auditResult := "ok"
@@ -162,7 +176,7 @@ func (r *Runner) executeToolCall(
 	if execution.Result.ErrorCode != "" {
 		metadata["error_code"] = execution.Result.ErrorCode
 	}
-	r.appendAudit(ctx, storagepkg.AuditEvent{
+	runner.appendAudit(ctx, storagepkg.AuditEvent{
 		SessionID: sessionID,
 		TaskID:    execution.TaskID,
 		TraceID:   traceID,
@@ -178,13 +192,13 @@ func (r *Runner) executeToolCall(
 		return err
 	}
 	sess.Messages = append(sess.Messages, toolMessage)
-	if r.store != nil {
-		if err := r.store.Save(sess); err != nil {
+	if runner.store != nil {
+		if err := runner.store.Save(sess); err != nil {
 			return err
 		}
 	}
 	if call.Function.Name == "update_plan" {
-		r.emit(Event{
+		runner.emit(Event{
 			Type:      EventPlanUpdated,
 			SessionID: sessionID,
 			Plan:      planpkg.CloneState(sess.Plan),
@@ -193,11 +207,16 @@ func (r *Runner) executeToolCall(
 	return nil
 }
 
-func (r *Runner) toolSafetyClass(name string) tools.SafetyClass {
+func (e *defaultEngine) toolSafetyClass(name string) tools.SafetyClass {
+	if e == nil || e.runner == nil {
+		return tools.SafetyClassModerate
+	}
+	runner := e.runner
+
 	type toolSpecLookup interface {
 		Spec(name string) (tools.ToolSpec, bool)
 	}
-	lookup, ok := r.registry.(toolSpecLookup)
+	lookup, ok := runner.registry.(toolSpecLookup)
 	if !ok {
 		return tools.SafetyClassModerate
 	}
@@ -208,13 +227,18 @@ func (r *Runner) toolSafetyClass(name string) tools.SafetyClass {
 	return spec.SafetyClass
 }
 
-func (r *Runner) handleRejectedToolCall(
+func (e *defaultEngine) handleRejectedToolCall(
 	ctx context.Context,
 	sess *session.Session,
 	call llm.ToolCall,
 	out io.Writer,
 	decision ToolDecision,
 ) error {
+	if e == nil || e.runner == nil {
+		return fmt.Errorf("agent engine is unavailable")
+	}
+	runner := e.runner
+
 	errorText := fmt.Sprintf("tool %q blocked by policy (%s): %s", call.Function.Name, decision.ReasonCode, decision.Reason)
 	if decision.ReasonCode == policyReasonExplicitDeny {
 		errorText = fmt.Sprintf("tool %q is unavailable by active skill policy: %s", call.Function.Name, decision.Reason)
@@ -227,18 +251,27 @@ func (r *Runner) handleRejectedToolCall(
 	})
 
 	if out != nil {
-		r.renderToolFeedback(out, call.Function.Name, result)
+		runner.renderToolFeedback(out, call.Function.Name, result)
 	}
 
-	r.emit(Event{
+	runner.emit(Event{
 		Type:       EventToolCallCompleted,
 		SessionID:  corepkg.SessionID(sess.ID),
 		ToolName:   call.Function.Name,
 		ToolResult: result,
 		Error:      errorText,
 	})
+	emitTurnEvent(ctx, TurnEvent{
+		Type: TurnEventToolResult,
+		Payload: map[string]any{
+			"tool_name":    call.Function.Name,
+			"tool_call_id": call.ID,
+			"tool_result":  result,
+			"error":        errorText,
+		},
+	})
 
-	r.appendAudit(ctx, storagepkg.AuditEvent{
+	runner.appendAudit(ctx, storagepkg.AuditEvent{
 		SessionID: corepkg.SessionID(sess.ID),
 		Actor:     "agent",
 		Action:    "tool_execute_result",
@@ -255,10 +288,39 @@ func (r *Runner) handleRejectedToolCall(
 		return err
 	}
 	sess.Messages = append(sess.Messages, toolMessage)
-	if r.store != nil {
-		if err := r.store.Save(sess); err != nil {
+	if runner.store != nil {
+		if err := runner.store.Save(sess); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (r *Runner) executeToolCall(
+	ctx context.Context,
+	sess *session.Session,
+	runMode planpkg.AgentMode,
+	call llm.ToolCall,
+	out io.Writer,
+	allowedTools map[string]struct{},
+	deniedTools map[string]struct{},
+) error {
+	engine := &defaultEngine{runner: r}
+	return engine.executeToolCall(ctx, sess, runMode, call, out, allowedTools, deniedTools)
+}
+
+func (r *Runner) toolSafetyClass(name string) tools.SafetyClass {
+	engine := &defaultEngine{runner: r}
+	return engine.toolSafetyClass(name)
+}
+
+func (r *Runner) handleRejectedToolCall(
+	ctx context.Context,
+	sess *session.Session,
+	call llm.ToolCall,
+	out io.Writer,
+	decision ToolDecision,
+) error {
+	engine := &defaultEngine{runner: r}
+	return engine.handleRejectedToolCall(ctx, sess, call, out, decision)
 }

--- a/internal/agent/turn_event_codec_test.go
+++ b/internal/agent/turn_event_codec_test.go
@@ -352,6 +352,18 @@ func (cancelAwareClient) StreamMessage(ctx context.Context, req llm.ChatRequest,
 	return llm.Message{}, ctx.Err()
 }
 
+type panicClient struct {
+	panicValue any
+}
+
+func (c panicClient) CreateMessage(context.Context, llm.ChatRequest) (llm.Message, error) {
+	panic(c.panicValue)
+}
+
+func (c panicClient) StreamMessage(context.Context, llm.ChatRequest, func(string)) (llm.Message, error) {
+	panic(c.panicValue)
+}
+
 func TestDefaultEngineHandleTurnEmitsToolResultWhenPolicyDenies(t *testing.T) {
 	workspace := t.TempDir()
 	store, err := session.NewStore(t.TempDir())
@@ -502,5 +514,61 @@ func TestDefaultEngineHandleTurnEmitsErrorEventOnContextCancel(t *testing.T) {
 	}
 	if terminal.ErrorCode != "run_failed" {
 		t.Fatalf("expected run_failed error code, got %q", terminal.ErrorCode)
+	}
+}
+
+func TestDefaultEngineHandleTurnEmitsErrorEventOnPanic(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Type: "openai-compatible", Model: "test-model"},
+			MaxIterations: 2,
+			Stream:        false,
+			TokenQuota:    100000,
+		},
+		Client:   panicClient{panicValue: "panic-from-client"},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	engine := NewDefaultEngine(runner)
+	events, err := engine.HandleTurn(context.Background(), TurnRequest{
+		Session: sess,
+		Input: RunPromptInput{
+			DisplayText: "panic test",
+		},
+		Mode: "build",
+		Out:  io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("HandleTurn failed: %v", err)
+	}
+
+	got := make([]TurnEvent, 0, 4)
+	for event := range events {
+		got = append(got, event)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected start+terminal event, got %d (%#v)", len(got), got)
+	}
+	if got[0].Type != TurnEventStart || got[1].Type != TurnEventError {
+		t.Fatalf("expected start->error sequence, got %#v", got)
+	}
+	if got[1].ErrorCode != "run_panicked" {
+		t.Fatalf("expected run_panicked error code, got %q", got[1].ErrorCode)
+	}
+	if got[1].Error == nil {
+		t.Fatalf("expected panic error payload, got %#v", got[1])
+	}
+	if !strings.Contains(got[1].Error.Error(), "panic-from-client") {
+		t.Fatalf("expected panic value in error payload, got %v", got[1].Error)
 	}
 }

--- a/internal/agent/turn_event_codec_test.go
+++ b/internal/agent/turn_event_codec_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"slices"
@@ -189,12 +188,6 @@ func TestDefaultEngineHandleTurnEmitsToolUseAndResultEvents(t *testing.T) {
 	sess := session.New(workspace)
 
 	registry := tools.DefaultRegistry()
-	registry.Add(&fakeTool{
-		name: "fake_tool",
-		run: func(raw json.RawMessage, execCtx *tools.ExecutionContext) (string, error) {
-			return `{"ok":true,"value":"done"}`, nil
-		},
-	})
 
 	client := &recordingClient{replies: []llm.Message{
 		{
@@ -203,8 +196,8 @@ func TestDefaultEngineHandleTurnEmitsToolUseAndResultEvents(t *testing.T) {
 				ID:   "call-1",
 				Type: "function",
 				Function: llm.ToolFunctionCall{
-					Name:      "fake_tool",
-					Arguments: `{"input":"hello"}`,
+					Name:      "list_files",
+					Arguments: `{"path":".","depth":1,"limit":20}`,
 				},
 			}},
 		},
@@ -257,7 +250,7 @@ func TestDefaultEngineHandleTurnEmitsToolUseAndResultEvents(t *testing.T) {
 	}
 
 	toolUse := got[1]
-	if toolUse.Payload["tool_name"] != "fake_tool" {
+	if toolUse.Payload["tool_name"] != "list_files" {
 		t.Fatalf("expected tool_use payload to include tool name, got %#v", toolUse.Payload)
 	}
 	if toolUse.Payload["tool_call_id"] != "call-1" {
@@ -265,7 +258,7 @@ func TestDefaultEngineHandleTurnEmitsToolUseAndResultEvents(t *testing.T) {
 	}
 
 	toolResult := got[2]
-	if toolResult.Payload["tool_name"] != "fake_tool" {
+	if toolResult.Payload["tool_name"] != "list_files" {
 		t.Fatalf("expected tool_result payload to include tool name, got %#v", toolResult.Payload)
 	}
 	resultRaw, _ := toolResult.Payload["tool_result"].(string)

--- a/internal/agent/turn_event_codec_test.go
+++ b/internal/agent/turn_event_codec_test.go
@@ -2,11 +2,16 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"io"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"bytemind/internal/config"
+	corepkg "bytemind/internal/core"
 	"bytemind/internal/llm"
 	"bytemind/internal/session"
 	"bytemind/internal/tools"
@@ -172,5 +177,330 @@ func TestDefaultEngineHandleTurnEmitsOrderedTerminalEvents(t *testing.T) {
 	}
 	if got[0].TraceID == "" || got[1].TraceID == "" {
 		t.Fatalf("expected trace id on all events, got %#v", got)
+	}
+}
+
+func TestDefaultEngineHandleTurnEmitsToolUseAndResultEvents(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+
+	registry := tools.DefaultRegistry()
+	registry.Add(&fakeTool{
+		name: "fake_tool",
+		run: func(raw json.RawMessage, execCtx *tools.ExecutionContext) (string, error) {
+			return `{"ok":true,"value":"done"}`, nil
+		},
+	})
+
+	client := &recordingClient{replies: []llm.Message{
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "fake_tool",
+					Arguments: `{"input":"hello"}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "engine answer",
+		},
+	}}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Type: "openai-compatible", Model: "test-model"},
+			MaxIterations: 4,
+			Stream:        false,
+			TokenQuota:    100000,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: registry,
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	engine := NewDefaultEngine(runner)
+	events, err := engine.HandleTurn(context.Background(), TurnRequest{
+		Session: sess,
+		Input: RunPromptInput{
+			DisplayText: "run tool",
+		},
+		Mode: "build",
+		Out:  io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("HandleTurn failed: %v", err)
+	}
+
+	got := make([]TurnEvent, 0, 6)
+	for event := range events {
+		got = append(got, event)
+	}
+
+	types := make([]TurnEventType, 0, len(got))
+	for _, event := range got {
+		types = append(types, event.Type)
+	}
+	wantTypes := []TurnEventType{TurnEventStart, TurnEventToolUse, TurnEventToolResult, TurnEventComplete}
+	if !slices.Equal(types, wantTypes) {
+		t.Fatalf("unexpected event sequence: got=%v want=%v", types, wantTypes)
+	}
+
+	toolUse := got[1]
+	if toolUse.Payload["tool_name"] != "fake_tool" {
+		t.Fatalf("expected tool_use payload to include tool name, got %#v", toolUse.Payload)
+	}
+	if toolUse.Payload["tool_call_id"] != "call-1" {
+		t.Fatalf("expected tool_use payload to include call id, got %#v", toolUse.Payload)
+	}
+
+	toolResult := got[2]
+	if toolResult.Payload["tool_name"] != "fake_tool" {
+		t.Fatalf("expected tool_result payload to include tool name, got %#v", toolResult.Payload)
+	}
+	resultRaw, _ := toolResult.Payload["tool_result"].(string)
+	if !strings.Contains(resultRaw, `"ok":true`) {
+		t.Fatalf("expected encoded tool result payload, got %#v", toolResult.Payload)
+	}
+}
+
+func TestDefaultEngineHandleTurnEmitsDeltaEventsForStreaming(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	client := &recordingClient{replies: []llm.Message{
+		{Role: llm.RoleAssistant, Content: "streamed answer"},
+	}}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Type: "openai-compatible", Model: "test-model"},
+			MaxIterations: 2,
+			Stream:        true,
+			TokenQuota:    100000,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	engine := NewDefaultEngine(runner)
+	events, err := engine.HandleTurn(context.Background(), TurnRequest{
+		Session: sess,
+		Input: RunPromptInput{
+			DisplayText: "hello",
+		},
+		Mode: "build",
+		Out:  io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("HandleTurn failed: %v", err)
+	}
+
+	got := make([]TurnEvent, 0, 4)
+	for event := range events {
+		got = append(got, event)
+	}
+	types := make([]TurnEventType, 0, len(got))
+	for _, event := range got {
+		types = append(types, event.Type)
+	}
+	wantTypes := []TurnEventType{TurnEventStart, TurnEventDelta, TurnEventComplete}
+	if !slices.Equal(types, wantTypes) {
+		t.Fatalf("unexpected event sequence: got=%v want=%v", types, wantTypes)
+	}
+	if got[1].Payload["content"] != "streamed answer" {
+		t.Fatalf("unexpected delta payload: %#v", got[1].Payload)
+	}
+}
+
+type denyAllPolicyGateway struct{}
+
+func (denyAllPolicyGateway) DecideTool(context.Context, ToolDecisionInput) (ToolDecision, error) {
+	return ToolDecision{
+		Decision:   corepkg.DecisionDeny,
+		ReasonCode: policyReasonRiskRule,
+		Reason:     "blocked for test",
+		RiskLevel:  corepkg.RiskHigh,
+	}, nil
+}
+
+type cancelAwareClient struct{}
+
+func (cancelAwareClient) CreateMessage(ctx context.Context, req llm.ChatRequest) (llm.Message, error) {
+	<-ctx.Done()
+	return llm.Message{}, ctx.Err()
+}
+
+func (cancelAwareClient) StreamMessage(ctx context.Context, req llm.ChatRequest, onDelta func(string)) (llm.Message, error) {
+	<-ctx.Done()
+	return llm.Message{}, ctx.Err()
+}
+
+func TestDefaultEngineHandleTurnEmitsToolResultWhenPolicyDenies(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	client := &recordingClient{replies: []llm.Message{
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-denied",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "run_shell",
+					Arguments: `{"command":"echo hi"}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "done after deny",
+		},
+	}}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Type: "openai-compatible", Model: "test-model"},
+			MaxIterations: 4,
+			Stream:        false,
+			TokenQuota:    100000,
+		},
+		Client:        client,
+		Store:         store,
+		Registry:      tools.DefaultRegistry(),
+		PolicyGateway: denyAllPolicyGateway{},
+		Stdin:         strings.NewReader(""),
+		Stdout:        io.Discard,
+	})
+
+	engine := NewDefaultEngine(runner)
+	events, err := engine.HandleTurn(context.Background(), TurnRequest{
+		Session: sess,
+		Input: RunPromptInput{
+			DisplayText: "try denied tool",
+		},
+		Mode: "build",
+		Out:  io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("HandleTurn failed: %v", err)
+	}
+
+	got := make([]TurnEvent, 0, 6)
+	for event := range events {
+		got = append(got, event)
+	}
+	types := make([]TurnEventType, 0, len(got))
+	for _, event := range got {
+		types = append(types, event.Type)
+	}
+	wantTypes := []TurnEventType{TurnEventStart, TurnEventToolUse, TurnEventToolResult, TurnEventComplete}
+	if !slices.Equal(types, wantTypes) {
+		t.Fatalf("unexpected event sequence: got=%v want=%v", types, wantTypes)
+	}
+
+	toolResult := got[2]
+	resultRaw, _ := toolResult.Payload["tool_result"].(string)
+	if !strings.Contains(resultRaw, `"ok":false`) {
+		t.Fatalf("expected deny result payload, got %#v", toolResult.Payload)
+	}
+	errText, _ := toolResult.Payload["error"].(string)
+	if !strings.Contains(errText, "blocked") {
+		t.Fatalf("expected blocked error text, got %#v", toolResult.Payload)
+	}
+}
+
+func TestDefaultEngineHandleTurnEmitsErrorEventOnContextCancel(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Type: "openai-compatible", Model: "test-model"},
+			MaxIterations: 2,
+			Stream:        false,
+			TokenQuota:    100000,
+		},
+		Client:   cancelAwareClient{},
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	engine := NewDefaultEngine(runner)
+	events, err := engine.HandleTurn(ctx, TurnRequest{
+		Session: sess,
+		Input: RunPromptInput{
+			DisplayText: "cancel test",
+		},
+		Mode: "build",
+		Out:  io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("HandleTurn failed: %v", err)
+	}
+
+	var start TurnEvent
+	select {
+	case event, ok := <-events:
+		if !ok {
+			t.Fatal("event stream closed before start event")
+		}
+		start = event
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for start event")
+	}
+	if start.Type != TurnEventStart {
+		t.Fatalf("expected start event, got %#v", start)
+	}
+
+	cancel()
+
+	var terminal TurnEvent
+	select {
+	case event, ok := <-events:
+		if !ok {
+			t.Fatal("event stream closed before terminal error")
+		}
+		terminal = event
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for terminal error")
+	}
+
+	if terminal.Type != TurnEventError {
+		t.Fatalf("expected error terminal event, got %#v", terminal)
+	}
+	if !errors.Is(terminal.Error, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", terminal.Error)
+	}
+	if terminal.ErrorCode != "run_failed" {
+		t.Fatalf("expected run_failed error code, got %q", terminal.ErrorCode)
 	}
 }

--- a/internal/agent/turn_event_runtime.go
+++ b/internal/agent/turn_event_runtime.go
@@ -1,0 +1,30 @@
+package agent
+
+import "context"
+
+type turnEventSink interface {
+	Emit(TurnEvent) error
+}
+
+type turnEventSinkContextKey struct{}
+
+func withTurnEventSink(ctx context.Context, sink turnEventSink) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if sink == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, turnEventSinkContextKey{}, sink)
+}
+
+func emitTurnEvent(ctx context.Context, event TurnEvent) {
+	if ctx == nil {
+		return
+	}
+	sink, ok := ctx.Value(turnEventSinkContextKey{}).(turnEventSink)
+	if !ok || sink == nil {
+		return
+	}
+	_ = sink.Emit(event)
+}

--- a/internal/agent/turn_processing.go
+++ b/internal/agent/turn_processing.go
@@ -30,13 +30,18 @@ type turnProcessParams struct {
 	Out              io.Writer
 }
 
-func (r *Runner) processTurn(ctx context.Context, p turnProcessParams) (string, bool, error) {
-	if r.registry == nil {
+func (e *defaultEngine) processTurn(ctx context.Context, p turnProcessParams) (string, bool, error) {
+	if e == nil || e.runner == nil {
+		return "", false, fmt.Errorf("agent engine is unavailable")
+	}
+	runner := e.runner
+
+	if runner.registry == nil {
 		return "", false, fmt.Errorf("tool registry is unavailable")
 	}
-	filteredTools := r.registry.DefinitionsForModeWithFilters(p.RunMode, p.AllowedToolNames, p.DeniedToolNames)
+	filteredTools := runner.registry.DefinitionsForModeWithFilters(p.RunMode, p.AllowedToolNames, p.DeniedToolNames)
 	request := contextpkg.BuildChatRequest(contextpkg.ChatRequestInput{
-		Model:       r.config.Provider.Model,
+		Model:       runner.config.Provider.Model,
 		Messages:    p.Messages,
 		Tools:       filteredTools,
 		Assets:      p.Assets,
@@ -45,20 +50,20 @@ func (r *Runner) processTurn(ctx context.Context, p turnProcessParams) (string, 
 
 	streamedText := false
 	turnStart := time.Now()
-	reply, err := r.completeTurn(ctx, request, p.Out, &streamedText)
+	reply, err := e.completeTurn(ctx, request, p.Out, &streamedText)
 	turnLatency := time.Since(turnStart)
 	if err != nil {
 		estimatedUsage := tokenusage.ResolveTurnUsage(request, nil)
-		r.recordTokenUsage(ctx, p.Session, request, estimatedUsage, turnLatency, false)
+		runner.recordTokenUsage(ctx, p.Session, request, estimatedUsage, turnLatency, false)
 		return "", false, err
 	}
 	reply.Normalize()
 	turnUsage := tokenusage.ResolveTurnUsage(request, &reply)
-	r.recordTokenUsage(ctx, p.Session, request, turnUsage, turnLatency, true)
-	r.emitUsageEvent(p.Session, &turnUsage)
+	runner.recordTokenUsage(ctx, p.Session, request, turnUsage, turnLatency, true)
+	runner.emitUsageEvent(p.Session, &turnUsage)
 
 	if len(reply.ToolCalls) == 0 {
-		answer, finalizeErr := r.finalizeTurnWithoutTools(p.RunMode, p.Session, reply, p.Out, streamedText)
+		answer, finalizeErr := e.finalizeTurnWithoutTools(p.RunMode, p.Session, reply, p.Out, streamedText)
 		return answer, true, finalizeErr
 	}
 
@@ -72,13 +77,13 @@ func (r *Runner) processTurn(ctx context.Context, p turnProcessParams) (string, 
 			Reason:        fmt.Sprintf("I stopped because the assistant repeated the same tool sequence %d times in a row (%s).", sequenceObservation.RepeatCount, strings.Join(sequenceObservation.UniqueToolNames, ", ")),
 			ExecutedTools: *p.ExecutedTools,
 		})
-		answer, summaryErr := r.finishWithSummary(p.Session, summary, p.Out, streamedText)
+		answer, summaryErr := e.finishWithSummary(p.Session, summary, p.Out, streamedText)
 		return answer, true, summaryErr
 	}
 
 	p.Session.Messages = append(p.Session.Messages, reply)
-	if r.store != nil {
-		if err := r.store.Save(p.Session); err != nil {
+	if runner.store != nil {
+		if err := runner.store.Save(p.Session); err != nil {
 			return "", false, err
 		}
 	}
@@ -88,9 +93,22 @@ func (r *Runner) processTurn(ctx context.Context, p turnProcessParams) (string, 
 	}
 	for _, call := range reply.ToolCalls {
 		*p.ExecutedTools = append(*p.ExecutedTools, call.Function.Name)
-		if err := r.executeToolCall(ctx, p.Session, p.RunMode, call, p.Out, p.AllowedTools, p.DeniedTools); err != nil {
+		emitTurnEvent(ctx, TurnEvent{
+			Type: TurnEventToolUse,
+			Payload: map[string]any{
+				"tool_name":      call.Function.Name,
+				"tool_arguments": call.Function.Arguments,
+				"tool_call_id":   call.ID,
+			},
+		})
+		if err := e.executeToolCall(ctx, p.Session, p.RunMode, call, p.Out, p.AllowedTools, p.DeniedTools); err != nil {
 			return "", false, err
 		}
 	}
 	return "", false, nil
+}
+
+func (r *Runner) processTurn(ctx context.Context, p turnProcessParams) (string, bool, error) {
+	engine := &defaultEngine{runner: r}
+	return engine.processTurn(ctx, p)
 }


### PR DESCRIPTION
## Summary
- move turn orchestration setup/run-loop/completion/tool/finalize flow into defaultEngine and keep Runner methods as compatibility delegators
- add runtime turn-event sink propagation and emit delta/tool_use/tool_result during real execution paths
- add contract tests for tool path, streaming delta, policy deny path, and context-cancel error terminal behavior

## Validation
- go test ./internal/agent -v
- go test ./internal/runtime -v
- go test ./...

Closes #237