### PR TITLE
Extension丨re:step3 实现发现与校验管线

### DIFF
--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -78,9 +78,6 @@ func (m *extensionManager) Unload(_ context.Context, extensionID string) error {
 	if _, ok := m.catalog[id]; !ok {
 		if _, ok := m.manual[id]; !ok {
 			if _, ok := m.discoverErrs[id]; !ok {
-				if discoverErr := m.discoveryErrorLocked(); discoverErr != nil {
-					return discoverErr
-				}
 				return wrapError(ErrCodeNotFound, "extension not found", nil)
 			}
 		}
@@ -112,7 +109,7 @@ func (m *extensionManager) Get(_ context.Context, extensionID string) (Extension
 		if err, ok := m.discoverErrs[id]; ok {
 			return ExtensionInfo{}, err
 		}
-		return ExtensionInfo{}, discoverErr
+		return ExtensionInfo{}, wrapError(ErrCodeNotFound, "extension not found", nil)
 	}
 	if _, disabled := m.disabled[id]; disabled {
 		return ExtensionInfo{}, wrapError(ErrCodeNotFound, "extension not found", nil)

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -264,6 +264,31 @@ func TestManagerGetReturnsHealthyExtensionWithObservableDiscoveryError(t *testin
 	}
 }
 
+func TestManagerGetMissingReturnsNotFoundDespiteOtherDiscoveryErrors(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	bad := filepath.Join(project, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, "skill.json"), []byte(`{"name":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	item, err := mgr.Get(context.Background(), "skill.missing")
+	if item != (ExtensionInfo{}) {
+		t.Fatal("expected zero extension info")
+	}
+	var extErr *ExtensionError
+	if !errors.As(err, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr.Code != ErrCodeNotFound {
+		t.Fatalf("unexpected code: %s", extErr.Code)
+	}
+}
+
 func TestManagerGetReturnsNotFound(t *testing.T) {
 	mgr := NewManager(t.TempDir())
 	item, err := mgr.Get(context.Background(), "skill.review")
@@ -273,6 +298,28 @@ func TestManagerGetReturnsNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected not found error")
 	}
+	var extErr *ExtensionError
+	if !errors.As(err, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr.Code != ErrCodeNotFound {
+		t.Fatalf("unexpected code: %s", extErr.Code)
+	}
+}
+
+func TestManagerUnloadMissingReturnsNotFoundDespiteOtherDiscoveryErrors(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	bad := filepath.Join(project, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, "skill.json"), []byte(`{"name":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	err := mgr.Unload(context.Background(), "skill.missing")
 	var extErr *ExtensionError
 	if !errors.As(err, &extErr) {
 		t.Fatalf("expected ExtensionError, got %T", err)


### PR DESCRIPTION
解决目标

> Medium Get/Unload 的 not_found 语义会被“无关的 discovery 错误”覆盖，导致失败不再局部化。
> internal/extensions/manager.go:105-116：当存在任意 discoverErrs 时，Get("skill.missing") 会返回 load_failed（聚合发现错误），而不是 not_found。
> internal/extensions/manager.go:80-84：Unload("skill.missing") 在同样场景下也会返回 discovery 错误，而不是 not_found。
> 影响：调用方无法区分“目标扩展不存在”与“其他扩展损坏”，会把无关故障传播到本次目标操作，和阶段3强调的“失败局部化”不一致。
> 建议：仅在目标 ID 本身命中 discoverErrs[id] 时返回该错误；否则维持 not_found 语义。并补充测试覆盖“存在坏扩展时 Get/Unload missing id 仍返回 ErrCodeNotFound”。