### PR TITLE
Extension丨step6实现 Bridge 接入 tools 与 policy 语义

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -68,6 +68,7 @@ func (e *defaultEngine) HandleTurn(ctx context.Context, req TurnRequest) (<-chan
 			})
 			return
 		}
+		defer e.runner.clearSessionSkillBridges(req.Session)
 
 		setup, err := e.prepareRunPrompt(req.Session, req.Input, req.Mode)
 		if err != nil {

--- a/internal/agent/engine_run_setup.go
+++ b/internal/agent/engine_run_setup.go
@@ -32,7 +32,7 @@ func (e *defaultEngine) prepareRunPrompt(sess *session.Session, input RunPromptI
 	}
 
 	activeSkill := runner.resolveActiveSkill(sess)
-	if err := runner.syncActiveSkillBridges(activeSkill); err != nil {
+	if err := runner.syncActiveSkillBridges(sess, activeSkill); err != nil {
 		return runPromptSetup{}, err
 	}
 	allowedTools, deniedTools, err := resolveSkillToolSets(activeSkill, runner.registry)

--- a/internal/agent/engine_run_setup.go
+++ b/internal/agent/engine_run_setup.go
@@ -32,6 +32,9 @@ func (e *defaultEngine) prepareRunPrompt(sess *session.Session, input RunPromptI
 	}
 
 	activeSkill := runner.resolveActiveSkill(sess)
+	if err := runner.syncActiveSkillBridges(activeSkill); err != nil {
+		return runPromptSetup{}, err
+	}
 	allowedTools, deniedTools, err := resolveSkillToolSets(activeSkill, runner.registry)
 	if err != nil {
 		return runPromptSetup{}, err

--- a/internal/agent/engine_run_setup.go
+++ b/internal/agent/engine_run_setup.go
@@ -32,7 +32,10 @@ func (e *defaultEngine) prepareRunPrompt(sess *session.Session, input RunPromptI
 	}
 
 	activeSkill := runner.resolveActiveSkill(sess)
-	allowedTools, deniedTools := resolveSkillToolSets(activeSkill)
+	allowedTools, deniedTools, err := resolveSkillToolSets(activeSkill, runner.registry)
+	if err != nil {
+		return runPromptSetup{}, err
+	}
 	promptHint := policypkg.EvaluatePromptHint(userInput)
 	availableTools := []string(nil)
 	if runner.registry != nil {

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -87,9 +87,10 @@ type Runner struct {
 	stdin         io.Reader
 	stdout        io.Writer
 
-	bridgeMu                  sync.Mutex
-	activeSkillBridgeID       string
-	activeSkillBridgeToolKeys map[string]struct{}
+	bridgeMu            sync.Mutex
+	bridgeSessions      map[string]bridgeSessionState
+	bridgeSessionTurns  map[string]int
+	bridgeToolRefCounts map[string]int
 }
 
 func NewRunner(opts Options) *Runner {

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"bytemind/internal/config"
 	extensionspkg "bytemind/internal/extensions"
@@ -85,6 +86,10 @@ type Runner struct {
 	approval      tools.ApprovalHandler
 	stdin         io.Reader
 	stdout        io.Writer
+
+	bridgeMu                  sync.Mutex
+	activeSkillBridgeID       string
+	activeSkillBridgeToolKeys map[string]struct{}
 }
 
 func NewRunner(opts Options) *Runner {

--- a/internal/agent/skills_bridge_runtime.go
+++ b/internal/agent/skills_bridge_runtime.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	extensionspkg "bytemind/internal/extensions"
+	"bytemind/internal/session"
 	toolspkg "bytemind/internal/tools"
 )
 
@@ -21,7 +22,12 @@ var nonBridgedBuiltinTools = map[string]struct{}{
 	"run_shell":       {},
 }
 
-func (r *Runner) syncActiveSkillBridges(active *activeSkillRuntime) error {
+type bridgeSessionState struct {
+	extensionID string
+	toolKeys    map[string]struct{}
+}
+
+func (r *Runner) syncActiveSkillBridges(sess *session.Session, active *activeSkillRuntime) error {
 	if r == nil {
 		return nil
 	}
@@ -29,26 +35,34 @@ func (r *Runner) syncActiveSkillBridges(active *activeSkillRuntime) error {
 	if !ok || registry == nil {
 		return nil
 	}
+	sessionKey := bridgeSessionKey(sess)
+	if sessionKey == "" {
+		return nil
+	}
 
 	r.bridgeMu.Lock()
 	defer r.bridgeMu.Unlock()
+	r.ensureBridgeStateLocked()
+	r.bridgeSessionTurns[sessionKey]++
 
+	state := r.bridgeSessions[sessionKey]
+	if state.toolKeys == nil {
+		state.toolKeys = map[string]struct{}{}
+	}
 	if active == nil {
-		r.clearActiveSkillBridgesLocked(registry)
-		return nil
+		return r.clearSessionBridgesLocked(registry, sessionKey)
 	}
 
 	extensionID := activeSkillExtensionID(active)
 	if extensionID == "" {
-		r.clearActiveSkillBridgesLocked(registry)
-		return nil
+		return r.clearSessionBridgesLocked(registry, sessionKey)
 	}
-	if r.activeSkillBridgeID != extensionID {
-		r.clearActiveSkillBridgesLocked(registry)
-		r.activeSkillBridgeID = extensionID
-	}
-	if r.activeSkillBridgeToolKeys == nil {
-		r.activeSkillBridgeToolKeys = map[string]struct{}{}
+	if state.extensionID != extensionID {
+		if err := r.releaseBridgeToolsLocked(registry, state.toolKeys); err != nil {
+			return err
+		}
+		state.extensionID = extensionID
+		state.toolKeys = map[string]struct{}{}
 	}
 
 	desired := map[string]struct{}{}
@@ -86,33 +100,117 @@ func (r *Runner) syncActiveSkillBridges(active *activeSkillRuntime) error {
 		desired[binding.StableKey] = struct{}{}
 	}
 
-	for toolKey := range r.activeSkillBridgeToolKeys {
+	for toolKey := range state.toolKeys {
 		if _, keep := desired[toolKey]; keep {
 			continue
 		}
+		if err := r.releaseBridgeToolRefLocked(registry, toolKey); err != nil {
+			return err
+		}
+	}
+
+	for toolKey := range desired {
+		if _, exists := state.toolKeys[toolKey]; exists {
+			continue
+		}
+		r.bridgeToolRefCounts[toolKey]++
+	}
+	state.toolKeys = desired
+	r.bridgeSessions[sessionKey] = state
+
+	return nil
+}
+
+func (r *Runner) clearSessionSkillBridges(sess *session.Session) {
+	if r == nil {
+		return
+	}
+	registry, ok := r.registry.(*toolspkg.Registry)
+	if !ok || registry == nil {
+		return
+	}
+	sessionKey := bridgeSessionKey(sess)
+	if sessionKey == "" {
+		return
+	}
+
+	r.bridgeMu.Lock()
+	defer r.bridgeMu.Unlock()
+	turns := r.bridgeSessionTurns[sessionKey]
+	if turns <= 0 {
+		return
+	}
+	turns--
+	if turns > 0 {
+		r.bridgeSessionTurns[sessionKey] = turns
+		return
+	}
+	delete(r.bridgeSessionTurns, sessionKey)
+	_ = r.clearSessionBridgesLocked(registry, sessionKey)
+}
+
+func (r *Runner) ensureBridgeStateLocked() {
+	if r.bridgeSessions == nil {
+		r.bridgeSessions = map[string]bridgeSessionState{}
+	}
+	if r.bridgeSessionTurns == nil {
+		r.bridgeSessionTurns = map[string]int{}
+	}
+	if r.bridgeToolRefCounts == nil {
+		r.bridgeToolRefCounts = map[string]int{}
+	}
+}
+
+func (r *Runner) clearSessionBridgesLocked(registry *toolspkg.Registry, sessionKey string) error {
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return nil
+	}
+	state, ok := r.bridgeSessions[sessionKey]
+	if !ok {
+		return nil
+	}
+	if err := r.releaseBridgeToolsLocked(registry, state.toolKeys); err != nil {
+		return err
+	}
+	delete(r.bridgeSessions, sessionKey)
+	return nil
+}
+
+func (r *Runner) releaseBridgeToolsLocked(registry *toolspkg.Registry, toolKeys map[string]struct{}) error {
+	for toolKey := range toolKeys {
+		if err := r.releaseBridgeToolRefLocked(registry, toolKey); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Runner) releaseBridgeToolRefLocked(registry *toolspkg.Registry, toolKey string) error {
+	toolKey = strings.TrimSpace(toolKey)
+	if toolKey == "" {
+		return nil
+	}
+	refs := r.bridgeToolRefCounts[toolKey]
+	if refs <= 1 {
+		delete(r.bridgeToolRefCounts, toolKey)
 		if err := registry.Unregister(toolKey); err != nil {
 			var regErr *toolspkg.RegistryError
 			if !errors.As(err, &regErr) || regErr.Code != toolspkg.RegistryErrorNotFound {
 				return err
 			}
 		}
-		delete(r.activeSkillBridgeToolKeys, toolKey)
+		return nil
 	}
-	for toolKey := range desired {
-		r.activeSkillBridgeToolKeys[toolKey] = struct{}{}
-	}
-
+	r.bridgeToolRefCounts[toolKey] = refs - 1
 	return nil
 }
 
-func (r *Runner) clearActiveSkillBridgesLocked(registry *toolspkg.Registry) {
-	if registry != nil {
-		for toolKey := range r.activeSkillBridgeToolKeys {
-			_ = registry.Unregister(toolKey)
-		}
+func bridgeSessionKey(sess *session.Session) string {
+	if sess == nil {
+		return ""
 	}
-	r.activeSkillBridgeID = ""
-	r.activeSkillBridgeToolKeys = map[string]struct{}{}
+	return strings.TrimSpace(sess.ID)
 }
 
 func normalizeBridgePolicyItem(item string) string {

--- a/internal/agent/skills_bridge_runtime.go
+++ b/internal/agent/skills_bridge_runtime.go
@@ -1,0 +1,131 @@
+package agent
+
+import (
+	"errors"
+	"strings"
+
+	extensionspkg "bytemind/internal/extensions"
+	toolspkg "bytemind/internal/tools"
+)
+
+var nonBridgedBuiltinTools = map[string]struct{}{
+	"list_files":      {},
+	"read_file":       {},
+	"search_text":     {},
+	"web_search":      {},
+	"web_fetch":       {},
+	"write_file":      {},
+	"replace_in_file": {},
+	"apply_patch":     {},
+	"update_plan":     {},
+	"run_shell":       {},
+}
+
+func (r *Runner) syncActiveSkillBridges(active *activeSkillRuntime) error {
+	if r == nil {
+		return nil
+	}
+	registry, ok := r.registry.(*toolspkg.Registry)
+	if !ok || registry == nil {
+		return nil
+	}
+
+	r.bridgeMu.Lock()
+	defer r.bridgeMu.Unlock()
+
+	if active == nil {
+		r.clearActiveSkillBridgesLocked(registry)
+		return nil
+	}
+
+	extensionID := activeSkillExtensionID(active)
+	if extensionID == "" {
+		r.clearActiveSkillBridgesLocked(registry)
+		return nil
+	}
+	if r.activeSkillBridgeID != extensionID {
+		r.clearActiveSkillBridgesLocked(registry)
+		r.activeSkillBridgeID = extensionID
+	}
+	if r.activeSkillBridgeToolKeys == nil {
+		r.activeSkillBridgeToolKeys = map[string]struct{}{}
+	}
+
+	desired := map[string]struct{}{}
+	for _, item := range active.Skill.ToolPolicy.Items {
+		original := normalizeBridgePolicyItem(item)
+		if original == "" || !shouldBridgePolicyItem(original) {
+			continue
+		}
+		resolved, exists := registry.Get(original)
+		if !exists {
+			continue
+		}
+		binding, err := extensionspkg.RegisterBridgedToolWithOptions(registry, extensionspkg.ExtensionTool{
+			Source:      extensionspkg.ExtensionSkill,
+			ExtensionID: extensionID,
+			Tool:        resolved.Tool,
+		}, extensionspkg.BridgeRegisterOptions{
+			AllowOriginalNameShadowBuiltin: true,
+		})
+		if err != nil {
+			stableKey, stableErr := extensionspkg.StableToolKey(extensionspkg.ExtensionSkill, extensionID, original)
+			if stableErr != nil {
+				return err
+			}
+			if _, ok := registry.Get(stableKey); !ok {
+				return err
+			}
+			binding = extensionspkg.BridgeBinding{
+				Source:       extensionspkg.ExtensionSkill,
+				ExtensionID:  extensionID,
+				OriginalName: original,
+				StableKey:    stableKey,
+			}
+		}
+		desired[binding.StableKey] = struct{}{}
+	}
+
+	for toolKey := range r.activeSkillBridgeToolKeys {
+		if _, keep := desired[toolKey]; keep {
+			continue
+		}
+		if err := registry.Unregister(toolKey); err != nil {
+			var regErr *toolspkg.RegistryError
+			if !errors.As(err, &regErr) || regErr.Code != toolspkg.RegistryErrorNotFound {
+				return err
+			}
+		}
+		delete(r.activeSkillBridgeToolKeys, toolKey)
+	}
+	for toolKey := range desired {
+		r.activeSkillBridgeToolKeys[toolKey] = struct{}{}
+	}
+
+	return nil
+}
+
+func (r *Runner) clearActiveSkillBridgesLocked(registry *toolspkg.Registry) {
+	if registry != nil {
+		for toolKey := range r.activeSkillBridgeToolKeys {
+			_ = registry.Unregister(toolKey)
+		}
+	}
+	r.activeSkillBridgeID = ""
+	r.activeSkillBridgeToolKeys = map[string]struct{}{}
+}
+
+func normalizeBridgePolicyItem(item string) string {
+	return strings.TrimSpace(item)
+}
+
+func shouldBridgePolicyItem(item string) bool {
+	if item == "" {
+		return false
+	}
+	if strings.Contains(item, ":") {
+		return false
+	}
+	_, blocked := nonBridgedBuiltinTools[strings.ToLower(item)]
+	return !blocked
+}

--- a/internal/agent/skills_bridge_runtime_test.go
+++ b/internal/agent/skills_bridge_runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"bytemind/internal/llm"
@@ -151,5 +152,209 @@ allowed-tools: "open_doc"
 	}
 	if !slices.Contains(setup.AllowedToolNames, "skill:skill_plan:open_doc") {
 		t.Fatalf("expected plan stable key in allowlist, got %#v", setup.AllowedToolNames)
+	}
+}
+
+func TestPrepareRunPromptSessionIsolationKeepsOtherSessionBridges(t *testing.T) {
+	workspace := t.TempDir()
+	builtinDir := filepath.Join(workspace, "builtin")
+	userDir := filepath.Join(workspace, "user")
+	projectDir := filepath.Join(workspace, "project")
+	for _, name := range []string{"review", "plan"} {
+		dir := filepath.Join(builtinDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(`---
+name: `+name+`
+allowed-tools: "open_doc"
+---
+# /`+name+`
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	skillManager := skills.NewManagerWithDirs(workspace, builtinDir, userDir, projectDir)
+	registry := tools.DefaultRegistry()
+	if err := registry.Register(runtimeBridgeTool{name: "open_doc"}, tools.RegisterOptions{
+		Source: tools.RegistrationSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("register open_doc failed: %v", err)
+	}
+	runner := NewRunner(Options{
+		Workspace:    workspace,
+		Registry:     registry,
+		SkillManager: skillManager,
+		Stdin:        strings.NewReader(""),
+		Stdout:       io.Discard,
+	})
+
+	sessReview := session.New(workspace)
+	sessReview.ActiveSkill = &session.ActiveSkill{Name: "review"}
+	if _, err := runner.prepareRunPrompt(sessReview, RunPromptInput{
+		UserMessage: llm.NewUserTextMessage("review"),
+		DisplayText: "review",
+	}, "build"); err != nil {
+		t.Fatalf("prepareRunPrompt review failed: %v", err)
+	}
+
+	sessPlan := session.New(workspace)
+	sessPlan.ActiveSkill = &session.ActiveSkill{Name: "plan"}
+	if _, err := runner.prepareRunPrompt(sessPlan, RunPromptInput{
+		UserMessage: llm.NewUserTextMessage("plan"),
+		DisplayText: "plan",
+	}, "build"); err != nil {
+		t.Fatalf("prepareRunPrompt plan failed: %v", err)
+	}
+
+	if len(registry.FindByExtensionID("skill.review")) == 0 {
+		t.Fatalf("expected review bridge metadata to remain registered for review session")
+	}
+	if len(registry.FindByExtensionID("skill.plan")) == 0 {
+		t.Fatalf("expected plan bridge metadata to be registered")
+	}
+}
+
+func TestClearSessionSkillBridgesHonorsSharedBridgeReferences(t *testing.T) {
+	workspace := t.TempDir()
+	builtinDir := filepath.Join(workspace, "builtin")
+	userDir := filepath.Join(workspace, "user")
+	projectDir := filepath.Join(workspace, "project")
+	reviewDir := filepath.Join(builtinDir, "review")
+	if err := os.MkdirAll(reviewDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(reviewDir, "SKILL.md"), []byte(`---
+name: review
+allowed-tools: "open_doc"
+---
+# /review
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skillManager := skills.NewManagerWithDirs(workspace, builtinDir, userDir, projectDir)
+	registry := tools.DefaultRegistry()
+	if err := registry.Register(runtimeBridgeTool{name: "open_doc"}, tools.RegisterOptions{
+		Source: tools.RegistrationSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("register open_doc failed: %v", err)
+	}
+	runner := NewRunner(Options{
+		Workspace:    workspace,
+		Registry:     registry,
+		SkillManager: skillManager,
+		Stdin:        strings.NewReader(""),
+		Stdout:       io.Discard,
+	})
+
+	sessA := session.New(workspace)
+	sessA.ActiveSkill = &session.ActiveSkill{Name: "review"}
+	sessB := session.New(workspace)
+	sessB.ActiveSkill = &session.ActiveSkill{Name: "review"}
+
+	if _, err := runner.prepareRunPrompt(sessA, RunPromptInput{
+		UserMessage: llm.NewUserTextMessage("a"),
+		DisplayText: "a",
+	}, "build"); err != nil {
+		t.Fatalf("prepareRunPrompt session A failed: %v", err)
+	}
+	if _, err := runner.prepareRunPrompt(sessB, RunPromptInput{
+		UserMessage: llm.NewUserTextMessage("b"),
+		DisplayText: "b",
+	}, "build"); err != nil {
+		t.Fatalf("prepareRunPrompt session B failed: %v", err)
+	}
+
+	stable := "skill:skill_review:open_doc"
+	if _, ok := registry.Get(stable); !ok {
+		t.Fatalf("expected shared bridge tool %q", stable)
+	}
+
+	runner.clearSessionSkillBridges(sessA)
+	if _, ok := registry.Get(stable); !ok {
+		t.Fatalf("expected bridge tool %q to stay while another session still references it", stable)
+	}
+
+	runner.clearSessionSkillBridges(sessB)
+	if _, ok := registry.Get(stable); ok {
+		t.Fatalf("expected bridge tool %q to be removed after last session is cleared", stable)
+	}
+}
+
+func TestPrepareRunPromptConcurrentSessionsIsolation(t *testing.T) {
+	workspace := t.TempDir()
+	builtinDir := filepath.Join(workspace, "builtin")
+	userDir := filepath.Join(workspace, "user")
+	projectDir := filepath.Join(workspace, "project")
+	for _, name := range []string{"review", "plan"} {
+		dir := filepath.Join(builtinDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(`---
+name: `+name+`
+allowed-tools: "open_doc"
+---
+# /`+name+`
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	skillManager := skills.NewManagerWithDirs(workspace, builtinDir, userDir, projectDir)
+	registry := tools.DefaultRegistry()
+	if err := registry.Register(runtimeBridgeTool{name: "open_doc"}, tools.RegisterOptions{
+		Source: tools.RegistrationSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("register open_doc failed: %v", err)
+	}
+	runner := NewRunner(Options{
+		Workspace:    workspace,
+		Registry:     registry,
+		SkillManager: skillManager,
+		Stdin:        strings.NewReader(""),
+		Stdout:       io.Discard,
+	})
+
+	sessReview := session.New(workspace)
+	sessReview.ActiveSkill = &session.ActiveSkill{Name: "review"}
+	sessPlan := session.New(workspace)
+	sessPlan.ActiveSkill = &session.ActiveSkill{Name: "plan"}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, err := runner.prepareRunPrompt(sessReview, RunPromptInput{
+			UserMessage: llm.NewUserTextMessage("review"),
+			DisplayText: "review",
+		}, "build")
+		errs <- err
+	}()
+	go func() {
+		defer wg.Done()
+		_, err := runner.prepareRunPrompt(sessPlan, RunPromptInput{
+			UserMessage: llm.NewUserTextMessage("plan"),
+			DisplayText: "plan",
+		}, "build")
+		errs <- err
+	}()
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("prepareRunPrompt failed: %v", err)
+		}
+	}
+
+	if len(registry.FindByExtensionID("skill.review")) == 0 {
+		t.Fatalf("expected review bridge metadata after concurrent sync")
+	}
+	if len(registry.FindByExtensionID("skill.plan")) == 0 {
+		t.Fatalf("expected plan bridge metadata after concurrent sync")
 	}
 }

--- a/internal/agent/skills_bridge_runtime_test.go
+++ b/internal/agent/skills_bridge_runtime_test.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"bytemind/internal/llm"
+	"bytemind/internal/session"
+	"bytemind/internal/skills"
+	"bytemind/internal/tools"
+)
+
+type runtimeBridgeTool struct {
+	name string
+}
+
+func (t runtimeBridgeTool) Definition() llm.ToolDefinition {
+	return llm.ToolDefinition{
+		Type: "function",
+		Function: llm.FunctionDefinition{
+			Name:        t.name,
+			Description: "runtime bridge tool",
+			Parameters:  map[string]any{"type": "object"},
+		},
+	}
+}
+
+func (runtimeBridgeTool) Run(context.Context, json.RawMessage, *tools.ExecutionContext) (string, error) {
+	return `{"ok":true}`, nil
+}
+
+func TestPrepareRunPromptRegistersActiveSkillBridgeTools(t *testing.T) {
+	workspace := t.TempDir()
+	builtinDir := filepath.Join(workspace, "builtin")
+	userDir := filepath.Join(workspace, "user")
+	projectDir := filepath.Join(workspace, "project")
+	reviewDir := filepath.Join(builtinDir, "review")
+	if err := os.MkdirAll(reviewDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(reviewDir, "SKILL.md"), []byte(`---
+name: review
+allowed-tools: "open_doc"
+---
+# /review
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skillManager := skills.NewManagerWithDirs(workspace, builtinDir, userDir, projectDir)
+	registry := tools.DefaultRegistry()
+	if err := registry.Register(runtimeBridgeTool{name: "open_doc"}, tools.RegisterOptions{
+		Source: tools.RegistrationSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("register open_doc failed: %v", err)
+	}
+	runner := NewRunner(Options{
+		Workspace:    workspace,
+		Registry:     registry,
+		SkillManager: skillManager,
+		Stdin:        strings.NewReader(""),
+		Stdout:       io.Discard,
+	})
+	sess := session.New(workspace)
+	sess.ActiveSkill = &session.ActiveSkill{Name: "review"}
+
+	setup, err := runner.prepareRunPrompt(sess, RunPromptInput{
+		UserMessage: llm.NewUserTextMessage("bridge setup"),
+		DisplayText: "bridge setup",
+	}, "build")
+	if err != nil {
+		t.Fatalf("prepareRunPrompt failed: %v", err)
+	}
+
+	expectedStable := "skill:skill_review:open_doc"
+	if !slices.Contains(setup.AllowedToolNames, expectedStable) {
+		t.Fatalf("expected stable bridge key in allowlist, got %#v", setup.AllowedToolNames)
+	}
+	if slices.Contains(setup.AllowedToolNames, "open_doc") {
+		t.Fatalf("did not expect legacy tool name in allowlist after bridge, got %#v", setup.AllowedToolNames)
+	}
+	metas := registry.FindByExtensionID("skill.review")
+	if len(metas) == 0 {
+		t.Fatal("expected extension bridge metadata to be registered")
+	}
+}
+
+func TestPrepareRunPromptSwitchingActiveSkillReplacesBridgeTools(t *testing.T) {
+	workspace := t.TempDir()
+	builtinDir := filepath.Join(workspace, "builtin")
+	userDir := filepath.Join(workspace, "user")
+	projectDir := filepath.Join(workspace, "project")
+	for _, name := range []string{"review", "plan"} {
+		dir := filepath.Join(builtinDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(`---
+name: `+name+`
+allowed-tools: "open_doc"
+---
+# /`+name+`
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	skillManager := skills.NewManagerWithDirs(workspace, builtinDir, userDir, projectDir)
+	registry := tools.DefaultRegistry()
+	if err := registry.Register(runtimeBridgeTool{name: "open_doc"}, tools.RegisterOptions{
+		Source: tools.RegistrationSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("register open_doc failed: %v", err)
+	}
+	runner := NewRunner(Options{
+		Workspace:    workspace,
+		Registry:     registry,
+		SkillManager: skillManager,
+		Stdin:        strings.NewReader(""),
+		Stdout:       io.Discard,
+	})
+	sess := session.New(workspace)
+	sess.ActiveSkill = &session.ActiveSkill{Name: "review"}
+	if _, err := runner.prepareRunPrompt(sess, RunPromptInput{
+		UserMessage: llm.NewUserTextMessage("review"),
+		DisplayText: "review",
+	}, "build"); err != nil {
+		t.Fatalf("prepareRunPrompt review failed: %v", err)
+	}
+
+	sess.ActiveSkill = &session.ActiveSkill{Name: "plan"}
+	setup, err := runner.prepareRunPrompt(sess, RunPromptInput{
+		UserMessage: llm.NewUserTextMessage("plan"),
+		DisplayText: "plan",
+	}, "build")
+	if err != nil {
+		t.Fatalf("prepareRunPrompt plan failed: %v", err)
+	}
+
+	if len(registry.FindByExtensionID("skill.review")) != 0 {
+		t.Fatalf("expected stale review bridge metadata to be removed")
+	}
+	if len(registry.FindByExtensionID("skill.plan")) == 0 {
+		t.Fatalf("expected active plan bridge metadata")
+	}
+	if !slices.Contains(setup.AllowedToolNames, "skill:skill_plan:open_doc") {
+		t.Fatalf("expected plan stable key in allowlist, got %#v", setup.AllowedToolNames)
+	}
+}

--- a/internal/agent/skills_bridge_runtime_test.go
+++ b/internal/agent/skills_bridge_runtime_test.go
@@ -102,9 +102,13 @@ func TestPrepareRunPromptSwitchingActiveSkillReplacesBridgeTools(t *testing.T) {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
+		allowed := "open_doc"
+		if name == "plan" {
+			allowed = "plan_doc"
+		}
 		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(`---
 name: `+name+`
-allowed-tools: "open_doc"
+allowed-tools: "`+allowed+`"
 ---
 # /`+name+`
 `), 0o644); err != nil {
@@ -118,6 +122,11 @@ allowed-tools: "open_doc"
 		Source: tools.RegistrationSourceBuiltin,
 	}); err != nil {
 		t.Fatalf("register open_doc failed: %v", err)
+	}
+	if err := registry.Register(runtimeBridgeTool{name: "plan_doc"}, tools.RegisterOptions{
+		Source: tools.RegistrationSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("register plan_doc failed: %v", err)
 	}
 	runner := NewRunner(Options{
 		Workspace:    workspace,
@@ -150,7 +159,7 @@ allowed-tools: "open_doc"
 	if len(registry.FindByExtensionID("skill.plan")) == 0 {
 		t.Fatalf("expected active plan bridge metadata")
 	}
-	if !slices.Contains(setup.AllowedToolNames, "skill:skill_plan:open_doc") {
+	if !slices.Contains(setup.AllowedToolNames, "skill:skill_plan:plan_doc") {
 		t.Fatalf("expected plan stable key in allowlist, got %#v", setup.AllowedToolNames)
 	}
 }
@@ -165,9 +174,13 @@ func TestPrepareRunPromptSessionIsolationKeepsOtherSessionBridges(t *testing.T) 
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
+		allowed := "open_doc"
+		if name == "plan" {
+			allowed = "plan_doc"
+		}
 		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(`---
 name: `+name+`
-allowed-tools: "open_doc"
+allowed-tools: "`+allowed+`"
 ---
 # /`+name+`
 `), 0o644); err != nil {
@@ -181,6 +194,11 @@ allowed-tools: "open_doc"
 		Source: tools.RegistrationSourceBuiltin,
 	}); err != nil {
 		t.Fatalf("register open_doc failed: %v", err)
+	}
+	if err := registry.Register(runtimeBridgeTool{name: "plan_doc"}, tools.RegisterOptions{
+		Source: tools.RegistrationSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("register plan_doc failed: %v", err)
 	}
 	runner := NewRunner(Options{
 		Workspace:    workspace,
@@ -293,9 +311,13 @@ func TestPrepareRunPromptConcurrentSessionsIsolation(t *testing.T) {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
+		allowed := "open_doc"
+		if name == "plan" {
+			allowed = "plan_doc"
+		}
 		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(`---
 name: `+name+`
-allowed-tools: "open_doc"
+allowed-tools: "`+allowed+`"
 ---
 # /`+name+`
 `), 0o644); err != nil {
@@ -309,6 +331,11 @@ allowed-tools: "open_doc"
 		Source: tools.RegistrationSourceBuiltin,
 	}); err != nil {
 		t.Fatalf("register open_doc failed: %v", err)
+	}
+	if err := registry.Register(runtimeBridgeTool{name: "plan_doc"}, tools.RegisterOptions{
+		Source: tools.RegistrationSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("register plan_doc failed: %v", err)
 	}
 	runner := NewRunner(Options{
 		Workspace:    workspace,

--- a/internal/agent/skills_bridge_runtime_test.go
+++ b/internal/agent/skills_bridge_runtime_test.go
@@ -311,13 +311,9 @@ func TestPrepareRunPromptConcurrentSessionsIsolation(t *testing.T) {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		allowed := "open_doc"
-		if name == "plan" {
-			allowed = "plan_doc"
-		}
 		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(`---
 name: `+name+`
-allowed-tools: "`+allowed+`"
+allowed-tools: "open_doc"
 ---
 # /`+name+`
 `), 0o644); err != nil {
@@ -331,11 +327,6 @@ allowed-tools: "`+allowed+`"
 		Source: tools.RegistrationSourceBuiltin,
 	}); err != nil {
 		t.Fatalf("register open_doc failed: %v", err)
-	}
-	if err := registry.Register(runtimeBridgeTool{name: "plan_doc"}, tools.RegisterOptions{
-		Source: tools.RegistrationSourceBuiltin,
-	}); err != nil {
-		t.Fatalf("register plan_doc failed: %v", err)
 	}
 	runner := NewRunner(Options{
 		Workspace:    workspace,
@@ -383,5 +374,11 @@ allowed-tools: "`+allowed+`"
 	}
 	if len(registry.FindByExtensionID("skill.plan")) == 0 {
 		t.Fatalf("expected plan bridge metadata after concurrent sync")
+	}
+	if _, ok := registry.Get("skill:skill_review:open_doc"); !ok {
+		t.Fatalf("expected review bridge tool to be registered")
+	}
+	if _, ok := registry.Get("skill:skill_plan:open_doc"); !ok {
+		t.Fatalf("expected plan bridge tool to be registered")
 	}
 }

--- a/internal/agent/skills_runtime.go
+++ b/internal/agent/skills_runtime.go
@@ -103,14 +103,7 @@ func activeSkillExtensionID(active *activeSkillRuntime) string {
 	if active == nil {
 		return ""
 	}
-	name := strings.TrimSpace(active.Skill.Name)
-	if name == "" {
-		return ""
-	}
-	if strings.HasPrefix(strings.ToLower(name), "skill.") {
-		return name
-	}
-	return "skill." + name
+	return extensionspkg.SkillExtensionID(active.Skill.Name)
 }
 
 func bridgeSourceFromStableKey(stable string) extensionspkg.ExtensionKind {

--- a/internal/agent/skills_runtime.go
+++ b/internal/agent/skills_runtime.go
@@ -7,10 +7,12 @@ import (
 	"time"
 	"unicode"
 
+	extensionspkg "bytemind/internal/extensions"
 	"bytemind/internal/llm"
 	policypkg "bytemind/internal/policy"
 	"bytemind/internal/session"
 	"bytemind/internal/skills"
+	toolspkg "bytemind/internal/tools"
 )
 
 type activeSkillRuntime struct {
@@ -38,11 +40,93 @@ func (r *Runner) resolveActiveSkill(sess *session.Session) *activeSkillRuntime {
 	}
 }
 
-func resolveSkillToolSets(active *activeSkillRuntime) (map[string]struct{}, map[string]struct{}) {
+func resolveSkillToolSets(active *activeSkillRuntime, registry ToolRegistry) (map[string]struct{}, map[string]struct{}, error) {
 	if active == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
-	return policypkg.ResolveToolSets(active.Skill.ToolPolicy)
+	bindings := activeSkillBridgeBindings(active, registry)
+	if len(bindings) == 0 {
+		allow, deny := policypkg.ResolveToolSets(active.Skill.ToolPolicy)
+		return allow, deny, nil
+	}
+	allow, deny, err := extensionspkg.ResolvePolicyToolSets(active.Skill.ToolPolicy, bindings)
+	if err != nil {
+		return nil, nil, err
+	}
+	return allow, deny, nil
+}
+
+type extensionToolMetaFinder interface {
+	FindByExtensionID(extensionID string) []toolspkg.RegistrationMeta
+}
+
+func activeSkillBridgeBindings(active *activeSkillRuntime, registry ToolRegistry) []extensionspkg.BridgeBinding {
+	if active == nil || registry == nil {
+		return nil
+	}
+	finder, ok := registry.(extensionToolMetaFinder)
+	if !ok {
+		return nil
+	}
+	extensionID := activeSkillExtensionID(active)
+	if extensionID == "" {
+		return nil
+	}
+	metas := finder.FindByExtensionID(extensionID)
+	if len(metas) == 0 {
+		return nil
+	}
+	bindings := make([]extensionspkg.BridgeBinding, 0, len(metas))
+	for _, meta := range metas {
+		if meta.Source != toolspkg.RegistrationSourceExtension {
+			continue
+		}
+		stable := strings.TrimSpace(meta.StableToolKey)
+		if stable == "" {
+			stable = strings.TrimSpace(meta.ToolKey)
+		}
+		original := strings.TrimSpace(meta.OriginalToolName)
+		if stable == "" || original == "" {
+			continue
+		}
+		bindings = append(bindings, extensionspkg.BridgeBinding{
+			Source:       bridgeSourceFromStableKey(stable),
+			ExtensionID:  strings.TrimSpace(meta.ExtensionID),
+			OriginalName: original,
+			StableKey:    stable,
+		})
+	}
+	return bindings
+}
+
+func activeSkillExtensionID(active *activeSkillRuntime) string {
+	if active == nil {
+		return ""
+	}
+	name := strings.TrimSpace(active.Skill.Name)
+	if name == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(name), "skill.") {
+		return name
+	}
+	return "skill." + name
+}
+
+func bridgeSourceFromStableKey(stable string) extensionspkg.ExtensionKind {
+	stable = strings.TrimSpace(stable)
+	if stable == "" {
+		return extensionspkg.ExtensionSkill
+	}
+	segments := strings.SplitN(stable, ":", 2)
+	switch strings.ToLower(strings.TrimSpace(segments[0])) {
+	case string(extensionspkg.ExtensionMCP):
+		return extensionspkg.ExtensionMCP
+	case string(extensionspkg.ExtensionSkill):
+		return extensionspkg.ExtensionSkill
+	default:
+		return extensionspkg.ExtensionSkill
+	}
 }
 
 func promptActiveSkill(active *activeSkillRuntime) *PromptActiveSkill {

--- a/internal/agent/skills_runtime_test.go
+++ b/internal/agent/skills_runtime_test.go
@@ -121,3 +121,37 @@ func TestResolveSkillToolSetsFallsBackWithoutBridgeBindings(t *testing.T) {
 		t.Fatalf("expected read_file in allow set, got %#v", allow)
 	}
 }
+
+func TestResolveSkillToolSetsDenylistIncludesOriginalAndStableKeys(t *testing.T) {
+	registry := &toolspkg.Registry{}
+	if err := registry.Register(skillRuntimeTestTool{name: "skill:skill_review:open_doc"}, toolspkg.RegisterOptions{
+		Source:       toolspkg.RegistrationSourceExtension,
+		ExtensionID:  "skill.review",
+		OriginalName: "open_doc",
+	}); err != nil {
+		t.Fatalf("register extension tool failed: %v", err)
+	}
+
+	active := &activeSkillRuntime{
+		Skill: skillspkg.Skill{
+			Name: "review",
+			ToolPolicy: skillspkg.ToolPolicy{
+				Policy: skillspkg.ToolPolicyDenylist,
+				Items:  []string{"open_doc"},
+			},
+		},
+	}
+	allow, deny, err := resolveSkillToolSets(active, registry)
+	if err != nil {
+		t.Fatalf("resolveSkillToolSets failed: %v", err)
+	}
+	if allow != nil {
+		t.Fatalf("expected nil allow set for denylist, got %#v", allow)
+	}
+	if _, ok := deny["skill:skill_review:open_doc"]; !ok {
+		t.Fatalf("expected stable key in deny set, got %#v", deny)
+	}
+	if _, ok := deny["open_doc"]; !ok {
+		t.Fatalf("expected original key in deny set, got %#v", deny)
+	}
+}

--- a/internal/agent/skills_runtime_test.go
+++ b/internal/agent/skills_runtime_test.go
@@ -66,6 +66,40 @@ func TestResolveSkillToolSetsMapsActiveSkillPolicyToStableKeys(t *testing.T) {
 	}
 }
 
+func TestResolveSkillToolSetsMapsWhenSkillNameAlreadyHasPrefix(t *testing.T) {
+	registry := &toolspkg.Registry{}
+	if err := registry.Register(skillRuntimeTestTool{name: "skill:skill_skill_review:open_doc"}, toolspkg.RegisterOptions{
+		Source:       toolspkg.RegistrationSourceExtension,
+		ExtensionID:  "skill.skill.review",
+		OriginalName: "open_doc",
+	}); err != nil {
+		t.Fatalf("register extension tool failed: %v", err)
+	}
+
+	active := &activeSkillRuntime{
+		Skill: skillspkg.Skill{
+			Name: "skill.review",
+			ToolPolicy: skillspkg.ToolPolicy{
+				Policy: skillspkg.ToolPolicyAllowlist,
+				Items:  []string{"open_doc"},
+			},
+		},
+	}
+	allow, deny, err := resolveSkillToolSets(active, registry)
+	if err != nil {
+		t.Fatalf("resolveSkillToolSets failed: %v", err)
+	}
+	if deny != nil {
+		t.Fatalf("expected nil deny set, got %#v", deny)
+	}
+	if _, ok := allow["skill:skill_skill_review:open_doc"]; !ok {
+		t.Fatalf("expected stable tool key in allow set, got %#v", allow)
+	}
+	if _, ok := allow["open_doc"]; ok {
+		t.Fatalf("did not expect original tool name in allow set, got %#v", allow)
+	}
+}
+
 func TestResolveSkillToolSetsFallsBackWithoutBridgeBindings(t *testing.T) {
 	active := &activeSkillRuntime{
 		Skill: skillspkg.Skill{

--- a/internal/agent/skills_runtime_test.go
+++ b/internal/agent/skills_runtime_test.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"bytemind/internal/llm"
+	skillspkg "bytemind/internal/skills"
+	toolspkg "bytemind/internal/tools"
+)
+
+type skillRuntimeTestTool struct {
+	name string
+}
+
+func (t skillRuntimeTestTool) Definition() llm.ToolDefinition {
+	return llm.ToolDefinition{
+		Type: "function",
+		Function: llm.FunctionDefinition{
+			Name:        t.name,
+			Description: "skills runtime test tool",
+			Parameters:  map[string]any{"type": "object"},
+		},
+	}
+}
+
+func (skillRuntimeTestTool) Run(context.Context, json.RawMessage, *toolspkg.ExecutionContext) (string, error) {
+	return "ok", nil
+}
+
+func TestResolveSkillToolSetsMapsActiveSkillPolicyToStableKeys(t *testing.T) {
+	registry := &toolspkg.Registry{}
+	if err := registry.Register(skillRuntimeTestTool{name: "skill:skill_review:open_doc"}, toolspkg.RegisterOptions{
+		Source:       toolspkg.RegistrationSourceExtension,
+		ExtensionID:  "skill.review",
+		OriginalName: "Open_Doc",
+	}); err != nil {
+		t.Fatalf("register extension tool failed: %v", err)
+	}
+
+	active := &activeSkillRuntime{
+		Skill: skillspkg.Skill{
+			Name: "review",
+			ToolPolicy: skillspkg.ToolPolicy{
+				Policy: skillspkg.ToolPolicyAllowlist,
+				Items:  []string{"open_doc", "read_file"},
+			},
+		},
+	}
+	allow, deny, err := resolveSkillToolSets(active, registry)
+	if err != nil {
+		t.Fatalf("resolveSkillToolSets failed: %v", err)
+	}
+	if deny != nil {
+		t.Fatalf("expected nil deny set, got %#v", deny)
+	}
+	if _, ok := allow["skill:skill_review:open_doc"]; !ok {
+		t.Fatalf("expected stable tool key in allow set, got %#v", allow)
+	}
+	if _, ok := allow["open_doc"]; ok {
+		t.Fatalf("did not expect original tool name in allow set, got %#v", allow)
+	}
+	if _, ok := allow["read_file"]; !ok {
+		t.Fatalf("expected builtin tool name to remain in allow set, got %#v", allow)
+	}
+}
+
+func TestResolveSkillToolSetsFallsBackWithoutBridgeBindings(t *testing.T) {
+	active := &activeSkillRuntime{
+		Skill: skillspkg.Skill{
+			Name: "review",
+			ToolPolicy: skillspkg.ToolPolicy{
+				Policy: skillspkg.ToolPolicyAllowlist,
+				Items:  []string{"read_file"},
+			},
+		},
+	}
+	allow, deny, err := resolveSkillToolSets(active, nil)
+	if err != nil {
+		t.Fatalf("resolveSkillToolSets failed: %v", err)
+	}
+	if deny != nil {
+		t.Fatalf("expected nil deny set, got %#v", deny)
+	}
+	if _, ok := allow["read_file"]; !ok {
+		t.Fatalf("expected read_file in allow set, got %#v", allow)
+	}
+}

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -133,7 +133,7 @@ func Bootstrap(req BootstrapRequest) (Runtime, error) {
 	taskManager := runtimepkg.NewInMemoryTaskManager(
 		runtimepkg.WithTaskEventStore(taskEventStore),
 	)
-	extensions := extensionspkg.NopManager{}
+	extensions := extensionspkg.NewManager(workspace)
 	runner := agent.NewRunner(agent.Options{
 		Workspace:   workspace,
 		Config:      cfg,

--- a/internal/extensions/bridge.go
+++ b/internal/extensions/bridge.go
@@ -33,6 +33,10 @@ type BridgeBinding struct {
 	StableKey    string
 }
 
+type BridgeRegisterOptions struct {
+	AllowOriginalNameShadowBuiltin bool
+}
+
 // Bridge projects an extension tool to the source-aware tool namespace.
 // Invalid inputs are returned unchanged; callers that need strict validation
 // should use RegisterBridgedTool.
@@ -45,6 +49,10 @@ func Bridge(extensionTool ExtensionTool) toolspkg.Tool {
 }
 
 func RegisterBridgedTool(registry *toolspkg.Registry, extensionTool ExtensionTool) (BridgeBinding, error) {
+	return RegisterBridgedToolWithOptions(registry, extensionTool, BridgeRegisterOptions{})
+}
+
+func RegisterBridgedToolWithOptions(registry *toolspkg.Registry, extensionTool ExtensionTool, opts BridgeRegisterOptions) (BridgeBinding, error) {
 	if registry == nil {
 		return BridgeBinding{}, wrapError(ErrCodeInvalidExtension, "tool registry is required", nil)
 	}
@@ -53,9 +61,10 @@ func RegisterBridgedTool(registry *toolspkg.Registry, extensionTool ExtensionToo
 		return BridgeBinding{}, err
 	}
 	if err := registry.Register(bridged, toolspkg.RegisterOptions{
-		Source:       toolspkg.RegistrationSourceExtension,
-		ExtensionID:  binding.ExtensionID,
-		OriginalName: binding.OriginalName,
+		Source:                         toolspkg.RegistrationSourceExtension,
+		ExtensionID:                    binding.ExtensionID,
+		OriginalName:                   binding.OriginalName,
+		AllowOriginalNameShadowBuiltin: opts.AllowOriginalNameShadowBuiltin,
 	}); err != nil {
 		return BridgeBinding{}, err
 	}

--- a/internal/extensions/bridge.go
+++ b/internal/extensions/bridge.go
@@ -111,8 +111,11 @@ func mapPolicyItems(policy skillspkg.ToolPolicy, bindings []BridgeBinding) (skil
 		if item == "" {
 			continue
 		}
-		if stable, ok := aliases[normalizePolicyAlias(item)]; ok {
-			mappedItems = append(mappedItems, stable)
+		if alias, ok := aliases[normalizePolicyAlias(item)]; ok {
+			mappedItems = append(mappedItems, alias.StableKey)
+			if policy.Policy == skillspkg.ToolPolicyDenylist {
+				mappedItems = append(mappedItems, alias.OriginalName)
+			}
 			continue
 		}
 		mappedItems = append(mappedItems, item)
@@ -123,8 +126,13 @@ func mapPolicyItems(policy skillspkg.ToolPolicy, bindings []BridgeBinding) (skil
 	}, nil
 }
 
-func buildPolicyAliases(bindings []BridgeBinding) (map[string]string, error) {
-	aliases := make(map[string]string, len(bindings)*2)
+type policyAlias struct {
+	OriginalName string
+	StableKey    string
+}
+
+func buildPolicyAliases(bindings []BridgeBinding) (map[string]policyAlias, error) {
+	aliases := make(map[string]policyAlias, len(bindings)*2)
 	for _, binding := range bindings {
 		original := strings.TrimSpace(binding.OriginalName)
 		stable := strings.TrimSpace(binding.StableKey)
@@ -137,10 +145,13 @@ func buildPolicyAliases(bindings []BridgeBinding) (map[string]string, error) {
 				continue
 			}
 			existing, ok := aliases[normalizedAlias]
-			if ok && existing != stable {
+			if ok && existing.StableKey != stable {
 				return nil, wrapError(ErrCodeConflict, fmt.Sprintf("policy alias %q maps to multiple tools", alias), nil)
 			}
-			aliases[normalizedAlias] = stable
+			aliases[normalizedAlias] = policyAlias{
+				OriginalName: original,
+				StableKey:    stable,
+			}
 		}
 	}
 	return aliases, nil

--- a/internal/extensions/bridge.go
+++ b/internal/extensions/bridge.go
@@ -204,13 +204,33 @@ func enforceStableToolKeyLength(stable string) string {
 		if len(suffix) <= maxStableToolKeyLength {
 			return suffix
 		}
-		return suffix[:maxStableToolKeyLength]
+		return truncateUTF8ByBytes(suffix, maxStableToolKeyLength)
 	}
-	prefix := strings.TrimRight(stable[:cut], stableToolKeySeparator)
+	prefix := strings.TrimRight(truncateUTF8ByBytes(stable, cut), stableToolKeySeparator)
 	if prefix == "" {
 		return suffix
 	}
 	return prefix + stableToolKeySeparator + suffix
+}
+
+func truncateUTF8ByBytes(input string, maxBytes int) string {
+	if maxBytes <= 0 || input == "" {
+		return ""
+	}
+	if len(input) <= maxBytes {
+		return input
+	}
+	total := 0
+	var out strings.Builder
+	for _, r := range input {
+		size := len(string(r))
+		if total+size > maxBytes {
+			break
+		}
+		out.WriteRune(r)
+		total += size
+	}
+	return out.String()
 }
 
 type bridgedTool struct {

--- a/internal/extensions/bridge.go
+++ b/internal/extensions/bridge.go
@@ -102,7 +102,7 @@ func mapPolicyItems(policy skillspkg.ToolPolicy, bindings []BridgeBinding) (skil
 		if item == "" {
 			continue
 		}
-		if stable, ok := aliases[item]; ok {
+		if stable, ok := aliases[normalizePolicyAlias(item)]; ok {
 			mappedItems = append(mappedItems, stable)
 			continue
 		}
@@ -123,14 +123,22 @@ func buildPolicyAliases(bindings []BridgeBinding) (map[string]string, error) {
 			return nil, wrapError(ErrCodeInvalidExtension, "bridge binding requires original and stable tool names", nil)
 		}
 		for _, alias := range []string{original, stable} {
-			existing, ok := aliases[alias]
+			normalizedAlias := normalizePolicyAlias(alias)
+			if normalizedAlias == "" {
+				continue
+			}
+			existing, ok := aliases[normalizedAlias]
 			if ok && existing != stable {
 				return nil, wrapError(ErrCodeConflict, fmt.Sprintf("policy alias %q maps to multiple tools", alias), nil)
 			}
-			aliases[alias] = stable
+			aliases[normalizedAlias] = stable
 		}
 	}
 	return aliases, nil
+}
+
+func normalizePolicyAlias(alias string) string {
+	return strings.ToLower(strings.TrimSpace(alias))
 }
 
 func buildBridgedTool(extensionTool ExtensionTool) (toolspkg.Tool, BridgeBinding, error) {

--- a/internal/extensions/bridge.go
+++ b/internal/extensions/bridge.go
@@ -1,0 +1,231 @@
+package extensions
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"bytemind/internal/llm"
+	policypkg "bytemind/internal/policy"
+	skillspkg "bytemind/internal/skills"
+	toolspkg "bytemind/internal/tools"
+)
+
+const (
+	stableToolKeySeparator = ":"
+	maxStableToolKeyLength = 128
+)
+
+type ExtensionTool struct {
+	Source      ExtensionKind
+	ExtensionID string
+	Tool        toolspkg.Tool
+}
+
+type BridgeBinding struct {
+	Source       ExtensionKind
+	ExtensionID  string
+	OriginalName string
+	StableKey    string
+}
+
+// Bridge projects an extension tool to the source-aware tool namespace.
+// Invalid inputs are returned unchanged; callers that need strict validation
+// should use RegisterBridgedTool.
+func Bridge(extensionTool ExtensionTool) toolspkg.Tool {
+	bridged, _, err := buildBridgedTool(extensionTool)
+	if err != nil {
+		return extensionTool.Tool
+	}
+	return bridged
+}
+
+func RegisterBridgedTool(registry *toolspkg.Registry, extensionTool ExtensionTool) (BridgeBinding, error) {
+	if registry == nil {
+		return BridgeBinding{}, wrapError(ErrCodeInvalidExtension, "tool registry is required", nil)
+	}
+	bridged, binding, err := buildBridgedTool(extensionTool)
+	if err != nil {
+		return BridgeBinding{}, err
+	}
+	if err := registry.Register(bridged, toolspkg.RegisterOptions{
+		Source:       toolspkg.RegistrationSourceExtension,
+		ExtensionID:  binding.ExtensionID,
+		OriginalName: binding.OriginalName,
+	}); err != nil {
+		return BridgeBinding{}, err
+	}
+	return binding, nil
+}
+
+func StableToolKey(source ExtensionKind, extensionID, toolName string) (string, error) {
+	sourceKey := normalizeStableSegment(string(source))
+	if sourceKey == "" {
+		return "", wrapError(ErrCodeInvalidSource, "extension source is required", nil)
+	}
+	extensionKey := normalizeStableSegment(extensionID)
+	if extensionKey == "" {
+		return "", wrapError(ErrCodeInvalidExtension, "extension id is required", nil)
+	}
+	toolKey := normalizeStableSegment(toolName)
+	if toolKey == "" {
+		return "", wrapError(ErrCodeInvalidExtension, "tool name is required", nil)
+	}
+	stable := strings.Join([]string{sourceKey, extensionKey, toolKey}, stableToolKeySeparator)
+	return enforceStableToolKeyLength(stable), nil
+}
+
+func ResolvePolicyToolSets(policy skillspkg.ToolPolicy, bindings []BridgeBinding) (map[string]struct{}, map[string]struct{}, error) {
+	mapped, err := mapPolicyItems(policy, bindings)
+	if err != nil {
+		return nil, nil, err
+	}
+	allow, deny := policypkg.ResolveToolSets(mapped)
+	return allow, deny, nil
+}
+
+func mapPolicyItems(policy skillspkg.ToolPolicy, bindings []BridgeBinding) (skillspkg.ToolPolicy, error) {
+	if len(policy.Items) == 0 || len(bindings) == 0 {
+		return policy, nil
+	}
+	aliases, err := buildPolicyAliases(bindings)
+	if err != nil {
+		return skillspkg.ToolPolicy{}, err
+	}
+	mappedItems := make([]string, 0, len(policy.Items))
+	for _, item := range policy.Items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if stable, ok := aliases[item]; ok {
+			mappedItems = append(mappedItems, stable)
+			continue
+		}
+		mappedItems = append(mappedItems, item)
+	}
+	return skillspkg.ToolPolicy{
+		Policy: policy.Policy,
+		Items:  mappedItems,
+	}, nil
+}
+
+func buildPolicyAliases(bindings []BridgeBinding) (map[string]string, error) {
+	aliases := make(map[string]string, len(bindings)*2)
+	for _, binding := range bindings {
+		original := strings.TrimSpace(binding.OriginalName)
+		stable := strings.TrimSpace(binding.StableKey)
+		if original == "" || stable == "" {
+			return nil, wrapError(ErrCodeInvalidExtension, "bridge binding requires original and stable tool names", nil)
+		}
+		for _, alias := range []string{original, stable} {
+			existing, ok := aliases[alias]
+			if ok && existing != stable {
+				return nil, wrapError(ErrCodeConflict, fmt.Sprintf("policy alias %q maps to multiple tools", alias), nil)
+			}
+			aliases[alias] = stable
+		}
+	}
+	return aliases, nil
+}
+
+func buildBridgedTool(extensionTool ExtensionTool) (toolspkg.Tool, BridgeBinding, error) {
+	if extensionTool.Tool == nil {
+		return nil, BridgeBinding{}, wrapError(ErrCodeInvalidExtension, "extension tool is required", nil)
+	}
+	definition := extensionTool.Tool.Definition()
+	originalName := strings.TrimSpace(definition.Function.Name)
+	if originalName == "" {
+		return nil, BridgeBinding{}, wrapError(ErrCodeInvalidExtension, "tool name is required", nil)
+	}
+	stableKey, err := StableToolKey(extensionTool.Source, extensionTool.ExtensionID, originalName)
+	if err != nil {
+		return nil, BridgeBinding{}, err
+	}
+	binding := BridgeBinding{
+		Source:       extensionTool.Source,
+		ExtensionID:  strings.TrimSpace(extensionTool.ExtensionID),
+		OriginalName: originalName,
+		StableKey:    stableKey,
+	}
+	return bridgedTool{
+		delegate:  extensionTool.Tool,
+		stableKey: stableKey,
+	}, binding, nil
+}
+
+func normalizeStableSegment(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	if raw == "" {
+		return ""
+	}
+	var out strings.Builder
+	lastUnderscore := false
+	for _, r := range raw {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			out.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if r == '-' || r == '_' {
+			out.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			out.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(out.String(), "_-")
+}
+
+func enforceStableToolKeyLength(stable string) string {
+	stable = strings.TrimSpace(stable)
+	if len(stable) <= maxStableToolKeyLength {
+		return stable
+	}
+	sum := sha1.Sum([]byte(stable))
+	suffix := hex.EncodeToString(sum[:6])
+	cut := maxStableToolKeyLength - len(suffix) - len(stableToolKeySeparator)
+	if cut <= 0 {
+		if len(suffix) <= maxStableToolKeyLength {
+			return suffix
+		}
+		return suffix[:maxStableToolKeyLength]
+	}
+	prefix := strings.TrimRight(stable[:cut], stableToolKeySeparator)
+	if prefix == "" {
+		return suffix
+	}
+	return prefix + stableToolKeySeparator + suffix
+}
+
+type bridgedTool struct {
+	delegate  toolspkg.Tool
+	stableKey string
+}
+
+func (t bridgedTool) Definition() llm.ToolDefinition {
+	def := t.delegate.Definition()
+	def.Function.Name = t.stableKey
+	return def
+}
+
+func (t bridgedTool) Run(ctx context.Context, raw json.RawMessage, execCtx *toolspkg.ExecutionContext) (string, error) {
+	return t.delegate.Run(ctx, raw, execCtx)
+}
+
+func (t bridgedTool) Spec() toolspkg.ToolSpec {
+	provider, ok := t.delegate.(toolspkg.ToolSpecProvider)
+	if !ok {
+		return toolspkg.ToolSpec{Name: t.stableKey}
+	}
+	spec := provider.Spec()
+	spec.Name = t.stableKey
+	return spec
+}

--- a/internal/extensions/bridge_test.go
+++ b/internal/extensions/bridge_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"bytemind/internal/llm"
 	skillspkg "bytemind/internal/skills"
@@ -31,6 +32,21 @@ func TestStableToolKeyAppliesLengthLimit(t *testing.T) {
 	}
 	if len(key) > maxStableToolKeyLength {
 		t.Fatalf("stable key exceeded max length: %d", len(key))
+	}
+}
+
+func TestStableToolKeyTruncationKeepsValidUTF8(t *testing.T) {
+	extensionID := strings.Repeat("技能", 80)
+	toolName := strings.Repeat("工具", 80)
+	key, err := StableToolKey(ExtensionSkill, extensionID, toolName)
+	if err != nil {
+		t.Fatalf("StableToolKey failed: %v", err)
+	}
+	if len(key) > maxStableToolKeyLength {
+		t.Fatalf("stable key exceeded max length: %d", len(key))
+	}
+	if !utf8.ValidString(key) {
+		t.Fatalf("stable key must remain valid UTF-8, got %q", key)
 	}
 }
 

--- a/internal/extensions/bridge_test.go
+++ b/internal/extensions/bridge_test.go
@@ -230,6 +230,30 @@ func TestResolvePolicyToolSetsMapsAliasesCaseInsensitively(t *testing.T) {
 	}
 }
 
+func TestResolvePolicyToolSetsDenylistIncludesOriginalAndStableKeys(t *testing.T) {
+	allow, deny, err := ResolvePolicyToolSets(skillspkg.ToolPolicy{
+		Policy: skillspkg.ToolPolicyDenylist,
+		Items:  []string{"OPEN_DOC"},
+	}, []BridgeBinding{{
+		Source:       ExtensionSkill,
+		ExtensionID:  "skill.review",
+		OriginalName: "open_doc",
+		StableKey:    "skill:skill_review:open_doc",
+	}})
+	if err != nil {
+		t.Fatalf("ResolvePolicyToolSets failed: %v", err)
+	}
+	if allow != nil {
+		t.Fatalf("expected nil allow set, got %#v", allow)
+	}
+	if _, ok := deny["skill:skill_review:open_doc"]; !ok {
+		t.Fatalf("expected stable key in deny set: %#v", deny)
+	}
+	if _, ok := deny["open_doc"]; !ok {
+		t.Fatalf("expected original key in deny set: %#v", deny)
+	}
+}
+
 func TestResolvePolicyToolSetsRejectsAmbiguousAliases(t *testing.T) {
 	_, _, err := ResolvePolicyToolSets(skillspkg.ToolPolicy{
 		Policy: skillspkg.ToolPolicyAllowlist,

--- a/internal/extensions/bridge_test.go
+++ b/internal/extensions/bridge_test.go
@@ -113,6 +113,26 @@ func TestRegisterBridgedToolRejectsBuiltinOriginalNameConflict(t *testing.T) {
 	}
 }
 
+func TestRegisterBridgedToolWithOptionsAllowsBuiltinOriginalNameShadow(t *testing.T) {
+	registry := toolspkg.DefaultRegistry()
+	binding, err := RegisterBridgedToolWithOptions(registry, ExtensionTool{
+		Source:      ExtensionSkill,
+		ExtensionID: "skill.review",
+		Tool:        bridgeTestTool{name: "read_file"},
+	}, BridgeRegisterOptions{
+		AllowOriginalNameShadowBuiltin: true,
+	})
+	if err != nil {
+		t.Fatalf("expected bridge registration to allow builtin shadow, got %v", err)
+	}
+	if binding.StableKey == "" {
+		t.Fatal("expected stable key")
+	}
+	if _, ok := registry.Get(binding.StableKey); !ok {
+		t.Fatalf("expected bridged tool %q to be registered", binding.StableKey)
+	}
+}
+
 func TestRegisterBridgedToolRejectsExtensionOriginalNameConflict(t *testing.T) {
 	registry := &toolspkg.Registry{}
 	_, err := RegisterBridgedTool(registry, ExtensionTool{

--- a/internal/extensions/bridge_test.go
+++ b/internal/extensions/bridge_test.go
@@ -173,6 +173,27 @@ func TestResolvePolicyToolSetsMapsOriginalNamesToStableKeys(t *testing.T) {
 	}
 }
 
+func TestResolvePolicyToolSetsMapsAliasesCaseInsensitively(t *testing.T) {
+	allow, deny, err := ResolvePolicyToolSets(skillspkg.ToolPolicy{
+		Policy: skillspkg.ToolPolicyAllowlist,
+		Items:  []string{"OPEN_DOC"},
+	}, []BridgeBinding{{
+		Source:       ExtensionSkill,
+		ExtensionID:  "skill.review",
+		OriginalName: "open_doc",
+		StableKey:    "skill:skill_review:open_doc",
+	}})
+	if err != nil {
+		t.Fatalf("ResolvePolicyToolSets failed: %v", err)
+	}
+	if deny != nil {
+		t.Fatalf("expected nil deny set, got %#v", deny)
+	}
+	if _, ok := allow["skill:skill_review:open_doc"]; !ok {
+		t.Fatalf("expected mapped stable key in allow set: %#v", allow)
+	}
+}
+
 func TestResolvePolicyToolSetsRejectsAmbiguousAliases(t *testing.T) {
 	_, _, err := ResolvePolicyToolSets(skillspkg.ToolPolicy{
 		Policy: skillspkg.ToolPolicyAllowlist,
@@ -182,6 +203,36 @@ func TestResolvePolicyToolSetsRejectsAmbiguousAliases(t *testing.T) {
 			Source:       ExtensionSkill,
 			ExtensionID:  "skill.first",
 			OriginalName: "open_doc",
+			StableKey:    "skill:skill_first:open_doc",
+		},
+		{
+			Source:       ExtensionMCP,
+			ExtensionID:  "mcp.docs",
+			OriginalName: "open_doc",
+			StableKey:    "mcp:mcp_docs:open_doc",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	var extErr *ExtensionError
+	if !errors.As(err, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr.Code != ErrCodeConflict {
+		t.Fatalf("unexpected error code: %s", extErr.Code)
+	}
+}
+
+func TestResolvePolicyToolSetsRejectsAmbiguousAliasesIgnoringCase(t *testing.T) {
+	_, _, err := ResolvePolicyToolSets(skillspkg.ToolPolicy{
+		Policy: skillspkg.ToolPolicyAllowlist,
+		Items:  []string{"open_doc"},
+	}, []BridgeBinding{
+		{
+			Source:       ExtensionSkill,
+			ExtensionID:  "skill.first",
+			OriginalName: "Open_Doc",
 			StableKey:    "skill:skill_first:open_doc",
 		},
 		{

--- a/internal/extensions/bridge_test.go
+++ b/internal/extensions/bridge_test.go
@@ -1,0 +1,234 @@
+package extensions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"bytemind/internal/llm"
+	skillspkg "bytemind/internal/skills"
+	toolspkg "bytemind/internal/tools"
+)
+
+func TestStableToolKeyNormalizesSegments(t *testing.T) {
+	key, err := StableToolKey(ExtensionSkill, " Skill.Review/One ", "Open Doc!!")
+	if err != nil {
+		t.Fatalf("StableToolKey failed: %v", err)
+	}
+	if key != "skill:skill_review_one:open_doc" {
+		t.Fatalf("unexpected stable key: %q", key)
+	}
+}
+
+func TestStableToolKeyAppliesLengthLimit(t *testing.T) {
+	extensionID := strings.Repeat("x", 128)
+	toolName := strings.Repeat("y", 128)
+	key, err := StableToolKey(ExtensionMCP, extensionID, toolName)
+	if err != nil {
+		t.Fatalf("StableToolKey failed: %v", err)
+	}
+	if len(key) > maxStableToolKeyLength {
+		t.Fatalf("stable key exceeded max length: %d", len(key))
+	}
+}
+
+func TestRegisterBridgedToolRegistersStableKeyAndMetadata(t *testing.T) {
+	registry := &toolspkg.Registry{}
+	binding, err := RegisterBridgedTool(registry, ExtensionTool{
+		Source:      ExtensionSkill,
+		ExtensionID: "skill.review",
+		Tool:        bridgeTestTool{name: "open_doc"},
+	})
+	if err != nil {
+		t.Fatalf("RegisterBridgedTool failed: %v", err)
+	}
+	if binding.StableKey != "skill:skill_review:open_doc" {
+		t.Fatalf("unexpected stable key: %q", binding.StableKey)
+	}
+	resolved, ok := registry.Get(binding.StableKey)
+	if !ok {
+		t.Fatalf("expected bridged tool %q", binding.StableKey)
+	}
+	if resolved.Definition.Function.Name != binding.StableKey {
+		t.Fatalf("unexpected resolved tool key: %q", resolved.Definition.Function.Name)
+	}
+	metas := registry.FindByOriginalName("open_doc")
+	if len(metas) != 1 {
+		t.Fatalf("expected one metadata item, got %d", len(metas))
+	}
+	if metas[0].StableToolKey != binding.StableKey {
+		t.Fatalf("unexpected metadata stable key: %q", metas[0].StableToolKey)
+	}
+	if metas[0].Source != toolspkg.RegistrationSourceExtension {
+		t.Fatalf("unexpected metadata source: %q", metas[0].Source)
+	}
+	if metas[0].ExtensionID != "skill.review" {
+		t.Fatalf("unexpected metadata extension id: %q", metas[0].ExtensionID)
+	}
+	if metas[0].OriginalToolName != "open_doc" {
+		t.Fatalf("unexpected original name: %q", metas[0].OriginalToolName)
+	}
+}
+
+func TestRegisterBridgedToolRejectsBuiltinOriginalNameConflict(t *testing.T) {
+	registry := toolspkg.DefaultRegistry()
+	_, err := RegisterBridgedTool(registry, ExtensionTool{
+		Source:      ExtensionSkill,
+		ExtensionID: "skill.review",
+		Tool:        bridgeTestTool{name: "read_file"},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate name error")
+	}
+	var regErr *toolspkg.RegistryError
+	if !errors.As(err, &regErr) {
+		t.Fatalf("expected RegistryError, got %T", err)
+	}
+	if regErr.Code != toolspkg.RegistryErrorDuplicateName {
+		t.Fatalf("unexpected code: %s", regErr.Code)
+	}
+	if regErr.ConflictWith.Source != toolspkg.RegistrationSourceBuiltin {
+		t.Fatalf("unexpected conflict source: %+v", regErr.ConflictWith)
+	}
+	if regErr.ConflictWith.OriginalToolName != "read_file" {
+		t.Fatalf("unexpected conflict original name: %q", regErr.ConflictWith.OriginalToolName)
+	}
+}
+
+func TestRegisterBridgedToolRejectsExtensionOriginalNameConflict(t *testing.T) {
+	registry := &toolspkg.Registry{}
+	_, err := RegisterBridgedTool(registry, ExtensionTool{
+		Source:      ExtensionSkill,
+		ExtensionID: "skill.first",
+		Tool:        bridgeTestTool{name: "open_doc"},
+	})
+	if err != nil {
+		t.Fatalf("first RegisterBridgedTool failed: %v", err)
+	}
+	_, err = RegisterBridgedTool(registry, ExtensionTool{
+		Source:      ExtensionSkill,
+		ExtensionID: "skill.second",
+		Tool:        bridgeTestTool{name: "open_doc"},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate name error")
+	}
+	var regErr *toolspkg.RegistryError
+	if !errors.As(err, &regErr) {
+		t.Fatalf("expected RegistryError, got %T", err)
+	}
+	if regErr.Code != toolspkg.RegistryErrorDuplicateName {
+		t.Fatalf("unexpected code: %s", regErr.Code)
+	}
+	if regErr.ConflictWith.ExtensionID != "skill.first" {
+		t.Fatalf("unexpected conflict extension id: %q", regErr.ConflictWith.ExtensionID)
+	}
+}
+
+func TestRegisterBridgedToolPropagatesSchemaValidationError(t *testing.T) {
+	registry := &toolspkg.Registry{}
+	_, err := RegisterBridgedTool(registry, ExtensionTool{
+		Source:      ExtensionSkill,
+		ExtensionID: "skill.review",
+		Tool:        bridgeInvalidSpecTool{bridgeTestTool{name: "invalid_schema"}},
+	})
+	if err == nil {
+		t.Fatal("expected schema error")
+	}
+	var regErr *toolspkg.RegistryError
+	if !errors.As(err, &regErr) {
+		t.Fatalf("expected RegistryError, got %T", err)
+	}
+	if regErr.Code != toolspkg.RegistryErrorInvalidSchema {
+		t.Fatalf("unexpected code: %s", regErr.Code)
+	}
+}
+
+func TestResolvePolicyToolSetsMapsOriginalNamesToStableKeys(t *testing.T) {
+	allow, deny, err := ResolvePolicyToolSets(skillspkg.ToolPolicy{
+		Policy: skillspkg.ToolPolicyAllowlist,
+		Items:  []string{"open_doc", "read_file"},
+	}, []BridgeBinding{{
+		Source:       ExtensionSkill,
+		ExtensionID:  "skill.review",
+		OriginalName: "open_doc",
+		StableKey:    "skill:skill_review:open_doc",
+	}})
+	if err != nil {
+		t.Fatalf("ResolvePolicyToolSets failed: %v", err)
+	}
+	if deny != nil {
+		t.Fatalf("expected nil deny set, got %#v", deny)
+	}
+	if _, ok := allow["skill:skill_review:open_doc"]; !ok {
+		t.Fatalf("expected mapped stable key in allow set: %#v", allow)
+	}
+	if _, ok := allow["read_file"]; !ok {
+		t.Fatalf("expected builtin tool in allow set: %#v", allow)
+	}
+	if _, ok := allow["open_doc"]; ok {
+		t.Fatalf("did not expect legacy name after mapping: %#v", allow)
+	}
+}
+
+func TestResolvePolicyToolSetsRejectsAmbiguousAliases(t *testing.T) {
+	_, _, err := ResolvePolicyToolSets(skillspkg.ToolPolicy{
+		Policy: skillspkg.ToolPolicyAllowlist,
+		Items:  []string{"open_doc"},
+	}, []BridgeBinding{
+		{
+			Source:       ExtensionSkill,
+			ExtensionID:  "skill.first",
+			OriginalName: "open_doc",
+			StableKey:    "skill:skill_first:open_doc",
+		},
+		{
+			Source:       ExtensionMCP,
+			ExtensionID:  "mcp.docs",
+			OriginalName: "open_doc",
+			StableKey:    "mcp:mcp_docs:open_doc",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	var extErr *ExtensionError
+	if !errors.As(err, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr.Code != ErrCodeConflict {
+		t.Fatalf("unexpected error code: %s", extErr.Code)
+	}
+}
+
+type bridgeTestTool struct {
+	name string
+}
+
+func (t bridgeTestTool) Definition() llm.ToolDefinition {
+	return llm.ToolDefinition{
+		Type: "function",
+		Function: llm.FunctionDefinition{
+			Name:        t.name,
+			Description: "bridge test tool",
+			Parameters:  map[string]any{"type": "object"},
+		},
+	}
+}
+
+func (bridgeTestTool) Run(context.Context, json.RawMessage, *toolspkg.ExecutionContext) (string, error) {
+	return "ok", nil
+}
+
+type bridgeInvalidSpecTool struct {
+	bridgeTestTool
+}
+
+func (t bridgeInvalidSpecTool) Spec() toolspkg.ToolSpec {
+	return toolspkg.ToolSpec{
+		Name:        t.name,
+		SafetyClass: "invalid",
+	}
+}

--- a/internal/extensions/bridge_test.go
+++ b/internal/extensions/bridge_test.go
@@ -133,7 +133,7 @@ func TestRegisterBridgedToolWithOptionsAllowsBuiltinOriginalNameShadow(t *testin
 	}
 }
 
-func TestRegisterBridgedToolRejectsExtensionOriginalNameConflict(t *testing.T) {
+func TestRegisterBridgedToolAllowsCrossExtensionOriginalNameReuse(t *testing.T) {
 	registry := &toolspkg.Registry{}
 	_, err := RegisterBridgedTool(registry, ExtensionTool{
 		Source:      ExtensionSkill,
@@ -148,18 +148,12 @@ func TestRegisterBridgedToolRejectsExtensionOriginalNameConflict(t *testing.T) {
 		ExtensionID: "skill.second",
 		Tool:        bridgeTestTool{name: "open_doc"},
 	})
-	if err == nil {
-		t.Fatal("expected duplicate name error")
+	if err != nil {
+		t.Fatalf("expected cross-extension reuse to succeed, got %v", err)
 	}
-	var regErr *toolspkg.RegistryError
-	if !errors.As(err, &regErr) {
-		t.Fatalf("expected RegistryError, got %T", err)
-	}
-	if regErr.Code != toolspkg.RegistryErrorDuplicateName {
-		t.Fatalf("unexpected code: %s", regErr.Code)
-	}
-	if regErr.ConflictWith.ExtensionID != "skill.first" {
-		t.Fatalf("unexpected conflict extension id: %q", regErr.ConflictWith.ExtensionID)
+	metas := registry.FindByOriginalName("open_doc")
+	if len(metas) != 2 {
+		t.Fatalf("expected two extension records for open_doc, got %#v", metas)
 	}
 }
 

--- a/internal/extensions/ids.go
+++ b/internal/extensions/ids.go
@@ -1,0 +1,14 @@
+package extensions
+
+import "strings"
+
+// SkillExtensionID builds the canonical extension id from a skill name.
+// It intentionally prefixes with "skill." even when the input already has
+// that prefix to keep backward compatibility with existing extension ids.
+func SkillExtensionID(skillName string) string {
+	name := strings.TrimSpace(skillName)
+	if name == "" {
+		return ""
+	}
+	return "skill." + name
+}

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -387,11 +387,7 @@ func skillsScopeForExtension(scope ExtensionScope) skillspkg.Scope {
 }
 
 func extensionIDForDir(dirName string) string {
-	name := strings.TrimSpace(dirName)
-	if name == "" {
-		return ""
-	}
-	return "skill." + name
+	return SkillExtensionID(dirName)
 }
 
 func fileExists(path string) bool {

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -2,6 +2,7 @@ package extensions
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -317,21 +318,11 @@ func (m *extensionManager) discoverOne(source string) (ExtensionInfo, error) {
 	if !ok {
 		scope = ExtensionScopeRemote
 	}
-	catalog := skillspkg.NewManagerWithDirs(m.workspace, "", "", filepath.Dir(resolved)).Reload()
-	var matched skillspkg.Skill
-	for _, skill := range catalog.Skills {
-		if sameExtensionSource(skill.SourceDir, resolved) {
-			matched = skill
-			break
-		}
+	skill, err := discoverSkillFromDir(resolved, extensionScopeToSkillScope(scope))
+	if err != nil {
+		return ExtensionInfo{}, err
 	}
-	if strings.TrimSpace(matched.Name) == "" {
-		if len(catalog.Diagnostics) > 0 {
-			return ExtensionInfo{}, wrapError(ErrCodeInvalidManifest, catalog.Diagnostics[0].Message, nil)
-		}
-		return ExtensionInfo{}, wrapError(ErrCodeInvalidSource, "extension source does not contain a supported extension", nil)
-	}
-	item := m.adapter.FromSkill(matched)
+	item := m.adapter.FromSkill(skill)
 	item.Source.Scope = scope
 	item.Source.Ref = resolved
 	item.Manifest.Source.Scope = scope
@@ -400,4 +391,198 @@ func fileExists(path string) bool {
 
 func sameExtensionSource(left, right string) bool {
 	return filepath.Clean(strings.TrimSpace(left)) == filepath.Clean(strings.TrimSpace(right))
+}
+
+type discoverSkillManifest struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Entry       struct {
+		Slash string `json:"slash"`
+	} `json:"entry"`
+	Prompts []struct {
+		ID   string `json:"id"`
+		Path string `json:"path"`
+	} `json:"prompts"`
+	Resources []struct {
+		ID       string `json:"id"`
+		URI      string `json:"uri"`
+		Optional bool   `json:"optional"`
+	} `json:"resources"`
+	Tools struct {
+		Policy string   `json:"policy"`
+		Items  []string `json:"items"`
+	} `json:"tools"`
+	Args []struct {
+		Name        string `json:"name"`
+		Type        string `json:"type"`
+		Required    bool   `json:"required"`
+		Description string `json:"description"`
+		Default     string `json:"default"`
+	} `json:"args"`
+}
+
+func discoverSkillFromDir(dir string, scope skillspkg.Scope) (skillspkg.Skill, error) {
+	manifestPath := filepath.Join(dir, "skill.json")
+	if !fileExists(manifestPath) {
+		return skillspkg.Skill{}, wrapError(ErrCodeInvalidSource, "extension source does not contain skill.json", nil)
+	}
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return skillspkg.Skill{}, wrapError(ErrCodeInvalidManifest, "failed to read skill.json", err)
+	}
+
+	var manifest discoverSkillManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return skillspkg.Skill{}, wrapError(ErrCodeInvalidManifest, "invalid skill.json", err)
+	}
+
+	name := strings.TrimSpace(manifest.Name)
+	if name == "" {
+		return skillspkg.Skill{}, wrapError(ErrCodeInvalidExtension, "skill.json name is required", nil)
+	}
+
+	title := strings.TrimSpace(manifest.Title)
+	if title == "" {
+		title = name
+	}
+	description := strings.TrimSpace(manifest.Description)
+	if description == "" {
+		description = "No description provided."
+	}
+
+	instruction := ""
+	skillPath := filepath.Join(dir, "SKILL.md")
+	if fileExists(skillPath) {
+		skillData, err := os.ReadFile(skillPath)
+		if err != nil {
+			return skillspkg.Skill{}, wrapError(ErrCodeInvalidManifest, "failed to read SKILL.md", err)
+		}
+		instruction = strings.TrimSpace(string(skillData))
+	}
+
+	entrySlash := strings.TrimSpace(manifest.Entry.Slash)
+	if entrySlash == "" {
+		entrySlash = "/" + name
+	} else if !strings.HasPrefix(entrySlash, "/") {
+		entrySlash = "/" + entrySlash
+	}
+
+	prompts := make([]skillspkg.PromptRef, 0, len(manifest.Prompts))
+	for _, prompt := range manifest.Prompts {
+		id := strings.TrimSpace(prompt.ID)
+		path := strings.TrimSpace(prompt.Path)
+		if id == "" && path == "" {
+			continue
+		}
+		prompts = append(prompts, skillspkg.PromptRef{ID: id, Path: path})
+	}
+
+	resources := make([]skillspkg.ResourceRef, 0, len(manifest.Resources))
+	for _, resource := range manifest.Resources {
+		id := strings.TrimSpace(resource.ID)
+		uri := strings.TrimSpace(resource.URI)
+		if id == "" && uri == "" {
+			continue
+		}
+		resources = append(resources, skillspkg.ResourceRef{
+			ID:       id,
+			URI:      uri,
+			Optional: resource.Optional,
+		})
+	}
+
+	args := make([]skillspkg.Arg, 0, len(manifest.Args))
+	for _, arg := range manifest.Args {
+		name := strings.TrimSpace(arg.Name)
+		if name == "" {
+			continue
+		}
+		args = append(args, skillspkg.Arg{
+			Name:        name,
+			Type:        strings.TrimSpace(arg.Type),
+			Required:    arg.Required,
+			Description: strings.TrimSpace(arg.Description),
+			Default:     strings.TrimSpace(arg.Default),
+		})
+	}
+
+	aliases := uniqueExtensionStrings([]string{
+		name,
+		filepath.Base(dir),
+		entrySlash,
+		strings.TrimPrefix(entrySlash, "/"),
+	})
+
+	return skillspkg.Skill{
+		Name:         name,
+		Version:      strings.TrimSpace(manifest.Version),
+		Title:        title,
+		Description:  description,
+		Scope:        scope,
+		SourceDir:    dir,
+		Instruction:  instruction,
+		Entry:        skillspkg.Entry{Slash: entrySlash},
+		Prompts:      prompts,
+		Resources:    resources,
+		ToolPolicy:   discoverToolPolicy(manifest.Tools.Policy, manifest.Tools.Items),
+		Args:         args,
+		Aliases:      aliases,
+		DiscoveredAt: time.Now().UTC(),
+	}, nil
+}
+
+func discoverToolPolicy(policy string, items []string) skillspkg.ToolPolicy {
+	policy = strings.TrimSpace(strings.ToLower(policy))
+	cleanItems := uniqueExtensionStrings(items)
+	if policy == "" {
+		return skillspkg.ToolPolicy{
+			Policy: skillspkg.ToolPolicyInherit,
+			Items:  cleanItems,
+		}
+	}
+	switch skillspkg.ToolPolicyMode(policy) {
+	case skillspkg.ToolPolicyInherit, skillspkg.ToolPolicyAllowlist, skillspkg.ToolPolicyDenylist:
+		return skillspkg.ToolPolicy{
+			Policy: skillspkg.ToolPolicyMode(policy),
+			Items:  cleanItems,
+		}
+	default:
+		return skillspkg.ToolPolicy{
+			Policy: skillspkg.ToolPolicyInherit,
+			Items:  cleanItems,
+		}
+	}
+}
+
+func extensionScopeToSkillScope(scope ExtensionScope) skillspkg.Scope {
+	switch scope {
+	case ExtensionScopeBuiltin:
+		return skillspkg.ScopeBuiltin
+	case ExtensionScopeUser:
+		return skillspkg.ScopeUser
+	default:
+		return skillspkg.ScopeProject
+	}
+}
+
+func uniqueExtensionStrings(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(items))
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		result = append(result, item)
+	}
+	return result
 }

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -2,7 +2,6 @@ package extensions
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -318,9 +317,9 @@ func (m *extensionManager) discoverOne(source string) (ExtensionInfo, error) {
 	if !ok {
 		scope = ExtensionScopeRemote
 	}
-	skill, err := discoverSkillFromDir(resolved, skillsScopeForExtension(scope))
-	if err != nil {
-		return ExtensionInfo{}, err
+	skill, ok, diags := skillspkg.LoadFromDir(skillsScopeForExtension(scope), resolved)
+	if !ok {
+		return ExtensionInfo{}, discoverOneErrorFromDiagnostics(diags)
 	}
 	item := m.adapter.FromSkill(skill)
 	item.Source.Scope = scope
@@ -404,185 +403,26 @@ func sameExtensionSource(left, right string) bool {
 	return filepath.Clean(strings.TrimSpace(left)) == filepath.Clean(strings.TrimSpace(right))
 }
 
-type discoverSkillManifest struct {
-	Name        string `json:"name"`
-	Version     string `json:"version"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Entry       struct {
-		Slash string `json:"slash"`
-	} `json:"entry"`
-	Prompts []struct {
-		ID   string `json:"id"`
-		Path string `json:"path"`
-	} `json:"prompts"`
-	Resources []struct {
-		ID       string `json:"id"`
-		URI      string `json:"uri"`
-		Optional bool   `json:"optional"`
-	} `json:"resources"`
-	Tools struct {
-		Policy string   `json:"policy"`
-		Items  []string `json:"items"`
-	} `json:"tools"`
-	Args []struct {
-		Name        string `json:"name"`
-		Type        string `json:"type"`
-		Required    bool   `json:"required"`
-		Description string `json:"description"`
-		Default     string `json:"default"`
-	} `json:"args"`
-}
-
-func discoverSkillFromDir(dir string, scope skillspkg.Scope) (skillspkg.Skill, error) {
-	manifestPath := filepath.Join(dir, "skill.json")
-	if !fileExists(manifestPath) {
-		return skillspkg.Skill{}, wrapError(ErrCodeInvalidSource, "extension source does not contain skill.json", nil)
-	}
-	data, err := os.ReadFile(manifestPath)
-	if err != nil {
-		return skillspkg.Skill{}, wrapError(ErrCodeInvalidManifest, "failed to read skill.json", err)
+func discoverOneErrorFromDiagnostics(diags []skillspkg.Diagnostic) error {
+	if len(diags) == 0 {
+		return wrapError(ErrCodeInvalidSource, "extension source does not contain skill.json or SKILL.md", nil)
 	}
 
-	var manifest discoverSkillManifest
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return skillspkg.Skill{}, wrapError(ErrCodeInvalidManifest, "invalid skill.json", err)
-	}
-
-	name := strings.TrimSpace(manifest.Name)
-	if name == "" {
-		return skillspkg.Skill{}, wrapError(ErrCodeInvalidExtension, "skill.json name is required", nil)
-	}
-
-	title := strings.TrimSpace(manifest.Title)
-	if title == "" {
-		title = name
-	}
-	description := strings.TrimSpace(manifest.Description)
-	if description == "" {
-		description = "No description provided."
-	}
-
-	instruction := ""
-	skillPath := filepath.Join(dir, "SKILL.md")
-	if fileExists(skillPath) {
-		skillData, err := os.ReadFile(skillPath)
-		if err != nil {
-			return skillspkg.Skill{}, wrapError(ErrCodeInvalidManifest, "failed to read SKILL.md", err)
-		}
-		instruction = strings.TrimSpace(string(skillData))
-	}
-
-	entrySlash := strings.TrimSpace(manifest.Entry.Slash)
-	if entrySlash == "" {
-		entrySlash = "/" + name
-	} else if !strings.HasPrefix(entrySlash, "/") {
-		entrySlash = "/" + entrySlash
-	}
-
-	prompts := make([]skillspkg.PromptRef, 0, len(manifest.Prompts))
-	for _, prompt := range manifest.Prompts {
-		id := strings.TrimSpace(prompt.ID)
-		path := strings.TrimSpace(prompt.Path)
-		if id == "" && path == "" {
-			continue
-		}
-		prompts = append(prompts, skillspkg.PromptRef{ID: id, Path: path})
-	}
-
-	resources := make([]skillspkg.ResourceRef, 0, len(manifest.Resources))
-	for _, resource := range manifest.Resources {
-		id := strings.TrimSpace(resource.ID)
-		uri := strings.TrimSpace(resource.URI)
-		if id == "" && uri == "" {
-			continue
-		}
-		resources = append(resources, skillspkg.ResourceRef{
-			ID:       id,
-			URI:      uri,
-			Optional: resource.Optional,
-		})
-	}
-
-	args := make([]skillspkg.Arg, 0, len(manifest.Args))
-	for _, arg := range manifest.Args {
-		name := strings.TrimSpace(arg.Name)
-		if name == "" {
-			continue
-		}
-		args = append(args, skillspkg.Arg{
-			Name:        name,
-			Type:        strings.TrimSpace(arg.Type),
-			Required:    arg.Required,
-			Description: strings.TrimSpace(arg.Description),
-			Default:     strings.TrimSpace(arg.Default),
-		})
-	}
-
-	aliases := uniqueExtensionStrings([]string{
-		name,
-		filepath.Base(dir),
-		entrySlash,
-		strings.TrimPrefix(entrySlash, "/"),
-	})
-
-	return skillspkg.Skill{
-		Name:         name,
-		Version:      strings.TrimSpace(manifest.Version),
-		Title:        title,
-		Description:  description,
-		Scope:        scope,
-		SourceDir:    dir,
-		Instruction:  instruction,
-		Entry:        skillspkg.Entry{Slash: entrySlash},
-		Prompts:      prompts,
-		Resources:    resources,
-		ToolPolicy:   discoverToolPolicy(manifest.Tools.Policy, manifest.Tools.Items),
-		Args:         args,
-		Aliases:      aliases,
-		DiscoveredAt: time.Now().UTC(),
-	}, nil
-}
-
-func discoverToolPolicy(policy string, items []string) skillspkg.ToolPolicy {
-	policy = strings.TrimSpace(strings.ToLower(policy))
-	cleanItems := uniqueExtensionStrings(items)
-	if policy == "" {
-		return skillspkg.ToolPolicy{
-			Policy: skillspkg.ToolPolicyInherit,
-			Items:  cleanItems,
+	for _, diag := range diags {
+		msg := strings.ToLower(strings.TrimSpace(diag.Message))
+		switch {
+		case strings.Contains(msg, "invalid skill.json"), strings.Contains(msg, "failed to read skill.json"):
+			return wrapError(ErrCodeInvalidManifest, strings.TrimSpace(diag.Message), nil)
+		case strings.Contains(msg, "failed to read skill.md"):
+			return wrapError(ErrCodeInvalidManifest, strings.TrimSpace(diag.Message), nil)
+		case strings.Contains(msg, "invalid skill name"):
+			return wrapError(ErrCodeInvalidExtension, strings.TrimSpace(diag.Message), nil)
 		}
 	}
-	switch skillspkg.ToolPolicyMode(policy) {
-	case skillspkg.ToolPolicyInherit, skillspkg.ToolPolicyAllowlist, skillspkg.ToolPolicyDenylist:
-		return skillspkg.ToolPolicy{
-			Policy: skillspkg.ToolPolicyMode(policy),
-			Items:  cleanItems,
-		}
-	default:
-		return skillspkg.ToolPolicy{
-			Policy: skillspkg.ToolPolicyInherit,
-			Items:  cleanItems,
-		}
-	}
-}
 
-func uniqueExtensionStrings(items []string) []string {
-	if len(items) == 0 {
-		return nil
+	first := strings.TrimSpace(diags[0].Message)
+	if first == "" {
+		first = "extension source is invalid"
 	}
-	seen := make(map[string]struct{}, len(items))
-	result := make([]string, 0, len(items))
-	for _, item := range items {
-		item = strings.TrimSpace(item)
-		if item == "" {
-			continue
-		}
-		if _, ok := seen[item]; ok {
-			continue
-		}
-		seen[item] = struct{}{}
-		result = append(result, item)
-	}
-	return result
+	return wrapError(ErrCodeInvalidExtension, first, nil)
 }

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -546,6 +546,62 @@ func TestDiscoverOneRejectsMissingDirectory(t *testing.T) {
 	}
 }
 
+func TestDiscoverOneIgnoresBrokenSibling(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	good := filepath.Join(project, "good")
+	bad := filepath.Join(project, "bad")
+	if err := os.MkdirAll(good, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(good, "skill.json"), []byte(`{"name":"good","description":"ok"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(good, "SKILL.md"), []byte("# /good"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, "skill.json"), []byte(`{"name":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	item, err := mgr.(*extensionManager).discoverOne(good)
+	if err != nil {
+		t.Fatalf("discoverOne should ignore broken sibling, got %v", err)
+	}
+	if item.ID != "skill.good" {
+		t.Fatalf("unexpected discovered extension id: %q", item.ID)
+	}
+}
+
+func TestDiscoverOneRejectsInvalidManifestInTargetDir(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	bad := filepath.Join(project, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, "skill.json"), []byte(`{"name":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	_, err := mgr.(*extensionManager).discoverOne(bad)
+	if err == nil {
+		t.Fatal("expected invalid manifest error")
+	}
+	var extErr *ExtensionError
+	if !errors.As(err, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr.Code != ErrCodeInvalidManifest {
+		t.Fatalf("unexpected code: %s", extErr.Code)
+	}
+}
+
 func TestReloadCollectsSkillDiagnosticsAsDiscoveryErrors(t *testing.T) {
 	root := t.TempDir()
 	project := filepath.Join(root, "project")

--- a/internal/extensions/manager_test.go
+++ b/internal/extensions/manager_test.go
@@ -546,6 +546,64 @@ func TestDiscoverOneRejectsMissingDirectory(t *testing.T) {
 	}
 }
 
+func TestDiscoverOneAcceptsSkillMarkdownOnly(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	solo := filepath.Join(project, "solo")
+	if err := os.MkdirAll(solo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(solo, "SKILL.md"), []byte("# /solo\n\nUse this skill when needed."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	item, err := mgr.(*extensionManager).discoverOne(solo)
+	if err != nil {
+		t.Fatalf("discoverOne should accept SKILL.md-only directory, got %v", err)
+	}
+	if item.ID != "skill.solo" {
+		t.Fatalf("unexpected discovered extension id: %q", item.ID)
+	}
+	if item.Name != "solo" {
+		t.Fatalf("expected name fallback to directory, got %q", item.Name)
+	}
+}
+
+func TestDiscoverOneUsesFrontmatterWhenManifestNameMissing(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	review := filepath.Join(project, "review")
+	if err := os.MkdirAll(review, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(review, "skill.json"), []byte(`{"name":"","description":"from manifest"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(review, "SKILL.md"), []byte(`---
+name: review
+allowed-tools: "read_file,search_text"
+---
+# /review
+
+Use this skill when reviewing changes.
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManagerWithDirs(root, filepath.Join(root, "builtin"), filepath.Join(root, "user"), project)
+	item, err := mgr.(*extensionManager).discoverOne(review)
+	if err != nil {
+		t.Fatalf("discoverOne should fallback to frontmatter name, got %v", err)
+	}
+	if item.ID != "skill.review" {
+		t.Fatalf("unexpected discovered extension id: %q", item.ID)
+	}
+	if item.Capabilities.Tools != 2 {
+		t.Fatalf("expected frontmatter allowed-tools to map to tool capabilities, got %#v", item.Capabilities)
+	}
+}
+
 func TestDiscoverOneIgnoresBrokenSibling(t *testing.T) {
 	root := t.TempDir()
 	project := filepath.Join(root, "project")

--- a/internal/extensions/skills_adapter.go
+++ b/internal/extensions/skills_adapter.go
@@ -90,7 +90,7 @@ func (a *skillAdapter) FromSkill(skill skillspkg.Skill) ExtensionInfo {
 		manifestRef = filepath.Join(normalized.SourceDir, "skill.json")
 	}
 	return ExtensionInfo{
-		ID:           "skill." + normalized.Name,
+		ID:           SkillExtensionID(normalized.Name),
 		Name:         normalized.Name,
 		Kind:         ExtensionSkill,
 		Version:      strings.TrimSpace(normalized.Version),

--- a/internal/extensions/skills_adapter.go
+++ b/internal/extensions/skills_adapter.go
@@ -5,12 +5,14 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	skillspkg "bytemind/internal/skills"
 )
 
 type skillAdapter struct {
+	mu    sync.RWMutex
 	cache map[string]cachedSkillExtension
 }
 
@@ -28,32 +30,41 @@ func (a *skillAdapter) Sync(catalog skillspkg.Catalog) []ExtensionInfo {
 	if a == nil {
 		return nil
 	}
-	seen := make(map[string]struct{}, len(catalog.Skills))
+
+	a.mu.RLock()
+	current := make(map[string]cachedSkillExtension, len(a.cache))
+	for id, entry := range a.cache {
+		current[id] = entry
+	}
+	a.mu.RUnlock()
+
+	nextCache := make(map[string]cachedSkillExtension, len(catalog.Skills))
 	for _, skill := range catalog.Skills {
 		item := a.FromSkill(skill)
-		seen[item.ID] = struct{}{}
-		entry, ok := a.cache[item.ID]
+		entry, ok := current[item.ID]
 		if ok && entry.ref == item.Source.Ref && entry.updatedAt.Equal(skill.DiscoveredAt) {
+			nextCache[item.ID] = entry
 			continue
 		}
-		a.cache[item.ID] = cachedSkillExtension{
+		nextCache[item.ID] = cachedSkillExtension{
 			item:      item,
 			ref:       item.Source.Ref,
 			updatedAt: skill.DiscoveredAt,
 		}
 	}
-	for id := range a.cache {
-		if _, ok := seen[id]; !ok {
-			delete(a.cache, id)
-		}
-	}
-	items := make([]ExtensionInfo, 0, len(a.cache))
-	for _, entry := range a.cache {
-		items = append(items, entry.item)
+
+	items := make([]ExtensionInfo, 0, len(nextCache))
+	for _, entry := range nextCache {
+		items = append(items, cloneExtensionInfo(entry.item))
 	}
 	sort.Slice(items, func(i, j int) bool {
 		return items[i].ID < items[j].ID
 	})
+
+	a.mu.Lock()
+	a.cache = nextCache
+	a.mu.Unlock()
+
 	return items
 }
 

--- a/internal/extensions/skills_adapter_test.go
+++ b/internal/extensions/skills_adapter_test.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -54,4 +55,41 @@ func TestSkillAdapterFromSkillMarksManifestOnlyAsDegraded(t *testing.T) {
 	if item.Health.Status != ExtensionStatusDegraded {
 		t.Fatalf("expected degraded health, got %q", item.Health.Status)
 	}
+}
+
+func TestSkillAdapterSyncConcurrentDoesNotPanic(t *testing.T) {
+	adapter := newSkillAdapter()
+	now := time.Now().UTC()
+	catalogs := []skillspkg.Catalog{
+		{
+			Skills: []skillspkg.Skill{{
+				Name:         "review",
+				Title:        "review",
+				Scope:        skillspkg.ScopeProject,
+				SourceDir:    `C:\\repo\\.bytemind\\skills\\review`,
+				DiscoveredAt: now,
+			}},
+		},
+		{
+			Skills: []skillspkg.Skill{{
+				Name:         "lint",
+				Title:        "lint",
+				Scope:        skillspkg.ScopeProject,
+				SourceDir:    `C:\\repo\\.bytemind\\skills\\lint`,
+				DiscoveredAt: now.Add(1 * time.Second),
+			}},
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		for _, catalog := range catalogs {
+			wg.Add(1)
+			go func(c skillspkg.Catalog) {
+				defer wg.Done()
+				_ = adapter.Sync(c)
+			}(catalog)
+		}
+	}
+	wg.Wait()
 }

--- a/internal/extensions/skills_adapter_test.go
+++ b/internal/extensions/skills_adapter_test.go
@@ -57,6 +57,20 @@ func TestSkillAdapterFromSkillMarksManifestOnlyAsDegraded(t *testing.T) {
 	}
 }
 
+func TestSkillAdapterFromSkillKeepsPrefixedNameIDCompatibility(t *testing.T) {
+	adapter := newSkillAdapter()
+	item := adapter.FromSkill(skillspkg.Skill{
+		Name:         "skill.review",
+		Title:        "skill.review",
+		Scope:        skillspkg.ScopeProject,
+		SourceDir:    `C:\\repo\\.bytemind\\skills\\skill.review`,
+		DiscoveredAt: time.Now().UTC(),
+	})
+	if item.ID != "skill.skill.review" {
+		t.Fatalf("expected compat id skill.skill.review, got %q", item.ID)
+	}
+}
+
 func TestSkillAdapterSyncConcurrentDoesNotPanic(t *testing.T) {
 	adapter := newSkillAdapter()
 	base := time.Now().UTC()

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -132,6 +132,13 @@ func (r *Registry) Register(tool Tool, opts RegisterOptions) error {
 		}
 	}
 	if conflict, exists := r.findConflictByOriginalNameLocked(meta.OriginalToolName, meta.ToolKey); exists {
+		if opts.AllowOriginalNameShadowBuiltin &&
+			meta.Source == RegistrationSourceExtension &&
+			conflict.Source == RegistrationSourceBuiltin {
+			r.tools[meta.ToolKey] = resolved
+			r.meta[meta.ToolKey] = meta
+			return nil
+		}
 		return &RegistryError{
 			Code:             RegistryErrorDuplicateName,
 			Message:          fmt.Sprintf("tool original name %q already registered", meta.OriginalToolName),

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -190,7 +190,7 @@ func (r *Registry) List() []ResolvedTool {
 }
 
 func (r *Registry) FindByOriginalName(name string) []RegistrationMeta {
-	original := strings.TrimSpace(name)
+	original := normalizeOriginalToolName(name)
 	if original == "" {
 		return nil
 	}
@@ -198,6 +198,29 @@ func (r *Registry) FindByOriginalName(name string) []RegistrationMeta {
 	items := make([]RegistrationMeta, 0, len(r.meta))
 	for _, meta := range r.meta {
 		if meta.OriginalToolName != original {
+			continue
+		}
+		items = append(items, cloneRegistrationMeta(meta))
+	}
+	r.mu.RUnlock()
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].ToolKey < items[j].ToolKey
+	})
+	return items
+}
+
+func (r *Registry) FindByExtensionID(extensionID string) []RegistrationMeta {
+	extensionID = strings.TrimSpace(extensionID)
+	if extensionID == "" {
+		return nil
+	}
+	r.mu.RLock()
+	items := make([]RegistrationMeta, 0, len(r.meta))
+	for _, meta := range r.meta {
+		if meta.Source != RegistrationSourceExtension {
+			continue
+		}
+		if meta.ExtensionID != extensionID {
 			continue
 		}
 		items = append(items, cloneRegistrationMeta(meta))
@@ -280,7 +303,7 @@ func (r *Registry) ensureMapsLocked() {
 }
 
 func (r *Registry) findConflictByOriginalNameLocked(originalName, toolKey string) (RegistrationMeta, bool) {
-	originalName = strings.TrimSpace(originalName)
+	originalName = normalizeOriginalToolName(originalName)
 	toolKey = strings.TrimSpace(toolKey)
 	if originalName == "" {
 		return RegistrationMeta{}, false

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -132,28 +132,14 @@ func (r *Registry) Register(tool Tool, opts RegisterOptions) error {
 		}
 	}
 	if conflicts := r.findConflictsByOriginalNameLocked(meta.OriginalToolName, meta.ToolKey); len(conflicts) > 0 {
-		if opts.AllowOriginalNameShadowBuiltin && meta.Source == RegistrationSourceExtension {
-			allBuiltin := true
-			for _, conflict := range conflicts {
-				if conflict.Source == RegistrationSourceBuiltin {
-					continue
-				}
-				allBuiltin = false
-				return &RegistryError{
-					Code:             RegistryErrorDuplicateName,
-					Message:          fmt.Sprintf("tool original name %q already registered", meta.OriginalToolName),
-					ToolKey:          meta.ToolKey,
-					OriginalToolName: meta.OriginalToolName,
-					Source:           meta.Source,
-					ExtensionID:      meta.ExtensionID,
-					ConflictWith:     conflict,
-				}
-			}
-			if allBuiltin {
-				r.tools[meta.ToolKey] = resolved
-				r.meta[meta.ToolKey] = meta
-				return nil
-			}
+		blocking := conflicts
+		if meta.Source == RegistrationSourceExtension {
+			blocking = filterBlockingOriginalNameConflicts(meta, conflicts, opts.AllowOriginalNameShadowBuiltin)
+		}
+		if len(blocking) == 0 {
+			r.tools[meta.ToolKey] = resolved
+			r.meta[meta.ToolKey] = meta
+			return nil
 		}
 		return &RegistryError{
 			Code:             RegistryErrorDuplicateName,
@@ -162,7 +148,7 @@ func (r *Registry) Register(tool Tool, opts RegisterOptions) error {
 			OriginalToolName: meta.OriginalToolName,
 			Source:           meta.Source,
 			ExtensionID:      meta.ExtensionID,
-			ConflictWith:     conflicts[0],
+			ConflictWith:     blocking[0],
 		}
 	}
 	r.tools[meta.ToolKey] = resolved
@@ -345,6 +331,29 @@ func (r *Registry) findConflictsByOriginalNameLocked(originalName, toolKey strin
 		return conflicts[i].ToolKey < conflicts[j].ToolKey
 	})
 	return conflicts
+}
+
+func filterBlockingOriginalNameConflicts(meta RegistrationMeta, conflicts []RegistrationMeta, allowShadowBuiltin bool) []RegistrationMeta {
+	if len(conflicts) == 0 {
+		return nil
+	}
+	blocking := make([]RegistrationMeta, 0, len(conflicts))
+	for _, conflict := range conflicts {
+		switch conflict.Source {
+		case RegistrationSourceBuiltin:
+			if allowShadowBuiltin {
+				continue
+			}
+		case RegistrationSourceExtension:
+			// Session-isolated bridges may share original tool names across extensions.
+			// Keep same-extension conflicts rejected to avoid ambiguous aliases.
+			if meta.ExtensionID != "" && conflict.ExtensionID != "" && conflict.ExtensionID != meta.ExtensionID {
+				continue
+			}
+		}
+		blocking = append(blocking, conflict)
+	}
+	return blocking
 }
 
 func sortedResolvedTools(snapshot map[string]ResolvedTool, allowlist, denylist []string, include func(ResolvedTool) bool) []ResolvedTool {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -131,13 +131,29 @@ func (r *Registry) Register(tool Tool, opts RegisterOptions) error {
 			ConflictWith:     existingMeta,
 		}
 	}
-	if conflict, exists := r.findConflictByOriginalNameLocked(meta.OriginalToolName, meta.ToolKey); exists {
-		if opts.AllowOriginalNameShadowBuiltin &&
-			meta.Source == RegistrationSourceExtension &&
-			conflict.Source == RegistrationSourceBuiltin {
-			r.tools[meta.ToolKey] = resolved
-			r.meta[meta.ToolKey] = meta
-			return nil
+	if conflicts := r.findConflictsByOriginalNameLocked(meta.OriginalToolName, meta.ToolKey); len(conflicts) > 0 {
+		if opts.AllowOriginalNameShadowBuiltin && meta.Source == RegistrationSourceExtension {
+			allBuiltin := true
+			for _, conflict := range conflicts {
+				if conflict.Source == RegistrationSourceBuiltin {
+					continue
+				}
+				allBuiltin = false
+				return &RegistryError{
+					Code:             RegistryErrorDuplicateName,
+					Message:          fmt.Sprintf("tool original name %q already registered", meta.OriginalToolName),
+					ToolKey:          meta.ToolKey,
+					OriginalToolName: meta.OriginalToolName,
+					Source:           meta.Source,
+					ExtensionID:      meta.ExtensionID,
+					ConflictWith:     conflict,
+				}
+			}
+			if allBuiltin {
+				r.tools[meta.ToolKey] = resolved
+				r.meta[meta.ToolKey] = meta
+				return nil
+			}
 		}
 		return &RegistryError{
 			Code:             RegistryErrorDuplicateName,
@@ -146,7 +162,7 @@ func (r *Registry) Register(tool Tool, opts RegisterOptions) error {
 			OriginalToolName: meta.OriginalToolName,
 			Source:           meta.Source,
 			ExtensionID:      meta.ExtensionID,
-			ConflictWith:     conflict,
+			ConflictWith:     conflicts[0],
 		}
 	}
 	r.tools[meta.ToolKey] = resolved
@@ -309,12 +325,13 @@ func (r *Registry) ensureMapsLocked() {
 	}
 }
 
-func (r *Registry) findConflictByOriginalNameLocked(originalName, toolKey string) (RegistrationMeta, bool) {
+func (r *Registry) findConflictsByOriginalNameLocked(originalName, toolKey string) []RegistrationMeta {
 	originalName = normalizeOriginalToolName(originalName)
 	toolKey = strings.TrimSpace(toolKey)
 	if originalName == "" {
-		return RegistrationMeta{}, false
+		return nil
 	}
+	conflicts := make([]RegistrationMeta, 0, len(r.meta))
 	for existingKey, existingMeta := range r.meta {
 		if existingKey == toolKey {
 			continue
@@ -322,9 +339,12 @@ func (r *Registry) findConflictByOriginalNameLocked(originalName, toolKey string
 		if existingMeta.OriginalToolName != originalName {
 			continue
 		}
-		return cloneRegistrationMeta(existingMeta), true
+		conflicts = append(conflicts, cloneRegistrationMeta(existingMeta))
 	}
-	return RegistrationMeta{}, false
+	sort.Slice(conflicts, func(i, j int) bool {
+		return conflicts[i].ToolKey < conflicts[j].ToolKey
+	})
+	return conflicts
 }
 
 func sortedResolvedTools(snapshot map[string]ResolvedTool, allowlist, denylist []string, include func(ResolvedTool) bool) []ResolvedTool {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	extensionspkg "bytemind/internal/extensions"
 	"bytemind/internal/llm"
 	planpkg "bytemind/internal/plan"
 	runtimepkg "bytemind/internal/runtime"
@@ -24,12 +23,14 @@ type ExecutionContext struct {
 	Approval       ApprovalHandler
 	Session        *session.Session
 	TaskManager    runtimepkg.TaskManager
-	Extensions     extensionspkg.Manager
-	Mode           planpkg.AgentMode
-	Stdin          io.Reader
-	Stdout         io.Writer
-	AllowedTools   map[string]struct{}
-	DeniedTools    map[string]struct{}
+	// Extensions is an optional passthrough hook for callers that need extension context.
+	// It stays untyped here to keep tools/extension packages decoupled.
+	Extensions   any
+	Mode         planpkg.AgentMode
+	Stdin        io.Reader
+	Stdout       io.Writer
+	AllowedTools map[string]struct{}
+	DeniedTools  map[string]struct{}
 }
 
 const (
@@ -121,12 +122,24 @@ func (r *Registry) Register(tool Tool, opts RegisterOptions) error {
 	r.ensureMapsLocked()
 	if existingMeta, exists := r.meta[meta.ToolKey]; exists {
 		return &RegistryError{
-			Code:         RegistryErrorDuplicateName,
-			Message:      fmt.Sprintf("tool %q already registered", meta.ToolKey),
-			ToolKey:      meta.ToolKey,
-			Source:       meta.Source,
-			ExtensionID:  meta.ExtensionID,
-			ConflictWith: existingMeta,
+			Code:             RegistryErrorDuplicateName,
+			Message:          fmt.Sprintf("tool %q already registered", meta.ToolKey),
+			ToolKey:          meta.ToolKey,
+			OriginalToolName: meta.OriginalToolName,
+			Source:           meta.Source,
+			ExtensionID:      meta.ExtensionID,
+			ConflictWith:     existingMeta,
+		}
+	}
+	if conflict, exists := r.findConflictByOriginalNameLocked(meta.OriginalToolName, meta.ToolKey); exists {
+		return &RegistryError{
+			Code:             RegistryErrorDuplicateName,
+			Message:          fmt.Sprintf("tool original name %q already registered", meta.OriginalToolName),
+			ToolKey:          meta.ToolKey,
+			OriginalToolName: meta.OriginalToolName,
+			Source:           meta.Source,
+			ExtensionID:      meta.ExtensionID,
+			ConflictWith:     conflict,
 		}
 	}
 	r.tools[meta.ToolKey] = resolved
@@ -174,6 +187,26 @@ func (r *Registry) List() []ResolvedTool {
 	}
 	r.mu.RUnlock()
 	return sortedResolvedTools(snapshot, nil, nil, func(ResolvedTool) bool { return true })
+}
+
+func (r *Registry) FindByOriginalName(name string) []RegistrationMeta {
+	original := strings.TrimSpace(name)
+	if original == "" {
+		return nil
+	}
+	r.mu.RLock()
+	items := make([]RegistrationMeta, 0, len(r.meta))
+	for _, meta := range r.meta {
+		if meta.OriginalToolName != original {
+			continue
+		}
+		items = append(items, cloneRegistrationMeta(meta))
+	}
+	r.mu.RUnlock()
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].ToolKey < items[j].ToolKey
+	})
+	return items
 }
 
 func (r *Registry) Definitions() []llm.ToolDefinition {
@@ -246,6 +279,24 @@ func (r *Registry) ensureMapsLocked() {
 	}
 }
 
+func (r *Registry) findConflictByOriginalNameLocked(originalName, toolKey string) (RegistrationMeta, bool) {
+	originalName = strings.TrimSpace(originalName)
+	toolKey = strings.TrimSpace(toolKey)
+	if originalName == "" {
+		return RegistrationMeta{}, false
+	}
+	for existingKey, existingMeta := range r.meta {
+		if existingKey == toolKey {
+			continue
+		}
+		if existingMeta.OriginalToolName != originalName {
+			continue
+		}
+		return cloneRegistrationMeta(existingMeta), true
+	}
+	return RegistrationMeta{}, false
+}
+
 func sortedResolvedTools(snapshot map[string]ResolvedTool, allowlist, denylist []string, include func(ResolvedTool) bool) []ResolvedTool {
 	allowSet := toNameSet(allowlist)
 	denySet := toNameSet(denylist)
@@ -285,4 +336,15 @@ func toNameSet(items []string) map[string]struct{} {
 		result[item] = struct{}{}
 	}
 	return result
+}
+
+func cloneRegistrationMeta(meta RegistrationMeta) RegistrationMeta {
+	return RegistrationMeta{
+		ToolKey:          meta.ToolKey,
+		StableToolKey:    meta.StableToolKey,
+		OriginalToolName: meta.OriginalToolName,
+		Source:           meta.Source,
+		ExtensionID:      meta.ExtensionID,
+		ConflictPolicy:   meta.ConflictPolicy,
+	}
 }

--- a/internal/tools/registry_contract_test.go
+++ b/internal/tools/registry_contract_test.go
@@ -173,6 +173,31 @@ func TestRegistryContractDuplicateOriginalNameIncludesConflictContext(t *testing
 	}
 }
 
+func TestRegistryContractDuplicateOriginalNameIsCaseInsensitive(t *testing.T) {
+	registry := &Registry{}
+	if err := registry.Register(contractTestTool{name: "read_file"}, RegisterOptions{Source: RegistrationSourceBuiltin}); err != nil {
+		t.Fatalf("first register failed: %v", err)
+	}
+	err := registry.Register(contractTestTool{name: "skill:skill_demo:read_file"}, RegisterOptions{
+		Source:       RegistrationSourceExtension,
+		ExtensionID:  "skill.demo",
+		OriginalName: "Read_File",
+	})
+	if err == nil {
+		t.Fatal("expected duplicate error")
+	}
+	var regErr *RegistryError
+	if !errors.As(err, &regErr) {
+		t.Fatalf("expected RegistryError, got %T", err)
+	}
+	if regErr.Code != RegistryErrorDuplicateName {
+		t.Fatalf("unexpected code: %s", regErr.Code)
+	}
+	if regErr.OriginalToolName != "read_file" {
+		t.Fatalf("expected normalized original tool name, got %q", regErr.OriginalToolName)
+	}
+}
+
 func TestRegistryContractInvalidSchemaIncludesCause(t *testing.T) {
 	registry := &Registry{}
 	err := registry.Register(contractInvalidSpecTool{

--- a/internal/tools/registry_contract_test.go
+++ b/internal/tools/registry_contract_test.go
@@ -142,6 +142,37 @@ func TestRegistryContractDuplicateIncludesConflictContext(t *testing.T) {
 	}
 }
 
+func TestRegistryContractDuplicateOriginalNameIncludesConflictContext(t *testing.T) {
+	registry := &Registry{}
+	if err := registry.Register(contractTestTool{name: "read_file"}, RegisterOptions{Source: RegistrationSourceBuiltin}); err != nil {
+		t.Fatalf("first register failed: %v", err)
+	}
+	err := registry.Register(contractTestTool{name: "skill:skill_demo:read_file"}, RegisterOptions{
+		Source:       RegistrationSourceExtension,
+		ExtensionID:  "skill.demo",
+		OriginalName: "read_file",
+	})
+	if err == nil {
+		t.Fatal("expected duplicate error")
+	}
+	var regErr *RegistryError
+	if !errors.As(err, &regErr) {
+		t.Fatalf("expected RegistryError, got %T", err)
+	}
+	if regErr.Code != RegistryErrorDuplicateName {
+		t.Fatalf("unexpected code: %s", regErr.Code)
+	}
+	if regErr.OriginalToolName != "read_file" {
+		t.Fatalf("unexpected original tool name: %q", regErr.OriginalToolName)
+	}
+	if regErr.ConflictWith.Source != RegistrationSourceBuiltin {
+		t.Fatalf("unexpected conflict source: %+v", regErr.ConflictWith)
+	}
+	if regErr.ConflictWith.OriginalToolName != "read_file" {
+		t.Fatalf("unexpected conflict original tool name: %q", regErr.ConflictWith.OriginalToolName)
+	}
+}
+
 func TestRegistryContractInvalidSchemaIncludesCause(t *testing.T) {
 	registry := &Registry{}
 	err := registry.Register(contractInvalidSpecTool{

--- a/internal/tools/registry_errors.go
+++ b/internal/tools/registry_errors.go
@@ -20,6 +20,10 @@ type RegisterOptions struct {
 	Source       RegistrationSource
 	ExtensionID  string
 	OriginalName string
+	// AllowOriginalNameShadowBuiltin permits extension registrations to reuse an
+	// existing builtin original tool name. This is only intended for bridge
+	// aliases whose tool key is source-aware and unique.
+	AllowOriginalNameShadowBuiltin bool
 }
 
 type RegistrationMeta struct {

--- a/internal/tools/registry_errors.go
+++ b/internal/tools/registry_errors.go
@@ -17,15 +17,18 @@ const (
 )
 
 type RegisterOptions struct {
-	Source      RegistrationSource
-	ExtensionID string
+	Source       RegistrationSource
+	ExtensionID  string
+	OriginalName string
 }
 
 type RegistrationMeta struct {
-	ToolKey        string
-	Source         RegistrationSource
-	ExtensionID    string
-	ConflictPolicy string
+	ToolKey          string
+	StableToolKey    string
+	OriginalToolName string
+	Source           RegistrationSource
+	ExtensionID      string
+	ConflictPolicy   string
 }
 
 type RegistryErrorCode string
@@ -40,13 +43,14 @@ const (
 )
 
 type RegistryError struct {
-	Code         RegistryErrorCode
-	Message      string
-	ToolKey      string
-	Source       RegistrationSource
-	ExtensionID  string
-	ConflictWith RegistrationMeta
-	Cause        error
+	Code             RegistryErrorCode
+	Message          string
+	ToolKey          string
+	OriginalToolName string
+	Source           RegistrationSource
+	ExtensionID      string
+	ConflictWith     RegistrationMeta
+	Cause            error
 }
 
 func (e *RegistryError) Error() string {
@@ -88,6 +92,11 @@ func buildRegistration(tool Tool, opts RegisterOptions) (RegistrationMeta, Resol
 	meta.ToolKey = strings.TrimSpace(definition.Function.Name)
 	if meta.ToolKey == "" {
 		return RegistrationMeta{}, ResolvedTool{}, &RegistryError{Code: RegistryErrorInvalidToolKey, Message: "tool key is required", Source: meta.Source, ExtensionID: meta.ExtensionID}
+	}
+	meta.StableToolKey = meta.ToolKey
+	meta.OriginalToolName = strings.TrimSpace(opts.OriginalName)
+	if meta.OriginalToolName == "" {
+		meta.OriginalToolName = meta.ToolKey
 	}
 	definition.Function.Name = meta.ToolKey
 	if provider, ok := tool.(ToolSpecProvider); ok {

--- a/internal/tools/registry_errors.go
+++ b/internal/tools/registry_errors.go
@@ -94,9 +94,9 @@ func buildRegistration(tool Tool, opts RegisterOptions) (RegistrationMeta, Resol
 		return RegistrationMeta{}, ResolvedTool{}, &RegistryError{Code: RegistryErrorInvalidToolKey, Message: "tool key is required", Source: meta.Source, ExtensionID: meta.ExtensionID}
 	}
 	meta.StableToolKey = meta.ToolKey
-	meta.OriginalToolName = strings.TrimSpace(opts.OriginalName)
+	meta.OriginalToolName = normalizeOriginalToolName(opts.OriginalName)
 	if meta.OriginalToolName == "" {
-		meta.OriginalToolName = meta.ToolKey
+		meta.OriginalToolName = normalizeOriginalToolName(meta.ToolKey)
 	}
 	definition.Function.Name = meta.ToolKey
 	if provider, ok := tool.(ToolSpecProvider); ok {
@@ -125,6 +125,10 @@ func normalizeRegistrationSource(source RegistrationSource) RegistrationSource {
 	default:
 		return ""
 	}
+}
+
+func normalizeOriginalToolName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
 }
 
 func cloneResolvedTool(resolved ResolvedTool) ResolvedTool {

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -331,6 +331,26 @@ func TestRegistryRegisterRejectsCaseInsensitiveOriginalNameConflict(t *testing.T
 	}
 }
 
+func TestRegistryRegisterAllowsShadowBuiltinOriginalNameWhenOptedIn(t *testing.T) {
+	registry := &Registry{}
+	if err := registry.Register(testTool{name: "read_file"}, RegisterOptions{Source: RegistrationSourceBuiltin}); err != nil {
+		t.Fatalf("register builtin failed: %v", err)
+	}
+	if err := registry.Register(testTool{name: "skill:skill_demo:read_file"}, RegisterOptions{
+		Source:                         RegistrationSourceExtension,
+		ExtensionID:                    "skill.demo",
+		OriginalName:                   "read_file",
+		AllowOriginalNameShadowBuiltin: true,
+	}); err != nil {
+		t.Fatalf("register extension shadow tool failed: %v", err)
+	}
+
+	metas := registry.FindByOriginalName("read_file")
+	if len(metas) != 2 {
+		t.Fatalf("expected two metadata records for read_file, got %#v", metas)
+	}
+}
+
 func TestRegistryFindByOriginalNameIsCaseInsensitive(t *testing.T) {
 	registry := &Registry{}
 	if err := registry.Register(testTool{name: "skill:skill_demo:open_doc"}, RegisterOptions{

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -351,6 +351,40 @@ func TestRegistryRegisterAllowsShadowBuiltinOriginalNameWhenOptedIn(t *testing.T
 	}
 }
 
+func TestRegistryRegisterShadowBuiltinStillRejectsExistingExtensionConflict(t *testing.T) {
+	registry := &Registry{}
+	if err := registry.Register(testTool{name: "read_file"}, RegisterOptions{Source: RegistrationSourceBuiltin}); err != nil {
+		t.Fatalf("register builtin failed: %v", err)
+	}
+	if err := registry.Register(testTool{name: "skill:skill_review:read_file"}, RegisterOptions{
+		Source:                         RegistrationSourceExtension,
+		ExtensionID:                    "skill.review",
+		OriginalName:                   "read_file",
+		AllowOriginalNameShadowBuiltin: true,
+	}); err != nil {
+		t.Fatalf("register first extension shadow tool failed: %v", err)
+	}
+	err := registry.Register(testTool{name: "skill:skill_plan:read_file"}, RegisterOptions{
+		Source:                         RegistrationSourceExtension,
+		ExtensionID:                    "skill.plan",
+		OriginalName:                   "read_file",
+		AllowOriginalNameShadowBuiltin: true,
+	})
+	if err == nil {
+		t.Fatal("expected duplicate original name error against existing extension")
+	}
+	regErr, ok := err.(*RegistryError)
+	if !ok {
+		t.Fatalf("expected RegistryError, got %T", err)
+	}
+	if regErr.Code != RegistryErrorDuplicateName {
+		t.Fatalf("expected duplicate_name, got %s", regErr.Code)
+	}
+	if regErr.ConflictWith.Source != RegistrationSourceExtension {
+		t.Fatalf("expected extension conflict source, got %+v", regErr.ConflictWith)
+	}
+}
+
 func TestRegistryFindByOriginalNameIsCaseInsensitive(t *testing.T) {
 	registry := &Registry{}
 	if err := registry.Register(testTool{name: "skill:skill_demo:open_doc"}, RegisterOptions{

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -351,7 +351,7 @@ func TestRegistryRegisterAllowsShadowBuiltinOriginalNameWhenOptedIn(t *testing.T
 	}
 }
 
-func TestRegistryRegisterShadowBuiltinStillRejectsExistingExtensionConflict(t *testing.T) {
+func TestRegistryRegisterShadowBuiltinAllowsExistingExtensionConflictAcrossExtensions(t *testing.T) {
 	registry := &Registry{}
 	if err := registry.Register(testTool{name: "read_file"}, RegisterOptions{Source: RegistrationSourceBuiltin}); err != nil {
 		t.Fatalf("register builtin failed: %v", err)
@@ -364,14 +364,41 @@ func TestRegistryRegisterShadowBuiltinStillRejectsExistingExtensionConflict(t *t
 	}); err != nil {
 		t.Fatalf("register first extension shadow tool failed: %v", err)
 	}
-	err := registry.Register(testTool{name: "skill:skill_plan:read_file"}, RegisterOptions{
+	if err := registry.Register(testTool{name: "skill:skill_plan:read_file"}, RegisterOptions{
 		Source:                         RegistrationSourceExtension,
 		ExtensionID:                    "skill.plan",
 		OriginalName:                   "read_file",
 		AllowOriginalNameShadowBuiltin: true,
+	}); err != nil {
+		t.Fatalf("register second extension shadow tool failed: %v", err)
+	}
+	metas := registry.FindByOriginalName("read_file")
+	if len(metas) != 3 {
+		t.Fatalf("expected builtin + 2 extension records, got %#v", metas)
+	}
+}
+
+func TestRegistryRegisterShadowBuiltinRejectsExistingExtensionConflictWithinSameExtension(t *testing.T) {
+	registry := &Registry{}
+	if err := registry.Register(testTool{name: "read_file"}, RegisterOptions{Source: RegistrationSourceBuiltin}); err != nil {
+		t.Fatalf("register builtin failed: %v", err)
+	}
+	if err := registry.Register(testTool{name: "skill:skill_review:read_file"}, RegisterOptions{
+		Source:                         RegistrationSourceExtension,
+		ExtensionID:                    "skill.review",
+		OriginalName:                   "read_file",
+		AllowOriginalNameShadowBuiltin: true,
+	}); err != nil {
+		t.Fatalf("register first extension shadow tool failed: %v", err)
+	}
+	err := registry.Register(testTool{name: "skill:skill_review_v2:read_file"}, RegisterOptions{
+		Source:                         RegistrationSourceExtension,
+		ExtensionID:                    "skill.review",
+		OriginalName:                   "read_file",
+		AllowOriginalNameShadowBuiltin: true,
 	})
 	if err == nil {
-		t.Fatal("expected duplicate original name error against existing extension")
+		t.Fatal("expected duplicate original-name error within same extension")
 	}
 	regErr, ok := err.(*RegistryError)
 	if !ok {
@@ -382,6 +409,9 @@ func TestRegistryRegisterShadowBuiltinStillRejectsExistingExtensionConflict(t *t
 	}
 	if regErr.ConflictWith.Source != RegistrationSourceExtension {
 		t.Fatalf("expected extension conflict source, got %+v", regErr.ConflictWith)
+	}
+	if regErr.ConflictWith.ExtensionID != "skill.review" {
+		t.Fatalf("expected same extension conflict, got %+v", regErr.ConflictWith)
 	}
 }
 

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -306,6 +306,80 @@ func TestRegistryFindByOriginalName(t *testing.T) {
 	}
 }
 
+func TestRegistryRegisterRejectsCaseInsensitiveOriginalNameConflict(t *testing.T) {
+	registry := &Registry{}
+	if err := registry.Register(testTool{name: "read_file"}, RegisterOptions{Source: RegistrationSourceBuiltin}); err != nil {
+		t.Fatalf("register builtin failed: %v", err)
+	}
+	err := registry.Register(testTool{name: "skill:skill_demo:read_file"}, RegisterOptions{
+		Source:       RegistrationSourceExtension,
+		ExtensionID:  "skill.demo",
+		OriginalName: "Read_File",
+	})
+	if err == nil {
+		t.Fatal("expected duplicate original-name error")
+	}
+	regErr, ok := err.(*RegistryError)
+	if !ok {
+		t.Fatalf("unexpected error type: %T", err)
+	}
+	if regErr.Code != RegistryErrorDuplicateName {
+		t.Fatalf("unexpected error code: %s", regErr.Code)
+	}
+	if regErr.OriginalToolName != "read_file" {
+		t.Fatalf("expected normalized original name, got %q", regErr.OriginalToolName)
+	}
+}
+
+func TestRegistryFindByOriginalNameIsCaseInsensitive(t *testing.T) {
+	registry := &Registry{}
+	if err := registry.Register(testTool{name: "skill:skill_demo:open_doc"}, RegisterOptions{
+		Source:       RegistrationSourceExtension,
+		ExtensionID:  "skill.demo",
+		OriginalName: "Open_Doc",
+	}); err != nil {
+		t.Fatalf("register bridged tool failed: %v", err)
+	}
+	metas := registry.FindByOriginalName("OPEN_doc")
+	if len(metas) != 1 {
+		t.Fatalf("expected one metadata record, got %d", len(metas))
+	}
+	if metas[0].OriginalToolName != "open_doc" {
+		t.Fatalf("expected normalized original name, got %q", metas[0].OriginalToolName)
+	}
+}
+
+func TestRegistryFindByExtensionID(t *testing.T) {
+	registry := &Registry{}
+	if err := registry.Register(testTool{name: "read_file"}, RegisterOptions{Source: RegistrationSourceBuiltin}); err != nil {
+		t.Fatalf("register builtin failed: %v", err)
+	}
+	if err := registry.Register(testTool{name: "skill:skill_demo:open_doc"}, RegisterOptions{
+		Source:       RegistrationSourceExtension,
+		ExtensionID:  "skill.demo",
+		OriginalName: "open_doc",
+	}); err != nil {
+		t.Fatalf("register extension tool failed: %v", err)
+	}
+	if err := registry.Register(testTool{name: "skill:skill_other:search_doc"}, RegisterOptions{
+		Source:       RegistrationSourceExtension,
+		ExtensionID:  "skill.other",
+		OriginalName: "search_doc",
+	}); err != nil {
+		t.Fatalf("register second extension tool failed: %v", err)
+	}
+	metas := registry.FindByExtensionID("skill.demo")
+	if len(metas) != 1 {
+		t.Fatalf("expected one metadata for extension, got %d", len(metas))
+	}
+	if metas[0].ToolKey != "skill:skill_demo:open_doc" {
+		t.Fatalf("unexpected tool key: %q", metas[0].ToolKey)
+	}
+	if got := registry.FindByExtensionID("missing"); len(got) != 0 {
+		t.Fatalf("expected no metadata for missing extension, got %#v", got)
+	}
+}
+
 func TestRegistryResolveForModeRejectsUnavailableTool(t *testing.T) {
 	registry := &Registry{}
 	if err := registry.Register(invalidSpecTool{

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -276,6 +276,36 @@ func TestRegistryListReturnsSortedSnapshot(t *testing.T) {
 	}
 }
 
+func TestRegistryFindByOriginalName(t *testing.T) {
+	registry := &Registry{}
+	if err := registry.Register(testTool{name: "alpha_tool"}, RegisterOptions{Source: RegistrationSourceBuiltin}); err != nil {
+		t.Fatalf("register alpha_tool failed: %v", err)
+	}
+	if err := registry.Register(testTool{name: "skill:skill_demo:open_doc"}, RegisterOptions{
+		Source:       RegistrationSourceExtension,
+		ExtensionID:  "skill.demo",
+		OriginalName: "open_doc",
+	}); err != nil {
+		t.Fatalf("register bridged tool failed: %v", err)
+	}
+	metas := registry.FindByOriginalName("open_doc")
+	if len(metas) != 1 {
+		t.Fatalf("expected one metadata record, got %d", len(metas))
+	}
+	if metas[0].ToolKey != "skill:skill_demo:open_doc" {
+		t.Fatalf("unexpected tool key: %q", metas[0].ToolKey)
+	}
+	if metas[0].OriginalToolName != "open_doc" {
+		t.Fatalf("unexpected original tool name: %q", metas[0].OriginalToolName)
+	}
+	if metas[0].Source != RegistrationSourceExtension {
+		t.Fatalf("unexpected source: %q", metas[0].Source)
+	}
+	if got := registry.FindByOriginalName("missing"); len(got) != 0 {
+		t.Fatalf("expected no metadata for missing original name, got %#v", got)
+	}
+}
+
 func TestRegistryResolveForModeRejectsUnavailableTool(t *testing.T) {
 	registry := &Registry{}
 	if err := registry.Register(invalidSpecTool{


### PR DESCRIPTION
## 背景
按 `extension-iteration-plan.md` 与 `prd-extension.md` 的阶段 6 目标，实现 extension -> tools -> policy 的 bridge 能力，确保 source-aware 命名与冲突可追踪，并保持执行主链路（runner/executor）不做 extension 特判。

## 本次改动
1. 新增 extension bridge 实现
- 新增 `internal/extensions/bridge.go`
- 提供 `Bridge(extensionTool) tools.Tool`
- 提供 `RegisterBridgedTool(...)`，将 extension tool 注册到 tools registry
- 提供 `StableToolKey(source, extensionID, toolName)`，生成 source-aware 稳定键
- 提供 `ResolvePolicyToolSets(...)`，把策略项映射到 stable key 后再走 policy allow/deny 语义

2. 新增 bridge 单测
- 新增 `internal/extensions/bridge_test.go`
- 覆盖 stable key 归一化/长度约束
- 覆盖 builtin 与 extension 同原名冲突
- 覆盖 extension 间同原名冲突
- 覆盖 schema 非法时错误透传
- 覆盖 policy 名称映射与歧义冲突

3. 增强 tools registry 的桥接元信息与冲突检测
- 修改 `internal/tools/registry_errors.go`
- `RegisterOptions` 新增 `OriginalName`
- `RegistrationMeta` 新增 `StableToolKey`、`OriginalToolName`
- `RegistryError` 新增 `OriginalToolName`

- 修改 `internal/tools/registry.go`
- `Register(...)` 除 `ToolKey` 冲突外，新增 `OriginalToolName` 冲突拒绝
- 新增 `FindByOriginalName(...)` 查询能力
- 补充元信息 clone 逻辑

4. 补充 registry 相关测试
- 修改 `internal/tools/registry_contract_test.go`
- 新增 original name 冲突上下文断言
- 修改 `internal/tools/registry_test.go`
- 新增 `FindByOriginalName` 行为测试

## 关键行为变化
- extension 工具通过 stable key（`source:extensionID:toolName`）进入 registry。
- policy 可使用 stable key 进行权限判定，避免 extension 与 builtin 同名污染语义。
- 冲突错误可返回更完整上下文（source/extension/original name/conflict）。

## 影响范围
- 仅涉及 extension bridge 与 tools registry 注册语义。
- 未改动 executor/runner 的执行决策流程。

## 验证
已通过：
- `go test ./internal/extensions -v`
- `go test ./internal/tools -run Registry -v`
- `go test ./internal/policy -v`
- `go test ./internal/agent -run Tool -v`

备注：
- `go test ./...` 在当前环境下 `internal/app` 存在既有失败（`TestBootstrapEntrypointRejectsBroadWorkspaceWithoutOverride`），与本 PR 改动无关。

## 变更统计
- 6 files changed, 623 insertions(+), 26 deletions(-)
