### PR TITLE
[codex] docs(architecture): simplify subagent RFC title

### DIFF
--- a/docs/architecture/subagent-rfc.md
+++ b/docs/architecture/subagent-rfc.md
@@ -1,4 +1,4 @@
-# Subagent 架构设计 RFC
+# Subagent 架构设计
 
 ## 背景
 


### PR DESCRIPTION
﻿## Summary
- update the document title in `docs/architecture/subagent-rfc.md`
- remove the `RFC` suffix from the heading to align naming with current architecture docs

## Why
- keeps naming concise and consistent with adjacent architecture documents

## Validation
- docs-only change; no code or test impact
