### PR TITLE
Extension丨step5优先落地 Skills Adapter &&   Provider丨step9测试矩阵与门禁建设

### DIFF
--- a/.github/workflows/provider-contracts.yml
+++ b/.github/workflows/provider-contracts.yml
@@ -1,0 +1,42 @@
+name: Provider Contract Gates
+
+on:
+  pull_request:
+    paths:
+      - 'internal/provider/**'
+      - '.github/workflows/provider-contracts.yml'
+      - 'go.mod'
+      - 'go.sum'
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'internal/provider/**'
+      - '.github/workflows/provider-contracts.yml'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+
+jobs:
+  provider-contracts:
+    name: Provider Contract Gates
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+          cache: true
+
+      - name: Run provider contract matrix
+        run: go test ./internal/provider/... -run 'TestProviderContract|TestNormalizeEvent|TestWrapClientStream|TestMapError|TestMapLLMProviderError|TestRouter|TestListModels|TestRegistry|TestHealth' -count=1 -v
+
+      - name: Run provider package suite
+        run: go test ./internal/provider/... -count=1 -v

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -317,17 +317,10 @@ func (m *extensionManager) discoverOne(source string) (ExtensionInfo, error) {
 	if !ok {
 		scope = ExtensionScopeRemote
 	}
-	catalog := skillspkg.NewManagerWithDirs(m.workspace, "", "", filepath.Dir(resolved)).Reload()
-	var matched skillspkg.Skill
-	for _, skill := range catalog.Skills {
-		if sameExtensionSource(skill.SourceDir, resolved) {
-			matched = skill
-			break
-		}
-	}
-	if strings.TrimSpace(matched.Name) == "" {
-		if len(catalog.Diagnostics) > 0 {
-			return ExtensionInfo{}, wrapError(ErrCodeInvalidManifest, catalog.Diagnostics[0].Message, nil)
+	matched, ok, diags := skillspkg.LoadFromDir(skillsScopeForExtension(scope), resolved)
+	if !ok {
+		if len(diags) > 0 {
+			return ExtensionInfo{}, wrapError(ErrCodeInvalidManifest, diags[0].Message, nil)
 		}
 		return ExtensionInfo{}, wrapError(ErrCodeInvalidSource, "extension source does not contain a supported extension", nil)
 	}
@@ -383,6 +376,17 @@ func scopeForPath(path string, m *extensionManager) (ExtensionScope, bool) {
 		}
 	}
 	return "", false
+}
+
+func skillsScopeForExtension(scope ExtensionScope) skillspkg.Scope {
+	switch scope {
+	case ExtensionScopeBuiltin:
+		return skillspkg.ScopeBuiltin
+	case ExtensionScopeUser:
+		return skillspkg.ScopeUser
+	default:
+		return skillspkg.ScopeProject
+	}
 }
 
 func extensionIDForDir(dirName string) string {

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -2,7 +2,6 @@ package extensions
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	skillspkg "bytemind/internal/skills"
 )
 
 type extensionManager struct {
@@ -19,6 +20,9 @@ type extensionManager struct {
 	builtinDir string
 	userDir    string
 	projectDir string
+
+	skills  *skillspkg.Manager
+	adapter *skillAdapter
 
 	state        *stateStore
 	manual       map[string]struct{}
@@ -45,6 +49,8 @@ func NewManagerWithDirs(workspace, builtinDir, userDir, projectDir string) Manag
 		builtinDir:   builtinDir,
 		userDir:      userDir,
 		projectDir:   projectDir,
+		skills:       skillspkg.NewManagerWithDirs(workspace, builtinDir, userDir, projectDir),
+		adapter:      newSkillAdapter(),
 		state:        newStateStore(),
 		manual:       map[string]struct{}{},
 		disabled:     map[string]struct{}{},
@@ -172,23 +178,35 @@ func (m *extensionManager) List(_ context.Context) ([]ExtensionInfo, error) {
 }
 
 func (m *extensionManager) reload() error {
-	type scopeDir struct {
-		scope ExtensionScope
-		dir   string
-	}
 	loaded := map[string]ExtensionInfo{}
 	discoverErrs := map[string]error{}
-	for _, item := range []scopeDir{{ExtensionScopeBuiltin, m.builtinDir}, {ExtensionScopeUser, m.userDir}, {ExtensionScopeProject, m.projectDir}} {
-		entries, errs, err := discoverScope(item.scope, item.dir)
-		if err != nil {
-			return err
+	catalog := m.skills.Reload()
+	for _, entry := range m.adapter.Sync(catalog) {
+		if strings.TrimSpace(entry.Source.Ref) != "" {
+			entry.Status = extensionStatusForPath(entry.Source.Ref)
+			entry.Health.Status = entry.Status
+			if entry.Status == ExtensionStatusDegraded {
+				entry.Health.Message = "manifest discovered without SKILL.md"
+			} else {
+				entry.Health.Message = "extension loaded"
+			}
+			entry.Health.CheckedAtUTC = time.Now().UTC().Format(time.RFC3339)
+			entry.Manifest.Source.Ref = filepath.Join(entry.Source.Ref, "skill.json")
 		}
-		for _, entry := range entries {
-			loaded[entry.ID] = entry
+		loaded[entry.ID] = entry
+	}
+	for _, diag := range catalog.Diagnostics {
+		id := extensionIDForDir(diag.Skill)
+		if id == "" {
+			id = extensionIDForDir(filepath.Base(diag.Path))
 		}
-		for id, discoverErr := range errs {
-			discoverErrs[id] = discoverErr
+		if id == "" {
+			id = strings.TrimSpace(diag.Path)
 		}
+		if id == "" {
+			continue
+		}
+		discoverErrs[id] = wrapError(ErrCodeLoadFailed, diag.Message, nil)
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -299,155 +317,29 @@ func (m *extensionManager) discoverOne(source string) (ExtensionInfo, error) {
 	if !ok {
 		scope = ExtensionScopeRemote
 	}
-	item, ok, err := discoverExtension(scope, resolved, filepath.Base(resolved))
-	if err != nil {
-		return ExtensionInfo{}, err
+	catalog := skillspkg.NewManagerWithDirs(m.workspace, "", "", filepath.Dir(resolved)).Reload()
+	var matched skillspkg.Skill
+	for _, skill := range catalog.Skills {
+		if sameExtensionSource(skill.SourceDir, resolved) {
+			matched = skill
+			break
+		}
 	}
-	if !ok {
+	if strings.TrimSpace(matched.Name) == "" {
+		if len(catalog.Diagnostics) > 0 {
+			return ExtensionInfo{}, wrapError(ErrCodeInvalidManifest, catalog.Diagnostics[0].Message, nil)
+		}
 		return ExtensionInfo{}, wrapError(ErrCodeInvalidSource, "extension source does not contain a supported extension", nil)
 	}
+	item := m.adapter.FromSkill(matched)
+	item.Source.Scope = scope
+	item.Source.Ref = resolved
+	item.Manifest.Source.Scope = scope
+	item.Manifest.Source.Ref = filepath.Join(resolved, "skill.json")
+	if !item.Valid() {
+		return ExtensionInfo{}, wrapError(ErrCodeInvalidExtension, "extension info is invalid", nil)
+	}
 	return item, nil
-}
-
-func discoverScope(scope ExtensionScope, root string) ([]ExtensionInfo, map[string]error, error) {
-	root = strings.TrimSpace(root)
-	if root == "" {
-		return nil, nil, nil
-	}
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil, nil
-		}
-		id := extensionIDForDir(filepath.Base(root))
-		if id == "" {
-			id = root
-		}
-		return nil, map[string]error{id: wrapError(ErrCodeLoadFailed, fmt.Sprintf("discover extensions from %s", root), err)}, nil
-	}
-	items := make([]ExtensionInfo, 0, len(entries))
-	discoverErrs := make(map[string]error)
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		dir := filepath.Join(root, entry.Name())
-		item, ok, err := discoverExtension(scope, dir, entry.Name())
-		if err != nil {
-			discoverErrs[extensionIDForDir(entry.Name())] = err
-			continue
-		}
-		if ok {
-			items = append(items, item)
-		}
-	}
-	return items, discoverErrs, nil
-}
-
-func discoverExtension(scope ExtensionScope, dir, dirName string) (ExtensionInfo, bool, error) {
-	manifestPath := filepath.Join(dir, "skill.json")
-	skillPath := filepath.Join(dir, "SKILL.md")
-	if !fileExists(manifestPath) && !fileExists(skillPath) {
-		return ExtensionInfo{}, false, nil
-	}
-	manifest, err := readManifest(manifestPath, dirName)
-	if err != nil {
-		return ExtensionInfo{}, false, err
-	}
-	info := buildExtensionInfo(scope, dir, dirName, manifest, fileExists(skillPath))
-	if !info.Valid() {
-		return ExtensionInfo{}, false, wrapError(ErrCodeInvalidExtension, "extension info is invalid", nil)
-	}
-	return info, true, nil
-}
-
-func readManifest(path, dirName string) (Manifest, error) {
-	manifest := Manifest{}
-	if !fileExists(path) {
-		manifest.Name = dirName
-		manifest.Title = dirName
-		manifest.Kind = ExtensionSkill
-		manifest.Source = ExtensionSource{Ref: path}
-		return manifest, nil
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return Manifest{}, wrapError(ErrCodeInvalidManifest, "failed to read manifest", err)
-	}
-	var raw struct {
-		Name        string     `json:"name"`
-		Version     string     `json:"version"`
-		Title       string     `json:"title"`
-		Description string     `json:"description"`
-		Prompts     []struct{} `json:"prompts"`
-		Resources   []struct{} `json:"resources"`
-		Tools       struct {
-			Items []string `json:"items"`
-		} `json:"tools"`
-		Args []struct{} `json:"args"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return Manifest{}, wrapError(ErrCodeInvalidManifest, "invalid manifest", err)
-	}
-	manifest.Name = strings.TrimSpace(raw.Name)
-	if manifest.Name == "" {
-		manifest.Name = dirName
-	}
-	manifest.Version = strings.TrimSpace(raw.Version)
-	manifest.Title = strings.TrimSpace(raw.Title)
-	if manifest.Title == "" {
-		manifest.Title = manifest.Name
-	}
-	manifest.Description = strings.TrimSpace(raw.Description)
-	manifest.Kind = ExtensionSkill
-	manifest.Source = ExtensionSource{Ref: path}
-	manifest.Capabilities = CapabilitySet{
-		Prompts:   len(raw.Prompts),
-		Resources: len(raw.Resources),
-		Tools:     len(raw.Tools.Items),
-		Commands:  len(raw.Args),
-	}
-	return manifest, nil
-}
-
-func buildExtensionInfo(scope ExtensionScope, dir, dirName string, manifest Manifest, hasSkill bool) ExtensionInfo {
-	name := strings.TrimSpace(manifest.Name)
-	if name == "" {
-		name = dirName
-	}
-	ref := dir
-	status := ExtensionStatusLoaded
-	message := "extension loaded"
-	if !hasSkill {
-		status = ExtensionStatusDegraded
-		message = "manifest discovered without SKILL.md"
-	}
-	now := time.Now().UTC().Format(time.RFC3339)
-	return ExtensionInfo{
-		ID:           "skill." + name,
-		Name:         name,
-		Kind:         ExtensionSkill,
-		Version:      strings.TrimSpace(manifest.Version),
-		Title:        strings.TrimSpace(manifest.Title),
-		Description:  strings.TrimSpace(manifest.Description),
-		Source:       ExtensionSource{Scope: scope, Ref: ref},
-		Status:       status,
-		Capabilities: manifest.Capabilities,
-		Manifest: Manifest{
-			Name:         name,
-			Version:      strings.TrimSpace(manifest.Version),
-			Title:        strings.TrimSpace(manifest.Title),
-			Description:  strings.TrimSpace(manifest.Description),
-			Kind:         ExtensionSkill,
-			Source:       ExtensionSource{Scope: scope, Ref: filepath.Join(dir, "skill.json")},
-			Capabilities: manifest.Capabilities,
-		},
-		Health: HealthSnapshot{
-			Status:       status,
-			Message:      message,
-			CheckedAtUTC: now,
-		},
-	}
 }
 
 func discoveryError(discoverErrs map[string]error) error {

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -546,6 +546,42 @@ func TestDiscoverOneRejectsMissingDirectory(t *testing.T) {
 	}
 }
 
+func TestManagerLoadHandlesDuplicateSkillNamesInSameParentBySourceDir(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, ".bytemind", "skills")
+	first := filepath.Join(project, "alpha")
+	second := filepath.Join(project, "beta")
+	for _, dir := range []string{first, second} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(first, "skill.json"), []byte(`{"name":"review","description":"alpha"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(second, "skill.json"), []byte(`{"name":"review","description":"beta"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(first, "SKILL.md"), []byte("# /review"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(second, "SKILL.md"), []byte("# /review"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManager(root)
+	item, err := mgr.(*extensionManager).discoverOne(first)
+	if err != nil {
+		t.Fatalf("discoverOne failed: %v", err)
+	}
+	if item.Source.Ref != first {
+		t.Fatalf("expected source %q, got %q", first, item.Source.Ref)
+	}
+	if item.Description != "alpha" {
+		t.Fatalf("expected extension from alpha, got description %q", item.Description)
+	}
+}
+
 func TestReloadCollectsSkillDiagnosticsAsDiscoveryErrors(t *testing.T) {
 	root := t.TempDir()
 	project := filepath.Join(root, "project")

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -546,24 +546,23 @@ func TestDiscoverOneRejectsMissingDirectory(t *testing.T) {
 	}
 }
 
-func TestDiscoverScopeCollectsManifestErrors(t *testing.T) {
+func TestReloadCollectsSkillDiagnosticsAsDiscoveryErrors(t *testing.T) {
 	root := t.TempDir()
-	bad := filepath.Join(root, "bad")
+	project := filepath.Join(root, "project")
+	bad := filepath.Join(project, "bad")
 	if err := os.MkdirAll(bad, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(bad, "skill.json"), []byte(`{"name":`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	items, errs, err := discoverScope(ExtensionScopeProject, root)
-	if err != nil {
-		t.Fatalf("discoverScope failed: %v", err)
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	items, err := mgr.List(context.Background())
+	if err == nil {
+		t.Fatal("expected discovery error")
 	}
 	if len(items) != 0 {
 		t.Fatalf("expected no discovered items, got %d", len(items))
-	}
-	if len(errs) != 1 {
-		t.Fatalf("expected one discovery error, got %d", len(errs))
 	}
 }
 

--- a/internal/extensions/skills_adapter.go
+++ b/internal/extensions/skills_adapter.go
@@ -1,0 +1,144 @@
+package extensions
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	skillspkg "bytemind/internal/skills"
+)
+
+type skillAdapter struct {
+	cache map[string]cachedSkillExtension
+}
+
+type cachedSkillExtension struct {
+	item      ExtensionInfo
+	ref       string
+	updatedAt time.Time
+}
+
+func newSkillAdapter() *skillAdapter {
+	return &skillAdapter{cache: map[string]cachedSkillExtension{}}
+}
+
+func (a *skillAdapter) Sync(catalog skillspkg.Catalog) []ExtensionInfo {
+	if a == nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(catalog.Skills))
+	for _, skill := range catalog.Skills {
+		item := a.FromSkill(skill)
+		seen[item.ID] = struct{}{}
+		entry, ok := a.cache[item.ID]
+		if ok && entry.ref == item.Source.Ref && entry.updatedAt.Equal(skill.DiscoveredAt) {
+			continue
+		}
+		a.cache[item.ID] = cachedSkillExtension{
+			item:      item,
+			ref:       item.Source.Ref,
+			updatedAt: skill.DiscoveredAt,
+		}
+	}
+	for id := range a.cache {
+		if _, ok := seen[id]; !ok {
+			delete(a.cache, id)
+		}
+	}
+	items := make([]ExtensionInfo, 0, len(a.cache))
+	for _, entry := range a.cache {
+		items = append(items, entry.item)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].ID < items[j].ID
+	})
+	return items
+}
+
+func (a *skillAdapter) FromSkill(skill skillspkg.Skill) ExtensionInfo {
+	normalized := NormalizeLegacySkill(skill)
+	status := extensionStatusForPath(normalized.SourceDir)
+	message := "extension loaded"
+	if status == ExtensionStatusDegraded {
+		message = "manifest discovered without SKILL.md"
+	}
+	checkedAt := normalized.DiscoveredAt.UTC().Format(time.RFC3339)
+	if normalized.DiscoveredAt.IsZero() {
+		checkedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	capabilities := CapabilitySet{
+		Prompts:   len(normalized.Prompts),
+		Resources: len(normalized.Resources),
+		Tools:     len(normalized.ToolPolicy.Items),
+		Commands:  len(normalized.Args),
+	}
+	manifestRef := ""
+	if normalized.SourceDir != "" {
+		manifestRef = filepath.Join(normalized.SourceDir, "skill.json")
+	}
+	return ExtensionInfo{
+		ID:           "skill." + normalized.Name,
+		Name:         normalized.Name,
+		Kind:         ExtensionSkill,
+		Version:      strings.TrimSpace(normalized.Version),
+		Title:        strings.TrimSpace(normalized.Title),
+		Description:  strings.TrimSpace(normalized.Description),
+		Source:       ExtensionSource{Scope: extensionScope(normalized.Scope), Ref: strings.TrimSpace(normalized.SourceDir)},
+		Status:       status,
+		Capabilities: capabilities,
+		Manifest: Manifest{
+			Name:         normalized.Name,
+			Version:      strings.TrimSpace(normalized.Version),
+			Title:        strings.TrimSpace(normalized.Title),
+			Description:  strings.TrimSpace(normalized.Description),
+			Kind:         ExtensionSkill,
+			Source:       ExtensionSource{Scope: extensionScope(normalized.Scope), Ref: manifestRef},
+			Capabilities: capabilities,
+		},
+		Health: HealthSnapshot{
+			Status:       status,
+			Message:      message,
+			CheckedAtUTC: checkedAt,
+		},
+	}
+}
+
+func NormalizeLegacySkill(skill skillspkg.Skill) skillspkg.Skill {
+	normalized := skill
+	normalized.Name = strings.TrimSpace(normalized.Name)
+	if normalized.Name == "" {
+		normalized.Name = strings.TrimSpace(normalized.Title)
+	}
+	if normalized.Title == "" {
+		normalized.Title = normalized.Name
+	}
+	if normalized.DiscoveredAt.IsZero() {
+		normalized.DiscoveredAt = time.Now().UTC()
+	}
+	return normalized
+}
+
+func extensionScope(scope skillspkg.Scope) ExtensionScope {
+	switch scope {
+	case skillspkg.ScopeBuiltin:
+		return ExtensionScopeBuiltin
+	case skillspkg.ScopeUser:
+		return ExtensionScopeUser
+	case skillspkg.ScopeProject:
+		return ExtensionScopeProject
+	default:
+		return ExtensionScopeRemote
+	}
+}
+
+func extensionStatusForPath(dir string) ExtensionStatus {
+	if strings.TrimSpace(dir) == "" {
+		return ExtensionStatusDegraded
+	}
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err != nil {
+		return ExtensionStatusDegraded
+	}
+	return ExtensionStatusLoaded
+}

--- a/internal/extensions/skills_adapter.go
+++ b/internal/extensions/skills_adapter.go
@@ -5,12 +5,14 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	skillspkg "bytemind/internal/skills"
 )
 
 type skillAdapter struct {
+	mu    sync.RWMutex
 	cache map[string]cachedSkillExtension
 }
 
@@ -28,6 +30,9 @@ func (a *skillAdapter) Sync(catalog skillspkg.Catalog) []ExtensionInfo {
 	if a == nil {
 		return nil
 	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	seen := make(map[string]struct{}, len(catalog.Skills))
 	for _, skill := range catalog.Skills {
 		item := a.FromSkill(skill)

--- a/internal/extensions/skills_adapter_test.go
+++ b/internal/extensions/skills_adapter_test.go
@@ -1,0 +1,57 @@
+package extensions
+
+import (
+	"testing"
+	"time"
+
+	skillspkg "bytemind/internal/skills"
+)
+
+func TestSkillAdapterSyncCachesSkillExtensions(t *testing.T) {
+	adapter := newSkillAdapter()
+	now := time.Now().UTC()
+	items := adapter.Sync(skillspkg.Catalog{Skills: []skillspkg.Skill{{
+		Name:         "review",
+		Title:        "review",
+		Description:  "desc",
+		Scope:        skillspkg.ScopeProject,
+		SourceDir:    `C:\\repo\\.bytemind\\skills\\review`,
+		Instruction:  "body",
+		DiscoveredAt: now,
+	}}})
+	if len(items) != 1 {
+		t.Fatalf("expected 1 extension, got %d", len(items))
+	}
+	if items[0].ID != "skill.review" {
+		t.Fatalf("unexpected id: %q", items[0].ID)
+	}
+	cached := adapter.Sync(skillspkg.Catalog{Skills: []skillspkg.Skill{{
+		Name:         "review",
+		Title:        "review",
+		Description:  "desc",
+		Scope:        skillspkg.ScopeProject,
+		SourceDir:    `C:\\repo\\.bytemind\\skills\\review`,
+		Instruction:  "body",
+		DiscoveredAt: now,
+	}}})
+	if len(cached) != 1 {
+		t.Fatalf("expected cached extension, got %d", len(cached))
+	}
+}
+
+func TestSkillAdapterFromSkillMarksManifestOnlyAsDegraded(t *testing.T) {
+	adapter := newSkillAdapter()
+	item := adapter.FromSkill(skillspkg.Skill{
+		Name:         "review",
+		Title:        "review",
+		Scope:        skillspkg.ScopeProject,
+		SourceDir:    `C:\\repo\\.bytemind\\skills\\review`,
+		DiscoveredAt: time.Now().UTC(),
+	})
+	if item.Status != ExtensionStatusDegraded {
+		t.Fatalf("expected degraded status, got %q", item.Status)
+	}
+	if item.Health.Status != ExtensionStatusDegraded {
+		t.Fatalf("expected degraded health, got %q", item.Health.Status)
+	}
+}

--- a/internal/extensions/skills_adapter_test.go
+++ b/internal/extensions/skills_adapter_test.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -54,4 +55,45 @@ func TestSkillAdapterFromSkillMarksManifestOnlyAsDegraded(t *testing.T) {
 	if item.Health.Status != ExtensionStatusDegraded {
 		t.Fatalf("expected degraded health, got %q", item.Health.Status)
 	}
+}
+
+func TestSkillAdapterSyncIsConcurrentSafe(t *testing.T) {
+	adapter := newSkillAdapter()
+	base := time.Now().UTC()
+	catalogs := []skillspkg.Catalog{
+		{Skills: []skillspkg.Skill{{
+			Name:         "review",
+			Title:        "review",
+			Description:  "desc",
+			Scope:        skillspkg.ScopeProject,
+			SourceDir:    `C:\\repo\\.bytemind\\skills\\review`,
+			Instruction:  "body",
+			DiscoveredAt: base,
+		}}},
+		{Skills: []skillspkg.Skill{{
+			Name:         "plan",
+			Title:        "plan",
+			Description:  "desc",
+			Scope:        skillspkg.ScopeProject,
+			SourceDir:    `C:\\repo\\.bytemind\\skills\\plan`,
+			Instruction:  "body",
+			DiscoveredAt: base.Add(time.Second),
+		}}},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				items := adapter.Sync(catalogs[(idx+j)%len(catalogs)])
+				if len(items) != 1 {
+					t.Errorf("expected 1 extension, got %d", len(items))
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
 }

--- a/internal/provider/contract_test.go
+++ b/internal/provider/contract_test.go
@@ -1,0 +1,288 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"bytemind/internal/llm"
+)
+
+type contractStubCompatClient struct {
+	message llm.Message
+	err     error
+	deltas  []string
+}
+
+func (s contractStubCompatClient) CreateMessage(context.Context, llm.ChatRequest) (llm.Message, error) {
+	return s.message, s.err
+}
+
+func (s contractStubCompatClient) StreamMessage(_ context.Context, _ llm.ChatRequest, onDelta func(string)) (llm.Message, error) {
+	if s.err != nil {
+		return llm.Message{}, s.err
+	}
+	if onDelta != nil {
+		for _, delta := range s.deltas {
+			onDelta(delta)
+		}
+	}
+	return s.message, nil
+}
+
+func collectContractEvents(t *testing.T, client Client, req Request) []Event {
+	t.Helper()
+	stream, err := client.Stream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("stream setup: %v", err)
+	}
+	var events []Event
+	for event := range stream {
+		events = append(events, event)
+	}
+	return events
+}
+
+func assertContractEventEnvelope(t *testing.T, events []Event, providerID ProviderID, modelID ModelID, traceID string) {
+	t.Helper()
+	if len(events) == 0 {
+		t.Fatal("expected events")
+	}
+	if events[0].Type != EventStart {
+		t.Fatalf("expected start event first, got %#v", events[0])
+	}
+	terminalCount := 0
+	for i, event := range events {
+		if event.ID == "" {
+			t.Fatalf("expected event %d to have id", i)
+		}
+		if event.TraceID != traceID {
+			t.Fatalf("expected trace %q on event %d, got %#v", traceID, i, event)
+		}
+		if event.ProviderID != providerID {
+			t.Fatalf("expected provider %q on event %d, got %#v", providerID, i, event)
+		}
+		if event.ModelID != modelID {
+			t.Fatalf("expected model %q on event %d, got %#v", modelID, i, event)
+		}
+		if event.Type == EventResult || event.Type == EventError {
+			terminalCount++
+			if i != len(events)-1 {
+				t.Fatalf("expected terminal event last, got %#v", events)
+			}
+		}
+	}
+	if terminalCount != 1 {
+		t.Fatalf("expected exactly one terminal event, got %#v", events)
+	}
+}
+
+func TestProviderContractWrapClientSuccessMatrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID ProviderID
+		modelID    ModelID
+		client     llm.Client
+		assert     func(*testing.T, []Event)
+	}{
+		{
+			name:       "openai compatible preserves normalized success contract",
+			providerID: ProviderOpenAI,
+			modelID:    "gpt-5.4",
+			client: contractStubCompatClient{
+				deltas: []string{"hello", " world"},
+				message: llm.Message{
+					Role:    llm.RoleAssistant,
+					Content: "hello world",
+					Usage:   &llm.Usage{InputTokens: 3, OutputTokens: 2, TotalTokens: 5},
+					ToolCalls: []llm.ToolCall{{
+						ID:   "call-1",
+						Type: "function",
+						Function: llm.ToolFunctionCall{Name: "list_files", Arguments: "{}"},
+					}},
+				},
+			},
+			assert: func(t *testing.T, events []Event) {
+				assertContractEventEnvelope(t, events, ProviderOpenAI, "gpt-5.4", "trace-openai")
+				if len(events) != 6 {
+					t.Fatalf("expected start + 2 delta + usage + tool_call + result, got %#v", events)
+				}
+				if events[1].Type != EventDelta || events[1].Delta != "hello" {
+					t.Fatalf("unexpected first delta %#v", events[1])
+				}
+				if events[2].Type != EventDelta || events[2].Delta != " world" {
+					t.Fatalf("unexpected second delta %#v", events[2])
+				}
+				if events[3].Type != EventUsage || events[3].Usage == nil || events[3].Usage.TotalTokens != 5 {
+					t.Fatalf("unexpected usage event %#v", events[3])
+				}
+				if events[4].Type != EventToolCall || events[4].ToolCall == nil || events[4].ToolCall.Function.Name != "list_files" {
+					t.Fatalf("unexpected tool call event %#v", events[4])
+				}
+				if events[5].Type != EventResult || events[5].Result == nil || events[5].Result.Content != "hello world" {
+					t.Fatalf("unexpected result event %#v", events[5])
+				}
+			},
+		},
+		{
+			name:       "anthropic preserves normalized success contract",
+			providerID: ProviderAnthropic,
+			modelID:    "claude-sonnet",
+			client: contractStubCompatClient{
+				deltas: []string{"plan ready"},
+				message: llm.Message{
+					Role:    llm.RoleAssistant,
+					Content: "plan ready",
+					Usage:   &llm.Usage{InputTokens: 10, OutputTokens: 6, TotalTokens: 16},
+				},
+			},
+			assert: func(t *testing.T, events []Event) {
+				assertContractEventEnvelope(t, events, ProviderAnthropic, "claude-sonnet", "trace-anthropic")
+				if len(events) != 4 {
+					t.Fatalf("expected start + delta + usage + result, got %#v", events)
+				}
+				if events[1].Type != EventDelta || events[1].Delta != "plan ready" {
+					t.Fatalf("unexpected delta %#v", events[1])
+				}
+				if events[2].Type != EventUsage || events[2].Usage == nil || events[2].Usage.TotalTokens != 16 {
+					t.Fatalf("unexpected usage %#v", events[2])
+				}
+				if events[3].Type != EventResult || events[3].Result == nil || events[3].Result.Content != "plan ready" {
+					t.Fatalf("unexpected result %#v", events[3])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			traceID := "trace-openai"
+			if tt.providerID == ProviderAnthropic {
+				traceID = "trace-anthropic"
+			}
+			adapter := WrapClient(tt.providerID, tt.modelID, tt.client)
+			events := collectContractEvents(t, adapter, Request{ChatRequest: llm.ChatRequest{Model: string(tt.modelID)}, TraceID: traceID})
+			tt.assert(t, events)
+		})
+	}
+}
+
+func TestProviderContractWrapClientErrorMatrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID ProviderID
+		modelID    ModelID
+		err        error
+		code       ErrorCode
+		retryable  bool
+		message    string
+	}{
+		{
+			name:       "openai 429 maps to rate limited",
+			providerID: ProviderOpenAI,
+			modelID:    "gpt-5.4",
+			err:        &llm.ProviderError{Code: llm.ErrorCodeRateLimited, Status: 429, Message: "slow down"},
+			code:       ErrCodeRateLimited,
+			retryable:  true,
+			message:    "provider rate limited",
+		},
+		{
+			name:       "anthropic unauthorized maps to non-retryable",
+			providerID: ProviderAnthropic,
+			modelID:    "claude-sonnet",
+			err:        &llm.ProviderError{Status: 401, Message: "bad auth"},
+			code:       ErrCodeUnauthorized,
+			retryable:  false,
+			message:    "provider unauthorized",
+		},
+		{
+			name:       "timeout maps to retryable timeout",
+			providerID: ProviderOpenAI,
+			modelID:    "gpt-5.4",
+			err:        context.DeadlineExceeded,
+			code:       ErrCodeTimeout,
+			retryable:  true,
+			message:    "provider request timed out",
+		},
+		{
+			name:       "unknown failure maps to unavailable",
+			providerID: ProviderAnthropic,
+			modelID:    "claude-sonnet",
+			err:        errors.New("raw upstream body"),
+			code:       ErrCodeUnavailable,
+			retryable:  true,
+			message:    "provider unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := WrapClient(tt.providerID, tt.modelID, contractStubCompatClient{err: tt.err})
+			events := collectContractEvents(t, adapter, Request{ChatRequest: llm.ChatRequest{Model: string(tt.modelID)}, TraceID: "trace-error"})
+			assertContractEventEnvelope(t, events, tt.providerID, tt.modelID, "trace-error")
+			last := events[len(events)-1]
+			if last.Type != EventError || last.Error == nil {
+				t.Fatalf("expected terminal error event, got %#v", last)
+			}
+			if last.Error.Code != tt.code || last.Error.Retryable != tt.retryable || last.Error.Message != tt.message {
+				t.Fatalf("unexpected mapped error %#v", last.Error)
+			}
+		})
+	}
+}
+
+func TestProviderContractNormalizerMatrix(t *testing.T) {
+	tests := []struct {
+		name    string
+		events  []Event
+		assert  func(*testing.T, []Event)
+	}{
+		{
+			name: "duplicate start becomes terminal error",
+			events: []Event{{Type: EventStart}, {Type: EventStart}},
+			assert: func(t *testing.T, events []Event) {
+				if len(events) != 2 || events[1].Type != EventError || events[1].Error == nil || events[1].Error.Code != ErrCodeUnavailable {
+					t.Fatalf("unexpected events %#v", events)
+				}
+			},
+		},
+		{
+			name: "unknown event type becomes terminal error",
+			events: []Event{{Type: EventStart}, {Type: EventType("mystery")}},
+			assert: func(t *testing.T, events []Event) {
+				if len(events) != 2 || events[1].Type != EventError || events[1].Error == nil {
+					t.Fatalf("unexpected events %#v", events)
+				}
+			},
+		},
+		{
+			name: "error without payload becomes terminal error",
+			events: []Event{{Type: EventStart}, {Type: EventError}},
+			assert: func(t *testing.T, events []Event) {
+				if len(events) != 2 || events[1].Type != EventError || events[1].Error == nil {
+					t.Fatalf("unexpected events %#v", events)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			ch := make(chan Event, len(tt.events)+1)
+			normalizer := newStreamNormalizer("trace-normalize", ProviderOpenAI, "gpt-5.4")
+			for _, event := range tt.events {
+				if !normalizeEvent(ctx, normalizer, ch, event) {
+					break
+				}
+			}
+			close(ch)
+			var got []Event
+			for event := range ch {
+				got = append(got, event)
+			}
+			assertContractEventEnvelope(t, got, ProviderOpenAI, "gpt-5.4", "trace-normalize")
+			tt.assert(t, got)
+		})
+	}
+}

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -161,6 +161,14 @@ func (m *Manager) Workspace() string {
 	return m.workspace
 }
 
+func LoadFromDir(scope Scope, skillDir string) (Skill, bool, []Diagnostic) {
+	skillDir = strings.TrimSpace(skillDir)
+	if skillDir == "" {
+		return Skill{}, false, nil
+	}
+	return loadSkillFromDir(scope, skillDir, filepath.Base(skillDir))
+}
+
 type skillManifest struct {
 	Name        string `json:"name"`
 	Version     string `json:"version"`

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -117,6 +117,12 @@ func (m *Manager) Reload() Catalog {
 	return cloneCatalog(m.catalog)
 }
 
+func (m *Manager) Snapshot() Catalog {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return cloneCatalog(m.catalog)
+}
+
 func (m *Manager) List() ([]Skill, []Diagnostic) {
 	catalog := m.Reload()
 	return catalog.Skills, catalog.Diagnostics
@@ -385,12 +391,16 @@ func loadSkillFromDir(scope Scope, skillDir, dirName string) (Skill, bool, []Dia
 
 func buildToolPolicy(policy string, items []string, frontmatter map[string]string) (ToolPolicy, *Diagnostic) {
 	policy = strings.TrimSpace(strings.ToLower(policy))
+	cleanItems := uniqueStrings(items)
 	if policy == "" {
 		if allowed := parseToolList(frontmatter["allowed-tools"]); len(allowed) > 0 {
 			return ToolPolicy{
 				Policy: ToolPolicyAllowlist,
 				Items:  allowed,
 			}, nil
+		}
+		if len(cleanItems) > 0 {
+			return ToolPolicy{Policy: ToolPolicyInherit, Items: cleanItems}, nil
 		}
 		return ToolPolicy{Policy: ToolPolicyInherit}, nil
 	}
@@ -399,7 +409,7 @@ func buildToolPolicy(policy string, items []string, frontmatter map[string]strin
 	case ToolPolicyInherit, ToolPolicyAllowlist, ToolPolicyDenylist:
 		return ToolPolicy{
 			Policy: ToolPolicyMode(policy),
-			Items:  uniqueStrings(items),
+			Items:  cleanItems,
 		}, nil
 	default:
 		return ToolPolicy{Policy: ToolPolicyInherit}, &Diagnostic{

--- a/internal/skills/manager_snapshot_test.go
+++ b/internal/skills/manager_snapshot_test.go
@@ -1,0 +1,37 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestManagerSnapshotDoesNotReload(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, ".bytemind", "skills", "review")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "skill.json"), []byte(`{"name":"review"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "SKILL.md"), []byte("# /review"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManager(root)
+	catalog := mgr.Reload()
+	if len(catalog.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(catalog.Skills))
+	}
+	if err := os.Remove(filepath.Join(project, "SKILL.md")); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := mgr.Snapshot()
+	if len(snapshot.Skills) != 1 {
+		t.Fatalf("expected snapshot to preserve cached skill, got %d", len(snapshot.Skills))
+	}
+	if snapshot.Skills[0].Instruction == "" {
+		t.Fatal("expected snapshot to avoid reload and keep instruction")
+	}
+}


### PR DESCRIPTION
## extension Summary

阶段 5：优先落地 Skills Adapter，将 legacy skills 统一纳入 extension 系统管理。

## 改动点

### 1. 新增 Skills Adapter
- `internal/extensions/skills_adapter.go`：skill → extension 映射与缓存

### 2. 改造 Extension Manager
- 复用 `skills.Manager` + adapter，不再重复解析 manifest

### 3. 新增 Skills 只读快照 API
- `Snapshot()` 方法满足热路径性能约束

### 4. 修复 ToolPolicy 统计
- inherit 模式下保留 items 统计

## 测试
- `go test ./internal/extensions/... -v`
- `go test ./internal/skills -v`

## 验收
- [x] skills 可通过 extension manager 发现
- [x] 热路径不触发全量 reload
- [x] 旧 skill 兼容
EOF
)"

## provider Summary

### 变更概述
本 PR 完成 Provider 模块的 **Step 9：测试矩阵与门禁建设**，对应 `provider-iteration-plan.md` 中的迭代路线。

### 新增文件

| 文件 | 说明 |
|------|------|
| `internal/provider/contract_test.go` | Provider 契约测试矩阵 |
| `.github/workflows/provider-contracts.yml` | Provider CI 门禁工作流 |

### 测试覆盖

**测试矩阵 + 门禁测试**：

1. **流式事件契约** (`TestProviderContractWrapClientSuccessMatrix`)
   - 首事件必须为 `start`
   - `result`/`error` 互斥，仅一个终态事件
   - 事件后不得再发事件
   - 公共字段 `event_id`/`trace_id`/`provider_id`/`model_id` 非空

2. **错误映射矩阵** (`TestProviderContractWrapClientErrorMatrix`)
   - 429 → `rate_limited` (retryable)
   - 401 → `unauthorized` (non-retryable)
   - timeout → `timeout` (retryable)
   - unknown → `unavailable` (retryable)

3. **Normalizer 异常场景** (`TestProviderContractNormalizerMatrix`)
   - 重复 start → 终态 error
   - 未知 event type → 终态 error
   - Error 无 payload → 终态 error

### CI 门禁

- 触发条件：`internal/provider/**` 变更时
- 门禁命令：
  ```bash
  go test ./internal/provider/... -run 'TestProviderContract|TestNormalizeEvent|TestWrapClientStream|TestMapError|TestMapLLMProviderError|TestRouter|TestListModels|TestRegistry|TestHealth' -v