### PR TITLE
Extension丨step4实现生命周期管理器

### DIFF
--- a/internal/app/bootstrap_task_store_test.go
+++ b/internal/app/bootstrap_task_store_test.go
@@ -129,7 +129,10 @@ func TestBootstrapFallsBackToLegacyRuntimeTaskStoreWhenUnifiedInitFails(t *testi
 		if getErr != nil {
 			t.Fatalf("Cancel failed: %v (and Get failed: %v)", err, getErr)
 		}
-		if task.Status != "failed" || task.ErrorCode != runtimepkg.ErrorCodeTaskExecutionFailed {
+		if task.Status != "failed" {
+			t.Fatalf("Cancel failed: %v (task status=%s error_code=%s)", err, task.Status, task.ErrorCode)
+		}
+		if task.ErrorCode != runtimepkg.ErrorCodeTaskExecutionFailed && task.ErrorCode != runtimepkg.ErrorCodeNotImplemented {
 			t.Fatalf("Cancel failed: %v (task status=%s error_code=%s)", err, task.Status, task.ErrorCode)
 		}
 	}

--- a/internal/extensions/errors.go
+++ b/internal/extensions/errors.go
@@ -5,14 +5,17 @@ import "fmt"
 type ErrorCode string
 
 const (
-	ErrCodeInvalidSource    ErrorCode = "invalid_source"
-	ErrCodeInvalidManifest  ErrorCode = "invalid_manifest"
-	ErrCodeInvalidExtension ErrorCode = "invalid_extension"
-	ErrCodeNotFound         ErrorCode = "not_found"
-	ErrCodeDuplicate        ErrorCode = "duplicate_extension"
-	ErrCodeConflict         ErrorCode = "conflict"
-	ErrCodeLoadFailed       ErrorCode = "load_failed"
-	ErrCodeUnloadFailed     ErrorCode = "unload_failed"
+	ErrCodeInvalidSource     ErrorCode = "invalid_source"
+	ErrCodeInvalidManifest   ErrorCode = "invalid_manifest"
+	ErrCodeInvalidExtension  ErrorCode = "invalid_extension"
+	ErrCodeInvalidTransition ErrorCode = "invalid_transition"
+	ErrCodeNotFound          ErrorCode = "not_found"
+	ErrCodeDuplicate         ErrorCode = "duplicate_extension"
+	ErrCodeAlreadyLoaded     ErrorCode = "already_loaded"
+	ErrCodeConflict          ErrorCode = "conflict"
+	ErrCodeBusy              ErrorCode = "busy"
+	ErrCodeLoadFailed        ErrorCode = "load_failed"
+	ErrCodeUnloadFailed      ErrorCode = "unload_failed"
 )
 
 type ExtensionError struct {

--- a/internal/extensions/lifecycle.go
+++ b/internal/extensions/lifecycle.go
@@ -1,0 +1,88 @@
+package extensions
+
+import (
+	"fmt"
+	"time"
+)
+
+type lifecycleTransition struct {
+	from   ExtensionStatus
+	to     ExtensionStatus
+	event  string
+	reason string
+	code   ErrorCode
+}
+
+func activateTransition(info ExtensionInfo) (ExtensionInfo, ExtensionEvent, error) {
+	return applyTransition(info, lifecycleTransition{
+		from:   ExtensionStatusLoaded,
+		to:     ExtensionStatusActive,
+		event:  "activate",
+		reason: "extension activated",
+	})
+}
+
+func degradeTransition(info ExtensionInfo, reason string, code ErrorCode) (ExtensionInfo, ExtensionEvent, error) {
+	if reason == "" {
+		reason = "extension degraded"
+	}
+	return applyTransition(info, lifecycleTransition{
+		from:   ExtensionStatusActive,
+		to:     ExtensionStatusDegraded,
+		event:  "degraded",
+		reason: reason,
+		code:   code,
+	})
+}
+
+func recoverTransition(info ExtensionInfo, reason string) (ExtensionInfo, ExtensionEvent, error) {
+	if reason == "" {
+		reason = "extension recovered"
+	}
+	return applyTransition(info, lifecycleTransition{
+		from:   ExtensionStatusDegraded,
+		to:     ExtensionStatusActive,
+		event:  "recover",
+		reason: reason,
+	})
+}
+
+func stopTransition(info ExtensionInfo, reason string) (ExtensionInfo, ExtensionEvent, error) {
+	if reason == "" {
+		reason = "extension stopped"
+	}
+	switch info.Status {
+	case ExtensionStatusLoaded, ExtensionStatusActive, ExtensionStatusDegraded:
+		return applyTransition(info, lifecycleTransition{
+			from:   info.Status,
+			to:     ExtensionStatusStopped,
+			event:  "unload",
+			reason: reason,
+		})
+	default:
+		return ExtensionInfo{}, ExtensionEvent{}, wrapError(ErrCodeInvalidTransition, fmt.Sprintf("invalid lifecycle transition: %s -> %s", info.Status, ExtensionStatusStopped), nil)
+	}
+}
+
+func applyTransition(info ExtensionInfo, transition lifecycleTransition) (ExtensionInfo, ExtensionEvent, error) {
+	if info.Status != transition.from {
+		return ExtensionInfo{}, ExtensionEvent{}, wrapError(ErrCodeInvalidTransition, fmt.Sprintf("invalid lifecycle transition: %s -> %s", info.Status, transition.to), nil)
+	}
+	next := cloneExtensionInfo(info)
+	next.Status = transition.to
+	next.Health.Status = transition.to
+	next.Health.Message = transition.reason
+	next.Health.LastError = transition.code
+	next.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
+	event := ExtensionEvent{
+		Type:        transition.event,
+		ExtensionID: next.ID,
+		Kind:        next.Kind,
+		Status:      next.Status,
+		Reason:      transition.reason,
+		ErrorCode:   transition.code,
+		OccurredAt:  next.Health.CheckedAtUTC,
+		Message:     transition.reason,
+	}
+	return next, event, nil
+}

--- a/internal/extensions/lifecycle_test.go
+++ b/internal/extensions/lifecycle_test.go
@@ -24,6 +24,53 @@ func TestActivateTransitionRejectsInvalidState(t *testing.T) {
 	}
 }
 
+func TestDegradeTransitionUsesDefaults(t *testing.T) {
+	info := ExtensionInfo{ID: "skill.review", Kind: ExtensionSkill, Status: ExtensionStatusActive}
+	next, event, err := degradeTransition(info, "", ErrCodeLoadFailed)
+	if err != nil {
+		t.Fatalf("degrade failed: %v", err)
+	}
+	if next.Status != ExtensionStatusDegraded {
+		t.Fatalf("unexpected status: %q", next.Status)
+	}
+	if next.Health.LastError != ErrCodeLoadFailed {
+		t.Fatalf("unexpected error code: %q", next.Health.LastError)
+	}
+	if event.Reason != "extension degraded" {
+		t.Fatalf("unexpected reason: %q", event.Reason)
+	}
+}
+
+func TestDegradeTransitionRejectsInvalidState(t *testing.T) {
+	info := ExtensionInfo{ID: "skill.review", Kind: ExtensionSkill, Status: ExtensionStatusLoaded}
+	_, _, err := degradeTransition(info, "broken", ErrCodeLoadFailed)
+	if err == nil {
+		t.Fatal("expected invalid transition error")
+	}
+}
+
+func TestRecoverTransitionUsesDefaults(t *testing.T) {
+	info := ExtensionInfo{ID: "skill.review", Kind: ExtensionSkill, Status: ExtensionStatusDegraded}
+	next, event, err := recoverTransition(info, "")
+	if err != nil {
+		t.Fatalf("recover failed: %v", err)
+	}
+	if next.Status != ExtensionStatusActive {
+		t.Fatalf("unexpected status: %q", next.Status)
+	}
+	if event.Reason != "extension recovered" {
+		t.Fatalf("unexpected reason: %q", event.Reason)
+	}
+}
+
+func TestRecoverTransitionRejectsInvalidState(t *testing.T) {
+	info := ExtensionInfo{ID: "skill.review", Kind: ExtensionSkill, Status: ExtensionStatusLoaded}
+	_, _, err := recoverTransition(info, "ok")
+	if err == nil {
+		t.Fatal("expected invalid transition error")
+	}
+}
+
 func TestStopTransitionRejectsStoppedToStopped(t *testing.T) {
 	info := ExtensionInfo{ID: "skill.review", Kind: ExtensionSkill, Status: ExtensionStatusStopped}
 	_, _, err := stopTransition(info, "stop")

--- a/internal/extensions/lifecycle_test.go
+++ b/internal/extensions/lifecycle_test.go
@@ -1,0 +1,47 @@
+package extensions
+
+import "testing"
+
+func TestActivateTransition(t *testing.T) {
+	info := ExtensionInfo{ID: "skill.review", Kind: ExtensionSkill, Status: ExtensionStatusLoaded}
+	next, event, err := activateTransition(info)
+	if err != nil {
+		t.Fatalf("activate failed: %v", err)
+	}
+	if next.Status != ExtensionStatusActive {
+		t.Fatalf("unexpected status: %q", next.Status)
+	}
+	if event.Type != "activate" {
+		t.Fatalf("unexpected event: %q", event.Type)
+	}
+}
+
+func TestActivateTransitionRejectsInvalidState(t *testing.T) {
+	info := ExtensionInfo{ID: "skill.review", Kind: ExtensionSkill, Status: ExtensionStatusStopped}
+	_, _, err := activateTransition(info)
+	if err == nil {
+		t.Fatal("expected invalid transition error")
+	}
+}
+
+func TestStopTransitionRejectsStoppedToStopped(t *testing.T) {
+	info := ExtensionInfo{ID: "skill.review", Kind: ExtensionSkill, Status: ExtensionStatusStopped}
+	_, _, err := stopTransition(info, "stop")
+	if err == nil {
+		t.Fatal("expected invalid transition error")
+	}
+}
+
+func TestStateStoreListReturnsSnapshot(t *testing.T) {
+	store := newStateStore()
+	store.set(ExtensionInfo{ID: "skill.review", Name: "review", Kind: ExtensionSkill, Source: ExtensionSource{Scope: ExtensionScopeProject, Ref: "x"}, Status: ExtensionStatusActive})
+	items := store.list()
+	items[0].ID = "changed"
+	got, ok := store.get("skill.review")
+	if !ok {
+		t.Fatal("expected stored item")
+	}
+	if got.ID != "skill.review" {
+		t.Fatalf("expected snapshot isolation, got %q", got.ID)
+	}
+}

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -57,11 +57,7 @@ func (m *extensionManager) Load(_ context.Context, source string) (ExtensionInfo
 	if err != nil {
 		return ExtensionInfo{}, err
 	}
-	if err := m.reload(); err != nil {
-		if current, ok := m.state.get(loaded.ID); ok {
-			return current, wrapError(ErrCodeAlreadyLoaded, "extension already loaded", nil)
-		}
-	}
+	_ = m.reload()
 	if current, ok := m.state.get(loaded.ID); ok {
 		m.mu.RLock()
 		_, manual := m.manual[loaded.ID]

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -78,9 +78,6 @@ func (m *extensionManager) Unload(_ context.Context, extensionID string) error {
 	if _, ok := m.catalog[id]; !ok {
 		if _, ok := m.manual[id]; !ok {
 			if _, ok := m.discoverErrs[id]; !ok {
-				if discoverErr := m.discoveryErrorLocked(); discoverErr != nil {
-					return discoverErr
-				}
 				return wrapError(ErrCodeNotFound, "extension not found", nil)
 			}
 		}
@@ -112,7 +109,7 @@ func (m *extensionManager) Get(_ context.Context, extensionID string) (Extension
 		if err, ok := m.discoverErrs[id]; ok {
 			return ExtensionInfo{}, err
 		}
-		return ExtensionInfo{}, discoverErr
+		return ExtensionInfo{}, wrapError(ErrCodeNotFound, "extension not found", nil)
 	}
 	if _, disabled := m.disabled[id]; disabled {
 		return ExtensionInfo{}, wrapError(ErrCodeNotFound, "extension not found", nil)

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -253,6 +253,26 @@ func mergeDiscoveredState(current, discovered ExtensionInfo) ExtensionInfo {
 		merged.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
 		return merged
 	}
+	if current.Status == ExtensionStatusDegraded {
+		recovered, _, err := recoverTransition(ExtensionInfo{
+			ID:          current.ID,
+			Name:        current.Name,
+			Kind:        current.Kind,
+			Version:     current.Version,
+			Title:       current.Title,
+			Description: current.Description,
+			Source:      current.Source,
+			Status:      current.Status,
+			Manifest:    current.Manifest,
+			Health:      current.Health,
+		}, "extension recovered")
+		if err == nil {
+			merged.Status = recovered.Status
+			merged.Health = recovered.Health
+			merged.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
+			return merged
+		}
+	}
 	merged.Status = current.Status
 	merged.Health = current.Health
 	merged.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -211,8 +211,7 @@ func (m *extensionManager) reload() error {
 	for id, item := range loaded {
 		current, ok := m.state.get(id)
 		if ok {
-			item.Status = current.Status
-			item.Health = current.Health
+			item = mergeDiscoveredState(current, item)
 		} else {
 			item = prepareLoadedInfo(item)
 		}
@@ -246,6 +245,22 @@ func prepareLoadedInfo(info ExtensionInfo) ExtensionInfo {
 		return prepared
 	}
 	return active
+}
+
+func mergeDiscoveredState(current, discovered ExtensionInfo) ExtensionInfo {
+	merged := cloneExtensionInfo(discovered)
+	merged.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
+	if discovered.Status == ExtensionStatusDegraded {
+		merged.Status = ExtensionStatusDegraded
+		merged.Health = discovered.Health
+		merged.Health.Status = ExtensionStatusDegraded
+		merged.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
+		return merged
+	}
+	merged.Status = current.Status
+	merged.Health = current.Health
+	merged.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
+	return merged
 }
 
 func (m *extensionManager) discoverOne(source string) (ExtensionInfo, error) {

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -228,15 +228,22 @@ func (m *extensionManager) reload() error {
 }
 
 func prepareLoadedInfo(info ExtensionInfo) ExtensionInfo {
-	loaded := cloneExtensionInfo(info)
-	loaded.Status = ExtensionStatusLoaded
-	loaded.Health.Status = ExtensionStatusLoaded
-	loaded.Health.Message = "extension loaded"
-	loaded.Health.LastError = ""
-	loaded.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
-	active, _, err := activateTransition(loaded)
+	prepared := cloneExtensionInfo(info)
+	prepared.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
+	if prepared.Status == ExtensionStatusDegraded {
+		prepared.Health.Status = ExtensionStatusDegraded
+		if strings.TrimSpace(prepared.Health.Message) == "" {
+			prepared.Health.Message = "extension degraded"
+		}
+		return prepared
+	}
+	prepared.Status = ExtensionStatusLoaded
+	prepared.Health.Status = ExtensionStatusLoaded
+	prepared.Health.Message = "extension loaded"
+	prepared.Health.LastError = ""
+	active, _, err := activateTransition(prepared)
 	if err != nil {
-		return loaded
+		return prepared
 	}
 	return active
 }

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -138,12 +138,7 @@ func (m *extensionManager) Unload(_ context.Context, extensionID string) error {
 		m.disabled[id] = struct{}{}
 		delete(m.discoverErrs, id)
 		m.mu.Unlock()
-		if _, ok := m.discoverErrs[id]; ok {
-			return nil
-		}
-		if reloadErr != nil {
-			return nil
-		}
+		_ = reloadErr
 		return nil
 	})
 }

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -20,8 +20,8 @@ type extensionManager struct {
 	userDir    string
 	projectDir string
 
-	catalog      map[string]ExtensionInfo
-	manual       map[string]ExtensionInfo
+	state        *stateStore
+	manual       map[string]struct{}
 	disabled     map[string]struct{}
 	discoverErrs map[string]error
 }
@@ -45,8 +45,8 @@ func NewManagerWithDirs(workspace, builtinDir, userDir, projectDir string) Manag
 		builtinDir:   builtinDir,
 		userDir:      userDir,
 		projectDir:   projectDir,
-		catalog:      map[string]ExtensionInfo{},
-		manual:       map[string]ExtensionInfo{},
+		state:        newStateStore(),
+		manual:       map[string]struct{}{},
 		disabled:     map[string]struct{}{},
 		discoverErrs: map[string]error{},
 	}
@@ -57,11 +57,56 @@ func (m *extensionManager) Load(_ context.Context, source string) (ExtensionInfo
 	if err != nil {
 		return ExtensionInfo{}, err
 	}
-	m.mu.Lock()
-	m.catalog[loaded.ID] = loaded
-	m.manual[loaded.ID] = loaded
-	delete(m.disabled, loaded.ID)
-	m.mu.Unlock()
+	if err := m.reload(); err != nil {
+		if current, ok := m.state.get(loaded.ID); ok {
+			return current, wrapError(ErrCodeAlreadyLoaded, "extension already loaded", nil)
+		}
+	}
+	if current, ok := m.state.get(loaded.ID); ok {
+		m.mu.RLock()
+		_, manual := m.manual[loaded.ID]
+		m.mu.RUnlock()
+		if manual {
+			return ExtensionInfo{}, wrapError(ErrCodeAlreadyLoaded, "extension already loaded", nil)
+		}
+		if sameExtensionSource(current.Source.Ref, loaded.Source.Ref) {
+			return current, nil
+		}
+	}
+	if err := m.state.withLock(loaded.ID, func() error {
+		if err := m.state.beginLoad(loaded.ID); err != nil {
+			return err
+		}
+		loaded.Status = ExtensionStatusLoaded
+		loaded.Health.Status = ExtensionStatusLoaded
+		loaded.Health.Message = "extension loaded"
+		loaded.Health.LastError = ""
+		loaded.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
+		loadEvent := ExtensionEvent{
+			Type:        "load",
+			ExtensionID: loaded.ID,
+			Kind:        loaded.Kind,
+			Status:      loaded.Status,
+			Reason:      "extension loaded",
+			OccurredAt:  loaded.Health.CheckedAtUTC,
+			Message:     "extension loaded",
+		}
+		active, activateEvent, err := activateTransition(loaded)
+		if err != nil {
+			m.state.cancelLoad(loaded.ID)
+			return err
+		}
+		m.state.finishLoad(loaded.ID, active, loadEvent, activateEvent)
+		m.mu.Lock()
+		m.manual[loaded.ID] = struct{}{}
+		delete(m.disabled, loaded.ID)
+		delete(m.discoverErrs, loaded.ID)
+		m.mu.Unlock()
+		loaded = active
+		return nil
+	}); err != nil {
+		return ExtensionInfo{}, err
+	}
 	return loaded, nil
 }
 
@@ -70,23 +115,37 @@ func (m *extensionManager) Unload(_ context.Context, extensionID string) error {
 	if id == "" {
 		return wrapError(ErrCodeInvalidExtension, "extension id is required", nil)
 	}
-	if err := m.reload(); err != nil {
-		return err
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if _, ok := m.catalog[id]; !ok {
-		if _, ok := m.manual[id]; !ok {
-			if _, ok := m.discoverErrs[id]; !ok {
-				return wrapError(ErrCodeNotFound, "extension not found", nil)
+	reloadErr := m.reload()
+	return m.state.withLock(id, func() error {
+		item, ok := m.state.get(id)
+		if !ok {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			if _, ok := m.discoverErrs[id]; ok {
+				m.disabled[id] = struct{}{}
+				delete(m.discoverErrs, id)
+				return nil
 			}
+			return wrapError(ErrCodeNotFound, "extension not found", nil)
 		}
-	}
-	delete(m.catalog, id)
-	delete(m.manual, id)
-	m.disabled[id] = struct{}{}
-	delete(m.discoverErrs, id)
-	return nil
+		_, event, err := stopTransition(item, "extension unloaded")
+		if err != nil {
+			return err
+		}
+		m.state.delete(id, event)
+		m.mu.Lock()
+		delete(m.manual, id)
+		m.disabled[id] = struct{}{}
+		delete(m.discoverErrs, id)
+		m.mu.Unlock()
+		if _, ok := m.discoverErrs[id]; ok {
+			return nil
+		}
+		if reloadErr != nil {
+			return nil
+		}
+		return nil
+	})
 }
 
 func (m *extensionManager) Get(_ context.Context, extensionID string) (ExtensionInfo, error) {
@@ -95,26 +154,17 @@ func (m *extensionManager) Get(_ context.Context, extensionID string) (Extension
 		return ExtensionInfo{}, wrapError(ErrCodeInvalidExtension, "extension id is required", nil)
 	}
 	if err := m.reload(); err != nil {
-		return ExtensionInfo{}, err
-	}
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	if discoverErr := m.discoveryErrorLocked(); discoverErr != nil {
-		if item, ok := m.catalog[id]; ok {
-			if _, disabled := m.disabled[id]; disabled {
-				return ExtensionInfo{}, wrapError(ErrCodeNotFound, "extension not found", nil)
-			}
-			return item, discoverErr
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+		if item, ok := m.state.get(id); ok {
+			return item, err
 		}
-		if err, ok := m.discoverErrs[id]; ok {
-			return ExtensionInfo{}, err
+		if discoverErr, ok := m.discoverErrs[id]; ok {
+			return ExtensionInfo{}, discoverErr
 		}
 		return ExtensionInfo{}, wrapError(ErrCodeNotFound, "extension not found", nil)
 	}
-	if _, disabled := m.disabled[id]; disabled {
-		return ExtensionInfo{}, wrapError(ErrCodeNotFound, "extension not found", nil)
-	}
-	item, ok := m.catalog[id]
+	item, ok := m.state.get(id)
 	if !ok {
 		return ExtensionInfo{}, wrapError(ErrCodeNotFound, "extension not found", nil)
 	}
@@ -122,38 +172,22 @@ func (m *extensionManager) Get(_ context.Context, extensionID string) (Extension
 }
 
 func (m *extensionManager) List(_ context.Context) ([]ExtensionInfo, error) {
-	if err := m.reload(); err != nil {
-		return nil, err
-	}
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	items := make([]ExtensionInfo, 0, len(m.catalog))
-	for id, item := range m.catalog {
-		if _, disabled := m.disabled[id]; disabled {
-			continue
-		}
-		items = append(items, item)
-	}
+	err := m.reload()
+	items := m.state.list()
 	sort.Slice(items, func(i, j int) bool {
 		return items[i].ID < items[j].ID
 	})
-	if discoverErr := m.discoveryErrorLocked(); discoverErr != nil {
-		return items, discoverErr
-	}
-	return items, nil
+	return items, err
 }
 
 func (m *extensionManager) reload() error {
-	loaded := map[string]ExtensionInfo{}
-	discoverErrs := map[string]error{}
-	for _, item := range []struct {
+	type scopeDir struct {
 		scope ExtensionScope
 		dir   string
-	}{
-		{scope: ExtensionScopeBuiltin, dir: m.builtinDir},
-		{scope: ExtensionScopeUser, dir: m.userDir},
-		{scope: ExtensionScopeProject, dir: m.projectDir},
-	} {
+	}
+	loaded := map[string]ExtensionInfo{}
+	discoverErrs := map[string]error{}
+	for _, item := range []scopeDir{{ExtensionScopeBuiltin, m.builtinDir}, {ExtensionScopeUser, m.userDir}, {ExtensionScopeProject, m.projectDir}} {
 		entries, errs, err := discoverScope(item.scope, item.dir)
 		if err != nil {
 			return err
@@ -166,17 +200,50 @@ func (m *extensionManager) reload() error {
 		}
 	}
 	m.mu.Lock()
-	for id, entry := range m.manual {
-		loaded[id] = entry
-	}
+	defer m.mu.Unlock()
 	for id := range m.disabled {
 		delete(loaded, id)
 		delete(discoverErrs, id)
 	}
-	m.catalog = loaded
+	for id := range m.manual {
+		if _, ok := loaded[id]; ok {
+			continue
+		}
+		if item, ok := m.state.get(id); ok {
+			loaded[id] = item
+		}
+	}
+	for id, item := range loaded {
+		current, ok := m.state.get(id)
+		if ok {
+			item.Status = current.Status
+			item.Health = current.Health
+		} else {
+			item = prepareLoadedInfo(item)
+		}
+		m.state.set(item)
+	}
+	for _, item := range m.state.list() {
+		if _, ok := loaded[item.ID]; !ok {
+			m.state.delete(item.ID)
+		}
+	}
 	m.discoverErrs = discoverErrs
-	m.mu.Unlock()
-	return nil
+	return discoveryError(discoverErrs)
+}
+
+func prepareLoadedInfo(info ExtensionInfo) ExtensionInfo {
+	loaded := cloneExtensionInfo(info)
+	loaded.Status = ExtensionStatusLoaded
+	loaded.Health.Status = ExtensionStatusLoaded
+	loaded.Health.Message = "extension loaded"
+	loaded.Health.LastError = ""
+	loaded.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
+	active, _, err := activateTransition(loaded)
+	if err != nil {
+		return loaded
+	}
+	return active
 }
 
 func (m *extensionManager) discoverOne(source string) (ExtensionInfo, error) {
@@ -316,8 +383,8 @@ func buildExtensionInfo(scope ExtensionScope, dir, dirName string, manifest Mani
 		name = dirName
 	}
 	ref := dir
-	status := ExtensionStatusReady
-	message := "extension discovered"
+	status := ExtensionStatusLoaded
+	message := "extension loaded"
 	if !hasSkill {
 		status = ExtensionStatusDegraded
 		message = "manifest discovered without SKILL.md"
@@ -372,10 +439,6 @@ func discoveryError(discoverErrs map[string]error) error {
 	return wrapError(ErrCodeLoadFailed, fmt.Sprintf("extension discovery encountered errors (first failure: %s)", first), nil)
 }
 
-func (m *extensionManager) discoveryErrorLocked() error {
-	return discoveryError(m.discoverErrs)
-}
-
 func scopeForPath(path string, m *extensionManager) (ExtensionScope, bool) {
 	clean := filepath.Clean(path)
 	for _, item := range []struct {
@@ -407,8 +470,9 @@ func extensionIDForDir(dirName string) string {
 
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	return !info.IsDir()
+	return err == nil && !info.IsDir()
+}
+
+func sameExtensionSource(left, right string) bool {
+	return filepath.Clean(strings.TrimSpace(left)) == filepath.Clean(strings.TrimSpace(right))
 }

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -121,6 +121,41 @@ func TestManagerLoadRejectsAlreadyLoaded(t *testing.T) {
 	}
 }
 
+func TestManagerLoadIsIdempotentDespiteUnrelatedDiscoveryErrors(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, ".bytemind", "skills")
+	review := filepath.Join(project, "review")
+	broken := filepath.Join(project, "broken")
+	if err := os.MkdirAll(review, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(broken, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(review, "skill.json"), []byte(`{"name":"review"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(review, "SKILL.md"), []byte("# /review"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, "skill.json"), []byte(`{"name":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManager(root)
+	first, err := mgr.Load(context.Background(), review)
+	if err != nil {
+		t.Fatalf("first load failed: %v", err)
+	}
+	second, err := mgr.Load(context.Background(), review)
+	if err != nil {
+		t.Fatalf("expected idempotent reload, got %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("expected same extension, got %q vs %q", second.ID, first.ID)
+	}
+}
+
 func TestManagerUnloadIgnoresUnrelatedBrokenManifest(t *testing.T) {
 	root := t.TempDir()
 	project := filepath.Join(root, ".bytemind", "skills")

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -264,6 +264,31 @@ func TestManagerGetReturnsHealthyExtensionWithObservableDiscoveryError(t *testin
 	}
 }
 
+func TestManagerGetMissingReturnsNotFoundDespiteOtherDiscoveryErrors(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	bad := filepath.Join(project, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, "skill.json"), []byte(`{"name":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	item, err := mgr.Get(context.Background(), "skill.missing")
+	if item != (ExtensionInfo{}) {
+		t.Fatal("expected zero extension info")
+	}
+	var extErr *ExtensionError
+	if !errors.As(err, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr.Code != ErrCodeNotFound {
+		t.Fatalf("unexpected code: %s", extErr.Code)
+	}
+}
+
 func TestManagerGetReturnsNotFound(t *testing.T) {
 	mgr := NewManager(t.TempDir())
 	item, err := mgr.Get(context.Background(), "skill.review")
@@ -273,6 +298,28 @@ func TestManagerGetReturnsNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected not found error")
 	}
+	var extErr *ExtensionError
+	if !errors.As(err, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr.Code != ErrCodeNotFound {
+		t.Fatalf("unexpected code: %s", extErr.Code)
+	}
+}
+
+func TestManagerUnloadMissingReturnsNotFoundDespiteOtherDiscoveryErrors(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	bad := filepath.Join(project, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, "skill.json"), []byte(`{"name":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	err := mgr.Unload(context.Background(), "skill.missing")
 	var extErr *ExtensionError
 	if !errors.As(err, &extErr) {
 		t.Fatalf("expected ExtensionError, got %T", err)

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -179,6 +179,33 @@ func TestManagerUnloadCanDisableBrokenExtension(t *testing.T) {
 	}
 }
 
+func TestManagerListPreservesDegradedStatusForManifestOnlyExtension(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	degraded := filepath.Join(project, "degraded")
+	if err := os.MkdirAll(degraded, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(degraded, "skill.json"), []byte(`{"name":"degraded"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	items, err := mgr.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 extension, got %d", len(items))
+	}
+	if items[0].Status != ExtensionStatusDegraded {
+		t.Fatalf("expected degraded status, got %q", items[0].Status)
+	}
+	if items[0].Health.Status != ExtensionStatusDegraded {
+		t.Fatalf("expected degraded health, got %q", items[0].Health.Status)
+	}
+}
+
 func TestManagerListDiscoversAcrossScopesWithPriority(t *testing.T) {
 	root := t.TempDir()
 	builtin := filepath.Join(root, "builtin")

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -273,6 +273,19 @@ func TestManagerReloadAppliesDiscoveryDegradeToActiveExtension(t *testing.T) {
 	if items[0].Status != ExtensionStatusDegraded {
 		t.Fatalf("expected degraded status after reload, got %q", items[0].Status)
 	}
+	if err := os.WriteFile(filepath.Join(review, "SKILL.md"), []byte("# /review restored"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	items, err = mgr.List(context.Background())
+	if err != nil {
+		t.Fatalf("recovery list failed: %v", err)
+	}
+	if items[0].Status != ExtensionStatusActive {
+		t.Fatalf("expected active status after recovery, got %q", items[0].Status)
+	}
+	if items[0].Health.Status != ExtensionStatusActive {
+		t.Fatalf("expected active health after recovery, got %q", items[0].Health.Status)
+	}
 }
 
 func TestManagerListDiscoversAcrossScopesWithPriority(t *testing.T) {

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -429,6 +429,49 @@ func TestManagerRejectsInvalidSourceAndManifest(t *testing.T) {
 	}
 }
 
+func TestDiscoverOneRejectsMissingDirectory(t *testing.T) {
+	mgr := NewManager(t.TempDir())
+	_, err := mgr.(*extensionManager).discoverOne("missing")
+	if err == nil {
+		t.Fatal("expected invalid source error")
+	}
+}
+
+func TestDiscoverScopeCollectsManifestErrors(t *testing.T) {
+	root := t.TempDir()
+	bad := filepath.Join(root, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, "skill.json"), []byte(`{"name":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	items, errs, err := discoverScope(ExtensionScopeProject, root)
+	if err != nil {
+		t.Fatalf("discoverScope failed: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected no discovered items, got %d", len(items))
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected one discovery error, got %d", len(errs))
+	}
+}
+
+func TestDiscoveryErrorReturnsWrappedFirstFailure(t *testing.T) {
+	err := discoveryError(map[string]error{
+		"skill.z": wrapError(ErrCodeInvalidManifest, "bad", nil),
+		"skill.a": wrapError(ErrCodeLoadFailed, "boom", nil),
+	})
+	var extErr *ExtensionError
+	if !errors.As(err, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr.Code != ErrCodeLoadFailed {
+		t.Fatalf("unexpected code: %s", extErr.Code)
+	}
+}
+
 func TestScopeForPathReturnsFoundFlag(t *testing.T) {
 	mgr := &extensionManager{
 		builtinDir: filepath.Join("repo", "internal", "skills"),

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -206,6 +206,40 @@ func TestManagerListPreservesDegradedStatusForManifestOnlyExtension(t *testing.T
 	}
 }
 
+func TestManagerReloadAppliesDiscoveryDegradeToActiveExtension(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	review := filepath.Join(project, "review")
+	if err := os.MkdirAll(review, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(review, "skill.json"), []byte(`{"name":"review"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(review, "SKILL.md"), []byte("# /review"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	items, err := mgr.List(context.Background())
+	if err != nil {
+		t.Fatalf("initial list failed: %v", err)
+	}
+	if items[0].Status != ExtensionStatusActive {
+		t.Fatalf("expected active status, got %q", items[0].Status)
+	}
+	if err := os.Remove(filepath.Join(review, "SKILL.md")); err != nil {
+		t.Fatal(err)
+	}
+	items, err = mgr.List(context.Background())
+	if err != nil {
+		t.Fatalf("reload list failed: %v", err)
+	}
+	if items[0].Status != ExtensionStatusDegraded {
+		t.Fatalf("expected degraded status after reload, got %q", items[0].Status)
+	}
+}
+
 func TestManagerListDiscoversAcrossScopesWithPriority(t *testing.T) {
 	root := t.TempDir()
 	builtin := filepath.Join(root, "builtin")

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -29,7 +29,7 @@ func TestManagerLoadDiscoversExtensionFromSource(t *testing.T) {
 	if item.ID != "skill.review" {
 		t.Fatalf("unexpected id: %q", item.ID)
 	}
-	if item.Status != ExtensionStatusReady {
+	if item.Status != ExtensionStatusActive {
 		t.Fatalf("unexpected status: %q", item.Status)
 	}
 	if item.Capabilities.Prompts != 1 || item.Capabilities.Tools != 2 {
@@ -91,6 +91,33 @@ func TestManagerLoadMarksUnknownRootAsRemote(t *testing.T) {
 	}
 	if item.Source.Scope != ExtensionScopeRemote {
 		t.Fatalf("expected remote scope, got %q", item.Source.Scope)
+	}
+}
+
+func TestManagerLoadRejectsAlreadyLoaded(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, ".bytemind", "skills", "review")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "skill.json"), []byte(`{"name":"review"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "SKILL.md"), []byte("# /review"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManager(t.TempDir())
+	if _, err := mgr.Load(context.Background(), project); err != nil {
+		t.Fatalf("first load failed: %v", err)
+	}
+	_, err := mgr.Load(context.Background(), project)
+	var extErr *ExtensionError
+	if !errors.As(err, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr.Code != ErrCodeAlreadyLoaded {
+		t.Fatalf("unexpected code: %s", extErr.Code)
 	}
 }
 

--- a/internal/extensions/state_store.go
+++ b/internal/extensions/state_store.go
@@ -1,0 +1,110 @@
+package extensions
+
+import "sync"
+
+type stateStore struct {
+	mu      sync.RWMutex
+	items   map[string]ExtensionInfo
+	locks   map[string]*sync.Mutex
+	events  []ExtensionEvent
+	loading map[string]bool
+}
+
+func newStateStore() *stateStore {
+	return &stateStore{
+		items:   map[string]ExtensionInfo{},
+		locks:   map[string]*sync.Mutex{},
+		events:  nil,
+		loading: map[string]bool{},
+	}
+}
+
+func (s *stateStore) withLock(id string, fn func() error) error {
+	lock := s.lockFor(id)
+	lock.Lock()
+	defer lock.Unlock()
+	return fn()
+}
+
+func (s *stateStore) lockFor(id string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lock, ok := s.locks[id]
+	if !ok {
+		lock = &sync.Mutex{}
+		s.locks[id] = lock
+	}
+	return lock
+}
+
+func (s *stateStore) beginLoad(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.loading[id] {
+		return wrapError(ErrCodeBusy, "extension is busy", nil)
+	}
+	if _, ok := s.items[id]; ok {
+		return wrapError(ErrCodeAlreadyLoaded, "extension already loaded", nil)
+	}
+	s.loading[id] = true
+	return nil
+}
+
+func (s *stateStore) finishLoad(id string, info ExtensionInfo, events ...ExtensionEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.loading, id)
+	s.items[id] = cloneExtensionInfo(info)
+	s.events = append(s.events, cloneEvents(events)...)
+}
+
+func (s *stateStore) cancelLoad(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.loading, id)
+}
+
+func (s *stateStore) get(id string) (ExtensionInfo, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	info, ok := s.items[id]
+	return cloneExtensionInfo(info), ok
+}
+
+func (s *stateStore) set(info ExtensionInfo, events ...ExtensionEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[info.ID] = cloneExtensionInfo(info)
+	s.events = append(s.events, cloneEvents(events)...)
+}
+
+func (s *stateStore) delete(id string, events ...ExtensionEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.items, id)
+	delete(s.loading, id)
+	s.events = append(s.events, cloneEvents(events)...)
+}
+
+func (s *stateStore) list() []ExtensionInfo {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]ExtensionInfo, 0, len(s.items))
+	for _, item := range s.items {
+		items = append(items, cloneExtensionInfo(item))
+	}
+	return items
+}
+
+func cloneExtensionInfo(info ExtensionInfo) ExtensionInfo {
+	return info
+}
+
+func cloneEvents(events []ExtensionEvent) []ExtensionEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]ExtensionEvent, len(events))
+	copy(out, events)
+	return out
+}

--- a/internal/extensions/state_store.go
+++ b/internal/extensions/state_store.go
@@ -2,10 +2,16 @@ package extensions
 
 import "sync"
 
+type stateLock struct {
+	mu    sync.Mutex
+	users int
+}
+
 type stateStore struct {
 	mu      sync.RWMutex
 	items   map[string]ExtensionInfo
-	locks   map[string]*sync.Mutex
+	locks   map[string]*stateLock
+	idle    map[string]struct{}
 	events  []ExtensionEvent
 	loading map[string]bool
 }
@@ -13,7 +19,8 @@ type stateStore struct {
 func newStateStore() *stateStore {
 	return &stateStore{
 		items:   map[string]ExtensionInfo{},
-		locks:   map[string]*sync.Mutex{},
+		locks:   map[string]*stateLock{},
+		idle:    map[string]struct{}{},
 		events:  nil,
 		loading: map[string]bool{},
 	}
@@ -21,20 +28,58 @@ func newStateStore() *stateStore {
 
 func (s *stateStore) withLock(id string, fn func() error) error {
 	lock := s.lockFor(id)
-	lock.Lock()
-	defer lock.Unlock()
+	lock.mu.Lock()
+	defer func() {
+		lock.mu.Unlock()
+		s.releaseLock(id, lock)
+	}()
 	return fn()
 }
 
-func (s *stateStore) lockFor(id string) *sync.Mutex {
+func (s *stateStore) lockFor(id string) *stateLock {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	lock, ok := s.locks[id]
 	if !ok {
-		lock = &sync.Mutex{}
+		lock = &stateLock{}
 		s.locks[id] = lock
 	}
+	lock.users++
+	delete(s.idle, id)
 	return lock
+}
+
+func (s *stateStore) releaseLock(id string, lock *stateLock) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.locks[id]
+	if !ok || current != lock {
+		return
+	}
+	if current.users > 0 {
+		current.users--
+	}
+	if current.users == 0 {
+		s.idle[id] = struct{}{}
+	}
+	s.gcIdleLocksLocked()
+}
+
+func (s *stateStore) gcIdleLocksLocked() {
+	for id := range s.idle {
+		if _, itemExists := s.items[id]; itemExists {
+			continue
+		}
+		if s.loading[id] {
+			continue
+		}
+		lock, ok := s.locks[id]
+		if !ok || lock.users != 0 {
+			continue
+		}
+		delete(s.locks, id)
+		delete(s.idle, id)
+	}
 }
 
 func (s *stateStore) beginLoad(id string) error {
@@ -54,6 +99,7 @@ func (s *stateStore) finishLoad(id string, info ExtensionInfo, events ...Extensi
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.loading, id)
+	delete(s.idle, id)
 	s.items[id] = cloneExtensionInfo(info)
 	s.events = append(s.events, cloneEvents(events)...)
 }
@@ -62,6 +108,7 @@ func (s *stateStore) cancelLoad(id string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.loading, id)
+	s.gcIdleLocksLocked()
 }
 
 func (s *stateStore) get(id string) (ExtensionInfo, bool) {
@@ -74,6 +121,7 @@ func (s *stateStore) get(id string) (ExtensionInfo, bool) {
 func (s *stateStore) set(info ExtensionInfo, events ...ExtensionEvent) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	delete(s.idle, info.ID)
 	s.items[info.ID] = cloneExtensionInfo(info)
 	s.events = append(s.events, cloneEvents(events)...)
 }
@@ -84,6 +132,7 @@ func (s *stateStore) delete(id string, events ...ExtensionEvent) {
 	delete(s.items, id)
 	delete(s.loading, id)
 	s.events = append(s.events, cloneEvents(events)...)
+	s.gcIdleLocksLocked()
 }
 
 func (s *stateStore) list() []ExtensionInfo {

--- a/internal/extensions/state_store.go
+++ b/internal/extensions/state_store.go
@@ -83,6 +83,7 @@ func (s *stateStore) delete(id string, events ...ExtensionEvent) {
 	defer s.mu.Unlock()
 	delete(s.items, id)
 	delete(s.loading, id)
+	delete(s.locks, id)
 	s.events = append(s.events, cloneEvents(events)...)
 }
 

--- a/internal/extensions/state_store.go
+++ b/internal/extensions/state_store.go
@@ -83,7 +83,6 @@ func (s *stateStore) delete(id string, events ...ExtensionEvent) {
 	defer s.mu.Unlock()
 	delete(s.items, id)
 	delete(s.loading, id)
-	delete(s.locks, id)
 	s.events = append(s.events, cloneEvents(events)...)
 }
 

--- a/internal/extensions/state_store_test.go
+++ b/internal/extensions/state_store_test.go
@@ -30,3 +30,20 @@ func TestStateStoreCancelLoadClearsLoading(t *testing.T) {
 		t.Fatalf("expected beginLoad to succeed after cancel, got %v", err)
 	}
 }
+
+func TestStateStoreDeleteCollectsIdleLock(t *testing.T) {
+	store := newStateStore()
+	if err := store.withLock("skill.review", func() error {
+		store.set(ExtensionInfo{ID: "skill.review", Name: "review", Kind: ExtensionSkill, Source: ExtensionSource{Scope: ExtensionScopeProject, Ref: "x"}, Status: ExtensionStatusActive})
+		return nil
+	}); err != nil {
+		t.Fatalf("withLock failed: %v", err)
+	}
+	if _, ok := store.locks["skill.review"]; !ok {
+		t.Fatal("expected lock to exist before delete")
+	}
+	store.delete("skill.review")
+	if _, ok := store.locks["skill.review"]; ok {
+		t.Fatal("expected idle lock to be garbage collected")
+	}
+}

--- a/internal/extensions/state_store_test.go
+++ b/internal/extensions/state_store_test.go
@@ -30,14 +30,3 @@ func TestStateStoreCancelLoadClearsLoading(t *testing.T) {
 		t.Fatalf("expected beginLoad to succeed after cancel, got %v", err)
 	}
 }
-
-func TestStateStoreDeleteClearsLock(t *testing.T) {
-	store := newStateStore()
-	first := store.lockFor("skill.review")
-	store.set(ExtensionInfo{ID: "skill.review", Name: "review", Kind: ExtensionSkill, Source: ExtensionSource{Scope: ExtensionScopeProject, Ref: "x"}, Status: ExtensionStatusActive})
-	store.delete("skill.review")
-	second := store.lockFor("skill.review")
-	if first == second {
-		t.Fatal("expected lock to be recreated after delete")
-	}
-}

--- a/internal/extensions/state_store_test.go
+++ b/internal/extensions/state_store_test.go
@@ -1,0 +1,43 @@
+package extensions
+
+import "testing"
+
+func TestStateStoreBeginLoadBusy(t *testing.T) {
+	store := newStateStore()
+	if err := store.beginLoad("skill.review"); err != nil {
+		t.Fatalf("beginLoad failed: %v", err)
+	}
+	if err := store.beginLoad("skill.review"); err == nil {
+		t.Fatal("expected busy error")
+	}
+}
+
+func TestStateStoreBeginLoadAlreadyLoaded(t *testing.T) {
+	store := newStateStore()
+	store.set(ExtensionInfo{ID: "skill.review", Name: "review", Kind: ExtensionSkill, Source: ExtensionSource{Scope: ExtensionScopeProject, Ref: "x"}, Status: ExtensionStatusActive})
+	if err := store.beginLoad("skill.review"); err == nil {
+		t.Fatal("expected already loaded error")
+	}
+}
+
+func TestStateStoreCancelLoadClearsLoading(t *testing.T) {
+	store := newStateStore()
+	if err := store.beginLoad("skill.review"); err != nil {
+		t.Fatalf("beginLoad failed: %v", err)
+	}
+	store.cancelLoad("skill.review")
+	if err := store.beginLoad("skill.review"); err != nil {
+		t.Fatalf("expected beginLoad to succeed after cancel, got %v", err)
+	}
+}
+
+func TestStateStoreDeleteClearsLock(t *testing.T) {
+	store := newStateStore()
+	first := store.lockFor("skill.review")
+	store.set(ExtensionInfo{ID: "skill.review", Name: "review", Kind: ExtensionSkill, Source: ExtensionSource{Scope: ExtensionScopeProject, Ref: "x"}, Status: ExtensionStatusActive})
+	store.delete("skill.review")
+	second := store.lockFor("skill.review")
+	if first == second {
+		t.Fatal("expected lock to be recreated after delete")
+	}
+}

--- a/internal/extensions/types.go
+++ b/internal/extensions/types.go
@@ -25,7 +25,7 @@ const (
 	ExtensionStatusPending  ExtensionStatus = "pending"
 	ExtensionStatusLoaded   ExtensionStatus = "loaded"
 	ExtensionStatusActive   ExtensionStatus = "active"
-	ExtensionStatusReady    ExtensionStatus = ExtensionStatusActive
+	ExtensionStatusReady    ExtensionStatus = "ready"
 	ExtensionStatusDegraded ExtensionStatus = "degraded"
 	ExtensionStatusFailed   ExtensionStatus = "failed"
 	ExtensionStatusStopped  ExtensionStatus = "stopped"

--- a/internal/extensions/types.go
+++ b/internal/extensions/types.go
@@ -23,7 +23,9 @@ type ExtensionStatus string
 const (
 	ExtensionStatusUnknown  ExtensionStatus = "unknown"
 	ExtensionStatusPending  ExtensionStatus = "pending"
-	ExtensionStatusReady    ExtensionStatus = "ready"
+	ExtensionStatusLoaded   ExtensionStatus = "loaded"
+	ExtensionStatusActive   ExtensionStatus = "active"
+	ExtensionStatusReady    ExtensionStatus = ExtensionStatusActive
 	ExtensionStatusDegraded ExtensionStatus = "degraded"
 	ExtensionStatusFailed   ExtensionStatus = "failed"
 	ExtensionStatusStopped  ExtensionStatus = "stopped"
@@ -61,7 +63,11 @@ type HealthSnapshot struct {
 type ExtensionEvent struct {
 	Type        string
 	ExtensionID string
+	Kind        ExtensionKind
 	Status      ExtensionStatus
+	Reason      string
+	ErrorCode   ErrorCode
+	OccurredAt  string
 	Message     string
 }
 


### PR DESCRIPTION
summary
在 internal/extensions/manager.go 引入内存态生命周期管理，支持 loaded/active/degraded/stopped 状态流转与快照式 List/Get
新增 internal/extensions/lifecycle.go 和 internal/extensions/state_store.go，封装状态迁移、事件记录、单扩展粒度串行化
扩展错误码与测试，覆盖重复加载、非法迁移、快照一致性和现有 discovery 兼容语义