### PR TITLE
fix(installer): 兼容旧版 PowerShell 架构识别并补回归测试

### DIFF
--- a/internal/app/install_script_test.go
+++ b/internal/app/install_script_test.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func loadInstallPSScript(t *testing.T) string {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to resolve test file path")
+	}
+
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+	scriptPath := filepath.Join(repoRoot, "scripts", "install.ps1")
+
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read install.ps1: %v", err)
+	}
+
+	return string(content)
+}
+
+func TestInstallPSScript_ArchitectureFallbackForLegacyPowerShell(t *testing.T) {
+	script := loadInstallPSScript(t)
+
+	requiredSnippets := []string{
+		`GetProperty("OSArchitecture")`,
+		`PROCESSOR_ARCHITEW6432`,
+		`PROCESSOR_ARCHITECTURE`,
+		`"AMD64" { return "amd64" }`,
+		`"ARM64" { return "arm64" }`,
+	}
+
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(script, snippet) {
+			t.Fatalf("install.ps1 missing legacy-compat architecture logic snippet: %q", snippet)
+		}
+	}
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -23,10 +23,38 @@ function Get-LatestReleaseTag {
 }
 
 function Resolve-Architecture {
-    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    switch ($arch) {
+    $arch = ""
+
+    try {
+        $runtimeInfoType = [System.Runtime.InteropServices.RuntimeInformation]
+        if ($runtimeInfoType) {
+            $osArchProperty = $runtimeInfoType.GetProperty("OSArchitecture")
+            if ($osArchProperty) {
+                $runtimeArch = $runtimeInfoType::OSArchitecture
+                if ($runtimeArch) {
+                    $arch = [string]$runtimeArch
+                }
+            }
+        }
+    }
+    catch {
+        $arch = ""
+    }
+
+    if ([string]::IsNullOrWhiteSpace($arch)) {
+        # Fallback for older Windows PowerShell / .NET where RuntimeInformation.OSArchitecture is unavailable.
+        if (-not [string]::IsNullOrWhiteSpace($env:PROCESSOR_ARCHITEW6432)) {
+            $arch = [string]$env:PROCESSOR_ARCHITEW6432
+        }
+        else {
+            $arch = [string]$env:PROCESSOR_ARCHITECTURE
+        }
+    }
+
+    switch ($arch.ToUpperInvariant()) {
         "X64" { return "amd64" }
-        "Arm64" { return "arm64" }
+        "AMD64" { return "amd64" }
+        "ARM64" { return "arm64" }
         default { throw "Unsupported architecture: $arch" }
     }
 }


### PR DESCRIPTION
## 背景
在部分 Windows PowerShell / .NET 运行环境中，`[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture` 不可用，导致安装脚本在架构识别阶段直接报错，用户无法完成一键安装。

## 本次修改
- 更新 `scripts/install.ps1` 的 `Resolve-Architecture`：
  - 优先使用 `RuntimeInformation.OSArchitecture`
  - 若不可用则回退到 `PROCESSOR_ARCHITEW6432 / PROCESSOR_ARCHITECTURE`
  - 映射同时支持 `X64/AMD64` 和 `ARM64`
- 新增 `internal/app/install_script_test.go` 回归测试，防止后续误删老环境兼容逻辑。

## 验证
- `go test ./internal/app -run TestInstallPSScript_ArchitectureFallbackForLegacyPowerShell -v`
- 本地执行 `scripts/install.ps1`，确认不再出现 `OSArchitecture` 属性缺失异常，并可正常安装。