### PR TITLE
refactor: 收敛 shell 判定来源并明确 agent/runtime 边界

### DIFF
--- a/internal/agent/engine_run_loop.go
+++ b/internal/agent/engine_run_loop.go
@@ -9,7 +9,6 @@ import (
 	contextpkg "bytemind/internal/context"
 	corepkg "bytemind/internal/core"
 	"bytemind/internal/llm"
-	runtimepkg "bytemind/internal/runtime"
 	"bytemind/internal/session"
 )
 
@@ -19,10 +18,10 @@ func (e *defaultEngine) runPromptTurns(ctx context.Context, sess *session.Sessio
 	}
 
 	runner := e.runner
-	toolSequenceTracker := runtimepkg.NewToolSequenceTracker(runtimepkg.DefaultRepeatedToolSequenceThreshold)
+	toolSequenceTracker := NewToolSequenceTracker(DefaultRepeatedToolSequenceThreshold)
 	adaptiveState := newAdaptiveTurnState(runner.contextBudgetMaxReactiveRetry())
 	executedToolNames := make([]string, 0, 16)
-	taskReport := &runtimepkg.TaskReport{}
+	taskReport := &TaskReport{}
 	approvalHandler := runner.prepareRunApprovalHandler(setup, out)
 
 	for step := 0; step < runner.config.MaxIterations; step++ {
@@ -62,7 +61,7 @@ func (e *defaultEngine) runPromptTurns(ctx context.Context, sess *session.Sessio
 		}
 	}
 
-	summary := runtimepkg.BuildStopSummary(runtimepkg.StopSummaryInput{
+	summary := BuildStopSummary(StopSummaryInput{
 		SessionID:     corepkg.SessionID(sess.ID),
 		Reason:        fmt.Sprintf("I reached the current execution budget of %d turns before producing a final answer.", runner.config.MaxIterations),
 		ExecutedTools: executedToolNames,
@@ -134,7 +133,7 @@ func (e *defaultEngine) messagesForStep(ctx context.Context, sess *session.Sessi
 	return e.buildTurnMessages(sess, setup)
 }
 
-func appendTaskReportToError(err error, taskReport *runtimepkg.TaskReport) error {
+func appendTaskReportToError(err error, taskReport *TaskReport) error {
 	if err == nil || taskReport == nil || taskReport.IsEmpty() {
 		return err
 	}
@@ -145,7 +144,7 @@ func appendTaskReportToError(err error, taskReport *runtimepkg.TaskReport) error
 	return fmt.Errorf("%w\nTask report (json):\n%s", err, taskReport.JSON())
 }
 
-func writeCompletionTaskReport(out io.Writer, taskReport *runtimepkg.TaskReport) {
+func writeCompletionTaskReport(out io.Writer, taskReport *TaskReport) {
 	if out == nil || taskReport == nil || !taskReport.HasNonSuccessOutcomes() {
 		return
 	}

--- a/internal/agent/runner_branches_test.go
+++ b/internal/agent/runner_branches_test.go
@@ -12,7 +12,6 @@ import (
 	"bytemind/internal/llm"
 	policypkg "bytemind/internal/policy"
 	"bytemind/internal/provider"
-	runtimepkg "bytemind/internal/runtime"
 	"bytemind/internal/session"
 	"bytemind/internal/tools"
 )
@@ -411,7 +410,7 @@ func TestRenderToolFeedbackAdditionalBranches(t *testing.T) {
 }
 
 func TestUtilityHelpersBranches(t *testing.T) {
-	if got := runtimepkg.NormalizeToolArguments("{bad"); got != "{bad" {
+	if got := NormalizeToolArguments("{bad"); got != "{bad" {
 		t.Fatalf("expected raw fallback for invalid json, got %q", got)
 	}
 	if got := emptyDot("   "); got != "." {

--- a/internal/agent/stop_summary.go
+++ b/internal/agent/stop_summary.go
@@ -1,4 +1,4 @@
-package runtime
+package agent
 
 import (
 	"fmt"

--- a/internal/agent/stop_summary_test.go
+++ b/internal/agent/stop_summary_test.go
@@ -1,4 +1,4 @@
-package runtime
+package agent
 
 import (
 	"reflect"

--- a/internal/agent/task_report.go
+++ b/internal/agent/task_report.go
@@ -1,4 +1,4 @@
-package runtime
+package agent
 
 import (
 	"encoding/json"

--- a/internal/agent/task_report_test.go
+++ b/internal/agent/task_report_test.go
@@ -1,4 +1,4 @@
-package runtime
+package agent
 
 import (
 	"strings"

--- a/internal/agent/tool_sequence.go
+++ b/internal/agent/tool_sequence.go
@@ -1,4 +1,4 @@
-package runtime
+package agent
 
 import (
 	"encoding/json"

--- a/internal/agent/tool_sequence_test.go
+++ b/internal/agent/tool_sequence_test.go
@@ -1,4 +1,4 @@
-package runtime
+package agent
 
 import (
 	"reflect"

--- a/internal/agent/turn_processing.go
+++ b/internal/agent/turn_processing.go
@@ -12,7 +12,6 @@ import (
 	corepkg "bytemind/internal/core"
 	"bytemind/internal/llm"
 	planpkg "bytemind/internal/plan"
-	runtimepkg "bytemind/internal/runtime"
 	"bytemind/internal/session"
 	"bytemind/internal/tokenusage"
 	"bytemind/internal/tools"
@@ -27,11 +26,11 @@ type turnProcessParams struct {
 	DeniedToolNames  []string
 	AllowedTools     map[string]struct{}
 	DeniedTools      map[string]struct{}
-	SequenceTracker  *runtimepkg.ToolSequenceTracker
+	SequenceTracker  *ToolSequenceTracker
 	AdaptiveState    *adaptiveTurnState
 	ExecutedTools    *[]string
 	Approval         tools.ApprovalHandler
-	TaskReport       *runtimepkg.TaskReport
+	TaskReport       *TaskReport
 	Out              io.Writer
 }
 
@@ -93,7 +92,7 @@ func (e *defaultEngine) processTurn(ctx context.Context, p turnProcessParams) (s
 					if p.TaskReport != nil {
 						p.TaskReport.RecordEscalation("semantic repair retries exceeded while waiting for structured tool calls")
 					}
-					summary := runtimepkg.BuildStopSummary(runtimepkg.StopSummaryInput{
+					summary := BuildStopSummary(StopSummaryInput{
 						SessionID:     corepkg.SessionID(p.Session.ID),
 						Reason:        fmt.Sprintf("I paused because the assistant kept signaling ongoing work without structured tool calls (attempts=%d, explicit_intent=%t).", attempt, explicitIntent),
 						ExecutedTools: *p.ExecutedTools,
@@ -133,7 +132,7 @@ func (e *defaultEngine) processTurn(ctx context.Context, p turnProcessParams) (s
 		if sequenceObservation.MatchMode == "name_only" {
 			repeatKind = "same tool-name sequence (arguments varied)"
 		}
-		summary := runtimepkg.BuildStopSummary(runtimepkg.StopSummaryInput{
+		summary := BuildStopSummary(StopSummaryInput{
 			SessionID:     corepkg.SessionID(p.Session.ID),
 			Reason:        fmt.Sprintf("I stopped because the assistant repeated the %s %d times in a row (%s).", repeatKind, sequenceObservation.RepeatCount, strings.Join(sequenceObservation.UniqueToolNames, ", ")),
 			ExecutedTools: *p.ExecutedTools,

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -55,10 +55,13 @@ const (
 type SessionMode string
 
 const (
-	SessionModeDefault           SessionMode = "default"
-	SessionModeAcceptEdits       SessionMode = "acceptEdits"
-	SessionModeBypassPermissions SessionMode = "bypassPermissions"
-	SessionModePlan              SessionMode = "plan"
+	SessionModeBuild SessionMode = "build"
+	SessionModePlan  SessionMode = "plan"
+
+	// Legacy mode labels are treated as build mode for backward compatibility.
+	SessionModeDefault           SessionMode = SessionModeBuild
+	SessionModeAcceptEdits       SessionMode = SessionModeBuild
+	SessionModeBypassPermissions SessionMode = SessionModeBuild
 )
 
 // EventMeta carries cross-module event identity metadata.

--- a/internal/plan/types.go
+++ b/internal/plan/types.go
@@ -8,11 +8,11 @@ import (
 	corepkg "bytemind/internal/core"
 )
 
-type AgentMode string
+type AgentMode = corepkg.SessionMode
 
 const (
-	ModeBuild AgentMode = "build"
-	ModePlan  AgentMode = "plan"
+	ModeBuild AgentMode = corepkg.SessionModeBuild
+	ModePlan  AgentMode = corepkg.SessionModePlan
 )
 
 type Phase string
@@ -68,6 +68,8 @@ func NormalizeMode(raw string) AgentMode {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case string(ModePlan):
 		return ModePlan
+	case "default", "acceptedits", "bypasspermissions":
+		return ModeBuild
 	default:
 		return ModeBuild
 	}

--- a/internal/plan/types_mode_test.go
+++ b/internal/plan/types_mode_test.go
@@ -1,0 +1,28 @@
+package plan
+
+import (
+	"testing"
+
+	corepkg "bytemind/internal/core"
+)
+
+func TestNormalizeModeMapsLegacyLabelsToBuild(t *testing.T) {
+	legacy := []string{"default", "acceptEdits", "bypassPermissions"}
+	for _, raw := range legacy {
+		if got := NormalizeMode(raw); got != ModeBuild {
+			t.Fatalf("NormalizeMode(%q) = %q, want %q", raw, got, ModeBuild)
+		}
+	}
+}
+
+func TestAgentModeIsCoreSessionModeAlias(t *testing.T) {
+	var mode AgentMode = corepkg.SessionModePlan
+	if mode != ModePlan {
+		t.Fatalf("expected alias assignment to preserve mode, got %q", mode)
+	}
+
+	var coreMode corepkg.SessionMode = ModeBuild
+	if coreMode != corepkg.SessionModeBuild {
+		t.Fatalf("expected reverse assignment to preserve build mode, got %q", coreMode)
+	}
+}

--- a/internal/tools/run_shell.go
+++ b/internal/tools/run_shell.go
@@ -14,26 +14,23 @@ import (
 	"runtime"
 	"strings"
 	"time"
-	"unicode"
 
 	"bytemind/internal/llm"
 	planpkg "bytemind/internal/plan"
+	policypkg "bytemind/internal/policy"
 )
 
 type RunShellTool struct{}
 
-type shellRisk int
+type shellRisk = policypkg.ShellRisk
 
 const (
-	shellRiskSafe shellRisk = iota
-	shellRiskApproval
-	shellRiskBlocked
+	shellRiskSafe     shellRisk = policypkg.ShellRiskSafe
+	shellRiskApproval shellRisk = policypkg.ShellRiskApproval
+	shellRiskBlocked  shellRisk = policypkg.ShellRiskBlocked
 )
 
-type shellAssessment struct {
-	Risk   shellRisk
-	Reason string
-}
+type shellAssessment = policypkg.ShellAssessment
 
 func (RunShellTool) Definition() llm.ToolDefinition {
 	return llm.ToolDefinition{
@@ -148,70 +145,7 @@ func requireApproval(command string, execCtx *ExecutionContext) error {
 }
 
 func isPlanSafeCommand(command string) bool {
-	command = strings.TrimSpace(command)
-	if command == "" {
-		return false
-	}
-	if hasWriteRedirection(command) {
-		return false
-	}
-	segments := splitCommandSegments(command)
-	if len(segments) != 1 {
-		return false
-	}
-	fields := splitCommandFields(segments[0])
-	if len(fields) == 0 {
-		return false
-	}
-	first := strings.ToLower(strings.TrimSpace(fields[0]))
-	if first == "" {
-		return false
-	}
-	if looksLikeScript(first) {
-		return false
-	}
-	for _, field := range fields {
-		trimmed := strings.TrimSpace(field)
-		switch trimmed {
-		case "|", ">", ">>", "<", ";", "&&", "||":
-			return false
-		}
-	}
-
-	switch first {
-	case "ls", "dir", "pwd", "cat", "type", "rg", "grep", "find", "tree":
-		return true
-	case "git":
-		if len(fields) < 2 {
-			return false
-		}
-		sub := strings.ToLower(fields[1])
-		return sub == "status" || sub == "diff" || sub == "log"
-	case "go":
-		if len(fields) < 2 {
-			return false
-		}
-		sub := strings.ToLower(fields[1])
-		return sub == "env" || sub == "list"
-	case "bash", "sh", "pwsh", "powershell", "python", "python3", "node":
-		return false
-	default:
-		return false
-	}
-}
-
-func looksLikeScript(command string) bool {
-	command = strings.ToLower(strings.TrimSpace(command))
-	if strings.HasPrefix(command, "./") || strings.HasPrefix(command, ".\\") {
-		return true
-	}
-	ext := strings.ToLower(filepath.Ext(command))
-	switch ext {
-	case ".sh", ".ps1", ".bat", ".cmd":
-		return true
-	default:
-		return false
-	}
+	return policypkg.IsPlanSafeShellCommand(command)
 }
 
 func promptForApproval(command, reason string, execCtx *ExecutionContext) error {
@@ -257,250 +191,7 @@ func promptForApproval(command, reason string, execCtx *ExecutionContext) error 
 }
 
 func assessShellCommand(command string) shellAssessment {
-	segments := splitCommandSegments(command)
-	result := shellAssessment{Risk: shellRiskSafe}
-	for _, segment := range segments {
-		assessment := assessCommandSegment(segment)
-		if assessment.Risk > result.Risk {
-			result = assessment
-		}
-		if result.Risk == shellRiskBlocked {
-			return result
-		}
-	}
-	return result
-}
-
-func assessCommandSegment(segment string) shellAssessment {
-	segment = strings.TrimSpace(segment)
-	if segment == "" {
-		return shellAssessment{Risk: shellRiskSafe}
-	}
-	if hasWriteRedirection(segment) {
-		return shellAssessment{Risk: shellRiskApproval, Reason: "uses shell redirection"}
-	}
-
-	fields := splitCommandFields(segment)
-	if len(fields) == 0 {
-		return shellAssessment{Risk: shellRiskSafe}
-	}
-
-	command := strings.ToLower(fields[0])
-	if isBlockedCommand(command, fields) {
-		return shellAssessment{Risk: shellRiskBlocked, Reason: fmt.Sprintf("blocked dangerous shell command: %s", strings.TrimSpace(segment))}
-	}
-	if isReadOnlyCommand(command, fields) {
-		return shellAssessment{Risk: shellRiskSafe}
-	}
-	if isApprovalCommand(command, fields) {
-		return shellAssessment{Risk: shellRiskApproval, Reason: fmt.Sprintf("may modify files or environment: %s", fields[0])}
-	}
-	return shellAssessment{Risk: shellRiskApproval, Reason: fmt.Sprintf("requires approval for non-read-only command: %s", fields[0])}
-}
-
-func splitCommandSegments(command string) []string {
-	normalized := strings.ReplaceAll(command, "\r\n", "\n")
-	segments := make([]string, 0, 4)
-	var builder strings.Builder
-	inSingle := false
-	inDouble := false
-
-	flush := func() {
-		segment := strings.TrimSpace(builder.String())
-		if segment != "" {
-			segments = append(segments, segment)
-		}
-		builder.Reset()
-	}
-
-	for i := 0; i < len(normalized); i++ {
-		ch := normalized[i]
-		switch ch {
-		case '\'':
-			if !inDouble {
-				inSingle = !inSingle
-			}
-			builder.WriteByte(ch)
-		case '"':
-			if !inSingle {
-				inDouble = !inDouble
-			}
-			builder.WriteByte(ch)
-		case '\n', ';':
-			if inSingle || inDouble {
-				builder.WriteByte(ch)
-				continue
-			}
-			flush()
-		case '|', '&':
-			if inSingle || inDouble {
-				builder.WriteByte(ch)
-				continue
-			}
-			flush()
-			if i+1 < len(normalized) && normalized[i+1] == ch {
-				i++
-			}
-		default:
-			builder.WriteByte(ch)
-		}
-	}
-	flush()
-	return segments
-}
-
-func splitCommandFields(segment string) []string {
-	fields := make([]string, 0, 8)
-	var builder strings.Builder
-	inSingle := false
-	inDouble := false
-
-	flush := func() {
-		if builder.Len() == 0 {
-			return
-		}
-		fields = append(fields, builder.String())
-		builder.Reset()
-	}
-
-	for i := 0; i < len(segment); i++ {
-		ch := segment[i]
-		switch ch {
-		case '\'':
-			if !inDouble {
-				inSingle = !inSingle
-				continue
-			}
-		case '"':
-			if !inSingle {
-				inDouble = !inDouble
-				continue
-			}
-		}
-		if !inSingle && !inDouble && unicode.IsSpace(rune(ch)) {
-			flush()
-			continue
-		}
-		builder.WriteByte(ch)
-	}
-	flush()
-	return fields
-}
-
-func hasWriteRedirection(segment string) bool {
-	inSingle := false
-	inDouble := false
-	for i := 0; i < len(segment); i++ {
-		ch := segment[i]
-		switch ch {
-		case '\'':
-			if !inDouble {
-				inSingle = !inSingle
-			}
-		case '"':
-			if !inSingle {
-				inDouble = !inDouble
-			}
-		case '>':
-			if !inSingle && !inDouble {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func isBlockedCommand(command string, fields []string) bool {
-	switch command {
-	case "rm", "rmdir", "del", "erase", "remove-item", "ri", "rd", "format", "diskpart", "mkfs", "dd", "shutdown", "reboot", "halt", "poweroff":
-		return true
-	case "git":
-		return isBlockedGit(fields)
-	default:
-		return false
-	}
-}
-
-func isBlockedGit(fields []string) bool {
-	if len(fields) < 2 {
-		return false
-	}
-	sub := strings.ToLower(fields[1])
-	switch sub {
-	case "reset":
-		return hasAnyArg(fields[2:], "--hard")
-	case "clean":
-		for _, arg := range fields[2:] {
-			if strings.HasPrefix(arg, "-f") || strings.Contains(arg, "f") && strings.HasPrefix(arg, "-") {
-				return true
-			}
-		}
-	case "checkout":
-		return hasAnyArg(fields[2:], "--")
-	case "restore":
-		return len(fields) > 2
-	}
-	return false
-}
-
-func isReadOnlyCommand(command string, fields []string) bool {
-	switch command {
-	case "cat", "type", "ls", "dir", "pwd", "echo", "rg", "grep", "find", "where", "which", "env", "printenv", "uname", "whoami", "head", "tail", "sort", "uniq", "wc", "tree", "get-childitem", "get-content", "select-string", "get-location", "resolve-path":
-		return true
-	case "git":
-		return isReadOnlyGit(fields)
-	case "go":
-		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "env", "list", "version")
-	case "npm", "pnpm", "yarn":
-		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "list", "info", "view", "why")
-	default:
-		return false
-	}
-}
-
-func isApprovalCommand(command string, fields []string) bool {
-	switch command {
-	case "cp", "copy", "copy-item", "mv", "move", "move-item", "rename", "rename-item", "new-item", "mkdir", "md", "touch", "tee", "set-content", "add-content", "out-file":
-		return true
-	case "git":
-		return len(fields) > 1
-	case "go":
-		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "test", "build", "run", "mod", "get")
-	case "npm", "pnpm", "yarn":
-		return len(fields) > 1 && isOneOf(strings.ToLower(fields[1]), "install", "add", "remove", "update", "run")
-	case "pip", "pip3", "uv", "cargo", "make", "cmake", "python", "python3", "node", "pwsh", "powershell", "sh", "bash":
-		return true
-	default:
-		return false
-	}
-}
-
-func isReadOnlyGit(fields []string) bool {
-	if len(fields) < 2 {
-		return false
-	}
-	sub := strings.ToLower(fields[1])
-	return isOneOf(sub, "status", "diff", "log", "show", "rev-parse", "ls-files", "grep", "branch") && len(fields) == 2
-}
-
-func hasAnyArg(args []string, targets ...string) bool {
-	for _, arg := range args {
-		for _, target := range targets {
-			if strings.EqualFold(arg, target) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func isOneOf(value string, options ...string) bool {
-	for _, option := range options {
-		if value == option {
-			return true
-		}
-	}
-	return false
+	return policypkg.AssessShellCommand(command)
 }
 
 func shellCommand(ctx context.Context, command string) *exec.Cmd {


### PR DESCRIPTION
﻿## 变更背景
本 PR 解决了当前重构中的 3 个高优先/中优先边界问题：
1. shell 判定逻辑存在双份实现，容易漂移；
2. 对话语义组件落在 runtime 层，边界不清晰；
3. `core.SessionMode` 与 `plan.AgentMode` 类型并行，存在歧义。

## 主要改动
### 1) 合并 shell 判定逻辑为单一来源
- `internal/tools/run_shell.go` 删除重复的命令风险解析逻辑；
- 统一改为调用 `internal/policy/shell_command.go` 中的：
  - `AssessShellCommand`
  - `IsPlanSafeShellCommand`
- 保持原有审批交互流程不变（always/on-request/away 模式等）。

### 2) 将 stop_summary / task_report / tool_sequence 从 runtime 迁移到 agent
- 文件迁移到 `internal/agent`：
  - `stop_summary.go`
  - `task_report.go`
  - `tool_sequence.go`
- `engine_run_loop` / `turn_processing` 调用改为使用 agent 本地实现；
- runtime 目录保留任务状态机与并发执行内核能力，不再承载对话语义辅助结构。

### 3) 统一模式类型
- `plan.AgentMode` 改为 `core.SessionMode` 的别名；
- `core.SessionMode` 规范常量收敛为 `build/plan`；
- 为兼容历史数据，`default/acceptEdits/bypassPermissions` 归一映射到 `build`；
- 新增 `internal/plan/types_mode_test.go` 验证别名关系与 legacy 映射。

## 验证
已通过：
- `go test ./internal/tools -v`
- `go test ./internal/agent -v`
- `go test ./internal/plan -v`
- `go test ./internal/runtime -v`

补充：
- 全量 `go test ./...` 在当前环境中仍有 1 个与本 PR 无关的既有失败：
  - `internal/app`: `TestBootstrapEntrypointRejectsBroadWorkspaceWithoutOverride`
