### PR TITLE
修复：图片占位符支持整块删除，避免误删导致失效

### DIFF
--- a/tui/component_input_mutation.go
+++ b/tui/component_input_mutation.go
@@ -76,6 +76,9 @@ func (m *model) handleInputMutation(before, after, source string) string {
 			note = "Paste marker is locked to prevent accidental edits."
 		}
 	}
+	if locked, changed := m.protectImagePlaceholderDeletion(before, updated, source); changed {
+		updated = locked
+	}
 
 	if updated != after {
 		m.setInputValue(updated)

--- a/tui/input_images.go
+++ b/tui/input_images.go
@@ -972,6 +972,106 @@ func imageIDFromPlaceholder(value string) (int, bool) {
 	return id, true
 }
 
+type imagePlaceholderSpan struct {
+	Start int
+	End   int
+}
+
+func isImagePlaceholderDeletionSource(source string) bool {
+	key := normalizeKeyName(source)
+	return key == "backspace" || key == "delete" || key == "ctrl+h" || key == "ctrl+d"
+}
+
+func extractImagePlaceholderSpans(value string) []imagePlaceholderSpan {
+	matches := imagePlaceholderPattern.FindAllStringIndex(value, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	spans := make([]imagePlaceholderSpan, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 || match[0] >= match[1] {
+			continue
+		}
+		spans = append(spans, imagePlaceholderSpan{Start: match[0], End: match[1]})
+	}
+	return spans
+}
+
+func overlapsRange(startA, endA, startB, endB int) bool {
+	return startA < endB && startB < endA
+}
+
+func removeImagePlaceholderSpans(value string, spans []imagePlaceholderSpan) string {
+	if len(spans) == 0 {
+		return value
+	}
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].Start == spans[j].Start {
+			return spans[i].End < spans[j].End
+		}
+		return spans[i].Start < spans[j].Start
+	})
+
+	var b strings.Builder
+	cursor := 0
+	for _, span := range spans {
+		start := clamp(span.Start, 0, len(value))
+		end := clamp(span.End, start, len(value))
+		if start < cursor {
+			continue
+		}
+		if start > cursor {
+			b.WriteString(value[cursor:start])
+		}
+		cursor = end
+	}
+	if cursor < len(value) {
+		b.WriteString(value[cursor:])
+	}
+	return b.String()
+}
+
+func (m *model) protectImagePlaceholderDeletion(before, after, source string) (string, bool) {
+	if m == nil || !isImagePlaceholderDeletionSource(source) {
+		return after, false
+	}
+	if before == after || len(after) >= len(before) {
+		return after, false
+	}
+	// Restrict atomic deletion protection to single-rune delete/backspace edits.
+	if len(before)-len(after) != 1 {
+		return after, false
+	}
+	if !strings.Contains(before, "[Image #") {
+		return after, false
+	}
+
+	prefix, _, suffix := insertionDiff(before, after)
+	affectedStart := clamp(prefix, 0, len(before))
+	affectedEnd := clamp(len(before)-suffix, affectedStart, len(before))
+	if affectedEnd <= affectedStart {
+		return after, false
+	}
+
+	spans := extractImagePlaceholderSpans(before)
+	if len(spans) == 0 {
+		return after, false
+	}
+
+	toRemove := make([]imagePlaceholderSpan, 0, 1)
+	for _, span := range spans {
+		if overlapsRange(affectedStart, affectedEnd, span.Start, span.End) {
+			toRemove = append(toRemove, span)
+		}
+	}
+	if len(toRemove) == 0 {
+		return after, false
+	}
+
+	locked := removeImagePlaceholderSpans(before, toRemove)
+	return locked, locked != after
+}
+
 type mentionImageSpan struct {
 	Start   int
 	End     int

--- a/tui/input_images_test.go
+++ b/tui/input_images_test.go
@@ -614,3 +614,68 @@ func TestExtractMentionImageSpansOnlyReturnsBoundMentions(t *testing.T) {
 		t.Fatalf("unexpected bound asset id: %q", spans[0].AssetID)
 	}
 }
+
+func TestProtectImagePlaceholderDeletionRemovesOnlyTouchedPlaceholder(t *testing.T) {
+	m := newImagePipelineModel(t)
+	before := "[Image #1] and [Image #2]"
+	first := "[Image #1]"
+	cut := strings.Index(before, first) + len(first) - 1 // simulate deleting trailing ']'
+	after := before[:cut] + before[cut+1:]
+
+	updated, changed := m.protectImagePlaceholderDeletion(before, after, "backspace")
+	if !changed {
+		t.Fatal("expected atomic placeholder deletion to be applied")
+	}
+	if updated != " and [Image #2]" {
+		t.Fatalf("expected only touched placeholder removed, got %q", updated)
+	}
+}
+
+func TestProtectImagePlaceholderDeletionAllowsBulkClear(t *testing.T) {
+	m := newImagePipelineModel(t)
+	before := "[Image #1] keep"
+	after := ""
+
+	updated, changed := m.protectImagePlaceholderDeletion(before, after, "backspace")
+	if changed {
+		t.Fatalf("expected bulk clear not to be intercepted, got %q", updated)
+	}
+	if updated != after {
+		t.Fatalf("expected bulk clear value to remain unchanged, got %q", updated)
+	}
+}
+
+func TestProtectImagePlaceholderDeletionSkipsMalformedPlaceholder(t *testing.T) {
+	m := newImagePipelineModel(t)
+	before := "[Image #x]"
+	after := "[Image #x"
+
+	updated, changed := m.protectImagePlaceholderDeletion(before, after, "backspace")
+	if changed {
+		t.Fatalf("expected malformed placeholder not to trigger atomic deletion, got %q", updated)
+	}
+	if updated != after {
+		t.Fatalf("expected malformed placeholder edit to pass through, got %q", updated)
+	}
+}
+
+func TestRemoveImagePlaceholderSpansHandlesOverlapAndEmptyInput(t *testing.T) {
+	value := "x[Image #1]y"
+	start := strings.Index(value, "[Image #1]")
+	if start < 0 {
+		t.Fatalf("expected placeholder in value %q", value)
+	}
+	end := start + len("[Image #1]")
+
+	if got := removeImagePlaceholderSpans(value, nil); got != value {
+		t.Fatalf("expected empty spans to keep original value, got %q", got)
+	}
+
+	updated := removeImagePlaceholderSpans(value, []imagePlaceholderSpan{
+		{Start: start, End: end},
+		{Start: start + 1, End: end}, // overlap should be ignored safely
+	})
+	if updated != "xy" {
+		t.Fatalf("expected overlap-safe placeholder removal, got %q", updated)
+	}
+}

--- a/tui/model.go
+++ b/tui/model.go
@@ -264,98 +264,98 @@ type model struct {
 	input    textarea.Model
 	spinner  spinner.Model
 
-	viewportContentCache  string
-	viewportTopCache      viewportTopLookupCache
-	chatItems             []chatEntry
-	toolRuns              []toolRun
-	plan                  planpkg.State
-	sessions              []session.Summary
-	sessionLimit          int
-	sessionCursor         int
-	commandCursor         int
-	mentionCursor         int
-	screen                screenKind
-	mode                  agentMode
-	sessionsOpen          bool
-	skillsOpen            bool
-	helpOpen              bool
-	commandOpen           bool
-	mentionOpen           bool
-	promptSearchOpen      bool
-	busy                  bool
-	runStartedAt          time.Time
-	streamingIndex        int
-	statusNote            string
-	phase                 string
-	llmConnected          bool
-	approval              *approvalPrompt
-	mentionQuery          string
-	mentionToken          mention.Token
-	mentionResults        []mention.Candidate
-	mentionIndex          *mention.WorkspaceFileIndex
-	mentionRecent         map[string]int
-	mentionSeq            int
-	lastPasteAt           time.Time
-	lastInputAt           time.Time
-	inputBurstSize        int
+	viewportContentCache       string
+	viewportTopCache           viewportTopLookupCache
+	chatItems                  []chatEntry
+	toolRuns                   []toolRun
+	plan                       planpkg.State
+	sessions                   []session.Summary
+	sessionLimit               int
+	sessionCursor              int
+	commandCursor              int
+	mentionCursor              int
+	screen                     screenKind
+	mode                       agentMode
+	sessionsOpen               bool
+	skillsOpen                 bool
+	helpOpen                   bool
+	commandOpen                bool
+	mentionOpen                bool
+	promptSearchOpen           bool
+	busy                       bool
+	runStartedAt               time.Time
+	streamingIndex             int
+	statusNote                 string
+	phase                      string
+	llmConnected               bool
+	approval                   *approvalPrompt
+	mentionQuery               string
+	mentionToken               mention.Token
+	mentionResults             []mention.Candidate
+	mentionIndex               *mention.WorkspaceFileIndex
+	mentionRecent              map[string]int
+	mentionSeq                 int
+	lastPasteAt                time.Time
+	lastInputAt                time.Time
+	inputBurstSize             int
 	clipboardCaptureArmedUntil time.Time
-	chatAutoFollow        bool
-	draggingScrollbar     bool
-	scrollbarDragOffset   int
-	mouseSelecting        bool
-	mouseSelectionMouseX  int
-	mouseSelectionMouseY  int
-	mouseSelectionTickID  int
-	mouseSelectionActive  bool
-	mouseSelectionStart   viewportSelectionPoint
-	mouseSelectionEnd     viewportSelectionPoint
-	inputMouseSelecting   bool
-	inputSelectionActive  bool
-	inputSelectionStart   viewportSelectionPoint
-	inputSelectionEnd     viewportSelectionPoint
-	selectionToast        string
-	selectionToastID      int
-	tokenUsage            tokenUsageComponent
-	tokenUsedTotal        int
-	tokenBudget           int
-	tokenInput            int
-	tokenOutput           int
-	tokenContext          int
-	tokenHasOfficialUsage bool
-	tempEstimatedOutput   int
-	tokenEstimator        *realtimeTokenEstimator
-	promptHistoryLoaded   bool
-	promptHistoryLoading  bool
-	promptHistoryLoadErr  string
-	promptHistoryEntries  []history.PromptEntry
-	promptSearchMode      promptSearchMode
-	promptSearchQuery     string
-	promptSearchMatches   []history.PromptEntry
-	promptSearchCursor    int
-	promptSearchBaseInput string
-	inputImageRefs        map[int]llm.AssetID
-	inputImageMentions    map[string]llm.AssetID
-	orphanedImages        map[llm.AssetID]time.Time
-	nextImageID           int
-	pastedContents        map[string]pastedContent
-	pastedOrder           []string
-	nextPasteID           int
-	pastedStateLoaded     bool
-	lastCompressedPasteAt time.Time
-	virtualPasteParts     []virtualPastePart
-	nextVirtualPastePart  int
-	pasteTransaction      pasteTransactionState
-	clipboard             clipboardImageReader
-	clipboardRead         clipboardTextReader
-	clipboardText         clipboardTextWriter
-	runCancel             context.CancelFunc
-	pendingBTW            []string
-	interrupting          bool
-	interruptSafe         bool
-	runSeq                int
-	activeRunID           int
-	startupGuide          StartupGuide
-	mouseYOffset          int
+	chatAutoFollow             bool
+	draggingScrollbar          bool
+	scrollbarDragOffset        int
+	mouseSelecting             bool
+	mouseSelectionMouseX       int
+	mouseSelectionMouseY       int
+	mouseSelectionTickID       int
+	mouseSelectionActive       bool
+	mouseSelectionStart        viewportSelectionPoint
+	mouseSelectionEnd          viewportSelectionPoint
+	inputMouseSelecting        bool
+	inputSelectionActive       bool
+	inputSelectionStart        viewportSelectionPoint
+	inputSelectionEnd          viewportSelectionPoint
+	selectionToast             string
+	selectionToastID           int
+	tokenUsage                 tokenUsageComponent
+	tokenUsedTotal             int
+	tokenBudget                int
+	tokenInput                 int
+	tokenOutput                int
+	tokenContext               int
+	tokenHasOfficialUsage      bool
+	tempEstimatedOutput        int
+	tokenEstimator             *realtimeTokenEstimator
+	promptHistoryLoaded        bool
+	promptHistoryLoading       bool
+	promptHistoryLoadErr       string
+	promptHistoryEntries       []history.PromptEntry
+	promptSearchMode           promptSearchMode
+	promptSearchQuery          string
+	promptSearchMatches        []history.PromptEntry
+	promptSearchCursor         int
+	promptSearchBaseInput      string
+	inputImageRefs             map[int]llm.AssetID
+	inputImageMentions         map[string]llm.AssetID
+	orphanedImages             map[llm.AssetID]time.Time
+	nextImageID                int
+	pastedContents             map[string]pastedContent
+	pastedOrder                []string
+	nextPasteID                int
+	pastedStateLoaded          bool
+	lastCompressedPasteAt      time.Time
+	virtualPasteParts          []virtualPastePart
+	nextVirtualPastePart       int
+	pasteTransaction           pasteTransactionState
+	clipboard                  clipboardImageReader
+	clipboardRead              clipboardTextReader
+	clipboardText              clipboardTextWriter
+	runCancel                  context.CancelFunc
+	pendingBTW                 []string
+	interrupting               bool
+	interruptSafe              bool
+	runSeq                     int
+	activeRunID                int
+	startupGuide               StartupGuide
+	mouseYOffset               int
 }
 
 func newModel(opts Options) model {
@@ -701,6 +701,16 @@ func isCtrlVPasteKey(msg tea.KeyMsg) bool {
 	return key == "ctrl+v" || key == "ctrl+shift+v" || key == "shift+insert"
 }
 
+func isAltVImagePasteKey(msg tea.KeyMsg) bool {
+	if normalizeKeyName(msg.String()) == "alt+v" {
+		return true
+	}
+	if !msg.Alt || msg.Type != tea.KeyRunes || len(msg.Runes) != 1 {
+		return false
+	}
+	return strings.EqualFold(string(msg.Runes[0]), "v")
+}
+
 func (m model) pasteFragmentFromKey(msg tea.KeyMsg) (string, string, bool) {
 	if msg.Paste {
 		switch {
@@ -979,6 +989,14 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
+	if isAltVImagePasteKey(msg) {
+		if note := m.handleEmptyClipboardPaste(); strings.TrimSpace(note) != "" {
+			m.statusNote = note
+		}
+		m.syncInputOverlays()
+		return m, nil
+	}
+
 	if m.consumePasteEchoKey(msg) {
 		return m, nil
 	}
@@ -1032,12 +1050,6 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, m.loadSessionsCmd()
-	case "alt+v":
-		if note := m.handleEmptyClipboardPaste(); strings.TrimSpace(note) != "" {
-			m.statusNote = note
-		}
-		m.syncInputOverlays()
-		return m, nil
 	case "ctrl+n":
 		if !m.busy && m.screen == screenChat {
 			if err := m.newSession(); err != nil {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -1931,6 +1931,46 @@ func TestAltVPastesClipboardImage(t *testing.T) {
 	}
 }
 
+func TestAltVUppercaseRunePastesClipboardImage(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboard = fakeClipboardImageReader{
+		mediaType: "image/png",
+		data:      []byte("clipboard"),
+		fileName:  "clipboard.png",
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'V'}, Alt: true})
+	updated := got.(model)
+	if updated.input.Value() != "[Image #1]" {
+		t.Fatalf("expected alt+V to paste clipboard image placeholder, got %q", updated.input.Value())
+	}
+}
+
+func TestAltVPasteBypassesPasteEchoTransactionConsumption(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboard = fakeClipboardImageReader{
+		mediaType: "image/png",
+		data:      []byte("clipboard"),
+		fileName:  "clipboard.png",
+	}
+	m.pasteTransaction = pasteTransactionState{
+		Active:             true,
+		Source:             "paste-key",
+		Payload:            "value",
+		Consumed:           0,
+		StartedAt:          time.Now(),
+		AwaitTrailingEnter: true,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}, Alt: true})
+	updated := got.(model)
+	if updated.input.Value() != "[Image #1]" {
+		t.Fatalf("expected alt+v to paste image even when paste echo transaction is active, got %q", updated.input.Value())
+	}
+}
+
 func TestCtrlVPastesClipboardImage(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -1963,6 +1963,76 @@ func TestCtrlVControlMarkerRunePastesClipboardImage(t *testing.T) {
 	}
 }
 
+func TestBackspaceRemovesImagePlaceholderAsAtomicBlock(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	placeholder := mustIngestTestImage(t, m, "atomic-backspace")
+
+	m.input.SetValue("look " + placeholder + " now")
+	m.syncInputImageRefs(m.input.Value())
+	if _, ok := m.inputImageRefs[1]; !ok {
+		t.Fatalf("expected image placeholder to be tracked before deletion")
+	}
+
+	cursor := strings.Index(m.input.Value(), placeholder) + len(placeholder)
+	m.input.SetCursor(cursor)
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyBackspace})
+	updated := got.(model)
+	if updated.input.Value() != "look  now" {
+		t.Fatalf("expected backspace to remove whole image placeholder, got %q", updated.input.Value())
+	}
+	if strings.Contains(updated.input.Value(), "[Image #") {
+		t.Fatalf("expected no broken image placeholder text, got %q", updated.input.Value())
+	}
+	if _, ok := updated.inputImageRefs[1]; ok {
+		t.Fatalf("expected image placeholder reference to be cleared after atomic deletion")
+	}
+}
+
+func TestDeleteRemovesImagePlaceholderAsAtomicBlock(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	placeholder := mustIngestTestImage(t, m, "atomic-delete")
+
+	m.input.SetValue("look " + placeholder + " now")
+	m.syncInputImageRefs(m.input.Value())
+	if _, ok := m.inputImageRefs[1]; !ok {
+		t.Fatalf("expected image placeholder to be tracked before deletion")
+	}
+
+	cursor := strings.Index(m.input.Value(), placeholder)
+	m.input.SetCursor(cursor)
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyDelete})
+	updated := got.(model)
+	if updated.input.Value() != "look  now" {
+		t.Fatalf("expected delete to remove whole image placeholder, got %q", updated.input.Value())
+	}
+	if strings.Contains(updated.input.Value(), "[Image #") {
+		t.Fatalf("expected no broken image placeholder text, got %q", updated.input.Value())
+	}
+	if _, ok := updated.inputImageRefs[1]; ok {
+		t.Fatalf("expected image placeholder reference to be cleared after atomic deletion")
+	}
+}
+
+func TestBackspaceOutsideImagePlaceholderDoesNotTriggerAtomicDeletion(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	placeholder := mustIngestTestImage(t, m, "atomic-guard")
+
+	m.input.SetValue("x " + placeholder)
+	cursor := strings.Index(m.input.Value(), " ") + 1
+	m.input.SetCursor(cursor)
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyBackspace})
+	updated := got.(model)
+	if !strings.Contains(updated.input.Value(), placeholder) {
+		t.Fatalf("expected placeholder to remain when backspace is outside token, got %q", updated.input.Value())
+	}
+}
+
 func TestCtrlVWithoutImageShowsStatusNote(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat


### PR DESCRIPTION
## 变更说明
- 将 `[Image #n]` 占位符视为原子块：在输入框中按 `Backspace` / `Delete` 命中占位符时，整块删除，不再出现残缺文本。
- 保持普通文本删除行为不变，避免影响非占位符输入。

## 实现细节
- 在输入变更管线新增占位符删除保护逻辑，基于编辑差异区间判断是否命中占位符。
- 当命中占位符时回写“移除整块占位符”的结果，并同步引用状态。

## 测试
- `go test ./tui -run 'BackspaceRemovesImagePlaceholderAsAtomicBlock|DeleteRemovesImagePlaceholderAsAtomicBlock|BackspaceOutsideImagePlaceholderDoesNotTriggerAtomicDeletion' -v`
- `go test ./tui -run 'CtrlV.*Image|AltVPastesClipboardImage|HandleEmptyClipboardPasteReadsAndAttachesImage|ApplyInputImagePipelineConvertsPastedPathToPlaceholder|BackspaceRemovesImagePlaceholderAsAtomicBlock|DeleteRemovesImagePlaceholderAsAtomicBlock' -v`