### PR TITLE
fix(tui): 粘贴事务并修复占位符闪烁与误发送

### DIFF
--- a/tui/clipboard_text.go
+++ b/tui/clipboard_text.go
@@ -2,6 +2,9 @@ package tui
 
 import (
 	"context"
+	"os/exec"
+	"runtime"
+	"strings"
 
 	"github.com/atotto/clipboard"
 )
@@ -13,7 +16,15 @@ type clipboardTextWriter interface {
 	WriteText(ctx context.Context, text string) error
 }
 
+type clipboardTextReader interface {
+	// ReadText reads plain text from system clipboard storage.
+	// Callers should pass a timeout-bounded context to avoid hanging forever
+	// on clipboard backends that can block.
+	ReadText(ctx context.Context) (string, error)
+}
+
 type defaultClipboardTextWriter struct{}
+type defaultClipboardTextReader struct{}
 
 func (defaultClipboardTextWriter) WriteText(ctx context.Context, text string) error {
 	if ctx == nil {
@@ -29,4 +40,52 @@ func (defaultClipboardTextWriter) WriteText(ctx context.Context, text string) er
 	case err := <-done:
 		return err
 	}
+}
+
+func (defaultClipboardTextReader) ReadText(ctx context.Context) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	type result struct {
+		text string
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		text, err := clipboard.ReadAll()
+		done <- result{text: text, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case out := <-done:
+		if out.err == nil && strings.TrimSpace(out.text) != "" {
+			return out.text, nil
+		}
+		// On some Windows terminals/environments, the generic clipboard backend
+		// can fail while Ctrl+V still pastes text in the terminal. Retry via
+		// PowerShell to preserve a deterministic paste boundary.
+		if runtime.GOOS == "windows" {
+			if fallback, fallbackErr := readClipboardTextViaPowerShell(ctx); fallbackErr == nil && strings.TrimSpace(fallback) != "" {
+				return fallback, nil
+			}
+		}
+		return out.text, out.err
+	}
+}
+
+func readClipboardTextViaPowerShell(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(
+		ctx,
+		"powershell",
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		"Get-Clipboard -Raw",
+	)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
 }

--- a/tui/component_input_mutation.go
+++ b/tui/component_input_mutation.go
@@ -7,6 +7,10 @@ import (
 
 func (m *model) noteInputMutation(before, after, source string) {
 	now := time.Now()
+	gap := time.Duration(0)
+	if !m.lastInputAt.IsZero() {
+		gap = now.Sub(m.lastInputAt)
+	}
 	delta := len(after) - len(before)
 	if delta < 0 {
 		delta = 0
@@ -21,6 +25,11 @@ func (m *model) noteInputMutation(before, after, source string) {
 
 	if shouldRecordPasteSignal(source) {
 		m.lastPasteAt = now
+		m.armClipboardPasteCaptureSignal()
+		return
+	}
+	if m.shouldArmClipboardCaptureFromImplicitMutation(before, after, source, gap, delta) {
+		m.armClipboardPasteCaptureSignal()
 	}
 }
 
@@ -44,7 +53,7 @@ func (m *model) handleInputMutation(before, after, source string) string {
 			note = fallbackNote
 		}
 	}
-	if !isPasteLikeSource(source) {
+	if m.shouldAttemptClipboardPasteCapture(before, updated, source) {
 		captured, captureNote, ok := m.tryStartClipboardPasteCapture(before, updated, source)
 		if ok {
 			updated = captured

--- a/tui/component_input_mutation.go
+++ b/tui/component_input_mutation.go
@@ -7,7 +7,6 @@ import (
 
 func (m *model) noteInputMutation(before, after, source string) {
 	now := time.Now()
-	previousInputAt := m.lastInputAt
 	delta := len(after) - len(before)
 	if delta < 0 {
 		delta = 0
@@ -20,54 +19,13 @@ func (m *model) noteInputMutation(before, after, source string) {
 	}
 	m.lastInputAt = now
 
-	if shouldRecordPasteSignal(before, after, source) ||
-		shouldRecordImplicitPasteBurst(after, source, previousInputAt, now, m.inputBurstSize) ||
-		(m.inputBurstSize >= 4 && isLikelyPathInput(strings.TrimSpace(after))) {
+	if shouldRecordPasteSignal(source) {
 		m.lastPasteAt = now
-		m.armPasteSubmitGuard(now)
 	}
 }
 
-func shouldRecordPasteSignal(before, after, source string) bool {
-	if source == "paste-enter" || isPasteLikeSource(source) {
-		return true
-	}
-	if source == "rune" || source == "rapid-enter" {
-		return false
-	}
-	_, inserted, _ := insertionDiff(before, after)
-	inserted = strings.ReplaceAll(inserted, ctrlVMarkerRune, "")
-	trimmed := strings.TrimSpace(inserted)
-	if trimmed == "" {
-		return false
-	}
-	if strings.Contains(inserted, "\n") {
-		return true
-	}
-	return len(inserted) > 1 && len(trimmed) >= pasteBurstImmediateMinChars
-}
-
-func shouldRecordImplicitPasteBurst(after, source string, previousInputAt, now time.Time, burst int) bool {
-	if source == "paste-enter" || isPasteLikeSource(source) {
-		return false
-	}
-	if previousInputAt.IsZero() || now.Sub(previousInputAt) > 2*pasteBurstWindow {
-		return false
-	}
-	if burst < pasteBurstImmediateMinChars {
-		return false
-	}
-	trimmed := strings.TrimSpace(after)
-	if trimmed == "" || strings.Contains(trimmed, "[Paste #") || strings.Contains(trimmed, "[Pasted #") {
-		return false
-	}
-	if source == "rune" && !strings.Contains(after, "\n\n") {
-		return false
-	}
-	if strings.Count(after, "\n") >= 2 {
-		return true
-	}
-	if burst >= pasteBurstCharThreshold && len(trimmed) >= pasteQuickCharThreshold && looksLikePastedFragment(trimmed) {
+func shouldRecordPasteSignal(source string) bool {
+	if isPasteLikeSource(source) {
 		return true
 	}
 	return false
@@ -84,6 +42,15 @@ func (m *model) handleInputMutation(before, after, source string) string {
 		}
 		if strings.TrimSpace(note) == "" {
 			note = fallbackNote
+		}
+	}
+	if !isPasteLikeSource(source) {
+		captured, captureNote, ok := m.tryStartClipboardPasteCapture(before, updated, source)
+		if ok {
+			updated = captured
+			if strings.TrimSpace(note) == "" {
+				note = captureNote
+			}
 		}
 	}
 

--- a/tui/component_input_overlays_runtime.go
+++ b/tui/component_input_overlays_runtime.go
@@ -69,11 +69,13 @@ func (m model) handleCommandPaletteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.statusNote = "This command is unavailable while a run is in progress. Use /btw <message>."
 					return m, nil
 				}
-				m.closeCommandPalette()
-				return m.submitBTW(value)
+				m.statusNote = "Run is in progress. Use /btw <message> to interject, or Esc to interrupt."
+				return m, nil
 			}
 			m.closeCommandPalette()
 			m.input.Reset()
+			m.clearPasteTransaction()
+			m.clearVirtualPasteParts()
 			next, cmd, err := m.executeCommand(value)
 			if err != nil {
 				m.statusNote = err.Error()
@@ -91,6 +93,8 @@ func (m model) handleCommandPaletteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.input.Reset()
+			m.clearPasteTransaction()
+			m.clearVirtualPasteParts()
 			next, cmd, err := m.executeCommand(selected.Name)
 			if err != nil {
 				m.statusNote = err.Error()
@@ -416,6 +420,8 @@ func (m *model) closeCommandPalette() {
 	m.commandCursor = 0
 	m.closeMentionPalette()
 	m.input.Reset()
+	m.clearPasteTransaction()
+	m.clearVirtualPasteParts()
 }
 
 func (m model) selectedCommandItem() (commandItem, bool) {

--- a/tui/component_run_flow.go
+++ b/tui/component_run_flow.go
@@ -54,6 +54,8 @@ func (m model) submitPrompt(value string) (tea.Model, tea.Cmd) {
 	}
 
 	m.input.Reset()
+	m.clearPasteTransaction()
+	m.clearVirtualPasteParts()
 	m.screen = screenChat
 	if m.promptHistoryLoaded {
 		entry := history.PromptEntry{
@@ -88,6 +90,8 @@ func (m model) submitBTW(value string) (tea.Model, tea.Cmd) {
 	}
 
 	m.input.Reset()
+	m.clearPasteTransaction()
+	m.clearVirtualPasteParts()
 	m.screen = screenChat
 	m.appendChat(chatEntry{
 		Kind:   "user",

--- a/tui/component_sessions.go
+++ b/tui/component_sessions.go
@@ -145,6 +145,9 @@ func (m *model) newSession() error {
 	m.nextPasteID = 1
 	m.pastedStateLoaded = false
 	m.lastCompressedPasteAt = time.Time{}
+	m.virtualPasteParts = make([]virtualPastePart, 0, maxStoredPastedContents)
+	m.nextVirtualPastePart = 1
+	m.pasteTransaction = pasteTransactionState{}
 	m.ensurePastedContentState()
 	m.pendingBTW = nil
 	m.interrupting = false
@@ -199,6 +202,9 @@ func (m *model) resumeSession(prefix string) error {
 	m.nextPasteID = 1
 	m.pastedStateLoaded = false
 	m.lastCompressedPasteAt = time.Time{}
+	m.virtualPasteParts = make([]virtualPastePart, 0, maxStoredPastedContents)
+	m.nextVirtualPastePart = 1
+	m.pasteTransaction = pasteTransactionState{}
 	m.ensurePastedContentState()
 	m.syncInputImageRefs("")
 	m.pendingBTW = nil

--- a/tui/component_startup_guide.go
+++ b/tui/component_startup_guide.go
@@ -37,6 +37,8 @@ func (m *model) handleStartupGuideSubmission(rawInput string) error {
 		}
 		m.setStartupGuideStep(next, "")
 		m.input.Reset()
+		m.clearPasteTransaction()
+		m.clearVirtualPasteParts()
 		return nil
 	case startupFieldAPIKey:
 		return m.verifyAndFinalizeStartupAPIKey(rawInput)
@@ -92,6 +94,8 @@ func (m *model) verifyAndFinalizeStartupAPIKey(rawInput string) error {
 	}
 	m.syncInputStyle()
 	m.input.Reset()
+	m.clearPasteTransaction()
+	m.clearVirtualPasteParts()
 	return nil
 }
 

--- a/tui/input_images.go
+++ b/tui/input_images.go
@@ -599,7 +599,7 @@ func (m *model) buildPromptInput(raw string) (RunPromptInput, string, error) {
 		return RunPromptInput{}, "", fmt.Errorf("prompt is empty")
 	}
 	m.syncInputImageRefs(raw)
-	resolvedRaw, err := m.resolvePastedLineReference(raw)
+	resolvedRaw, err := m.resolvePromptPastedInput(raw)
 	if err != nil {
 		return RunPromptInput{}, "", err
 	}
@@ -795,7 +795,8 @@ func (m *model) findAssetByImageID(imageID int) (llm.AssetID, session.ImageAsset
 func classifyInputMutation(before, after, source string) (inputMutationClass, int, string, int) {
 	prefix, inserted, suffix := insertionDiff(before, after)
 	cleanInserted := strings.ReplaceAll(inserted, ctrlVMarkerRune, "")
-	pasteSignal := isCtrlVKey(source) || strings.Contains(strings.ToLower(source), "paste") || strings.Contains(cleanInserted, "\n") || len(cleanInserted) > 1
+	normalizedSource := strings.ToLower(strings.TrimSpace(source))
+	pasteSignal := isCtrlVKey(source) || strings.Contains(normalizedSource, "paste")
 	if shouldTriggerClipboardImagePaste(before, after, source) {
 		return inputMutationPasteEmpty, prefix, inserted, suffix
 	}

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -22,6 +22,8 @@ const (
 	opencodePasteSummaryMinLines   = 3
 	opencodePasteSummaryMinChars   = 150
 	pasteContinuationWindow        = 1500 * time.Millisecond
+	clipboardCaptureArmWindow      = 1200 * time.Millisecond
+	clipboardCaptureImplicitGap    = 80 * time.Millisecond
 	maxSinglePastedCharLength      = 200000
 	pasteSoftWrapWidth             = 72
 	clipboardCaptureMinPrefixRunes = 4
@@ -118,6 +120,54 @@ func (m *model) readClipboardTextForPaste() (string, bool) {
 		return "", false
 	}
 	return normalized, true
+}
+
+func (m *model) armClipboardPasteCaptureSignal() {
+	if m == nil {
+		return
+	}
+	until := time.Now().Add(clipboardCaptureArmWindow)
+	if until.After(m.clipboardCaptureArmedUntil) {
+		m.clipboardCaptureArmedUntil = until
+	}
+}
+
+func (m *model) isClipboardPasteCaptureArmed() bool {
+	if m == nil || m.clipboardCaptureArmedUntil.IsZero() {
+		return false
+	}
+	return time.Now().Before(m.clipboardCaptureArmedUntil)
+}
+
+func (m *model) shouldArmClipboardCaptureFromImplicitMutation(before, after, source string, gap time.Duration, delta int) bool {
+	if m == nil || isPasteLikeSource(source) {
+		return false
+	}
+	if delta <= 0 || m.inputBurstSize < clipboardCaptureMinPrefixRunes {
+		return false
+	}
+	if gap <= clipboardCaptureImplicitGap {
+		return true
+	}
+	_, inserted, _ := insertionDiff(before, after)
+	inserted = strings.ReplaceAll(normalizeNewlines(inserted), ctrlVMarkerRune, "")
+	if inserted == "" {
+		return false
+	}
+	if strings.Contains(inserted, "\n") || strings.Contains(inserted, "\t") {
+		return true
+	}
+	return len([]rune(inserted)) >= clipboardCaptureMinPrefixRunes
+}
+
+func (m *model) shouldAttemptClipboardPasteCapture(before, after, source string) bool {
+	if m == nil || isPasteLikeSource(source) || !m.isClipboardPasteCaptureArmed() {
+		return false
+	}
+	if strings.TrimSpace(after) == "" {
+		return false
+	}
+	return len([]rune(after)) > len([]rune(before))
 }
 
 func (m *model) tryCompressClipboardMatchedPaste(raw string) (string, string, bool) {
@@ -260,13 +310,14 @@ func (m *model) shouldTreatEnterAsClipboardPasteContinuation(raw string) bool {
 
 	// Exact prefix continuation: current buffer is beginning of clipboard,
 	// and the next clipboard rune is a newline.
-	if strings.HasPrefix(normalizedClipboard, normalizedRaw+"\n") {
+	if strings.HasPrefix(normalizedClipboard, normalizedRaw+"\n") &&
+		len([]rune(normalizedRaw)) >= clipboardCaptureMinPrefixRunes {
 		return true
 	}
 
 	// Suffix-prefix continuation: user might already have text before paste.
 	matchLen := longestClipboardPrefixSuffixLen(normalizedRaw, normalizedClipboard)
-	if matchLen <= 0 {
+	if matchLen < clipboardCaptureMinPrefixRunes {
 		return false
 	}
 	clipboardRunes := []rune(normalizedClipboard)

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -14,18 +15,16 @@ import (
 )
 
 const (
-	pastedContentMetaKey        = "pasted_contents"
-	maxStoredPastedContents     = 10
-	longPasteLineThreshold      = 10
-	longPasteCharThreshold      = 500
-	pasteQuickCharThreshold     = 80
-	pasteBurstImmediateMinChars = 12
-	flattenedPasteCharThreshold = 180
-	pasteBurstCharThreshold     = 120
-	pasteBurstWindow            = 80 * time.Millisecond
-	pasteContinuationWindow     = 1500 * time.Millisecond
-	maxSinglePastedCharLength   = 200000
-	pasteSoftWrapWidth          = 72
+	pastedContentMetaKey    = "pasted_contents"
+	maxStoredPastedContents = 10
+	// Align with opencode TUI paste summary behavior:
+	// summarize when pasted text is 3+ lines or over 150 chars.
+	opencodePasteSummaryMinLines   = 3
+	opencodePasteSummaryMinChars   = 150
+	pasteContinuationWindow        = 1500 * time.Millisecond
+	maxSinglePastedCharLength      = 200000
+	pasteSoftWrapWidth             = 72
+	clipboardCaptureMinPrefixRunes = 4
 )
 
 var pastedRefPattern = regexp.MustCompile(`\[(?:Paste|Pasted)(?:\s+#(\d+))?(?:\s+~(\d+)\s+lines)?(?:\s+line(\d+)(?:~line(\d+))?)?\]`)
@@ -67,180 +66,210 @@ func trimTrailingPasteTerminators(input string) string {
 	return normalizeNewlines(input)
 }
 
-func schedulePasteFinalize(id int) tea.Cmd {
-	return tea.Tick(pasteAggregateDebounce, func(time.Time) tea.Msg {
-		return pasteFinalizeMsg{ID: id}
-	})
-}
-
-func (m *model) beginPasteSession(source string) {
-	if m == nil {
-		return
-	}
-	if m.pasteSession.active {
-		return
-	}
-	now := time.Now()
-	m.pasteSession = pasteSessionState{
-		active:      true,
-		startedAt:   now,
-		lastEventAt: now,
-		sourceKind:  source,
-		baseInput:   m.input.Value(),
-	}
-}
-
-func (m *model) syncPasteSessionPreview() {
-	if m == nil || !m.pasteSession.active {
-		return
-	}
-	preview := m.pasteSession.baseInput + normalizeNewlines(m.pasteSession.bufferedText)
-	if m.input.Value() != preview {
-		m.setInputValue(preview)
-	}
-	m.syncInputOverlays()
-}
-
-func shouldPreviewPasteSession(source string) bool {
-	source = strings.TrimSpace(strings.ToLower(source))
-	return source == "paste-key"
-}
-
-func (m *model) appendPasteSessionFragment(fragment, source string) int {
-	if m == nil {
-		return 0
-	}
-	if !m.pasteSession.active {
-		m.beginPasteSession(source)
-	}
-	now := time.Now()
-	m.pasteSession.lastEventAt = now
-	if strings.TrimSpace(source) != "" {
-		m.pasteSession.sourceKind = source
-	}
-	normalized := normalizeNewlines(fragment)
-	if normalized != "" {
-		m.pasteSession.bufferedText += normalized
-		if strings.Contains(normalized, "\n") {
-			m.pasteSession.sawMultiline = true
+func (m model) handlePastePayload(payload string) (tea.Model, tea.Cmd) {
+	cleaned := trimTrailingPasteTerminators(payload)
+	candidate := strings.ReplaceAll(normalizeNewlines(cleaned), ctrlVMarkerRune, "")
+	if strings.TrimSpace(candidate) == "" {
+		m.clearPasteTransaction()
+		if note := m.handleEmptyClipboardPaste(); strings.TrimSpace(note) != "" {
+			m.statusNote = note
 		}
-		m.lastInputAt = now
-		m.inputBurstSize = max(m.inputBurstSize, len([]rune(strings.TrimSpace(normalized))))
+		m.syncInputOverlays()
+		return m, nil
 	}
-	m.pasteSession.finalizeID++
-	m.lastPasteAt = now
-	m.armPasteSubmitGuard(now)
-	return m.pasteSession.finalizeID
+	m.beginPasteTransaction(cleaned, "paste-payload")
+	m.applyDirectPasteInput(cleaned, "paste-payload")
+	return m, nil
 }
 
-func (m *model) clearPasteSession() {
+func (m *model) applyDirectPasteInput(fragment, source string) {
 	if m == nil {
 		return
-	}
-	m.pasteSession = pasteSessionState{}
-}
-
-func (m *model) hasActivePasteSession() bool {
-	return m != nil && m.pasteSession.active
-}
-
-func (m *model) shouldFinalizePasteImmediately(source, fragment string) bool {
-	if m == nil || !m.pasteSession.active {
-		return false
-	}
-	if !isPasteLikeSource(source) {
-		return false
-	}
-	normalized := normalizeNewlines(fragment)
-	if strings.Count(normalized, "\n") < 2 {
-		return false
-	}
-	return m.isLongPastedText(normalized) || strings.Count(normalized, "\n") >= longPasteLineThreshold
-}
-
-func (m *model) finalizePasteSession(id int) {
-	if m == nil || !m.pasteSession.active {
-		return
-	}
-	if id > 0 && id != m.pasteSession.finalizeID {
-		return
-	}
-
-	base := m.pasteSession.baseInput
-	content := normalizeNewlines(m.pasteSession.bufferedText)
-	source := m.pasteSession.sourceKind
-	m.clearPasteSession()
-
-	candidate := strings.ReplaceAll(content, ctrlVMarkerRune, "")
-	if candidate == "" {
-		m.setInputValue(base)
-		m.syncInputOverlays()
-		return
-	}
-
-	now := time.Now()
-	if source == "paste-key" && !m.shouldCompressPastedText(candidate, source) && !m.isLongPastedText(candidate) {
-		m.setInputValue(base + candidate)
-		if strings.Contains(candidate, "\n") || isPasteLikeSource(source) {
-			m.lastPasteAt = now
-			m.armPasteSubmitGuard(now)
-		}
-		m.lastInputAt = now
-		m.inputBurstSize = max(1, len([]rune(candidate)))
-		m.syncInputOverlays()
-		return
-	}
-	if (source != "paste-key" && strings.Contains(candidate, "\n")) || m.shouldCompressPastedText(candidate, source) || (isPasteLikeSource(source) && m.isLongPastedText(candidate)) {
-		marker, stored, err := m.compressPastedText(candidate)
-		if err != nil {
-			m.statusNote = err.Error()
-			m.setInputValue(base)
-			m.syncInputOverlays()
-			return
-		}
-		m.setInputValue(base + marker)
-		m.lastPasteAt = now
-		m.armPasteSubmitGuard(now)
-		m.statusNote = fmt.Sprintf("Long pasted text (%d lines) compressed as %s. Use [Paste #%s], [Paste #%s line10], or [Paste #%s line10~line20].",
-			stored.Lines, marker, stored.ID, stored.ID, stored.ID)
-		m.syncInputOverlays()
-		return
-	}
-
-	m.setInputValue(base + candidate)
-	if isPasteLikeSource(source) || strings.Contains(candidate, "\n") {
-		m.lastPasteAt = now
-		m.armPasteSubmitGuard(now)
-	}
-	m.lastInputAt = now
-	m.inputBurstSize = max(1, len([]rune(candidate)))
-	m.syncInputOverlays()
-}
-
-func (m *model) ingestPasteFragment(fragment, source string) tea.Cmd {
-	if m == nil {
-		return nil
 	}
 	if m.sessionsOpen || m.helpOpen || m.commandOpen || m.approval != nil {
-		return nil
+		return
 	}
 	candidate := strings.ReplaceAll(normalizeNewlines(fragment), ctrlVMarkerRune, "")
 	if candidate == "" {
-		return nil
+		return
 	}
-	id := m.appendPasteSessionFragment(candidate, source)
-	if m.shouldFinalizePasteImmediately(source, candidate) {
-		m.finalizePasteSession(id)
-		return nil
+	before := m.input.Value()
+	after := before + candidate
+	updated := m.handleInputMutation(before, after, source)
+	if updated == after && m.input.Value() != after {
+		m.setInputValue(after)
 	}
-	if shouldPreviewPasteSession(source) {
-		m.syncPasteSessionPreview()
-	}
-	return schedulePasteFinalize(id)
+	m.syncInputOverlays()
 }
 
-func (m model) handlePastePayload(payload string) (tea.Model, tea.Cmd) {
-	return m, m.ingestPasteFragment(trimTrailingPasteTerminators(payload), "paste-payload")
+func (m *model) readClipboardTextForPaste() (string, bool) {
+	if m == nil || m.clipboardRead == nil {
+		return "", false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Millisecond)
+	defer cancel()
+	text, err := m.clipboardRead.ReadText(ctx)
+	if err != nil {
+		return "", false
+	}
+	normalized := trimTrailingPasteTerminators(text)
+	candidate := strings.ReplaceAll(normalizeNewlines(normalized), ctrlVMarkerRune, "")
+	if strings.TrimSpace(candidate) == "" {
+		return "", false
+	}
+	return normalized, true
+}
+
+func (m *model) tryCompressClipboardMatchedPaste(raw string) (string, string, bool) {
+	if m == nil {
+		return raw, "", false
+	}
+	if strings.Contains(raw, "[Paste #") || strings.Contains(raw, "[Pasted #") {
+		return raw, "", false
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" || strings.HasPrefix(trimmed, "/") {
+		return raw, "", false
+	}
+	if !m.isLongPastedText(raw) {
+		return raw, "", false
+	}
+	clipboardText, ok := m.readClipboardTextForPaste()
+	if !ok {
+		return raw, "", false
+	}
+
+	normalizedRaw := normalizeNewlines(raw)
+	normalizedClipboard := normalizeNewlines(clipboardText)
+	if strings.TrimSpace(normalizedClipboard) == "" {
+		return raw, "", false
+	}
+	if normalizedRaw != normalizedClipboard && !strings.HasSuffix(normalizedRaw, normalizedClipboard) {
+		return raw, "", false
+	}
+
+	marker, content, err := m.compressPastedText(normalizedClipboard)
+	if err != nil {
+		return raw, err.Error(), false
+	}
+	if normalizedRaw == normalizedClipboard {
+		note := fmt.Sprintf("Detected clipboard-matched pasted text and compressed it as %s (%d lines). Press Enter again to send.",
+			marker, content.Lines)
+		return marker, note, true
+	}
+
+	prefix := normalizedRaw[:len(normalizedRaw)-len(normalizedClipboard)]
+	replacement := prefix + marker
+	note := fmt.Sprintf("Detected clipboard-matched pasted block and compressed it as %s (%d lines). Press Enter again to send.",
+		marker, content.Lines)
+	return replacement, note, true
+}
+
+func (m *model) tryStartClipboardPasteCapture(before, after, source string) (string, string, bool) {
+	if m == nil {
+		return after, "", false
+	}
+	if isPasteLikeSource(source) || m.pasteTransaction.Active {
+		return after, "", false
+	}
+	if strings.Contains(after, "[Paste #") || strings.Contains(after, "[Pasted #") {
+		return after, "", false
+	}
+	trimmedAfter := strings.TrimSpace(after)
+	if trimmedAfter == "" || strings.HasPrefix(trimmedAfter, "/") {
+		return after, "", false
+	}
+
+	clipboardText, ok := m.readClipboardTextForPaste()
+	if !ok || !m.isLongPastedText(clipboardText) {
+		return after, "", false
+	}
+	normalizedBefore := normalizeNewlines(before)
+	normalizedAfter := normalizeNewlines(after)
+	normalizedClipboard := normalizeNewlines(clipboardText)
+	if strings.TrimSpace(normalizedClipboard) == "" {
+		return after, "", false
+	}
+	if normalizedBefore != "" && !strings.HasPrefix(normalizedClipboard, normalizedBefore) {
+		return after, "", false
+	}
+	if !strings.HasPrefix(normalizedClipboard, normalizedAfter) {
+		return after, "", false
+	}
+	if len([]rune(strings.TrimSpace(normalizedAfter))) < clipboardCaptureMinPrefixRunes {
+		return after, "", false
+	}
+
+	marker, content, err := m.compressPastedText(normalizedClipboard)
+	if err != nil {
+		return after, err.Error(), false
+	}
+	m.beginPasteTransaction(normalizedClipboard, "clipboard-capture")
+	if m.pasteTransaction.Active {
+		consumed := len([]rune(normalizedAfter))
+		total := len([]rune(m.pasteTransaction.Payload))
+		if consumed > total {
+			consumed = total
+		}
+		if consumed > 0 {
+			m.pasteTransaction.Consumed = consumed
+		}
+	}
+	note := fmt.Sprintf("Detected clipboard paste and compressed it as %s (%d lines).",
+		marker, content.Lines)
+	return marker, note, true
+}
+
+func (m *model) shouldTreatEnterAsClipboardPasteContinuation(raw string) bool {
+	if m == nil {
+		return false
+	}
+	normalizedRaw := normalizeNewlines(raw)
+	if strings.TrimSpace(normalizedRaw) == "" {
+		return false
+	}
+	clipboardText, ok := m.readClipboardTextForPaste()
+	if !ok || !m.isLongPastedText(clipboardText) {
+		return false
+	}
+	normalizedClipboard := normalizeNewlines(clipboardText)
+	if strings.TrimSpace(normalizedClipboard) == "" {
+		return false
+	}
+
+	// Exact prefix continuation: current buffer is beginning of clipboard,
+	// and the next clipboard rune is a newline.
+	if strings.HasPrefix(normalizedClipboard, normalizedRaw+"\n") {
+		return true
+	}
+
+	// Suffix-prefix continuation: user might already have text before paste.
+	matchLen := longestClipboardPrefixSuffixLen(normalizedRaw, normalizedClipboard)
+	if matchLen <= 0 {
+		return false
+	}
+	clipboardRunes := []rune(normalizedClipboard)
+	if matchLen >= len(clipboardRunes) {
+		return false
+	}
+	return clipboardRunes[matchLen] == '\n'
+}
+
+func longestClipboardPrefixSuffixLen(raw, clipboard string) int {
+	rawRunes := []rune(raw)
+	clipboardRunes := []rune(clipboard)
+	maxLen := len(rawRunes)
+	if len(clipboardRunes) < maxLen {
+		maxLen = len(clipboardRunes)
+	}
+	for length := maxLen; length > 0; length-- {
+		rawSuffix := string(rawRunes[len(rawRunes)-length:])
+		clipboardPrefix := string(clipboardRunes[:length])
+		if rawSuffix == clipboardPrefix {
+			return length
+		}
+	}
+	return 0
 }
 
 func (m *model) ensurePastedContentState() {
@@ -347,6 +376,81 @@ func (m *model) persistPastedContentState() error {
 	return nil
 }
 
+func (m *model) upsertVirtualPastePart(pasteID, placeholder string) {
+	if m == nil {
+		return
+	}
+	pasteID = strings.TrimSpace(pasteID)
+	placeholder = strings.TrimSpace(placeholder)
+	if pasteID == "" || placeholder == "" {
+		return
+	}
+	if m.virtualPasteParts == nil {
+		m.virtualPasteParts = make([]virtualPastePart, 0, maxStoredPastedContents)
+	}
+	if m.nextVirtualPastePart <= 0 {
+		m.nextVirtualPastePart = 1
+	}
+	for i := range m.virtualPasteParts {
+		if m.virtualPasteParts[i].PasteID == pasteID {
+			m.virtualPasteParts[i].Placeholder = placeholder
+			return
+		}
+	}
+	part := virtualPastePart{
+		PartID:      strconv.Itoa(m.nextVirtualPastePart),
+		PasteID:     pasteID,
+		Placeholder: placeholder,
+	}
+	m.nextVirtualPastePart++
+	m.virtualPasteParts = append(m.virtualPasteParts, part)
+	if len(m.virtualPasteParts) > maxStoredPastedContents {
+		drop := len(m.virtualPasteParts) - maxStoredPastedContents
+		m.virtualPasteParts = append([]virtualPastePart(nil), m.virtualPasteParts[drop:]...)
+	}
+}
+
+func (m *model) clearVirtualPasteParts() {
+	if m == nil {
+		return
+	}
+	m.virtualPasteParts = m.virtualPasteParts[:0]
+}
+
+func (m *model) expandVirtualPasteParts(input string) (string, int) {
+	if m == nil || strings.TrimSpace(input) == "" || len(m.virtualPasteParts) == 0 {
+		return input, 0
+	}
+	expanded := input
+	applied := 0
+	for _, part := range m.virtualPasteParts {
+		placeholder := strings.TrimSpace(part.Placeholder)
+		if placeholder == "" || !strings.Contains(expanded, placeholder) {
+			continue
+		}
+		content, ok := m.findPastedContent(part.PasteID)
+		if !ok || strings.TrimSpace(content.Content) == "" {
+			continue
+		}
+		block := "```\n" + content.Content + "\n```"
+		expanded = strings.Replace(expanded, placeholder, block, 1)
+		applied++
+	}
+	return expanded, applied
+}
+
+func (m *model) resolvePromptPastedInput(raw string) (string, error) {
+	if m == nil {
+		return raw, nil
+	}
+	expanded, _ := m.expandVirtualPasteParts(raw)
+	resolved, err := m.resolvePastedLineReference(expanded)
+	if err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
 func (m *model) isLongPastedText(input string) bool {
 	normalized := normalizeNewlines(input)
 	trimmed := strings.TrimSpace(normalized)
@@ -357,23 +461,11 @@ func (m *model) isLongPastedText(input string) bool {
 		return false
 	}
 
-	lines := strings.Split(normalized, "\n")
-	lineCount := len(lines)
-	newlineCount := strings.Count(normalized, "\n")
-
-	if lineCount > longPasteLineThreshold || len(normalized) > longPasteCharThreshold {
+	lineCount := strings.Count(normalized, "\n") + 1
+	if lineCount >= opencodePasteSummaryMinLines {
 		return true
 	}
-
-	if lineCount <= 2 && len(normalized) >= flattenedPasteCharThreshold {
-		return true
-	}
-
-	if newlineCount >= 3 && len(normalized) >= pasteQuickCharThreshold {
-		return true
-	}
-
-	return false
+	return len([]rune(trimmed)) > opencodePasteSummaryMinChars
 }
 
 func isCtrlVSource(source string) bool {
@@ -394,57 +486,11 @@ func (m *model) shouldCompressPastedText(input, source string) bool {
 	if isLikelyPathInput(trimmed) || len(extractImagePathsFromChunk(input, m.workspace)) > 0 || len(extractInlineImagePathSpans(input)) > 0 {
 		return false
 	}
-	pasteContext := m.hasPasteCompressionContext(source)
-	if !pasteContext && !isSplitPasteContinuation(input, source, m.lastPasteAt) {
-		return false
-	}
-	if m.isLongPastedText(input) {
-		return true
-	}
-	if trimmed == "" {
-		return false
-	}
-	rapidBurst := pasteContext &&
-		!m.lastInputAt.IsZero() &&
-		time.Since(m.lastInputAt) <= pasteBurstWindow &&
-		m.inputBurstSize >= pasteBurstImmediateMinChars
-	if rapidBurst && len(trimmed) >= pasteBurstImmediateMinChars && looksLikePastedFragment(trimmed) {
-		return true
-	}
-	if len(trimmed) < pasteQuickCharThreshold {
-		return false
-	}
-	if isPasteLikeSource(source) {
-		return true
-	}
-	if !m.lastPasteAt.IsZero() && time.Since(m.lastPasteAt) <= 2*pasteSubmitGuard {
-		return true
-	}
-	if isSplitPasteContinuation(input, source, m.lastPasteAt) {
-		return true
-	}
-	if pasteContext && !m.lastInputAt.IsZero() && time.Since(m.lastInputAt) <= pasteBurstWindow && m.inputBurstSize >= pasteBurstCharThreshold {
-		return true
-	}
-	return pasteContext && m.inputBurstSize >= pasteBurstCharThreshold
-}
-
-func (m *model) hasPasteCompressionContext(source string) bool {
-	if m == nil {
-		return false
-	}
 	source = strings.TrimSpace(strings.ToLower(source))
-	if source == "paste-enter" || isPasteLikeSource(source) {
-		return true
+	if !isPasteLikeSource(source) {
+		return false
 	}
-	return !m.lastPasteAt.IsZero() && time.Since(m.lastPasteAt) <= pasteContinuationWindow
-}
-
-func looksLikePastedFragment(value string) bool {
-	if strings.ContainsAny(value, "\r\n\t ") {
-		return true
-	}
-	return len(value) >= 64
+	return m.isLongPastedText(input)
 }
 
 func isLikelyPathInput(value string) bool {
@@ -528,7 +574,9 @@ func (m *model) compressPastedText(input string) (string, pastedContent, error) 
 		return "", pastedContent{}, err
 	}
 	m.lastCompressedPasteAt = now
-	return fmt.Sprintf("[Paste #%s ~%d lines]", id, lineCount), content, nil
+	marker := fmt.Sprintf("[Paste #%s ~%d lines]", id, lineCount)
+	m.upsertVirtualPastePart(content.ID, marker)
+	return marker, content, nil
 }
 
 func countPastedDisplayLines(content string) int {
@@ -686,6 +734,7 @@ func (m *model) mergeTailIntoLatestMarker(chain, tail string) (string, bool, err
 	m.lastCompressedPasteAt = time.Now().UTC()
 
 	updatedMarker := fmt.Sprintf("[Paste #%s ~%d lines]", content.ID, content.Lines)
+	m.upsertVirtualPastePart(content.ID, updatedMarker)
 	updatedChain := chain[:loc.start] + updatedMarker + chain[loc.end:]
 	return strings.TrimSpace(updatedChain), true, nil
 }
@@ -869,8 +918,7 @@ func (m *model) protectCompressedMarkerChain(before, after, source string) (stri
 			// changes when they likely come from paste chunk coalescing logic.
 			if strings.TrimSpace(afterChain) == strings.TrimSpace(beforeChain) ||
 				len(afterIDs) > len(beforeIDs) ||
-				isPasteLikeSource(source) ||
-				source == "paste-enter" {
+				isPasteLikeSource(source) {
 				return after, false
 			}
 			tail := strings.TrimSpace(strings.TrimPrefix(afterTrimmed, afterChain))
@@ -893,23 +941,6 @@ func (m *model) protectCompressedMarkerChain(before, after, source string) (stri
 		return strings.TrimSpace(beforeChain) + afterTrimmed, true
 	}
 	return strings.TrimSpace(beforeChain), true
-}
-
-func isSplitPasteContinuation(input, source string, lastPasteAt time.Time) bool {
-	trimmed := strings.TrimSpace(input)
-	if trimmed == "" || isLikelyPathInput(trimmed) {
-		return false
-	}
-	if !isPasteLikeSource(source) {
-		return false
-	}
-	if strings.Contains(trimmed, "[Paste #") || strings.Contains(trimmed, "[Pasted #") {
-		return false
-	}
-	if !lastPasteAt.IsZero() && time.Since(lastPasteAt) <= pasteContinuationWindow {
-		return true
-	}
-	return strings.Contains(trimmed, "\n") || len(trimmed) >= pasteQuickCharThreshold
 }
 
 func (m *model) resolvePastedLineReference(input string) (string, error) {

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -172,11 +172,8 @@ func (m *model) tryStartClipboardPasteCapture(before, after, source string) (str
 	if isPasteLikeSource(source) || m.pasteTransaction.Active {
 		return after, "", false
 	}
-	if strings.Contains(after, "[Paste #") || strings.Contains(after, "[Pasted #") {
-		return after, "", false
-	}
 	trimmedAfter := strings.TrimSpace(after)
-	if trimmedAfter == "" || strings.HasPrefix(trimmedAfter, "/") {
+	if trimmedAfter == "" {
 		return after, "", false
 	}
 
@@ -184,29 +181,53 @@ func (m *model) tryStartClipboardPasteCapture(before, after, source string) (str
 	if !ok || !m.isLongPastedText(clipboardText) {
 		return after, "", false
 	}
-	normalizedBefore := normalizeNewlines(before)
-	normalizedAfter := normalizeNewlines(after)
+	prefix, inserted, suffix := insertionDiff(before, after)
+	inserted = strings.ReplaceAll(inserted, ctrlVMarkerRune, "")
+	normalizedInserted := normalizeNewlines(inserted)
+
 	normalizedClipboard := normalizeNewlines(clipboardText)
 	if strings.TrimSpace(normalizedClipboard) == "" {
 		return after, "", false
 	}
-	if normalizedBefore != "" && !strings.HasPrefix(normalizedClipboard, normalizedBefore) {
+	var buildReplacement func(marker string) string
+	consumedRunes := 0
+	insertedRunes := len([]rune(normalizedInserted))
+	if normalizedInserted != "" &&
+		insertedRunes >= clipboardCaptureMinPrefixRunes &&
+		strings.HasPrefix(normalizedClipboard, normalizedInserted) {
+		consumedRunes = insertedRunes
+		buildReplacement = func(marker string) string {
+			return after[:prefix] + marker + after[len(after)-suffix:]
+		}
+	} else {
+		normalizedBefore := normalizeNewlines(strings.ReplaceAll(before, ctrlVMarkerRune, ""))
+		normalizedAfter := normalizeNewlines(strings.ReplaceAll(after, ctrlVMarkerRune, ""))
+		beforeMatched := longestClipboardPrefixSuffixLen(normalizedBefore, normalizedClipboard)
+		afterMatched := longestClipboardPrefixSuffixLen(normalizedAfter, normalizedClipboard)
+		if afterMatched < clipboardCaptureMinPrefixRunes || afterMatched <= beforeMatched {
+			return after, "", false
+		}
+		afterRunes := []rune(after)
+		if afterMatched > len(afterRunes) {
+			return after, "", false
+		}
+		consumedRunes = afterMatched
+		buildReplacement = func(marker string) string {
+			return string(afterRunes[:len(afterRunes)-afterMatched]) + marker
+		}
+	}
+	if buildReplacement == nil {
 		return after, "", false
 	}
-	if !strings.HasPrefix(normalizedClipboard, normalizedAfter) {
-		return after, "", false
-	}
-	if len([]rune(strings.TrimSpace(normalizedAfter))) < clipboardCaptureMinPrefixRunes {
-		return after, "", false
-	}
-
 	marker, content, err := m.compressPastedText(normalizedClipboard)
 	if err != nil {
 		return after, err.Error(), false
 	}
+	replacement := buildReplacement(marker)
+
 	m.beginPasteTransaction(normalizedClipboard, "clipboard-capture")
 	if m.pasteTransaction.Active {
-		consumed := len([]rune(normalizedAfter))
+		consumed := consumedRunes
 		total := len([]rune(m.pasteTransaction.Payload))
 		if consumed > total {
 			consumed = total
@@ -217,7 +238,7 @@ func (m *model) tryStartClipboardPasteCapture(before, after, source string) (str
 	}
 	note := fmt.Sprintf("Detected clipboard paste and compressed it as %s (%d lines).",
 		marker, content.Lines)
-	return marker, note, true
+	return replacement, note, true
 }
 
 func (m *model) shouldTreatEnterAsClipboardPasteContinuation(raw string) bool {
@@ -253,6 +274,25 @@ func (m *model) shouldTreatEnterAsClipboardPasteContinuation(raw string) bool {
 		return false
 	}
 	return clipboardRunes[matchLen] == '\n'
+}
+
+func (m *model) isLikelyClipboardPrefixTail(rawTail string) bool {
+	if m == nil {
+		return false
+	}
+	normalizedTail := normalizeNewlines(strings.ReplaceAll(rawTail, ctrlVMarkerRune, ""))
+	if normalizedTail == "" {
+		return false
+	}
+	clipboardText, ok := m.readClipboardTextForPaste()
+	if !ok || !m.isLongPastedText(clipboardText) {
+		return false
+	}
+	normalizedClipboard := normalizeNewlines(clipboardText)
+	if strings.TrimSpace(normalizedClipboard) == "" {
+		return false
+	}
+	return strings.HasPrefix(normalizedClipboard, normalizedTail)
 }
 
 func longestClipboardPrefixSuffixLen(raw, clipboard string) int {
@@ -626,7 +666,9 @@ func (m *model) applyLongPastedTextPipeline(before, after, source string) (strin
 					len(extractInlineImagePathSpans(tail)) == 0
 				// Some terminals split one clipboard paste into multiple non-paste rune bursts.
 				// Merge those bursts into the latest marker to avoid leaking trailing raw text.
-				if safeTail && shouldMergeIntoLatestMarker(source, m.lastCompressedPasteAt) {
+				if safeTail &&
+					!m.isLikelyClipboardPrefixTail(rawTail) &&
+					shouldMergeIntoLatestMarker(source, m.lastCompressedPasteAt) {
 					merged, ok, err := m.mergeTailIntoLatestMarker(chain, rawTail)
 					if err != nil {
 						return after, err.Error()
@@ -645,7 +687,8 @@ func (m *model) applyLongPastedTextPipeline(before, after, source string) (strin
 						marker, content.Lines)
 					return updated, note
 				}
-				if shouldHoldCompressedMarker(before, after, source, m.lastPasteAt, m.inputBurstSize) {
+				if shouldHoldCompressedMarker(before, after, source, m.lastPasteAt, m.inputBurstSize) &&
+					!m.isLikelyClipboardPrefixTail(rawTail) {
 					// Hide transient continuation tails so split paste chunks do not
 					// visibly appear/disappear before marker coalescing completes.
 					return strings.TrimSpace(chain), ""
@@ -695,8 +738,11 @@ func shouldMergeIntoLatestMarker(source string, lastCompressedAt time.Time) bool
 	if lastCompressedAt.IsZero() {
 		return false
 	}
+	source = strings.ToLower(strings.TrimSpace(source))
+	// Keep explicit paste boundaries independent, matching opencode behavior
+	// where each paste operation is represented as its own placeholder.
 	if isPasteLikeSource(source) {
-		return time.Since(lastCompressedAt) <= 300*time.Millisecond
+		return false
 	}
 	return time.Since(lastCompressedAt) <= 500*time.Millisecond
 }

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -24,6 +24,7 @@ const (
 	pasteContinuationWindow        = 1500 * time.Millisecond
 	clipboardCaptureArmWindow      = 1200 * time.Millisecond
 	clipboardCaptureImplicitGap    = 80 * time.Millisecond
+	clipboardCaptureRapidRuneGap   = 30 * time.Millisecond
 	maxSinglePastedCharLength      = 200000
 	pasteSoftWrapWidth             = 72
 	clipboardCaptureMinPrefixRunes = 4
@@ -146,9 +147,6 @@ func (m *model) shouldArmClipboardCaptureFromImplicitMutation(before, after, sou
 	if delta <= 0 || m.inputBurstSize < clipboardCaptureMinPrefixRunes {
 		return false
 	}
-	if gap <= clipboardCaptureImplicitGap {
-		return true
-	}
 	_, inserted, _ := insertionDiff(before, after)
 	inserted = strings.ReplaceAll(normalizeNewlines(inserted), ctrlVMarkerRune, "")
 	if inserted == "" {
@@ -157,7 +155,13 @@ func (m *model) shouldArmClipboardCaptureFromImplicitMutation(before, after, sou
 	if strings.Contains(inserted, "\n") || strings.Contains(inserted, "\t") {
 		return true
 	}
-	return len([]rune(inserted)) >= clipboardCaptureMinPrefixRunes
+	insertedRunes := len([]rune(inserted))
+	if insertedRunes >= clipboardCaptureMinPrefixRunes {
+		return true
+	}
+	// Treat single-rune bursts as implicit paste only at a cadence that's
+	// far faster than typical manual typing.
+	return insertedRunes == 1 && gap <= clipboardCaptureRapidRuneGap
 }
 
 func (m *model) shouldAttemptClipboardPasteCapture(before, after, source string) bool {

--- a/tui/input_paste_test.go
+++ b/tui/input_paste_test.go
@@ -70,12 +70,12 @@ func TestApplyLongPastedTextPipelineCompressesSplitPasteChunks(t *testing.T) {
 	m.handleInputMutation(before, after, "paste")
 
 	got := m.input.Value()
-	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`)
+	re := regexp.MustCompile(`^(?:\s*\[Paste #\d+ ~\d+ lines\]\s*){2}$`)
 	if !re.MatchString(got) {
-		t.Fatalf("expected split paste to compress into marker, got %q", got)
+		t.Fatalf("expected split explicit paste boundaries to produce two markers, got %q", got)
 	}
-	if len(m.pastedContents) != 1 {
-		t.Fatalf("expected one stored pasted content after split paste, got %d", len(m.pastedContents))
+	if len(m.pastedContents) != 2 {
+		t.Fatalf("expected two stored pasted content entries after split explicit paste, got %d", len(m.pastedContents))
 	}
 }
 
@@ -182,9 +182,9 @@ func TestApplyLongPastedTextPipelineCompressesTailAfterMarkerIntoNewMarker(t *te
 	m.handleInputMutation(before, after, "paste")
 
 	got := m.input.Value()
-	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`)
+	re := regexp.MustCompile(`^(?:\s*\[Paste #\d+ ~\d+ lines\]\s*){2}$`)
 	if !re.MatchString(got) {
-		t.Fatalf("expected immediate followup paste chunk to merge into latest marker, got %q", got)
+		t.Fatalf("expected followup explicit paste to create a new marker, got %q", got)
 	}
 }
 
@@ -953,12 +953,18 @@ func TestProtectCompressedMarkerChainBackspaceDeletesLatestMarkerInChain(t *test
 	}
 }
 
-func TestShouldMergeIntoLatestMarkerAllowsFastPasteChunks(t *testing.T) {
+func TestShouldMergeIntoLatestMarkerSkipsExplicitPasteBoundaries(t *testing.T) {
 	now := time.Now()
-	if !shouldMergeIntoLatestMarker("paste", now.Add(-80*time.Millisecond)) {
-		t.Fatalf("expected immediate paste chunk to merge into latest marker")
+	if shouldMergeIntoLatestMarker("paste", now.Add(-80*time.Millisecond)) {
+		t.Fatalf("expected explicit paste chunk not to merge into latest marker")
 	}
-	if shouldMergeIntoLatestMarker("paste", now.Add(-900*time.Millisecond)) {
-		t.Fatalf("expected delayed paste chunk not to merge into latest marker")
+	if shouldMergeIntoLatestMarker("ctrl+v", now.Add(-80*time.Millisecond)) {
+		t.Fatalf("expected explicit ctrl+v chunk not to merge into latest marker")
+	}
+	if !shouldMergeIntoLatestMarker("rune", now.Add(-120*time.Millisecond)) {
+		t.Fatalf("expected immediate non-paste rune chunk to merge into latest marker")
+	}
+	if shouldMergeIntoLatestMarker("rune", now.Add(-900*time.Millisecond)) {
+		t.Fatalf("expected delayed non-paste chunk not to merge into latest marker")
 	}
 }

--- a/tui/input_paste_test.go
+++ b/tui/input_paste_test.go
@@ -107,8 +107,8 @@ func TestApplyLongPastedTextPipelineCompressesEarlyAndMergesFollowupPasteChunk(t
 
 	m.input.SetValue(chunk1)
 	m.handleInputMutation("", chunk1, "paste")
-	if got := m.input.Value(); !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(got) {
-		t.Fatalf("expected first chunk to compress immediately, got %q", got)
+	if got := m.input.Value(); got != chunk1 {
+		t.Fatalf("expected short first paste chunk to remain literal, got %q", got)
 	}
 
 	before := m.input.Value()
@@ -117,12 +117,15 @@ func TestApplyLongPastedTextPipelineCompressesEarlyAndMergesFollowupPasteChunk(t
 	m.handleInputMutation(before, after, "paste")
 
 	got := m.input.Value()
-	re := regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`)
+	if !strings.Contains(got, chunk1) {
+		t.Fatalf("expected first chunk to remain visible, got %q", got)
+	}
+	re := regexp.MustCompile(`\[Paste #\d+ ~\d+ lines\]`)
 	if !re.MatchString(got) {
-		t.Fatalf("expected followup paste chunk to merge into one marker, got %q", got)
+		t.Fatalf("expected long followup paste chunk to compress into marker, got %q", got)
 	}
 	if len(m.pastedOrder) != 1 {
-		t.Fatalf("expected one stored marker after merged paste chunks, got %d", len(m.pastedOrder))
+		t.Fatalf("expected one stored marker for followup chunk, got %d", len(m.pastedOrder))
 	}
 }
 
@@ -373,6 +376,30 @@ func TestBuildPromptInputExpandsStoredPastedReference(t *testing.T) {
 	}
 }
 
+func TestBuildPromptInputExpandsVirtualPartWithoutPasteRegexPattern(t *testing.T) {
+	m := newImagePipelineModel(t)
+	_, stored, err := m.compressPastedText("one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven")
+	if err != nil {
+		t.Fatalf("compress pasted text: %v", err)
+	}
+	if len(m.virtualPasteParts) == 0 {
+		t.Fatalf("expected virtual paste parts to be tracked")
+	}
+	custom := "<<PASTE_PART_1>>"
+	m.virtualPasteParts[0].Placeholder = custom
+
+	input, display, err := m.buildPromptInput("inspect " + custom)
+	if err != nil {
+		t.Fatalf("build prompt input: %v", err)
+	}
+	if display != "inspect "+custom {
+		t.Fatalf("expected display text unchanged, got %q", display)
+	}
+	if !strings.Contains(input.UserMessage.Text(), "```\n"+stored.Content+"\n```") {
+		t.Fatalf("expected virtual-part expansion without regex marker, got %q", input.UserMessage.Text())
+	}
+}
+
 func TestResolvePastedLineReferenceWithFullFormat(t *testing.T) {
 	m := newImagePipelineModel(t)
 	_, stored, err := m.compressPastedText("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11")
@@ -441,7 +468,7 @@ func TestBuildPromptInputDefaultsToLatestPastedReference(t *testing.T) {
 func TestStorePastedContentKeepsRecentLimit(t *testing.T) {
 	m := newImagePipelineModel(t)
 	for i := 0; i < maxStoredPastedContents+2; i++ {
-		content := strings.Repeat("x\n", longPasteLineThreshold+1) + "{\n}"
+		content := strings.Repeat("x\n", opencodePasteSummaryMinLines+2) + "{\n}"
 		if _, _, err := m.compressPastedText(content); err != nil {
 			t.Fatalf("compress pasted text #%d: %v", i, err)
 		}
@@ -609,7 +636,7 @@ func TestApplyLongPastedTextPipelineMergesSlashLeadingTrailingText(t *testing.T)
 	}
 }
 
-func TestHandleInputMutationCompressesImplicitRuneBurstImmediately(t *testing.T) {
+func TestHandleInputMutationDoesNotCompressImplicitRuneBurstWithoutPasteSource(t *testing.T) {
 	m := newImagePipelineModel(t)
 	longPaste := strings.Join([]string{
 		"package main",
@@ -634,25 +661,25 @@ func TestHandleInputMutationCompressesImplicitRuneBurstImmediately(t *testing.T)
 		before = m.input.Value()
 	}
 
-	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(before) {
-		t.Fatalf("expected implicit rune burst to compress immediately into marker, got %q", before)
+	if before != longPaste {
+		t.Fatalf("expected implicit rune burst to stay literal without paste signal, got %q", before)
 	}
 }
 
-func TestShouldCompressPastedTextQuickThresholdWithPasteSignal(t *testing.T) {
+func TestShouldCompressPastedTextDoesNotCompressShortSingleLineWithPasteSignal(t *testing.T) {
 	m := newImagePipelineModel(t)
 	text := strings.Repeat("alpha beta gamma ", 8)
-	if !m.shouldCompressPastedText(text, "ctrl+v") {
-		t.Fatalf("expected paste signal + quick threshold to trigger compression")
+	if m.shouldCompressPastedText(text, "ctrl+v") {
+		t.Fatalf("expected short single-line paste to stay literal")
 	}
 }
 
-func TestShouldCompressPastedTextQuickThresholdWithRecentPasteWindow(t *testing.T) {
+func TestShouldCompressPastedTextRequiresExplicitPasteSource(t *testing.T) {
 	m := newImagePipelineModel(t)
 	text := strings.Repeat("alpha beta gamma ", 8)
 	m.lastPasteAt = time.Now()
-	if !m.shouldCompressPastedText(text, "rune") {
-		t.Fatalf("expected recent paste window + quick threshold to trigger compression")
+	if m.shouldCompressPastedText(text, "rune") {
+		t.Fatalf("expected non-paste source to skip compression")
 	}
 }
 
@@ -667,8 +694,6 @@ func TestShouldCompressPastedTextSkipsLikelyPathInput(t *testing.T) {
 func TestShouldCompressPastedTextSkipsFastCharacterBurstWithoutPasteSignal(t *testing.T) {
 	m := newImagePipelineModel(t)
 	text := strings.Repeat("burst payload ", 10)
-	m.inputBurstSize = pasteBurstCharThreshold
-	m.lastInputAt = time.Now()
 	if m.shouldCompressPastedText(text, "rune") {
 		t.Fatalf("expected rapid burst without paste signal to skip compression")
 	}
@@ -676,9 +701,7 @@ func TestShouldCompressPastedTextSkipsFastCharacterBurstWithoutPasteSignal(t *te
 
 func TestShouldCompressPastedTextSkipsShortRapidBurstEarlyWithoutPasteSignal(t *testing.T) {
 	m := newImagePipelineModel(t)
-	text := strings.Repeat("x ", pasteBurstImmediateMinChars+2)
-	m.inputBurstSize = pasteBurstImmediateMinChars
-	m.lastInputAt = time.Now()
+	text := strings.Repeat("x ", 24)
 	if m.shouldCompressPastedText(text, "rune") {
 		t.Fatalf("expected short rapid burst without paste signal to skip compression")
 	}
@@ -686,9 +709,7 @@ func TestShouldCompressPastedTextSkipsShortRapidBurstEarlyWithoutPasteSignal(t *
 
 func TestShouldCompressPastedTextSkipsShortRapidBurstWithoutPasteSignals(t *testing.T) {
 	m := newImagePipelineModel(t)
-	text := strings.Repeat("x", pasteBurstImmediateMinChars+2)
-	m.inputBurstSize = pasteBurstImmediateMinChars
-	m.lastInputAt = time.Now()
+	text := strings.Repeat("x", 24)
 	if m.shouldCompressPastedText(text, "rune") {
 		t.Fatalf("expected short compact burst without paste traits to skip compression")
 	}

--- a/tui/input_paste_transaction.go
+++ b/tui/input_paste_transaction.go
@@ -1,0 +1,160 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func (m *model) beginPasteTransaction(payload, source string) {
+	if m == nil {
+		return
+	}
+	candidate := strings.ReplaceAll(normalizeNewlines(payload), ctrlVMarkerRune, "")
+	if strings.TrimSpace(candidate) == "" {
+		m.clearPasteTransaction()
+		return
+	}
+	m.pasteTransaction = pasteTransactionState{
+		Active:             true,
+		Source:             strings.TrimSpace(source),
+		Payload:            candidate,
+		Consumed:           0,
+		AwaitTrailingEnter: shouldGuardTrailingPasteEnter(source),
+	}
+}
+
+func (m *model) beginOrAppendPasteTransaction(payload, source string) {
+	if m == nil {
+		return
+	}
+	candidate := strings.ReplaceAll(normalizeNewlines(payload), ctrlVMarkerRune, "")
+	if candidate == "" {
+		return
+	}
+	source = strings.TrimSpace(source)
+	tx := m.pasteTransaction
+	if tx.Active && tx.Consumed == 0 && shouldAppendPasteTransactionPayload(tx.Source, source) {
+		tx.Payload += candidate
+		if strings.TrimSpace(tx.Source) == "" {
+			tx.Source = source
+		}
+		m.pasteTransaction = tx
+		return
+	}
+	if strings.TrimSpace(candidate) == "" {
+		return
+	}
+	m.beginPasteTransaction(candidate, source)
+}
+
+func (m *model) clearPasteTransaction() {
+	if m == nil {
+		return
+	}
+	m.pasteTransaction = pasteTransactionState{}
+}
+
+func (m *model) consumePasteEchoKey(msg tea.KeyMsg) bool {
+	if m == nil || !m.pasteTransaction.Active || msg.Paste {
+		return false
+	}
+	if isCtrlVControlKey(msg) {
+		// Some terminals emit Ctrl+V key markers before/within the echoed
+		// key stream. Ignore them so they do not tear down the active
+		// transaction and accidentally re-enable Enter submit.
+		return true
+	}
+	fragment, ok := pasteEchoFragmentFromKey(msg)
+	if !ok {
+		return false
+	}
+	fragment = normalizeNewlines(fragment)
+	if fragment == "" {
+		return false
+	}
+	remaining := remainingPasteTransactionPayload(m.pasteTransaction.Payload, m.pasteTransaction.Consumed)
+	if remaining == "" {
+		if m.pasteTransaction.AwaitTrailingEnter && msg.Type == tea.KeyEnter && !msg.Alt {
+			m.clearPasteTransaction()
+			return true
+		}
+		m.clearPasteTransaction()
+		return false
+	}
+	if strings.HasPrefix(remaining, fragment) {
+		m.pasteTransaction.Consumed += len([]rune(fragment))
+		if m.pasteTransaction.Consumed >= len([]rune(m.pasteTransaction.Payload)) {
+			if !m.pasteTransaction.AwaitTrailingEnter {
+				m.clearPasteTransaction()
+			}
+		}
+		return true
+	}
+	m.clearPasteTransaction()
+	return false
+}
+
+func shouldAppendPasteTransactionPayload(currentSource, nextSource string) bool {
+	current := strings.ToLower(strings.TrimSpace(currentSource))
+	next := strings.ToLower(strings.TrimSpace(nextSource))
+	if current == "" || next == "" {
+		return false
+	}
+	if current != next {
+		return false
+	}
+	switch current {
+	case "paste-key", "rune-burst-paste":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldGuardTrailingPasteEnter(source string) bool {
+	source = strings.ToLower(strings.TrimSpace(source))
+	switch source {
+	case "clipboard-capture":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCtrlVControlKey(msg tea.KeyMsg) bool {
+	if msg.Type == tea.KeyCtrlV {
+		return true
+	}
+	if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && string(msg.Runes[0]) == ctrlVMarkerRune {
+		return true
+	}
+	return normalizeKeyName(msg.String()) == "ctrl+v"
+}
+
+func pasteEchoFragmentFromKey(msg tea.KeyMsg) (string, bool) {
+	if msg.Type == tea.KeyEnter && !msg.Alt {
+		return "\n", true
+	}
+	if msg.Type == tea.KeyTab && !msg.Alt {
+		return "\t", true
+	}
+	if msg.Type == tea.KeySpace && !msg.Alt {
+		return " ", true
+	}
+	if msg.Type == tea.KeyRunes && len(msg.Runes) > 0 {
+		return string(msg.Runes), true
+	}
+	return "", false
+}
+
+func remainingPasteTransactionPayload(payload string, consumedRunes int) string {
+	runes := []rune(payload)
+	if consumedRunes <= 0 {
+		return payload
+	}
+	if consumedRunes >= len(runes) {
+		return ""
+	}
+	return string(runes[consumedRunes:])
+}

--- a/tui/input_paste_transaction.go
+++ b/tui/input_paste_transaction.go
@@ -2,9 +2,13 @@ package tui
 
 import (
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+const pasteCtrlVControlEchoWindow = 25 * time.Millisecond
+const pasteTransactionAppendWindow = 120 * time.Millisecond
 
 func (m *model) beginPasteTransaction(payload, source string) {
 	if m == nil {
@@ -15,11 +19,14 @@ func (m *model) beginPasteTransaction(payload, source string) {
 		m.clearPasteTransaction()
 		return
 	}
+	now := time.Now()
 	m.pasteTransaction = pasteTransactionState{
 		Active:             true,
 		Source:             strings.TrimSpace(source),
 		Payload:            candidate,
 		Consumed:           0,
+		StartedAt:          now,
+		LastEchoAt:         time.Time{},
 		AwaitTrailingEnter: shouldGuardTrailingPasteEnter(source),
 	}
 }
@@ -34,7 +41,9 @@ func (m *model) beginOrAppendPasteTransaction(payload, source string) {
 	}
 	source = strings.TrimSpace(source)
 	tx := m.pasteTransaction
-	if tx.Active && tx.Consumed == 0 && shouldAppendPasteTransactionPayload(tx.Source, source) {
+	now := time.Now()
+	if tx.Active && tx.Consumed == 0 && shouldAppendPasteTransactionPayload(tx.Source, source) &&
+		isPasteTransactionAppendWindowOpen(tx, now) {
 		tx.Payload += candidate
 		if strings.TrimSpace(tx.Source) == "" {
 			tx.Source = source
@@ -59,11 +68,24 @@ func (m *model) consumePasteEchoKey(msg tea.KeyMsg) bool {
 	if m == nil || !m.pasteTransaction.Active || msg.Paste {
 		return false
 	}
+	if msg.Type == tea.KeyRunes && m.shouldExpireStalePasteTransactionBeforeRunes() {
+		// No echoed payload arrived for a while; treat upcoming runes as fresh
+		// user input (for example a second paste operation), not stale echo.
+		m.clearPasteTransaction()
+		return false
+	}
 	if isCtrlVControlKey(msg) {
 		// Some terminals emit Ctrl+V key markers before/within the echoed
 		// key stream. Ignore them so they do not tear down the active
 		// transaction and accidentally re-enable Enter submit.
-		return true
+		if m.shouldConsumeCtrlVControlKey(msg) {
+			m.pasteTransaction.LastEchoAt = time.Now()
+			return true
+		}
+		// If the transaction is stale and a fresh Ctrl+V arrives, allow it to
+		// start a new paste boundary instead of swallowing the user's input.
+		m.clearPasteTransaction()
+		return false
 	}
 	fragment, ok := pasteEchoFragmentFromKey(msg)
 	if !ok {
@@ -75,15 +97,23 @@ func (m *model) consumePasteEchoKey(msg tea.KeyMsg) bool {
 	}
 	remaining := remainingPasteTransactionPayload(m.pasteTransaction.Payload, m.pasteTransaction.Consumed)
 	if remaining == "" {
-		if m.pasteTransaction.AwaitTrailingEnter && msg.Type == tea.KeyEnter && !msg.Alt {
+		if m.shouldConsumeTrailingPasteEnter(msg) {
 			m.clearPasteTransaction()
 			return true
 		}
 		m.clearPasteTransaction()
 		return false
 	}
+	if msg.Type == tea.KeyEnter && !msg.Alt && m.pasteTransaction.AwaitTrailingEnter && !strings.HasPrefix(remaining, "\n") {
+		// Terminal variation: some explicit paste flows do not echo payload
+		// characters back through key events. In that case the first plain Enter
+		// after paste should close the transaction but must not submit.
+		m.clearPasteTransaction()
+		return true
+	}
 	if strings.HasPrefix(remaining, fragment) {
 		m.pasteTransaction.Consumed += len([]rune(fragment))
+		m.pasteTransaction.LastEchoAt = time.Now()
 		if m.pasteTransaction.Consumed >= len([]rune(m.pasteTransaction.Payload)) {
 			if !m.pasteTransaction.AwaitTrailingEnter {
 				m.clearPasteTransaction()
@@ -93,6 +123,61 @@ func (m *model) consumePasteEchoKey(msg tea.KeyMsg) bool {
 	}
 	m.clearPasteTransaction()
 	return false
+}
+
+func (m *model) shouldExpireStalePasteTransactionBeforeRunes() bool {
+	if m == nil {
+		return false
+	}
+	tx := m.pasteTransaction
+	if !tx.Active || tx.StartedAt.IsZero() {
+		return false
+	}
+	if tx.Consumed > 0 || !tx.LastEchoAt.IsZero() {
+		return false
+	}
+	return time.Since(tx.StartedAt) > pasteTransactionAppendWindow
+}
+
+func (m *model) shouldConsumeCtrlVControlKey(msg tea.KeyMsg) bool {
+	if m == nil {
+		return false
+	}
+	tx := m.pasteTransaction
+	if tx.StartedAt.IsZero() {
+		return false
+	}
+	now := time.Now()
+	isCtrlVMarkerRune := msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && string(msg.Runes[0]) == ctrlVMarkerRune
+	if !isCtrlVMarkerRune && msg.Type != tea.KeyCtrlV && normalizeKeyName(msg.String()) != "ctrl+v" {
+		return false
+	}
+	// Treat Ctrl+V as control noise only in a tiny window right after
+	// transaction start or right after echoed key fragments. This avoids
+	// swallowing a user's intentional second paste.
+	if tx.Consumed == 0 && now.Sub(tx.StartedAt) <= pasteCtrlVControlEchoWindow {
+		return true
+	}
+	if !tx.LastEchoAt.IsZero() && now.Sub(tx.LastEchoAt) <= pasteCtrlVControlEchoWindow {
+		return true
+	}
+	return false
+}
+
+func (m *model) shouldConsumeTrailingPasteEnter(msg tea.KeyMsg) bool {
+	if m == nil {
+		return false
+	}
+	if !m.pasteTransaction.AwaitTrailingEnter {
+		return false
+	}
+	if msg.Type != tea.KeyEnter || msg.Alt {
+		return false
+	}
+	// In terminal mode we cannot reliably distinguish a user Enter from a
+	// delayed echoed Enter after paste. Consume the first plain Enter once the
+	// payload has been fully echoed, and require the next Enter to submit.
+	return true
 }
 
 func shouldAppendPasteTransactionPayload(currentSource, nextSource string) bool {
@@ -115,11 +200,27 @@ func shouldAppendPasteTransactionPayload(currentSource, nextSource string) bool 
 func shouldGuardTrailingPasteEnter(source string) bool {
 	source = strings.ToLower(strings.TrimSpace(source))
 	switch source {
-	case "clipboard-capture":
+	case "clipboard-capture", "ctrl+v", "paste-payload", "paste-key", "rune-burst-paste":
 		return true
 	default:
 		return false
 	}
+}
+
+func isPasteTransactionAppendWindowOpen(tx pasteTransactionState, now time.Time) bool {
+	if !tx.Active || tx.StartedAt.IsZero() {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if now.Sub(tx.StartedAt) <= pasteTransactionAppendWindow {
+		return true
+	}
+	if !tx.LastEchoAt.IsZero() && now.Sub(tx.LastEchoAt) <= pasteTransactionAppendWindow {
+		return true
+	}
+	return false
 }
 
 func isCtrlVControlKey(msg tea.KeyMsg) bool {

--- a/tui/model.go
+++ b/tui/model.go
@@ -50,7 +50,6 @@ const (
 	conversationViewportZoneID = "bytemind:conversation:viewport"
 	inputEditorZoneID          = "bytemind:input:editor"
 	thinkingSpinnerFPS         = 80 * time.Millisecond
-	pasteAggregateDebounce     = 120 * time.Millisecond
 )
 
 type footerShortcutHint struct {
@@ -219,19 +218,18 @@ type mouseSelectionScrollTickMsg struct {
 	ID int
 }
 
-type pasteFinalizeMsg struct {
-	ID int
+type pasteTransactionState struct {
+	Active             bool
+	Source             string
+	Payload            string
+	Consumed           int
+	AwaitTrailingEnter bool
 }
 
-type pasteSessionState struct {
-	active       bool
-	startedAt    time.Time
-	lastEventAt  time.Time
-	sourceKind   string
-	baseInput    string
-	bufferedText string
-	sawMultiline bool
-	finalizeID   int
+type virtualPastePart struct {
+	PartID      string
+	PasteID     string
+	Placeholder string
 }
 
 var commandItems = []commandItem{
@@ -296,7 +294,6 @@ type model struct {
 	mentionRecent         map[string]int
 	mentionSeq            int
 	lastPasteAt           time.Time
-	pasteSubmitGuardUntil time.Time
 	lastInputAt           time.Time
 	inputBurstSize        int
 	chatAutoFollow        bool
@@ -342,8 +339,11 @@ type model struct {
 	nextPasteID           int
 	pastedStateLoaded     bool
 	lastCompressedPasteAt time.Time
-	pasteSession          pasteSessionState
+	virtualPasteParts     []virtualPastePart
+	nextVirtualPastePart  int
+	pasteTransaction      pasteTransactionState
 	clipboard             clipboardImageReader
+	clipboardRead         clipboardTextReader
 	clipboardText         clipboardTextWriter
 	runCancel             context.CancelFunc
 	pendingBTW            []string
@@ -398,45 +398,48 @@ func newModel(opts Options) model {
 	}
 
 	m := model{
-		runner:             opts.Runner,
-		store:              opts.Store,
-		sess:               opts.Session,
-		imageStore:         opts.ImageStore,
-		cfg:                opts.Config,
-		workspace:          opts.Workspace,
-		async:              async,
-		viewport:           vp,
-		copyView:           copyVP,
-		planView:           planVP,
-		input:              input,
-		spinner:            spin,
-		chatItems:          chatItems,
-		toolRuns:           toolRuns,
-		plan:               copyPlanState(opts.Session.Plan),
-		sessions:           nil,
-		sessionLimit:       defaultSessionLimit,
-		screen:             initialScreen(opts.Session),
-		mode:               toAgentMode(opts.Session.Mode),
-		streamingIndex:     -1,
-		statusNote:         "Ready.",
-		phase:              "idle",
-		llmConnected:       true,
-		chatAutoFollow:     true,
-		mentionIndex:       mention.NewWorkspaceFileIndex(opts.Workspace),
-		tokenUsage:         newTokenUsageComponent(),
-		tokenBudget:        max(1, opts.Config.TokenQuota),
-		tokenEstimator:     newRealtimeTokenEstimator(opts.Config.Provider.Model),
-		inputImageRefs:     make(map[int]llm.AssetID, 8),
-		inputImageMentions: make(map[string]llm.AssetID, 8),
-		orphanedImages:     make(map[llm.AssetID]time.Time, 8),
-		nextImageID:        nextSessionImageID(opts.Session),
-		pastedContents:     make(map[string]pastedContent, maxStoredPastedContents),
-		pastedOrder:        make([]string, 0, maxStoredPastedContents),
-		nextPasteID:        1,
-		clipboard:          defaultClipboardImageReader{},
-		clipboardText:      defaultClipboardTextWriter{},
-		startupGuide:       opts.StartupGuide,
-		mouseYOffset:       resolveMouseYOffset(),
+		runner:               opts.Runner,
+		store:                opts.Store,
+		sess:                 opts.Session,
+		imageStore:           opts.ImageStore,
+		cfg:                  opts.Config,
+		workspace:            opts.Workspace,
+		async:                async,
+		viewport:             vp,
+		copyView:             copyVP,
+		planView:             planVP,
+		input:                input,
+		spinner:              spin,
+		chatItems:            chatItems,
+		toolRuns:             toolRuns,
+		plan:                 copyPlanState(opts.Session.Plan),
+		sessions:             nil,
+		sessionLimit:         defaultSessionLimit,
+		screen:               initialScreen(opts.Session),
+		mode:                 toAgentMode(opts.Session.Mode),
+		streamingIndex:       -1,
+		statusNote:           "Ready.",
+		phase:                "idle",
+		llmConnected:         true,
+		chatAutoFollow:       true,
+		mentionIndex:         mention.NewWorkspaceFileIndex(opts.Workspace),
+		tokenUsage:           newTokenUsageComponent(),
+		tokenBudget:          max(1, opts.Config.TokenQuota),
+		tokenEstimator:       newRealtimeTokenEstimator(opts.Config.Provider.Model),
+		inputImageRefs:       make(map[int]llm.AssetID, 8),
+		inputImageMentions:   make(map[string]llm.AssetID, 8),
+		orphanedImages:       make(map[llm.AssetID]time.Time, 8),
+		nextImageID:          nextSessionImageID(opts.Session),
+		pastedContents:       make(map[string]pastedContent, maxStoredPastedContents),
+		pastedOrder:          make([]string, 0, maxStoredPastedContents),
+		nextPasteID:          1,
+		virtualPasteParts:    make([]virtualPastePart, 0, maxStoredPastedContents),
+		nextVirtualPastePart: 1,
+		clipboard:            defaultClipboardImageReader{},
+		clipboardRead:        defaultClipboardTextReader{},
+		clipboardText:        defaultClipboardTextWriter{},
+		startupGuide:         opts.StartupGuide,
+		mouseYOffset:         resolveMouseYOffset(),
 	}
 	if opts.StartupGuide.Active {
 		m.statusNote = opts.StartupGuide.Status
@@ -492,12 +495,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
-	case pasteFinalizeMsg:
-		if !m.hasActivePasteSession() {
-			return m, nil
-		}
-		m.finalizePasteSession(msg.ID)
-		return m, nil
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -697,7 +694,8 @@ func isCtrlVPasteKey(msg tea.KeyMsg) bool {
 	if len(msg.Runes) == 1 && msg.Runes[0] == []rune(ctrlVMarkerRune)[0] {
 		return true
 	}
-	return normalizeKeyName(msg.String()) == "ctrl+v"
+	key := normalizeKeyName(msg.String())
+	return key == "ctrl+v" || key == "ctrl+shift+v" || key == "shift+insert"
 }
 
 func (m model) pasteFragmentFromKey(msg tea.KeyMsg) (string, string, bool) {
@@ -711,42 +709,15 @@ func (m model) pasteFragmentFromKey(msg tea.KeyMsg) (string, string, bool) {
 			return "", "", false
 		}
 	}
-	if m.hasActivePasteSession() {
-		switch {
-		case msg.Type == tea.KeyEnter && m.shouldAppendEnterToActivePasteSession():
-			return "\n", "rapid-enter", true
-		case msg.Type == tea.KeyRunes && len(msg.Runes) > 0:
-			return string(msg.Runes), "rune", true
-		default:
-			return "", "", false
+	if msg.Type == tea.KeyRunes && len(msg.Runes) > 1 {
+		fragment := string(msg.Runes)
+		candidate := strings.ReplaceAll(normalizeNewlines(fragment), ctrlVMarkerRune, "")
+		trimmed := strings.TrimSpace(candidate)
+		if trimmed != "" && (strings.Contains(candidate, "\n") || m.isLongPastedText(candidate)) {
+			return fragment, "rune-burst-paste", true
 		}
 	}
-	if msg.Type != tea.KeyRunes || len(msg.Runes) == 0 {
-		return "", "", false
-	}
-	fragment := string(msg.Runes)
-	if shouldStartPasteAggregationFromRunes(fragment) {
-		return fragment, "rune", true
-	}
 	return "", "", false
-}
-
-func shouldStartPasteAggregationFromRunes(fragment string) bool {
-	normalized := normalizeNewlines(fragment)
-	trimmed := strings.TrimSpace(normalized)
-	if trimmed == "" {
-		return false
-	}
-	if strings.Contains(normalized, "\n") {
-		return true
-	}
-	if len([]rune(fragment)) <= 1 {
-		return false
-	}
-	if looksLikeMarkdownPasteFragment(trimmed) {
-		return true
-	}
-	return len([]rune(trimmed)) >= pasteBurstImmediateMinChars
 }
 
 func inputMutationSource(msg tea.KeyMsg) string {
@@ -1005,33 +976,45 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
-	if msg.Type == tea.KeyEnter && !msg.Paste && !m.shouldSuppressEnterAfterPaste() && m.shouldTreatRapidEnterAsPasteContinuation() {
-		before := m.input.Value()
-		after := before + "\n"
-		m.setInputValue(after)
-		_ = m.handleInputMutation(before, after, "rapid-enter")
-		m.syncInputOverlays()
+	if m.consumePasteEchoKey(msg) {
 		return m, nil
 	}
 
 	if fragment, source, ok := m.pasteFragmentFromKey(msg); ok {
-		return m, m.ingestPasteFragment(fragment, source)
+		m.beginOrAppendPasteTransaction(fragment, source)
+		m.applyDirectPasteInput(fragment, source)
+		return m, nil
 	}
 
 	ctrlVPasteDetected := isCtrlVPasteKey(msg)
 	// Prefer Ctrl+V image paste first. If clipboard has no image, fall through
 	// so regular terminal paste behavior can continue.
 	if ctrlVPasteDetected {
-		if note := m.handleEmptyClipboardPaste(); strings.TrimSpace(note) != "" {
-			m.statusNote = note
-			if strings.Contains(note, "Attached image from clipboard") {
-				m.syncInputOverlays()
-				return m, nil
+		beforeClipboard := m.input.Value()
+		clipboardNote := strings.TrimSpace(m.handleEmptyClipboardPaste())
+		if m.input.Value() != beforeClipboard {
+			if clipboardNote != "" {
+				m.statusNote = clipboardNote
 			}
-			if !isClipboardNoImageNote(note) {
-				m.syncInputOverlays()
-				return m, nil
+			m.syncInputOverlays()
+			return m, nil
+		}
+		// If clipboard has text, treat Ctrl+V as one explicit paste boundary and
+		// handle insertion ourselves so long text can be summarized immediately.
+		if payload, ok := m.readClipboardTextForPaste(); ok {
+			m.beginPasteTransaction(payload, "ctrl+v")
+			m.applyDirectPasteInput(payload, "ctrl+v")
+			if strings.TrimSpace(m.statusNote) == "" || isClipboardNoImageNote(clipboardNote) {
+				m.statusNote = "Pasted text from clipboard."
 			}
+			m.syncInputOverlays()
+			return m, nil
+		}
+		if clipboardNote != "" {
+			m.clearPasteTransaction()
+			m.statusNote = clipboardNote
+			m.syncInputOverlays()
+			return m, nil
 		}
 	}
 
@@ -1070,50 +1053,18 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if msg.String() == "enter" && !msg.Paste {
-		if m.hasActivePasteSession() {
-			m.finalizePasteSession(m.pasteSession.finalizeID)
+		rawValue := m.input.Value()
+		if m.shouldTreatEnterAsClipboardPasteContinuation(rawValue) {
+			m.applyDirectPasteInput("\n", "clipboard-paste-continuation")
+			m.syncInputOverlays()
 			return m, nil
 		}
-		rawValue := m.input.Value()
-		if next, handled := m.handleSuppressedPasteEnter(rawValue); handled {
-			return next, nil
-		}
-		if markerChain, ok := extractLeadingCompressedMarker(rawValue); ok {
-			tail := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(rawValue), markerChain))
-			if tail != "" {
-				if m.shouldCompressPastedText(tail, "paste-enter") {
-					marker, content, err := m.compressPastedText(tail)
-					if err != nil {
-						m.statusNote = err.Error()
-						return m, nil
-					}
-					combined := strings.TrimSpace(markerChain) + marker
-					m.setInputValue(combined)
-					m.syncInputOverlays()
-					m.statusNote = fmt.Sprintf("Detected another pasted block and compressed it as %s (%d lines). Press Enter again to send.", marker, content.Lines)
-					return m, nil
-				}
-				if len(tail) >= 24 || strings.Contains(tail, "\n") {
-					m.setInputValue(strings.TrimSpace(markerChain))
-					m.syncInputOverlays()
-					m.statusNote = "Detected continued paste chunk after compressed marker. Kept compressed markers only; press Enter again to send."
-					return m, nil
-				}
-			}
-		}
-		// Check whether the input has already been compressed.
-		isAlreadyCompressed := strings.Contains(rawValue, "[Paste #") || strings.Contains(rawValue, "[Pasted #")
-
-		// Compress long pasted content before sending.
-		if !isAlreadyCompressed && m.shouldCompressPastedText(rawValue, inputMutationSource(msg)) {
-			marker, content, err := m.compressPastedText(rawValue)
-			if err != nil {
-				m.statusNote = err.Error()
-				return m, nil
-			}
-			m.setInputValue(marker)
+		if replacement, note, ok := m.tryCompressClipboardMatchedPaste(rawValue); ok {
+			m.setInputValue(replacement)
 			m.syncInputOverlays()
-			m.statusNote = fmt.Sprintf("Long pasted text (%d lines) compressed as %s. Press Enter again to send. Use [Paste #%s] or [Paste #%s line10~line20] later.", content.Lines, marker, content.ID, content.ID)
+			if strings.TrimSpace(note) != "" {
+				m.statusNote = note
+			}
 			return m, nil
 		}
 		value := strings.TrimSpace(rawValue)
@@ -1143,10 +1094,11 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if m.busy {
 			if strings.HasPrefix(value, "/") {
-				m.statusNote = "This command is unavailable while a run is in progress. Use /btw <message> or plain text."
+				m.statusNote = "This command is unavailable while a run is in progress. Use /btw <message>."
 				return m, nil
 			}
-			return m.submitBTW(value)
+			m.statusNote = "Run is in progress. Use /btw <message> to interject, or Esc to interrupt."
+			return m, nil
 		}
 		if isContinueExecutionInput(value) && planpkg.HasStructuredPlan(m.plan) {
 			state, err := preparePlanForContinuation(m.plan)
@@ -1169,6 +1121,8 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if strings.HasPrefix(value, "/") {
 			m.input.Reset()
+			m.clearPasteTransaction()
+			m.clearVirtualPasteParts()
 			next, cmd, err := m.executeCommand(value)
 			if err != nil {
 				m.statusNote = err.Error()
@@ -1223,162 +1177,6 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	m.syncInputOverlays()
 	return m, cmd
-}
-
-func (m model) shouldSuppressEnterAfterPaste() bool {
-	if !m.pasteSubmitGuardUntil.IsZero() && time.Now().Before(m.pasteSubmitGuardUntil) {
-		return true
-	}
-	if m.hasImplicitPasteBurst() {
-		return true
-	}
-	if m.lastPasteAt.IsZero() {
-		return false
-	}
-	if time.Since(m.lastPasteAt) > pasteSubmitGuard {
-		return false
-	}
-	if strings.Contains(m.input.Value(), "\n") {
-		return true
-	}
-	if strings.Contains(m.input.Value(), "[Paste #") || strings.Contains(m.input.Value(), "[Pasted #") {
-		return true
-	}
-	return time.Since(m.lastInputAt) <= 120*time.Millisecond
-}
-
-func (m model) hasImplicitPasteBurst() bool {
-	if m.lastInputAt.IsZero() {
-		return false
-	}
-	if time.Since(m.lastInputAt) > 250*time.Millisecond {
-		return false
-	}
-	if m.inputBurstSize < pasteBurstImmediateMinChars {
-		return false
-	}
-	trimmed := strings.TrimSpace(m.input.Value())
-	if trimmed == "" {
-		return false
-	}
-	if strings.Contains(trimmed, "[Paste #") || strings.Contains(trimmed, "[Pasted #") {
-		return true
-	}
-	if strings.Contains(trimmed, "\n") {
-		return true
-	}
-	if m.busy && m.inputBurstSize >= pasteBurstImmediateMinChars {
-		return looksLikePastedFragment(trimmed)
-	}
-	if m.inputBurstSize < pasteBurstCharThreshold {
-		return false
-	}
-	return looksLikePastedFragment(trimmed)
-}
-
-func (m model) shouldTreatRapidEnterAsPasteContinuation() bool {
-	if m.lastInputAt.IsZero() {
-		return false
-	}
-	if time.Since(m.lastInputAt) > 400*time.Millisecond {
-		return false
-	}
-	trimmed := strings.TrimSpace(m.input.Value())
-	if trimmed == "" {
-		return false
-	}
-	if m.inputBurstSize >= 2 && looksLikeMarkdownPasteFragment(trimmed) {
-		return true
-	}
-	return m.inputBurstSize >= pasteBurstImmediateMinChars
-}
-
-func (m model) shouldAppendEnterToActivePasteSession() bool {
-	if !m.hasActivePasteSession() {
-		return false
-	}
-	if m.pasteSession.lastEventAt.IsZero() {
-		return false
-	}
-	return time.Since(m.pasteSession.lastEventAt) <= 400*time.Millisecond
-}
-
-func looksLikeMarkdownPasteFragment(value string) bool {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return false
-	}
-	switch {
-	case strings.HasPrefix(value, "#"),
-		strings.HasPrefix(value, ">"),
-		strings.HasPrefix(value, "- "),
-		strings.HasPrefix(value, "* "),
-		strings.HasPrefix(value, "```"):
-		return true
-	}
-	if len(value) >= 3 && value[0] >= '0' && value[0] <= '9' {
-		if dot := strings.Index(value, ". "); dot > 0 && dot <= 2 {
-			return true
-		}
-	}
-	return false
-}
-
-func (m model) handleSuppressedPasteEnter(rawValue string) (tea.Model, bool) {
-	if !m.shouldSuppressEnterAfterPaste() {
-		return m, false
-	}
-	rawValue = strings.TrimSpace(rawValue)
-	if rawValue == "" {
-		return m, true
-	}
-	if markerChain, ok := extractLeadingCompressedMarker(rawValue); ok {
-		tail := strings.TrimSpace(strings.TrimPrefix(rawValue, markerChain))
-		if tail != "" {
-			if m.shouldCompressPastedText(tail, "paste-enter") || m.isLongPastedText(tail) {
-				marker, content, err := m.compressPastedText(tail)
-				if err != nil {
-					m.statusNote = err.Error()
-					return m, true
-				}
-				combined := strings.TrimSpace(markerChain) + marker
-				m.setInputValue(combined)
-				m.syncInputOverlays()
-				m.statusNote = fmt.Sprintf("Detected another pasted block and compressed it as %s (%d lines). Press Enter again to send.", marker, content.Lines)
-				return m, true
-			}
-			if len(tail) >= 24 || strings.Contains(tail, "\n") {
-				m.setInputValue(strings.TrimSpace(markerChain))
-				m.syncInputOverlays()
-				m.statusNote = "Detected continued paste chunk after compressed marker. Kept compressed markers only; press Enter again to send."
-				return m, true
-			}
-		}
-		return m, true
-	}
-	if m.shouldCompressPastedText(rawValue, "paste-enter") || (m.hasImplicitPasteBurst() && m.isLongPastedText(rawValue)) {
-		marker, content, err := m.compressPastedText(rawValue)
-		if err != nil {
-			m.statusNote = err.Error()
-			return m, true
-		}
-		m.setInputValue(marker)
-		m.syncInputOverlays()
-		m.statusNote = fmt.Sprintf("Long pasted text (%d lines) compressed as %s. Press Enter again to send. Use [Paste #%s] or [Paste #%s line10~line20] later.", content.Lines, marker, content.ID, content.ID)
-		return m, true
-	}
-	m.pasteSubmitGuardUntil = time.Time{}
-	return m, true
-}
-
-func (m *model) armPasteSubmitGuard(now time.Time) {
-	if m == nil {
-		return
-	}
-	if now.IsZero() {
-		now = time.Now()
-	}
-	m.pasteSubmitGuardUntil = now.Add(pasteSubmitGuard)
 }
 
 func extractBracketedPastePayload(msg tea.Msg) (string, bool) {

--- a/tui/model.go
+++ b/tui/model.go
@@ -223,6 +223,8 @@ type pasteTransactionState struct {
 	Source             string
 	Payload            string
 	Consumed           int
+	StartedAt          time.Time
+	LastEchoAt         time.Time
 	AwaitTrailingEnter bool
 }
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -298,6 +298,7 @@ type model struct {
 	lastPasteAt           time.Time
 	lastInputAt           time.Time
 	inputBurstSize        int
+	clipboardCaptureArmedUntil time.Time
 	chatAutoFollow        bool
 	draggingScrollbar     bool
 	scrollbarDragOffset   int
@@ -983,6 +984,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if fragment, source, ok := m.pasteFragmentFromKey(msg); ok {
+		m.armClipboardPasteCaptureSignal()
 		m.beginOrAppendPasteTransaction(fragment, source)
 		m.applyDirectPasteInput(fragment, source)
 		return m, nil
@@ -992,6 +994,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Prefer Ctrl+V image paste first. If clipboard has no image, fall through
 	// so regular terminal paste behavior can continue.
 	if ctrlVPasteDetected {
+		m.armClipboardPasteCaptureSignal()
 		beforeClipboard := m.input.Value()
 		clipboardNote := strings.TrimSpace(m.handleEmptyClipboardPaste())
 		if m.input.Value() != beforeClipboard {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -2901,6 +2901,42 @@ func TestPlainTypingDoesNotPollClipboardWithoutPasteSignal(t *testing.T) {
 	}
 }
 
+func TestFastTypingDoesNotArmClipboardCapture(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	reader := &countingClipboardTextReader{
+		text: strings.Join([]string{
+			"clipboard line 1",
+			"clipboard line 2",
+			"clipboard line 3",
+			"clipboard line 4",
+		}, "\n"),
+	}
+	m.clipboardRead = reader
+
+	fastTypingGap := clipboardCaptureRapidRuneGap + 15*time.Millisecond
+	if fastTypingGap >= clipboardCaptureImplicitGap {
+		t.Fatalf("invalid test setup: fast typing gap %v must be less than implicit gap %v", fastTypingGap, clipboardCaptureImplicitGap)
+	}
+
+	typed := "abcdefghijklmnopqrstuvwxyz"
+	for _, r := range typed {
+		// Keep cadence fast enough to maintain burst accumulation while still
+		// representing normal rapid typing instead of paste echo speed.
+		m.lastInputAt = time.Now().Add(-fastTypingGap)
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		next := got.(model)
+		m = &next
+	}
+
+	if reader.calls != 0 {
+		t.Fatalf("expected rapid manual typing not to read clipboard, got %d reads", reader.calls)
+	}
+	if m.input.Value() != typed {
+		t.Fatalf("expected typed input to remain literal, got %q", m.input.Value())
+	}
+}
+
 func TestClipboardCaptureConvertsBeforeFullStreamArrives(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -46,6 +46,23 @@ func (f *fakeClipboardTextWriter) WriteText(ctx context.Context, text string) er
 	return nil
 }
 
+type fakeClipboardTextReader struct {
+	text       string
+	err        error
+	waitForCtx bool
+}
+
+func (f fakeClipboardTextReader) ReadText(ctx context.Context) (string, error) {
+	if f.waitForCtx {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.text, nil
+}
+
 type compactCommandTestClient struct {
 	replies  []llm.Message
 	requests []llm.ChatRequest
@@ -1949,6 +1966,31 @@ func TestCtrlVWithoutImageShowsStatusNote(t *testing.T) {
 	}
 }
 
+func TestCtrlVWithoutImageFallsBackToClipboardTextAndCompresses(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboard = fakeClipboardImageReader{
+		err: errors.New("clipboard backend unavailable"),
+	}
+	m.clipboardRead = fakeClipboardTextReader{
+		text: strings.Join([]string{
+			"# heading",
+			"line 2",
+			"line 3",
+			"line 4",
+		}, "\n"),
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	updated := got.(model)
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected ctrl+v clipboard text fallback to compress into marker, got %q", updated.input.Value())
+	}
+	if len(updated.pastedOrder) != 1 {
+		t.Fatalf("expected one stored pasted content item, got %d", len(updated.pastedOrder))
+	}
+}
+
 func TestTerminalPasteEventWithEmptyPayloadPastesClipboardImage(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat
@@ -1982,7 +2024,7 @@ func TestTerminalPasteEventWithTextDoesNotForceClipboardImage(t *testing.T) {
 	}
 }
 
-func TestRapidRuneInputForImagePathTriggersFallbackPlaceholder(t *testing.T) {
+func TestRapidRuneInputForImagePathDoesNotTriggerPasteFallback(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat
 
@@ -1996,8 +2038,8 @@ func TestRapidRuneInputForImagePathTriggersFallbackPlaceholder(t *testing.T) {
 		next := got.(model)
 		m = &next
 	}
-	if m.input.Value() != "[Image #1]" {
-		t.Fatalf("expected rapid path input to convert to placeholder, got %q", m.input.Value())
+	if m.input.Value() != imagePath {
+		t.Fatalf("expected non-paste rapid rune input to stay literal, got %q", m.input.Value())
 	}
 }
 
@@ -2053,30 +2095,179 @@ func TestPasteEnterDoesNotSubmitAndKeepsNewline(t *testing.T) {
 	}
 }
 
-func TestShortBracketedPastePayloadKeepsTrailingNewlineBoundary(t *testing.T) {
+func TestShortBracketedPastePayloadKeepsLiteralMultilineInput(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat
 	got, cmd := m.handlePastePayload("# title\n")
 	updated := got.(model)
-	if cmd == nil {
-		t.Fatalf("expected short paste payload to schedule finalize")
+	if cmd != nil {
+		t.Fatalf("expected short paste payload to be handled immediately")
 	}
-	if updated.input.Value() != "" {
-		t.Fatalf("expected short paste payload to stay buffered before finalize, got %q", updated.input.Value())
+	if updated.input.Value() != "# title\n" {
+		t.Fatalf("expected short multiline paste payload to remain literal, got %q", updated.input.Value())
 	}
 	if len(updated.chatItems) != 0 {
 		t.Fatalf("expected short paste payload not to auto submit, got %d chat items", len(updated.chatItems))
 	}
-	if !updated.hasActivePasteSession() {
-		t.Fatalf("expected short paste payload to activate paste session")
+}
+
+func TestPasteMsgTransactionConsumesEchoedPlainKeyStream(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	got, _ := m.handlePastePayload("echo line\n")
+	updated := got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected paste transaction to activate for paste payload")
 	}
-	got, _ = updated.Update(pasteFinalizeMsg{ID: updated.pasteSession.finalizeID})
-	finalized := got.(model)
-	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(finalized.input.Value()) {
-		t.Fatalf("expected short multiline paste payload to finalize into marker, got %q", finalized.input.Value())
+	afterPaste := updated.input.Value()
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("echo line")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected echoed paste stream to be consumed, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected echoed paste stream not to submit, got %d items", len(updated.chatItems))
+	}
+	if updated.pasteTransaction.Active {
+		t.Fatalf("expected paste transaction to clear after payload echo is consumed")
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected enter after transaction completion to submit")
 	}
 }
-func TestRapidBareEnterAfterRecentBurstIsTreatedAsPasteContinuation(t *testing.T) {
+
+func TestPasteKeyTransactionConsumesEchoedPlainKeyStream(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("title\nbody"), Paste: true})
+	updated := got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected paste-key flow to activate paste transaction")
+	}
+	afterPaste := updated.input.Value()
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("title")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("body")})
+	updated = got.(model)
+
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected echoed plain stream after paste-key boundary to be consumed, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected echoed plain stream not to submit, got %d items", len(updated.chatItems))
+	}
+	if updated.pasteTransaction.Active {
+		t.Fatalf("expected paste transaction to clear after full payload echo")
+	}
+}
+
+func TestPasteKeyTransactionAccumulatesSplitPasteFragmentsForEchoConsumption(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("title"), Paste: true})
+	updated := got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter, Paste: true})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("body"), Paste: true})
+	updated = got.(model)
+
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected split paste-key flow to keep one active transaction")
+	}
+	afterPaste := updated.input.Value()
+	if afterPaste != "title\nbody" {
+		t.Fatalf("expected split paste fragments to be applied directly, got %q", afterPaste)
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("title")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("body")})
+	updated = got.(model)
+
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected echoed plain stream to be consumed after split paste fragments, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected echoed plain stream not to submit, got %d items", len(updated.chatItems))
+	}
+	if updated.pasteTransaction.Active {
+		t.Fatalf("expected transaction to clear after split payload echo is consumed")
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected enter after split-transaction completion to submit")
+	}
+}
+
+func TestCtrlVTextTransactionIgnoresControlMarkerEcho(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboard = fakeClipboardImageReader{
+		err: errors.New("clipboard backend unavailable"),
+	}
+	m.clipboardRead = fakeClipboardTextReader{
+		text: "echo line\n",
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	updated := got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected ctrl+v text fallback to start paste transaction")
+	}
+	afterPaste := updated.input.Value()
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'\x16'}})
+	updated = got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected ctrl+v marker rune to be ignored without clearing transaction")
+	}
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected ctrl+v marker rune not to change input, got %q", updated.input.Value())
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	updated = got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected ctrl+v key event to be ignored without clearing transaction")
+	}
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected ctrl+v key event not to change input, got %q", updated.input.Value())
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("echo line")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected echoed stream to be consumed after ctrl+v control noise, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected echoed ctrl+v stream not to submit, got %d items", len(updated.chatItems))
+	}
+	if updated.pasteTransaction.Active {
+		t.Fatalf("expected transaction to clear after payload echo is consumed")
+	}
+}
+
+func TestRapidBareEnterAfterRecentBurstSubmitsNormally(t *testing.T) {
 	input := textarea.New()
 	input.Focus()
 	input.SetWidth(40)
@@ -2096,15 +2287,15 @@ func TestRapidBareEnterAfterRecentBurstIsTreatedAsPasteContinuation(t *testing.T
 	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := got.(model)
 
-	if len(updated.chatItems) != 0 {
-		t.Fatalf("expected rapid bare enter to avoid submit, got %d chat items", len(updated.chatItems))
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected rapid bare enter to submit")
 	}
-	if !strings.Contains(updated.input.Value(), "\n") {
-		t.Fatalf("expected rapid bare enter to insert newline, got %q", updated.input.Value())
+	if updated.chatItems[0].Body != "# main heading" {
+		t.Fatalf("expected submitted body to preserve input, got %q", updated.chatItems[0].Body)
 	}
 }
 
-func TestBareEnterAfterRecentMarkdownBurstIsTreatedAsPasteContinuation(t *testing.T) {
+func TestBareEnterAfterRecentMarkdownBurstSubmitsNormally(t *testing.T) {
 	input := textarea.New()
 	input.Focus()
 	input.SetWidth(40)
@@ -2124,75 +2315,109 @@ func TestBareEnterAfterRecentMarkdownBurstIsTreatedAsPasteContinuation(t *testin
 	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := got.(model)
 
-	if len(updated.chatItems) != 0 {
-		t.Fatalf("expected markdown burst enter to avoid submit, got %d chat items", len(updated.chatItems))
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected markdown burst enter to submit")
 	}
-	if !strings.Contains(updated.input.Value(), "\n") {
-		t.Fatalf("expected markdown burst enter to insert newline, got %q", updated.input.Value())
+	if updated.chatItems[0].Body != "# 主标题" {
+		t.Fatalf("expected submitted body to preserve markdown text, got %q", updated.chatItems[0].Body)
 	}
 }
 
-func TestSplitPastePayloadFinalizesIntoSingleMarker(t *testing.T) {
+func TestSplitPastePayloadProcessesEachBoundaryImmediately(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat
 
 	got, cmd := m.handlePastePayload("# 主标题\n")
 	updated := got.(model)
-	if cmd == nil || !updated.hasActivePasteSession() {
-		t.Fatalf("expected first fragment to open paste session")
+	if cmd != nil {
+		t.Fatalf("expected first fragment to be processed immediately")
 	}
-	if updated.input.Value() != "" {
-		t.Fatalf("expected first fragment to stay buffered, got %q", updated.input.Value())
+	if updated.input.Value() != "# 主标题\n" {
+		t.Fatalf("expected first fragment to remain literal, got %q", updated.input.Value())
 	}
 
 	got, cmd = updated.handlePastePayload("## 二级标题\n```go\nfmt.Println(\"hi\")\n```\n")
 	updated = got.(model)
-	if cmd == nil || !updated.hasActivePasteSession() {
-		t.Fatalf("expected second fragment to keep paste session active")
+	if cmd != nil {
+		t.Fatalf("expected second fragment to be processed immediately")
 	}
-
-	got, _ = updated.Update(pasteFinalizeMsg{ID: updated.pasteSession.finalizeID})
-	finalized := got.(model)
-	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(finalized.input.Value()) {
-		t.Fatalf("expected split paste payload to finalize into one marker, got %q", finalized.input.Value())
+	if !strings.Contains(updated.input.Value(), "# 主标题\n") {
+		t.Fatalf("expected first fragment to stay in input, got %q", updated.input.Value())
 	}
-	if len(finalized.chatItems) != 0 {
-		t.Fatalf("expected split paste payload not to auto submit, got %d items", len(finalized.chatItems))
+	if !regexp.MustCompile(`\[Paste #\d+ ~\d+ lines\]`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected long second fragment to compress into marker, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected split paste payload not to auto submit, got %d items", len(updated.chatItems))
 	}
 }
 
-func TestRunesEnterRunesPasteFlowDoesNotSubmitFirstLine(t *testing.T) {
+func TestRunesEnterRunesPasteFlowDoesNotAutoSubmitWithoutBareEnter(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat
 
-	got, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("# 主标题")})
+	got, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("# 主标题"), Paste: true})
 	updated := got.(model)
-	if cmd == nil || !updated.hasActivePasteSession() {
-		t.Fatalf("expected initial rune burst to activate paste session")
+	if cmd != nil {
+		t.Fatalf("expected pasted rune burst to be handled without extra command")
 	}
-	if updated.input.Value() != "" {
-		t.Fatalf("expected initial rune burst to stay buffered, got %q", updated.input.Value())
+	if updated.input.Value() != "# 主标题" {
+		t.Fatalf("expected pasted rune burst to update input directly, got %q", updated.input.Value())
 	}
 
-	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter, Paste: true})
 	updated = got.(model)
 	if len(updated.chatItems) != 0 {
-		t.Fatalf("expected bare enter during paste flow not to submit first line, got %d items", len(updated.chatItems))
+		t.Fatalf("expected pasted enter not to submit first line, got %d items", len(updated.chatItems))
 	}
 
-	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("## 二级标题\n```go\nfmt.Println(\"hi\")\n```")})
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("## 二级标题\n```go\nfmt.Println(\"hi\")\n```"), Paste: true})
 	updated = got.(model)
-	got, _ = updated.Update(pasteFinalizeMsg{ID: updated.pasteSession.finalizeID})
-	finalized := got.(model)
-	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(finalized.input.Value()) {
-		t.Fatalf("expected rune-enter-rune paste flow to finalize into marker, got %q", finalized.input.Value())
+	if !regexp.MustCompile(`\[Paste #\d+ ~\d+ lines\]`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected long pasted fragment to compress into marker, got %q", updated.input.Value())
 	}
-	if len(finalized.chatItems) != 0 {
-		t.Fatalf("expected rune-enter-rune paste flow not to auto submit, got %d items", len(finalized.chatItems))
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected rune-enter-rune paste flow not to auto submit, got %d items", len(updated.chatItems))
 	}
 }
 
-func TestSuppressedEnterAfterPasteIsSwallowed(t *testing.T) {
+func TestMultiRuneBurstWithoutPasteFlagCompressesAsPasteBoundary(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	longPaste := strings.Join([]string{
+		"line 1", "line 2", "line 3", "line 4", "line 5", "line 6",
+		"line 7", "line 8", "line 9", "line 10", "line 11", "line 12",
+	}, "\n")
+
+	got, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(longPaste)})
+	updated := got.(model)
+	if cmd != nil {
+		t.Fatalf("expected rune burst paste boundary to be handled directly")
+	}
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected long multiline rune burst to compress into marker, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected rune burst paste boundary not to auto submit, got %d items", len(updated.chatItems))
+	}
+}
+
+func TestShortMultiRuneBurstWithoutPasteFlagStaysLiteral(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("你好")})
+	updated := got.(model)
+	if updated.input.Value() != "你好" {
+		t.Fatalf("expected short rune burst to remain literal, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected short rune burst not to auto submit, got %d items", len(updated.chatItems))
+	}
+}
+
+func TestImmediateEnterAfterPasteSubmits(t *testing.T) {
 	input := textarea.New()
 	input.Focus()
 	input.SetWidth(40)
@@ -2213,11 +2438,233 @@ func TestSuppressedEnterAfterPasteIsSwallowed(t *testing.T) {
 	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := got.(model)
 
-	if len(updated.chatItems) != 0 {
-		t.Fatalf("expected suppressed enter not to submit, got %d chat items", len(updated.chatItems))
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected enter after paste to submit")
 	}
-	if updated.input.Value() != "line1" {
-		t.Fatalf("expected suppressed enter to be swallowed, got %q", updated.input.Value())
+	if updated.chatItems[0].Body != "line1" {
+		t.Fatalf("expected submitted body to match input, got %q", updated.chatItems[0].Body)
+	}
+}
+
+func TestEnterCompressesClipboardMatchedLongInputWhenBoundaryMissing(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	longPaste := strings.Join([]string{
+		"func normalize(items []string) []string {",
+		"    out := make([]string, 0, len(items))",
+		"    for _, item := range items {",
+		"        v := strings.TrimSpace(item)",
+		"        if v == \"\" {",
+		"            continue",
+		"        }",
+		"        out = append(out, strings.ToLower(v))",
+		"    }",
+		"    return out",
+		"}",
+	}, "\n")
+	input.SetValue(longPaste)
+	input.CursorEnd()
+
+	m := model{
+		screen:         screenChat,
+		input:          input,
+		workspace:      "E:\\bytemind",
+		sess:           session.New("E:\\bytemind"),
+		clipboardRead:  fakeClipboardTextReader{text: longPaste},
+		pastedContents: make(map[string]pastedContent, maxStoredPastedContents),
+		pastedOrder:    make([]string, 0, maxStoredPastedContents),
+		nextPasteID:    1,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected first enter to compress clipboard-matched long paste without submitting, got %d items", len(updated.chatItems))
+	}
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected clipboard-matched long paste to compress into marker, got %q", updated.input.Value())
+	}
+	if !strings.Contains(updated.statusNote, "clipboard-matched") {
+		t.Fatalf("expected clipboard-matched compression note, got %q", updated.statusNote)
+	}
+}
+
+func TestEnterTreatsClipboardContinuationAsPasteNewline(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("line 1")
+	input.CursorEnd()
+
+	clipboardText := strings.Join([]string{
+		"line 1",
+		"line 2",
+		"line 3",
+		"line 4",
+	}, "\n")
+
+	m := model{
+		screen:         screenChat,
+		input:          input,
+		workspace:      "E:\\bytemind",
+		sess:           session.New("E:\\bytemind"),
+		clipboardRead:  fakeClipboardTextReader{text: clipboardText},
+		pastedContents: make(map[string]pastedContent, maxStoredPastedContents),
+		pastedOrder:    make([]string, 0, maxStoredPastedContents),
+		nextPasteID:    1,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected enter in clipboard continuation to avoid submit, got %d items", len(updated.chatItems))
+	}
+	if updated.input.Value() != "line 1\n" {
+		t.Fatalf("expected enter to be treated as paste newline continuation, got %q", updated.input.Value())
+	}
+}
+
+func TestEnterSubmitsLongInputWhenClipboardDoesNotMatch(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	longInput := strings.Join([]string{
+		"line 1", "line 2", "line 3", "line 4", "line 5", "line 6",
+		"line 7", "line 8", "line 9", "line 10", "line 11", "line 12",
+	}, "\n")
+	input.SetValue(longInput)
+	input.CursorEnd()
+
+	m := model{
+		screen:        screenChat,
+		input:         input,
+		workspace:     "E:\\bytemind",
+		sess:          session.New("E:\\bytemind"),
+		clipboardRead: fakeClipboardTextReader{text: "different clipboard text"},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected non-matching clipboard long input to submit")
+	}
+	if updated.chatItems[0].Body != longInput {
+		t.Fatalf("expected submitted body to remain unchanged, got %q", updated.chatItems[0].Body)
+	}
+}
+
+func TestPlainRuneStreamCompressesToMarkerWhenItMatchesLongClipboard(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	longPaste := strings.Join([]string{
+		"func normalize(items []string) []string {",
+		"    out := make([]string, 0, len(items))",
+		"    for _, item := range items {",
+		"        v := strings.TrimSpace(item)",
+		"        if v == \"\" {",
+		"            continue",
+		"        }",
+		"        out = append(out, strings.ToLower(v))",
+		"    }",
+		"    return out",
+		"}",
+	}, "\n")
+	m.clipboardRead = fakeClipboardTextReader{text: longPaste}
+
+	for _, r := range longPaste {
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		next := got.(model)
+		m = &next
+	}
+
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(m.input.Value()) {
+		t.Fatalf("expected plain rune stream matching clipboard to compress into marker, got %q", m.input.Value())
+	}
+	if len(m.pastedOrder) != 1 {
+		t.Fatalf("expected one stored pasted content item, got %d", len(m.pastedOrder))
+	}
+}
+
+func TestClipboardCaptureConvertsBeforeFullStreamArrives(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	longPaste := strings.Join([]string{
+		"func normalize(items []string) []string {",
+		"    out := make([]string, 0, len(items))",
+		"    for _, item := range items {",
+		"        v := strings.TrimSpace(item)",
+		"        if v == \"\" {",
+		"            continue",
+		"        }",
+		"        out = append(out, strings.ToLower(v))",
+		"    }",
+		"    return out",
+		"}",
+	}, "\n")
+	m.clipboardRead = fakeClipboardTextReader{text: longPaste}
+
+	runes := []rune(longPaste)
+	for i := 0; i < clipboardCaptureMinPrefixRunes && i < len(runes); i++ {
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{runes[i]}})
+		next := got.(model)
+		m = &next
+	}
+
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(m.input.Value()) {
+		t.Fatalf("expected clipboard capture to convert early into marker, got %q", m.input.Value())
+	}
+	if strings.Contains(m.input.Value(), "normalize(") {
+		t.Fatalf("expected no raw content after early capture, got %q", m.input.Value())
+	}
+	if !m.pasteTransaction.Active {
+		t.Fatalf("expected paste transaction to stay active after early clipboard capture")
+	}
+}
+
+func TestClipboardCaptureConsumesTrailingEnterEchoAndDoesNotAutoSubmit(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	longPaste := strings.Join([]string{
+		"func normalize(items []string) []string {",
+		"    out := make([]string, 0, len(items))",
+		"    for _, item := range items {",
+		"        v := strings.TrimSpace(item)",
+		"        if v == \"\" {",
+		"            continue",
+		"        }",
+		"        out = append(out, strings.ToLower(v))",
+		"    }",
+		"    return out",
+		"}",
+	}, "\n")
+	m.clipboardRead = fakeClipboardTextReader{text: longPaste}
+
+	for _, r := range longPaste {
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		next := got.(model)
+		m = &next
+	}
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(m.input.Value()) {
+		t.Fatalf("expected clipboard capture marker, got %q", m.input.Value())
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected trailing enter echo to be consumed without submit, got %d items", len(updated.chatItems))
+	}
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected marker to remain after consumed trailing enter, got %q", updated.input.Value())
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected second enter to submit marker prompt")
 	}
 }
 
@@ -3072,7 +3519,7 @@ func TestCommandPaletteEnterOnQuitReturnsQuitCmd(t *testing.T) {
 	}
 }
 
-func TestCommandPaletteBusyPlainTextQueuesBTW(t *testing.T) {
+func TestCommandPaletteBusyPlainTextDoesNotSubmitBTW(t *testing.T) {
 	input := textarea.New()
 	input.Focus()
 	input.SetValue("focus only on unit tests")
@@ -3092,17 +3539,17 @@ func TestCommandPaletteBusyPlainTextQueuesBTW(t *testing.T) {
 	got, _ := m.handleCommandPaletteKey(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := got.(model)
 
-	if !canceled {
-		t.Fatalf("expected command palette busy submit to cancel active run")
+	if canceled {
+		t.Fatalf("expected busy plain-text enter not to cancel active run")
 	}
-	if updated.commandOpen {
-		t.Fatalf("expected command palette to close after busy plain-text submit")
+	if !updated.commandOpen {
+		t.Fatalf("expected command palette to remain open for plain text while busy")
 	}
-	if len(updated.pendingBTW) != 1 || updated.pendingBTW[0] != "focus only on unit tests" {
-		t.Fatalf("expected plain text to queue as btw, got %#v", updated.pendingBTW)
+	if len(updated.pendingBTW) != 0 || len(updated.chatItems) != 0 || updated.interrupting {
+		t.Fatalf("expected no BTW side effects, got pending=%#v chat=%#v interrupting=%v", updated.pendingBTW, updated.chatItems, updated.interrupting)
 	}
-	if !updated.interrupting {
-		t.Fatalf("expected busy plain-text submit to enter interrupting state")
+	if updated.statusNote != "Run is in progress. Use /btw <message> to interject, or Esc to interrupt." {
+		t.Fatalf("expected explicit btw usage note, got %q", updated.statusNote)
 	}
 }
 
@@ -4219,7 +4666,7 @@ func TestBusyInputStillEditable(t *testing.T) {
 	}
 }
 
-func TestBusyEnterQueuesBTWAndCancelsRun(t *testing.T) {
+func TestBusyEnterWithPlainTextDoesNotSubmitBTW(t *testing.T) {
 	input := textarea.New()
 	input.Focus()
 	input.SetValue("focus only on unit tests")
@@ -4238,124 +4685,18 @@ func TestBusyEnterQueuesBTWAndCancelsRun(t *testing.T) {
 	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := got.(model)
 
-	if !canceled {
-		t.Fatalf("expected busy enter to cancel the active run")
-	}
-	if !updated.interrupting {
-		t.Fatalf("expected model to enter interrupting state")
-	}
-	if len(updated.pendingBTW) != 1 || updated.pendingBTW[0] != "focus only on unit tests" {
-		t.Fatalf("expected pending btw queue to capture input, got %#v", updated.pendingBTW)
-	}
-	if updated.input.Value() != "" {
-		t.Fatalf("expected btw submit to reset input, got %q", updated.input.Value())
-	}
-	if len(updated.chatItems) != 1 || updated.chatItems[0].Body != "focus only on unit tests" {
-		t.Fatalf("expected btw submit to append a user chat entry, got %#v", updated.chatItems)
-	}
-	if !strings.Contains(updated.chatItems[0].Meta, "btw") {
-		t.Fatalf("expected btw marker in chat meta, got %q", updated.chatItems[0].Meta)
-	}
-}
-
-func TestBusyEnterSuppressedAfterRecentMultilinePaste(t *testing.T) {
-	input := textarea.New()
-	input.Focus()
-	input.SetValue("Design a plugin platform\n- dynamic plugin loading\n- permission isolation")
-	input.CursorEnd()
-
-	canceled := false
-	m := model{
-		screen:      screenChat,
-		busy:        true,
-		input:       input,
-		lastPasteAt: time.Now(),
-		sess:        session.New("E:\\bytemind"),
-		workspace:   "E:\\bytemind",
-		runCancel:   func() { canceled = true },
-	}
-
-	got, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := got.(model)
-
-	if cmd != nil {
-		t.Fatalf("expected suppressed enter not to schedule a command")
-	}
 	if canceled {
-		t.Fatalf("expected suppressed enter not to cancel current run")
+		t.Fatalf("expected busy plain-text enter not to cancel the active run")
 	}
 	if updated.interrupting || len(updated.pendingBTW) != 0 || len(updated.chatItems) != 0 {
 		t.Fatalf("expected no BTW side effects, got interrupting=%v pending=%#v chat=%#v", updated.interrupting, updated.pendingBTW, updated.chatItems)
 	}
-}
-
-func TestBusyEnterSuppressedForRecentPasteBurstSingleLine(t *testing.T) {
-	input := textarea.New()
-	input.Focus()
-	input.SetValue("dynamic plugin loading")
-	input.CursorEnd()
-
-	canceled := false
-	now := time.Now()
-	m := model{
-		screen:      screenChat,
-		busy:        true,
-		input:       input,
-		lastPasteAt: now,
-		lastInputAt: now,
-		sess:        session.New("E:\\bytemind"),
-		workspace:   "E:\\bytemind",
-		runCancel:   func() { canceled = true },
-	}
-
-	got, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := got.(model)
-
-	if cmd != nil {
-		t.Fatalf("expected suppressed burst enter not to schedule a command")
-	}
-	if canceled {
-		t.Fatalf("expected suppressed burst enter not to cancel current run")
-	}
-	if updated.interrupting || len(updated.pendingBTW) != 0 || len(updated.chatItems) != 0 {
-		t.Fatalf("expected no BTW side effects, got interrupting=%v pending=%#v chat=%#v", updated.interrupting, updated.pendingBTW, updated.chatItems)
+	if updated.statusNote != "Run is in progress. Use /btw <message> to interject, or Esc to interrupt." {
+		t.Fatalf("expected explicit btw usage note, got %q", updated.statusNote)
 	}
 }
 
-func TestBusyEnterSuppressedForImplicitPasteBurstWithoutPasteFlag(t *testing.T) {
-	input := textarea.New()
-	input.Focus()
-	input.SetValue("A long multiline paste-burst candidate mentioning `main.go` should not auto-submit.")
-	input.CursorEnd()
-
-	canceled := false
-	now := time.Now()
-	m := model{
-		screen:         screenChat,
-		busy:           true,
-		input:          input,
-		lastInputAt:    now,
-		inputBurstSize: 64,
-		sess:           session.New("E:\\bytemind"),
-		workspace:      "E:\\bytemind",
-		runCancel:      func() { canceled = true },
-	}
-
-	got, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := got.(model)
-
-	if cmd != nil {
-		t.Fatalf("expected implicit paste-burst enter not to schedule a command")
-	}
-	if canceled {
-		t.Fatalf("expected implicit paste-burst enter not to cancel current run")
-	}
-	if updated.interrupting || len(updated.pendingBTW) != 0 || len(updated.chatItems) != 0 {
-		t.Fatalf("expected no BTW side effects, got interrupting=%v pending=%#v chat=%#v", updated.interrupting, updated.pendingBTW, updated.chatItems)
-	}
-}
-
-func TestIdleEnterCompressesImplicitLongPasteBurstWithoutPasteFlag(t *testing.T) {
+func TestIdleEnterSubmitsImplicitLongPasteBurstWithoutPasteFlag(t *testing.T) {
 	input := textarea.New()
 	input.Focus()
 	longPaste := strings.Join([]string{
@@ -4388,18 +4729,18 @@ func TestIdleEnterCompressesImplicitLongPasteBurstWithoutPasteFlag(t *testing.T)
 	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := got.(model)
 
-	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(updated.input.Value()) {
-		t.Fatalf("expected implicit long paste burst to compress into marker, got %q", updated.input.Value())
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected idle enter to submit prompt")
 	}
-	if len(updated.chatItems) != 0 {
-		t.Fatalf("expected compression step not to submit chat immediately, got %d items", len(updated.chatItems))
+	if updated.chatItems[0].Body != longPaste {
+		t.Fatalf("expected submitted body to keep original content, got %q", updated.chatItems[0].Body)
 	}
 }
 
 func TestBusyEnterInToolPhaseDefersBTWCancel(t *testing.T) {
 	input := textarea.New()
 	input.Focus()
-	input.SetValue("change plan after this step")
+	input.SetValue("/btw change plan after this step")
 	input.CursorEnd()
 
 	canceled := false
@@ -4621,7 +4962,7 @@ func TestComposeBTWPromptIgnoresEmptyEntries(t *testing.T) {
 func TestSubmitBTWShowsDropHintWhenQueueCapped(t *testing.T) {
 	input := textarea.New()
 	input.Focus()
-	input.SetValue("new update")
+	input.SetValue("/btw new update")
 	input.CursorEnd()
 
 	m := model{
@@ -5461,7 +5802,7 @@ func TestUpdatePasteMsgCompressesLongTextImmediately(t *testing.T) {
 	}
 }
 
-func TestUpdatePasteMsgSuppressesImmediateEnterSubmit(t *testing.T) {
+func TestUpdatePasteMsgAllowsImmediateEnterSubmit(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat
 	longPaste := strings.Join([]string{
@@ -5474,11 +5815,11 @@ func TestUpdatePasteMsgSuppressesImmediateEnterSubmit(t *testing.T) {
 	got, _ = afterPaste.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 	afterEnter := got.(model)
 
-	if len(afterEnter.chatItems) != 0 {
-		t.Fatalf("expected immediate enter after paste to be suppressed, got %d chat items", len(afterEnter.chatItems))
+	if len(afterEnter.chatItems) == 0 {
+		t.Fatalf("expected immediate enter after paste to submit")
 	}
-	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(afterEnter.input.Value()) {
-		t.Fatalf("expected compressed marker to remain after suppressed enter, got %q", afterEnter.input.Value())
+	if !strings.Contains(afterEnter.chatItems[0].Body, "[Paste #") {
+		t.Fatalf("expected submitted body to include compressed marker, got %q", afterEnter.chatItems[0].Body)
 	}
 }
 

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -2133,8 +2133,17 @@ func TestPasteMsgTransactionConsumesEchoedPlainKeyStream(t *testing.T) {
 	if len(updated.chatItems) != 0 {
 		t.Fatalf("expected echoed paste stream not to submit, got %d items", len(updated.chatItems))
 	}
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected paste transaction to stay active briefly to guard trailing enter echo")
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected trailing enter echo to be consumed, got %d items", len(updated.chatItems))
+	}
 	if updated.pasteTransaction.Active {
-		t.Fatalf("expected paste transaction to clear after payload echo is consumed")
+		t.Fatalf("expected paste transaction to clear after trailing enter echo is consumed")
 	}
 
 	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
@@ -2168,8 +2177,17 @@ func TestPasteKeyTransactionConsumesEchoedPlainKeyStream(t *testing.T) {
 	if len(updated.chatItems) != 0 {
 		t.Fatalf("expected echoed plain stream not to submit, got %d items", len(updated.chatItems))
 	}
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected paste transaction to stay active briefly to guard trailing enter echo")
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected trailing enter echo to be consumed, got %d items", len(updated.chatItems))
+	}
 	if updated.pasteTransaction.Active {
-		t.Fatalf("expected paste transaction to clear after full payload echo")
+		t.Fatalf("expected paste transaction to clear after trailing enter echo")
 	}
 }
 
@@ -2205,14 +2223,61 @@ func TestPasteKeyTransactionAccumulatesSplitPasteFragmentsForEchoConsumption(t *
 	if len(updated.chatItems) != 0 {
 		t.Fatalf("expected echoed plain stream not to submit, got %d items", len(updated.chatItems))
 	}
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected transaction to stay active briefly to guard trailing enter echo")
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected trailing enter echo to be consumed, got %d items", len(updated.chatItems))
+	}
 	if updated.pasteTransaction.Active {
-		t.Fatalf("expected transaction to clear after split payload echo is consumed")
+		t.Fatalf("expected transaction to clear after trailing enter echo is consumed")
 	}
 
 	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = got.(model)
 	if len(updated.chatItems) == 0 {
 		t.Fatalf("expected enter after split-transaction completion to submit")
+	}
+}
+
+func TestPasteKeySecondPasteStartsNewBoundaryAfterAppendWindow(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	first := strings.Join([]string{
+		"first block line 1",
+		"first block line 2",
+		"first block line 3",
+		"first block line 4",
+	}, "\n")
+	second := strings.Join([]string{
+		"second block line 1",
+		"second block line 2",
+		"second block line 3",
+		"second block line 4",
+	}, "\n")
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(first), Paste: true})
+	updated := got.(model)
+	if strings.Count(updated.input.Value(), "[Paste #") != 1 {
+		t.Fatalf("expected first paste-key boundary to create one marker, got %q", updated.input.Value())
+	}
+
+	// Simulate a user-triggered second paste after the first boundary has aged
+	// out. This should start a new transaction instead of appending payload.
+	updated.pasteTransaction.StartedAt = time.Now().Add(-2 * pasteTransactionAppendWindow)
+	updated.pasteTransaction.LastEchoAt = time.Now().Add(-2 * pasteTransactionAppendWindow)
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(second), Paste: true})
+	updated = got.(model)
+	if strings.Count(updated.input.Value(), "[Paste #") < 2 {
+		t.Fatalf("expected second paste-key boundary to create another marker, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected second paste-key boundary not to submit, got %d chat items", len(updated.chatItems))
 	}
 }
 
@@ -2262,8 +2327,179 @@ func TestCtrlVTextTransactionIgnoresControlMarkerEcho(t *testing.T) {
 	if len(updated.chatItems) != 0 {
 		t.Fatalf("expected echoed ctrl+v stream not to submit, got %d items", len(updated.chatItems))
 	}
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected transaction to stay active briefly to guard trailing enter echo")
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected trailing enter echo to be consumed, got %d items", len(updated.chatItems))
+	}
 	if updated.pasteTransaction.Active {
-		t.Fatalf("expected transaction to clear after payload echo is consumed")
+		t.Fatalf("expected transaction to clear after trailing enter echo is consumed")
+	}
+}
+
+func TestCtrlVAllowsSecondPasteAfterStaleTransaction(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboard = fakeClipboardImageReader{
+		err: errors.New("clipboard backend unavailable"),
+	}
+	m.clipboardRead = fakeClipboardTextReader{
+		text: strings.Join([]string{
+			"first block line 1",
+			"first block line 2",
+			"first block line 3",
+			"first block line 4",
+		}, "\n"),
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	updated := got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected first ctrl+v to start paste transaction")
+	}
+	beforeSecond := updated.input.Value()
+	if len(updated.pastedOrder) == 0 {
+		t.Fatalf("expected first ctrl+v to create compressed paste entry")
+	}
+
+	// Simulate a terminal that does not emit plain-key echo for this paste.
+	// The next Ctrl+V should be treated as a fresh paste, not swallowed forever.
+	updated.pasteTransaction.StartedAt = time.Now().Add(-2 * pasteCtrlVControlEchoWindow)
+	updated.clipboardRead = fakeClipboardTextReader{
+		text: strings.Join([]string{
+			"second block line 1",
+			"second block line 2",
+			"second block line 3",
+			"second block line 4",
+		}, "\n"),
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	updated = got.(model)
+
+	if updated.input.Value() == beforeSecond {
+		t.Fatalf("expected second ctrl+v to be handled, input stayed unchanged: %q", updated.input.Value())
+	}
+	if len(updated.pastedOrder) == 0 {
+		t.Fatalf("expected second ctrl+v to keep compressed paste entry state")
+	}
+	latestID := updated.pastedOrder[len(updated.pastedOrder)-1]
+	latest, ok := updated.findPastedContent(latestID)
+	if !ok {
+		t.Fatalf("expected latest pasted content to be available")
+	}
+	if !strings.Contains(latest.Content, "second block line 4") {
+		t.Fatalf("expected latest pasted content to include second block text, got %q", latest.Content)
+	}
+}
+
+func TestCtrlVMarkerRuneAllowsSecondPasteAfterStaleTransaction(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboard = fakeClipboardImageReader{
+		err: errors.New("clipboard backend unavailable"),
+	}
+	m.clipboardRead = fakeClipboardTextReader{
+		text: strings.Join([]string{
+			"first block line 1",
+			"first block line 2",
+			"first block line 3",
+			"first block line 4",
+		}, "\n"),
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	updated := got.(model)
+	if strings.Count(updated.input.Value(), "[Paste #") != 1 {
+		t.Fatalf("expected first ctrl+v to create one marker, got %q", updated.input.Value())
+	}
+
+	// Some terminals surface Ctrl+V as a control marker rune (\x16) instead of
+	// tea.KeyCtrlV. When transaction state is stale, this should start a fresh
+	// paste boundary rather than being swallowed as echo noise.
+	updated.pasteTransaction.StartedAt = time.Now().Add(-2 * pasteCtrlVControlEchoWindow)
+	updated.pasteTransaction.LastEchoAt = time.Now().Add(-2 * pasteCtrlVControlEchoWindow)
+	updated.clipboardRead = fakeClipboardTextReader{
+		text: strings.Join([]string{
+			"second block line 1",
+			"second block line 2",
+			"second block line 3",
+			"second block line 4",
+		}, "\n"),
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'\x16'}})
+	updated = got.(model)
+	if strings.Count(updated.input.Value(), "[Paste #") < 2 {
+		t.Fatalf("expected second ctrl+v marker-rune paste to create another marker, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected second ctrl+v marker-rune paste not to submit, got %d chat items", len(updated.chatItems))
+	}
+}
+
+func TestSecondCtrlVPasteEchoTrailingEnterDoesNotAutoSubmit(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboard = fakeClipboardImageReader{
+		err: errors.New("clipboard backend unavailable"),
+	}
+	first := strings.Join([]string{
+		"first block line 1",
+		"first block line 2",
+		"first block line 3",
+		"first block line 4",
+	}, "\n")
+	second := strings.Join([]string{
+		"second block line 1",
+		"second block line 2",
+		"second block line 3",
+		"second block line 4",
+	}, "\n")
+
+	m.clipboardRead = fakeClipboardTextReader{text: first}
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	updated := got.(model)
+	if strings.Count(updated.input.Value(), "[Paste #") != 1 {
+		t.Fatalf("expected first ctrl+v to create one marker, got %q", updated.input.Value())
+	}
+
+	updated.pasteTransaction.StartedAt = time.Now().Add(-2 * pasteCtrlVControlEchoWindow)
+	updated.clipboardRead = fakeClipboardTextReader{text: second}
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	updated = got.(model)
+
+	if strings.Count(updated.input.Value(), "[Paste #") < 2 {
+		t.Fatalf("expected second ctrl+v to create another marker, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected second paste not to submit, got %d chat items", len(updated.chatItems))
+	}
+	afterSecondPaste := updated.input.Value()
+
+	for i, line := range strings.Split(second, "\n") {
+		if strings.TrimSpace(line) != "" {
+			got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(line)})
+			updated = got.(model)
+		}
+		if i < len(strings.Split(second, "\n"))-1 {
+			got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+			updated = got.(model)
+		}
+	}
+	// Some terminals emit an extra trailing Enter after echoed paste payload.
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected trailing echoed enter not to submit, got %d chat items", len(updated.chatItems))
+	}
+	if updated.input.Value() != afterSecondPaste {
+		t.Fatalf("expected markers to remain unchanged after echoed stream, got %q", updated.input.Value())
 	}
 }
 
@@ -2665,6 +2901,89 @@ func TestClipboardCaptureConsumesTrailingEnterEchoAndDoesNotAutoSubmit(t *testin
 	updated = got.(model)
 	if len(updated.chatItems) == 0 {
 		t.Fatalf("expected second enter to submit marker prompt")
+	}
+}
+
+func TestSecondClipboardCaptureAfterExistingMarkerDoesNotAutoSubmitAndCreatesSecondMarker(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboard = fakeClipboardImageReader{
+		err: errors.New("clipboard backend unavailable"),
+	}
+
+	first := strings.Join([]string{
+		"first block line 1",
+		"first block line 2",
+		"first block line 3",
+		"first block line 4",
+	}, "\n")
+	second := strings.Join([]string{
+		"second block line 1",
+		"second block line 2",
+		"second block line 3",
+		"second block line 4",
+	}, "\n")
+
+	// First explicit paste boundary: turns into marker #1.
+	m.clipboardRead = fakeClipboardTextReader{text: first}
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	firstPaste := got.(model)
+	if strings.Count(firstPaste.input.Value(), "[Paste #") != 1 {
+		t.Fatalf("expected first paste to create one marker, got %q", firstPaste.input.Value())
+	}
+	if len(firstPaste.chatItems) != 0 {
+		t.Fatalf("expected first paste not to submit, got %d chat items", len(firstPaste.chatItems))
+	}
+
+	// Second paste arrives as plain rune stream (terminal echo path), not as
+	// msg.Paste boundary. It should still be captured and summarized into
+	// marker #2 even though marker #1 already exists in input.
+	firstPaste.clipboardRead = fakeClipboardTextReader{text: second}
+	next := &firstPaste
+	lines := strings.Split(second, "\n")
+	prevItems := len(next.chatItems)
+	for i, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			for _, r := range line {
+				got, _ := next.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+				updated := got.(model)
+				if len(updated.chatItems) > prevItems {
+					t.Fatalf("unexpected submit during rune echo %q at line %d: tx active=%v consumed=%d input=%q",
+						string(r), i, updated.pasteTransaction.Active, updated.pasteTransaction.Consumed, updated.input.Value())
+				}
+				next = &updated
+				prevItems = len(updated.chatItems)
+			}
+		}
+		if i < len(lines)-1 {
+			got, _ := next.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+			updated := got.(model)
+			if len(updated.chatItems) > prevItems {
+				t.Fatalf("unexpected submit during line-enter echo at line %d: tx active=%v consumed=%d input=%q",
+					i, updated.pasteTransaction.Active, updated.pasteTransaction.Consumed, updated.input.Value())
+			}
+			next = &updated
+			prevItems = len(updated.chatItems)
+		}
+	}
+	if strings.Count(next.input.Value(), "[Paste #") < 2 {
+		t.Fatalf("expected second paste to create another marker before trailing enter, got %q", next.input.Value())
+	}
+	if len(next.chatItems) != 0 {
+		t.Fatalf("expected second paste stream not to submit before trailing enter, got %d items", len(next.chatItems))
+	}
+	if !next.pasteTransaction.Active {
+		t.Fatalf("expected second clipboard capture transaction to remain active before trailing enter")
+	}
+
+	// Simulate terminal trailing enter echo after second paste stream.
+	got, _ = next.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	afterEcho := got.(model)
+	if len(afterEcho.chatItems) != 0 {
+		t.Fatalf("expected trailing enter echo not to submit, got %d chat items", len(afterEcho.chatItems))
+	}
+	if strings.Count(afterEcho.input.Value(), "[Paste #") < 2 {
+		t.Fatalf("expected second paste to create another marker, got %q", afterEcho.input.Value())
 	}
 }
 
@@ -5802,7 +6121,7 @@ func TestUpdatePasteMsgCompressesLongTextImmediately(t *testing.T) {
 	}
 }
 
-func TestUpdatePasteMsgAllowsImmediateEnterSubmit(t *testing.T) {
+func TestUpdatePasteMsgRequiresSecondEnterSubmit(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat
 	longPaste := strings.Join([]string{
@@ -5813,13 +6132,19 @@ func TestUpdatePasteMsgAllowsImmediateEnterSubmit(t *testing.T) {
 	got, _ := m.handlePastePayload(longPaste + "\r\n")
 	afterPaste := got.(model)
 	got, _ = afterPaste.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	afterEnter := got.(model)
+	afterFirstEnter := got.(model)
 
-	if len(afterEnter.chatItems) == 0 {
-		t.Fatalf("expected immediate enter after paste to submit")
+	if len(afterFirstEnter.chatItems) != 0 {
+		t.Fatalf("expected first enter after paste to be consumed, got %d chat items", len(afterFirstEnter.chatItems))
 	}
-	if !strings.Contains(afterEnter.chatItems[0].Body, "[Paste #") {
-		t.Fatalf("expected submitted body to include compressed marker, got %q", afterEnter.chatItems[0].Body)
+
+	got, _ = afterFirstEnter.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	afterSecondEnter := got.(model)
+	if len(afterSecondEnter.chatItems) == 0 {
+		t.Fatalf("expected second enter after paste to submit")
+	}
+	if !strings.Contains(afterSecondEnter.chatItems[0].Body, "[Paste #") {
+		t.Fatalf("expected submitted body to include compressed marker, got %q", afterSecondEnter.chatItems[0].Body)
 	}
 }
 

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -63,6 +63,20 @@ func (f fakeClipboardTextReader) ReadText(ctx context.Context) (string, error) {
 	return f.text, nil
 }
 
+type countingClipboardTextReader struct {
+	text  string
+	err   error
+	calls int
+}
+
+func (f *countingClipboardTextReader) ReadText(_ context.Context) (string, error) {
+	f.calls++
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.text, nil
+}
+
 type compactCommandTestClient struct {
 	replies  []llm.Message
 	requests []llm.ChatRequest
@@ -2761,6 +2775,38 @@ func TestEnterTreatsClipboardContinuationAsPasteNewline(t *testing.T) {
 	}
 }
 
+func TestEnterDoesNotTreatShortSuffixClipboardOverlapAsContinuation(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("notes: x")
+	input.CursorEnd()
+
+	clipboardText := strings.Join([]string{
+		"x",
+		"line 2",
+		"line 3",
+		"line 4",
+	}, "\n")
+
+	m := model{
+		screen:        screenChat,
+		input:         input,
+		workspace:     "E:\\bytemind",
+		sess:          session.New("E:\\bytemind"),
+		clipboardRead: fakeClipboardTextReader{text: clipboardText},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected enter to submit when clipboard overlap is shorter than threshold")
+	}
+	if updated.chatItems[0].Body != "notes: x" {
+		t.Fatalf("expected submitted body to remain unchanged, got %q", updated.chatItems[0].Body)
+	}
+}
+
 func TestEnterSubmitsLongInputWhenClipboardDoesNotMatch(t *testing.T) {
 	input := textarea.New()
 	input.Focus()
@@ -2810,6 +2856,8 @@ func TestPlainRuneStreamCompressesToMarkerWhenItMatchesLongClipboard(t *testing.
 	m.clipboardRead = fakeClipboardTextReader{text: longPaste}
 
 	for _, r := range longPaste {
+		// Simulate a rapid terminal echo burst for implicit paste detection.
+		m.lastInputAt = time.Now()
 		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 		next := got.(model)
 		m = &next
@@ -2820,6 +2868,36 @@ func TestPlainRuneStreamCompressesToMarkerWhenItMatchesLongClipboard(t *testing.
 	}
 	if len(m.pastedOrder) != 1 {
 		t.Fatalf("expected one stored pasted content item, got %d", len(m.pastedOrder))
+	}
+}
+
+func TestPlainTypingDoesNotPollClipboardWithoutPasteSignal(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	reader := &countingClipboardTextReader{
+		text: strings.Join([]string{
+			"clipboard line 1",
+			"clipboard line 2",
+			"clipboard line 3",
+			"clipboard line 4",
+		}, "\n"),
+	}
+	m.clipboardRead = reader
+
+	for _, r := range "hello world" {
+		// Simulate human typing cadence so we don't accidentally arm the
+		// implicit paste detector's rapid-burst heuristic.
+		m.lastInputAt = time.Now().Add(-(clipboardCaptureImplicitGap + 50*time.Millisecond))
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		next := got.(model)
+		m = &next
+	}
+
+	if reader.calls != 0 {
+		t.Fatalf("expected plain typing not to read clipboard, got %d reads", reader.calls)
+	}
+	if m.input.Value() != "hello world" {
+		t.Fatalf("expected typed input to remain literal, got %q", m.input.Value())
 	}
 }
 
@@ -2844,6 +2922,8 @@ func TestClipboardCaptureConvertsBeforeFullStreamArrives(t *testing.T) {
 
 	runes := []rune(longPaste)
 	for i := 0; i < clipboardCaptureMinPrefixRunes && i < len(runes); i++ {
+		// Simulate a rapid terminal echo burst for implicit paste detection.
+		m.lastInputAt = time.Now()
 		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{runes[i]}})
 		next := got.(model)
 		m = &next
@@ -2880,6 +2960,8 @@ func TestClipboardCaptureConsumesTrailingEnterEchoAndDoesNotAutoSubmit(t *testin
 	m.clipboardRead = fakeClipboardTextReader{text: longPaste}
 
 	for _, r := range longPaste {
+		// Simulate a rapid terminal echo burst for implicit paste detection.
+		m.lastInputAt = time.Now()
 		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 		next := got.(model)
 		m = &next


### PR DESCRIPTION
## 背景

当前 TUI 的粘贴处理依赖聚合/防抖与多组启发式规则，存在几个问题：

1. 终端回显按键流时，可能触发占位符闪烁或误判。
2. 长文本粘贴与普通快速输入边界不够清晰，容易误压缩或误发送。
3. 运行中按 Enter 的行为容易触发非预期 BTW 提交。
4. 粘贴占位符状态在部分流程中未及时清理，可能残留到下一次输入。

## 主要改动

1. 引入粘贴事务机制（`pasteTransaction`）
- 新增 `tui/input_paste_transaction.go`，统一管理粘贴源、payload、回显消费进度、尾随 Enter 防护。
- 消费终端回显的普通按键流，忽略 Ctrl+V 控制噪声，避免误发送。

2. 重构粘贴入口与压缩策略
- 移除原有 paste session finalize 防抖链路，改为“边界明确、即时处理”。
- `Ctrl+V` 优先走图片粘贴，失败后回退到剪贴板文本读取（含 Windows PowerShell fallback）。
- 压缩阈值对齐 opencode 语义：文本达到“3 行及以上”或“超过 150 字符”再摘要压缩。
- 仅在明确粘贴信号下触发压缩，降低普通输入误判。

3. 修复占位符闪烁与提示词解析链路
- 增加 `virtualPasteParts` 跟踪与扩展能力。
- `buildPromptInput` 改为先展开虚拟粘贴片段，再解析 `[Paste #]` 行引用。
- 在提交、命令执行、会话切换、启动向导等路径统一清理粘贴事务与虚拟片段状态。

4. 调整运行中 Enter 行为（避免误发送）
- run 进行中，普通文本 Enter 不再隐式当作 BTW 提交。
- 明确提示用户使用 `/btw <message>` 或 `Esc` 中断。

## 测试

- 补充与更新 `tui/input_paste_test.go`、`tui/model_test.go` 大量用例，覆盖：
  - 粘贴事务回显消费
  - Ctrl+V 文本回退
  - 剪贴板匹配压缩与续写
  - 占位符扩展
  - busy 场景下 Enter 行为
- 本地执行：
  - `go test ./tui -run "Test(CtrlVWithoutImageFallsBackToClipboardTextAndCompresses|PasteMsgTransactionConsumesEchoedPlainKeyStream|BuildPromptInputExpandsVirtualPartWithoutPasteRegexPattern|BusyEnterWithPlainTextDoesNotSubmitBTW|UpdatePasteMsgAllowsImmediateEnterSubmit)" -count=1`
  - 结果：通过

## 影响范围

- 主要影响 `tui` 输入/粘贴处理链路，不涉及外部 API 变更。
- 目标是减少误压缩、误发送与占位符状态残留，提升跨终端粘贴一致性。
