### PR TITLE
Extension丨step7补 MCP Adapter

### DIFF
--- a/internal/extensions/interface.go
+++ b/internal/extensions/interface.go
@@ -13,6 +13,15 @@ type Manager interface {
 	List(ctx context.Context) ([]ExtensionInfo, error)
 }
 
+// Extension models a loadable extension source (for example skill or mcp).
+// Implementations should keep failures local to the extension instance and
+// expose health degradation through Health rather than process-level errors.
+type Extension interface {
+	Info() ExtensionInfo
+	ResolveTools(ctx context.Context) ([]ExtensionTool, error)
+	Health(ctx context.Context) (HealthSnapshot, error)
+}
+
 type ToolUseContext struct {
 	SessionID corepkg.SessionID
 	TaskID    corepkg.TaskID

--- a/internal/extensions/mcp/adapter.go
+++ b/internal/extensions/mcp/adapter.go
@@ -1,0 +1,269 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	extensionspkg "bytemind/internal/extensions"
+	"bytemind/internal/llm"
+	toolspkg "bytemind/internal/tools"
+)
+
+type Option func(*adapterOptions)
+
+type adapterOptions struct {
+	client Client
+	now    func() time.Time
+}
+
+func WithClient(client Client) Option {
+	return func(opts *adapterOptions) {
+		if opts == nil {
+			return
+		}
+		opts.client = client
+	}
+}
+
+type Adapter struct {
+	mu sync.RWMutex
+
+	cfg    ServerConfig
+	client Client
+	now    func() time.Time
+
+	info  extensionspkg.ExtensionInfo
+	tools []ToolDescriptor
+}
+
+func FromMCPServer(cfg ServerConfig, opts ...Option) (extensionspkg.Extension, error) {
+	options := adapterOptions{
+		now: time.Now,
+	}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		opt(&options)
+	}
+	cfg = normalizeServerConfig(cfg)
+	if options.client == nil {
+		options.client = NewStdioClient()
+	}
+	if options.now == nil {
+		options.now = time.Now
+	}
+	if err := validateServerConfig(cfg, options.client != nil && cfg.Command != ""); err != nil {
+		return nil, toExtensionError(err, extensionspkg.ErrCodeInvalidSource, "invalid mcp server config")
+	}
+	if options.client == nil {
+		return nil, newExtensionError(extensionspkg.ErrCodeInvalidSource, "mcp client is required", nil)
+	}
+
+	adapter := &Adapter{
+		cfg:    cfg,
+		client: options.client,
+		now:    options.now,
+		info:   baseExtensionInfo(cfg, options.now()),
+		tools:  nil,
+	}
+
+	startupCtx, cancel := withTimeoutIfMissing(context.Background(), cfg.StartupTimeout)
+	defer cancel()
+	_ = adapter.refresh(startupCtx)
+	return adapter, nil
+}
+
+func (a *Adapter) Info() extensionspkg.ExtensionInfo {
+	if a == nil {
+		return extensionspkg.ExtensionInfo{}
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.info
+}
+
+func (a *Adapter) ResolveTools(ctx context.Context) ([]extensionspkg.ExtensionTool, error) {
+	if a == nil {
+		return nil, newExtensionError(extensionspkg.ErrCodeInvalidExtension, "mcp adapter is nil", nil)
+	}
+	if err := a.refresh(ctx); err != nil && contextError(err) != nil {
+		return nil, err
+	}
+
+	a.mu.RLock()
+	descriptors := cloneToolDescriptors(a.tools)
+	extensionID := a.info.ID
+	client := a.client
+	cfg := a.cfg
+	a.mu.RUnlock()
+
+	tools := make([]extensionspkg.ExtensionTool, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		name := strings.TrimSpace(descriptor.Name)
+		if name == "" {
+			continue
+		}
+		tools = append(tools, extensionspkg.ExtensionTool{
+			Source:      extensionspkg.ExtensionMCP,
+			ExtensionID: extensionID,
+			Tool: mcpTool{
+				server:     cfg,
+				client:     client,
+				descriptor: descriptor,
+			},
+		})
+	}
+	return tools, nil
+}
+
+func (a *Adapter) Health(ctx context.Context) (extensionspkg.HealthSnapshot, error) {
+	if a == nil {
+		return extensionspkg.HealthSnapshot{}, newExtensionError(extensionspkg.ErrCodeInvalidExtension, "mcp adapter is nil", nil)
+	}
+	err := a.refresh(ctx)
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.info.Health, err
+}
+
+func (a *Adapter) refresh(ctx context.Context) error {
+	if a == nil {
+		return newExtensionError(extensionspkg.ErrCodeInvalidExtension, "mcp adapter is nil", nil)
+	}
+	snapshot, err := a.client.Discover(ctx, a.cfg)
+	if err != nil {
+		a.markDegraded(err)
+		return toExtensionError(err, mapClientErrorToExtensionCode(err), "mcp discovery failed")
+	}
+
+	validTools, skipped := filterValidToolDescriptors(snapshot.Tools)
+	now := a.now().UTC()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if strings.TrimSpace(snapshot.Name) != "" {
+		a.info.Name = strings.TrimSpace(snapshot.Name)
+		a.info.Title = strings.TrimSpace(snapshot.Name)
+		a.info.Manifest.Name = strings.TrimSpace(snapshot.Name)
+		a.info.Manifest.Title = strings.TrimSpace(snapshot.Name)
+	}
+	if strings.TrimSpace(snapshot.Version) != "" {
+		a.info.Version = strings.TrimSpace(snapshot.Version)
+		a.info.Manifest.Version = strings.TrimSpace(snapshot.Version)
+	}
+	a.tools = validTools
+	a.info.Status = extensionspkg.ExtensionStatusActive
+	a.info.Capabilities.Tools = len(validTools)
+	a.info.Manifest.Capabilities.Tools = len(validTools)
+	a.info.Health.Status = extensionspkg.ExtensionStatusActive
+	a.info.Health.LastError = ""
+	a.info.Health.CheckedAtUTC = now.Format(time.RFC3339)
+	if skipped > 0 {
+		a.info.Health.Message = fmt.Sprintf("mcp server active; skipped %d invalid tool declarations", skipped)
+	} else {
+		a.info.Health.Message = "mcp server active"
+	}
+	return nil
+}
+
+func (a *Adapter) markDegraded(err error) {
+	now := a.now().UTC()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.info.Status = extensionspkg.ExtensionStatusDegraded
+	a.info.Health.Status = extensionspkg.ExtensionStatusDegraded
+	a.info.Health.LastError = mapClientErrorToExtensionCode(err)
+	a.info.Health.Message = strings.TrimSpace(err.Error())
+	a.info.Health.CheckedAtUTC = now.Format(time.RFC3339)
+}
+
+func baseExtensionInfo(cfg ServerConfig, now time.Time) extensionspkg.ExtensionInfo {
+	extensionID := "mcp." + cfg.ID
+	manifestRef := "mcp:" + cfg.ID
+	return extensionspkg.ExtensionInfo{
+		ID:          extensionID,
+		Name:        cfg.Name,
+		Kind:        extensionspkg.ExtensionMCP,
+		Version:     cfg.Version,
+		Title:       cfg.Name,
+		Description: fmt.Sprintf("MCP server %s", cfg.Name),
+		Source: extensionspkg.ExtensionSource{
+			Scope: extensionspkg.ExtensionScopeRemote,
+			Ref:   manifestRef,
+		},
+		Status: extensionspkg.ExtensionStatusLoaded,
+		Manifest: extensionspkg.Manifest{
+			Name:        cfg.Name,
+			Version:     cfg.Version,
+			Title:       cfg.Name,
+			Description: fmt.Sprintf("MCP server %s", cfg.Name),
+			Kind:        extensionspkg.ExtensionMCP,
+			Source: extensionspkg.ExtensionSource{
+				Scope: extensionspkg.ExtensionScopeRemote,
+				Ref:   manifestRef,
+			},
+		},
+		Health: extensionspkg.HealthSnapshot{
+			Status:       extensionspkg.ExtensionStatusLoaded,
+			Message:      "mcp server loaded",
+			CheckedAtUTC: now.UTC().Format(time.RFC3339),
+		},
+	}
+}
+
+type mcpTool struct {
+	server     ServerConfig
+	client     Client
+	descriptor ToolDescriptor
+}
+
+func (t mcpTool) Definition() llm.ToolDefinition {
+	name := strings.TrimSpace(t.descriptor.Name)
+	if name == "" {
+		name = "mcp_tool"
+	}
+	description := strings.TrimSpace(t.descriptor.Description)
+	if description == "" {
+		description = fmt.Sprintf("MCP tool %s", name)
+	}
+	parameters := normalizedSchema(t.descriptor.InputSchema)
+	return llm.ToolDefinition{
+		Type: "function",
+		Function: llm.FunctionDefinition{
+			Name:        name,
+			Description: description,
+			Parameters:  parameters,
+		},
+	}
+}
+
+func (t mcpTool) Spec() toolspkg.ToolSpec {
+	base := toolspkg.DefaultToolSpec(t.Definition())
+	return toolspkg.MergeToolSpec(base, toolspkg.ToolSpec{
+		Name:        strings.TrimSpace(t.descriptor.Name),
+		SafetyClass: toolspkg.SafetyClassSensitive,
+	})
+}
+
+func (t mcpTool) Run(ctx context.Context, raw json.RawMessage, _ *toolspkg.ExecutionContext) (string, error) {
+	if t.client == nil {
+		return "", toolspkg.NewToolExecError(toolspkg.ToolErrorInternal, "mcp client is unavailable", true, nil)
+	}
+	callCtx := ctx
+	cancel := func() {}
+	if _, has := ctx.Deadline(); !has && t.server.CallTimeout > 0 {
+		callCtx, cancel = context.WithTimeout(ctx, t.server.CallTimeout)
+	}
+	defer cancel()
+
+	output, err := t.client.CallTool(callCtx, t.server, t.descriptor.Name, raw)
+	if err != nil {
+		return "", mapClientErrorToToolExecError(err)
+	}
+	return output, nil
+}

--- a/internal/extensions/mcp/adapter.go
+++ b/internal/extensions/mcp/adapter.go
@@ -16,8 +16,9 @@ import (
 type Option func(*adapterOptions)
 
 type adapterOptions struct {
-	client Client
-	now    func() time.Time
+	client     Client
+	now        func() time.Time
+	refreshTTL time.Duration
 }
 
 func WithClient(client Client) Option {
@@ -29,20 +30,36 @@ func WithClient(client Client) Option {
 	}
 }
 
+func WithRefreshTTL(ttl time.Duration) Option {
+	return func(opts *adapterOptions) {
+		if opts == nil {
+			return
+		}
+		opts.refreshTTL = ttl
+	}
+}
+
+const defaultRefreshTTL = 30 * time.Second
+
 type Adapter struct {
-	mu sync.RWMutex
+	mu        sync.RWMutex
+	refreshMu sync.Mutex
 
-	cfg    ServerConfig
-	client Client
-	now    func() time.Time
+	cfg        ServerConfig
+	client     Client
+	now        func() time.Time
+	refreshTTL time.Duration
 
-	info  extensionspkg.ExtensionInfo
-	tools []ToolDescriptor
+	info        extensionspkg.ExtensionInfo
+	tools       []ToolDescriptor
+	lastRefresh time.Time
+	dirty       bool
 }
 
 func FromMCPServer(cfg ServerConfig, opts ...Option) (extensionspkg.Extension, error) {
 	options := adapterOptions{
-		now: time.Now,
+		now:        time.Now,
+		refreshTTL: defaultRefreshTTL,
 	}
 	for _, opt := range opts {
 		if opt == nil {
@@ -57,7 +74,10 @@ func FromMCPServer(cfg ServerConfig, opts ...Option) (extensionspkg.Extension, e
 	if options.now == nil {
 		options.now = time.Now
 	}
-	if err := validateServerConfig(cfg, options.client != nil && cfg.Command != ""); err != nil {
+	if options.refreshTTL <= 0 {
+		options.refreshTTL = defaultRefreshTTL
+	}
+	if err := validateServerConfig(cfg, true); err != nil {
 		return nil, toExtensionError(err, extensionspkg.ErrCodeInvalidSource, "invalid mcp server config")
 	}
 	if options.client == nil {
@@ -70,11 +90,15 @@ func FromMCPServer(cfg ServerConfig, opts ...Option) (extensionspkg.Extension, e
 		now:    options.now,
 		info:   baseExtensionInfo(cfg, options.now()),
 		tools:  nil,
+
+		refreshTTL:  options.refreshTTL,
+		lastRefresh: time.Time{},
+		dirty:       true,
 	}
 
 	startupCtx, cancel := withTimeoutIfMissing(context.Background(), cfg.StartupTimeout)
 	defer cancel()
-	_ = adapter.refresh(startupCtx)
+	_ = adapter.maybeRefresh(startupCtx, true)
 	return adapter, nil
 }
 
@@ -91,7 +115,7 @@ func (a *Adapter) ResolveTools(ctx context.Context) ([]extensionspkg.ExtensionTo
 	if a == nil {
 		return nil, newExtensionError(extensionspkg.ErrCodeInvalidExtension, "mcp adapter is nil", nil)
 	}
-	if err := a.refresh(ctx); err != nil && contextError(err) != nil {
+	if err := a.maybeRefresh(ctx, false); err != nil && contextError(err) != nil {
 		return nil, err
 	}
 
@@ -125,24 +149,78 @@ func (a *Adapter) Health(ctx context.Context) (extensionspkg.HealthSnapshot, err
 	if a == nil {
 		return extensionspkg.HealthSnapshot{}, newExtensionError(extensionspkg.ErrCodeInvalidExtension, "mcp adapter is nil", nil)
 	}
-	err := a.refresh(ctx)
+	err := a.maybeRefresh(ctx, false)
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.info.Health, err
+}
+
+func (a *Adapter) Reload(ctx context.Context) error {
+	return a.maybeRefresh(ctx, true)
+}
+
+func (a *Adapter) Invalidate() {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.dirty = true
+}
+
+func (a *Adapter) maybeRefresh(ctx context.Context, force bool) error {
+	if a == nil {
+		return newExtensionError(extensionspkg.ErrCodeInvalidExtension, "mcp adapter is nil", nil)
+	}
+	if !force {
+		a.mu.RLock()
+		should := a.shouldRefreshLocked(a.now().UTC())
+		a.mu.RUnlock()
+		if !should {
+			return nil
+		}
+	}
+
+	a.refreshMu.Lock()
+	defer a.refreshMu.Unlock()
+
+	if !force {
+		a.mu.RLock()
+		should := a.shouldRefreshLocked(a.now().UTC())
+		a.mu.RUnlock()
+		if !should {
+			return nil
+		}
+	}
+	return a.refresh(ctx)
+}
+
+func (a *Adapter) shouldRefreshLocked(now time.Time) bool {
+	if a == nil {
+		return false
+	}
+	if a.dirty || a.lastRefresh.IsZero() {
+		return true
+	}
+	if a.refreshTTL <= 0 {
+		return true
+	}
+	return now.Sub(a.lastRefresh) >= a.refreshTTL
 }
 
 func (a *Adapter) refresh(ctx context.Context) error {
 	if a == nil {
 		return newExtensionError(extensionspkg.ErrCodeInvalidExtension, "mcp adapter is nil", nil)
 	}
+	now := a.now().UTC()
 	snapshot, err := a.client.Discover(ctx, a.cfg)
 	if err != nil {
-		a.markDegraded(err)
-		return toExtensionError(err, mapClientErrorToExtensionCode(err), "mcp discovery failed")
+		code := mapClientErrorToExtensionCode(err)
+		a.markDegraded(err, code, now)
+		return toExtensionError(err, code, "mcp discovery failed")
 	}
 
 	validTools, skipped := filterValidToolDescriptors(snapshot.Tools)
-	now := a.now().UTC()
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -163,6 +241,8 @@ func (a *Adapter) refresh(ctx context.Context) error {
 	a.info.Health.Status = extensionspkg.ExtensionStatusActive
 	a.info.Health.LastError = ""
 	a.info.Health.CheckedAtUTC = now.Format(time.RFC3339)
+	a.lastRefresh = now
+	a.dirty = false
 	if skipped > 0 {
 		a.info.Health.Message = fmt.Sprintf("mcp server active; skipped %d invalid tool declarations", skipped)
 	} else {
@@ -171,15 +251,16 @@ func (a *Adapter) refresh(ctx context.Context) error {
 	return nil
 }
 
-func (a *Adapter) markDegraded(err error) {
-	now := a.now().UTC()
+func (a *Adapter) markDegraded(err error, code extensionspkg.ErrorCode, now time.Time) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.info.Status = extensionspkg.ExtensionStatusDegraded
 	a.info.Health.Status = extensionspkg.ExtensionStatusDegraded
-	a.info.Health.LastError = mapClientErrorToExtensionCode(err)
+	a.info.Health.LastError = code
 	a.info.Health.Message = strings.TrimSpace(err.Error())
 	a.info.Health.CheckedAtUTC = now.Format(time.RFC3339)
+	a.lastRefresh = now
+	a.dirty = false
 }
 
 func baseExtensionInfo(cfg ServerConfig, now time.Time) extensionspkg.ExtensionInfo {

--- a/internal/extensions/mcp/adapter_extra_test.go
+++ b/internal/extensions/mcp/adapter_extra_test.go
@@ -31,23 +31,27 @@ func TestFromMCPServerInvalidConfigAndDefaultClientPath(t *testing.T) {
 		t.Fatalf("expected invalid source code, got %q", extErr.Code)
 	}
 
-	ext, err := FromMCPServer(ServerConfig{
+	_, err = FromMCPServer(ServerConfig{
 		ID:   "auto-client",
 		Name: "Auto Client",
 	})
-	if err != nil {
-		t.Fatalf("default client construction should not fail hard, got %v", err)
+	if err == nil {
+		t.Fatal("expected invalid config when command is missing in stdio mode")
 	}
-	info := ext.Info()
-	if info.Status != extensionspkg.ExtensionStatusDegraded {
-		t.Fatalf("expected degraded status for missing command with default client, got %q", info.Status)
+	var extErr2 *extensionspkg.ExtensionError
+	if !errors.As(err, &extErr2) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr2.Code != extensionspkg.ErrCodeInvalidSource {
+		t.Fatalf("expected invalid source code, got %q", extErr2.Code)
 	}
 }
 
 func TestFromMCPServerHandlesNilOptionAndNilNowOverride(t *testing.T) {
 	ext, err := FromMCPServer(ServerConfig{
-		ID:   "github",
-		Name: "GitHub",
+		ID:      "github",
+		Name:    "GitHub",
+		Command: "stub",
 	}, nil, WithClient(&stubClient{
 		discoverSnapshot: ServerSnapshot{
 			ID:      "github",
@@ -94,12 +98,18 @@ func TestResolveToolsReturnsContextError(t *testing.T) {
 		discoverErr: context.DeadlineExceeded,
 	}
 	ext, err := FromMCPServer(ServerConfig{
-		ID:   "timeout",
-		Name: "Timeout",
+		ID:      "timeout",
+		Name:    "Timeout",
+		Command: "stub",
 	}, WithClient(client))
 	if err != nil {
 		t.Fatalf("FromMCPServer failed: %v", err)
 	}
+	adapter, ok := ext.(*Adapter)
+	if !ok {
+		t.Fatalf("expected *Adapter type, got %T", ext)
+	}
+	adapter.Invalidate()
 	_, err = ext.ResolveTools(context.Background())
 	if err == nil {
 		t.Fatal("expected context error from ResolveTools")
@@ -121,8 +131,9 @@ func TestAdapterRefreshActiveMessageWithoutSkippedTools(t *testing.T) {
 		},
 	}
 	ext, err := FromMCPServer(ServerConfig{
-		ID:   "server",
-		Name: "Server",
+		ID:      "server",
+		Name:    "Server",
+		Command: "stub",
 	}, WithClient(client), func(opts *adapterOptions) {
 		opts.now = func() time.Time {
 			return time.Date(2026, 4, 21, 1, 2, 3, 0, time.UTC)
@@ -134,6 +145,60 @@ func TestAdapterRefreshActiveMessageWithoutSkippedTools(t *testing.T) {
 	info := ext.Info()
 	if info.Health.Message != "mcp server active" {
 		t.Fatalf("expected active message without skipped tools, got %q", info.Health.Message)
+	}
+}
+
+func TestAdapterResolveToolsUsesTTLCacheAndInvalidate(t *testing.T) {
+	client := &stubClient{
+		discoverSnapshot: ServerSnapshot{
+			ID:      "cache",
+			Name:    "Cache",
+			Version: "1.0.0",
+			Tools: []ToolDescriptor{
+				{Name: "echo"},
+			},
+		},
+	}
+	ext, err := FromMCPServer(ServerConfig{
+		ID:      "cache",
+		Name:    "Cache",
+		Command: "stub",
+	}, WithClient(client), WithRefreshTTL(time.Hour))
+	if err != nil {
+		t.Fatalf("FromMCPServer failed: %v", err)
+	}
+	adapter, ok := ext.(*Adapter)
+	if !ok {
+		t.Fatalf("expected *Adapter type, got %T", ext)
+	}
+	initialDiscoverCount := client.discoverCount
+
+	_, err = ext.ResolveTools(context.Background())
+	if err != nil {
+		t.Fatalf("first ResolveTools failed: %v", err)
+	}
+	_, err = ext.ResolveTools(context.Background())
+	if err != nil {
+		t.Fatalf("second ResolveTools failed: %v", err)
+	}
+	if client.discoverCount != initialDiscoverCount {
+		t.Fatalf("expected cached resolve without extra discover, got %d -> %d", initialDiscoverCount, client.discoverCount)
+	}
+
+	adapter.Invalidate()
+	_, err = ext.ResolveTools(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveTools after invalidate failed: %v", err)
+	}
+	if client.discoverCount != initialDiscoverCount+1 {
+		t.Fatalf("expected one extra discover after invalidate, got %d -> %d", initialDiscoverCount, client.discoverCount)
+	}
+
+	if err := adapter.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+	if client.discoverCount != initialDiscoverCount+2 {
+		t.Fatalf("expected force reload to discover again, got %d -> %d", initialDiscoverCount, client.discoverCount)
 	}
 }
 

--- a/internal/extensions/mcp/adapter_extra_test.go
+++ b/internal/extensions/mcp/adapter_extra_test.go
@@ -1,0 +1,206 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	extensionspkg "bytemind/internal/extensions"
+	toolspkg "bytemind/internal/tools"
+)
+
+func TestWithClientOptionHandlesNilOptions(t *testing.T) {
+	opt := WithClient(&stubClient{})
+	opt(nil)
+}
+
+func TestFromMCPServerInvalidConfigAndDefaultClientPath(t *testing.T) {
+	_, err := FromMCPServer(ServerConfig{
+		Command: "echo",
+	}, WithClient(&stubClient{}))
+	if err == nil {
+		t.Fatal("expected invalid config error when id is missing")
+	}
+	var extErr *extensionspkg.ExtensionError
+	if !errors.As(err, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", err)
+	}
+	if extErr.Code != extensionspkg.ErrCodeInvalidSource {
+		t.Fatalf("expected invalid source code, got %q", extErr.Code)
+	}
+
+	ext, err := FromMCPServer(ServerConfig{
+		ID:   "auto-client",
+		Name: "Auto Client",
+	})
+	if err != nil {
+		t.Fatalf("default client construction should not fail hard, got %v", err)
+	}
+	info := ext.Info()
+	if info.Status != extensionspkg.ExtensionStatusDegraded {
+		t.Fatalf("expected degraded status for missing command with default client, got %q", info.Status)
+	}
+}
+
+func TestFromMCPServerHandlesNilOptionAndNilNowOverride(t *testing.T) {
+	ext, err := FromMCPServer(ServerConfig{
+		ID:   "github",
+		Name: "GitHub",
+	}, nil, WithClient(&stubClient{
+		discoverSnapshot: ServerSnapshot{
+			ID:      "github",
+			Name:    "GitHub",
+			Version: "1.0.0",
+			Tools: []ToolDescriptor{
+				{Name: "list_prs"},
+			},
+		},
+	}), func(opts *adapterOptions) {
+		opts.now = nil
+	})
+	if err != nil {
+		t.Fatalf("FromMCPServer failed: %v", err)
+	}
+	info := ext.Info()
+	if info.ID != "mcp.github" {
+		t.Fatalf("unexpected extension id: %q", info.ID)
+	}
+	if info.Health.CheckedAtUTC == "" {
+		t.Fatal("expected health timestamp to be set")
+	}
+}
+
+func TestAdapterNilReceiverBranches(t *testing.T) {
+	var adapter *Adapter
+	if info := adapter.Info(); !info.IsZero() {
+		t.Fatalf("expected zero info for nil receiver, got %#v", info)
+	}
+
+	if _, err := adapter.ResolveTools(context.Background()); err == nil {
+		t.Fatal("expected resolve error for nil receiver")
+	}
+	if _, err := adapter.Health(context.Background()); err == nil {
+		t.Fatal("expected health error for nil receiver")
+	}
+	if err := adapter.refresh(context.Background()); err == nil {
+		t.Fatal("expected refresh error for nil receiver")
+	}
+}
+
+func TestResolveToolsReturnsContextError(t *testing.T) {
+	client := &stubClient{
+		discoverErr: context.DeadlineExceeded,
+	}
+	ext, err := FromMCPServer(ServerConfig{
+		ID:   "timeout",
+		Name: "Timeout",
+	}, WithClient(client))
+	if err != nil {
+		t.Fatalf("FromMCPServer failed: %v", err)
+	}
+	_, err = ext.ResolveTools(context.Background())
+	if err == nil {
+		t.Fatal("expected context error from ResolveTools")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
+func TestAdapterRefreshActiveMessageWithoutSkippedTools(t *testing.T) {
+	client := &stubClient{
+		discoverSnapshot: ServerSnapshot{
+			ID:      "server",
+			Name:    "Server",
+			Version: "2.0.0",
+			Tools: []ToolDescriptor{
+				{Name: "echo"},
+			},
+		},
+	}
+	ext, err := FromMCPServer(ServerConfig{
+		ID:   "server",
+		Name: "Server",
+	}, WithClient(client), func(opts *adapterOptions) {
+		opts.now = func() time.Time {
+			return time.Date(2026, 4, 21, 1, 2, 3, 0, time.UTC)
+		}
+	})
+	if err != nil {
+		t.Fatalf("FromMCPServer failed: %v", err)
+	}
+	info := ext.Info()
+	if info.Health.Message != "mcp server active" {
+		t.Fatalf("expected active message without skipped tools, got %q", info.Health.Message)
+	}
+}
+
+func TestMCPToolDefinitionSpecAndRunBranches(t *testing.T) {
+	tool := mcpTool{
+		descriptor: ToolDescriptor{},
+	}
+	def := tool.Definition()
+	if def.Function.Name != "mcp_tool" {
+		t.Fatalf("expected fallback name, got %q", def.Function.Name)
+	}
+	if def.Function.Description != "MCP tool mcp_tool" {
+		t.Fatalf("expected fallback description, got %q", def.Function.Description)
+	}
+	if def.Function.Parameters["type"] != "object" {
+		t.Fatalf("expected normalized object schema, got %#v", def.Function.Parameters)
+	}
+
+	spec := tool.Spec()
+	if spec.SafetyClass != toolspkg.SafetyClassSensitive {
+		t.Fatalf("expected sensitive safety class, got %q", spec.SafetyClass)
+	}
+	if spec.Name != "mcp_tool" {
+		t.Fatalf("expected fallback spec name, got %q", spec.Name)
+	}
+
+	namedTool := mcpTool{
+		descriptor: ToolDescriptor{Name: "echo", Description: "echo"},
+		client:     &stubClient{callOutput: "ok"},
+	}
+	spec = namedTool.Spec()
+	if spec.Name != "echo" {
+		t.Fatalf("expected spec name to keep descriptor name, got %q", spec.Name)
+	}
+
+	tool = mcpTool{}
+	_, err := tool.Run(context.Background(), json.RawMessage(`{}`), nil)
+	if err == nil {
+		t.Fatal("expected internal error when client is nil")
+	}
+	execErr, ok := toolspkg.AsToolExecError(err)
+	if !ok || execErr.Code != toolspkg.ToolErrorInternal {
+		t.Fatalf("expected internal tool error, got %v", err)
+	}
+
+	tool = mcpTool{
+		client: &stubClient{
+			callErr: &ClientError{Code: ClientErrorPermission, Message: "denied"},
+		},
+	}
+	_, err = tool.Run(context.Background(), json.RawMessage(`{}`), nil)
+	execErr, ok = toolspkg.AsToolExecError(err)
+	if !ok || execErr.Code != toolspkg.ToolErrorPermissionDenied {
+		t.Fatalf("expected permission denied, got %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	tool = mcpTool{
+		client:     &stubClient{callOutput: "ok"},
+		descriptor: ToolDescriptor{Name: "echo"},
+	}
+	output, err := tool.Run(ctx, json.RawMessage(`{}`), nil)
+	if err != nil {
+		t.Fatalf("expected success with deadline context, got %v", err)
+	}
+	if output != "ok" {
+		t.Fatalf("unexpected output: %q", output)
+	}
+}

--- a/internal/extensions/mcp/adapter_test.go
+++ b/internal/extensions/mcp/adapter_test.go
@@ -36,8 +36,9 @@ func TestFromMCPServerBuildsActiveExtensionAndMapsTools(t *testing.T) {
 	}
 
 	ext, err := FromMCPServer(ServerConfig{
-		ID:   "github",
-		Name: "GitHub MCP",
+		ID:      "github",
+		Name:    "GitHub MCP",
+		Command: "stub",
 	}, WithClient(client))
 	if err != nil {
 		t.Fatalf("FromMCPServer failed: %v", err)
@@ -97,8 +98,9 @@ func TestFromMCPServerHandshakeFailureMarksDegraded(t *testing.T) {
 	}
 
 	ext, err := FromMCPServer(ServerConfig{
-		ID:   "broken",
-		Name: "Broken Server",
+		ID:      "broken",
+		Name:    "Broken Server",
+		Command: "stub",
 	}, WithClient(client))
 	if err != nil {
 		t.Fatalf("FromMCPServer should not fail hard on handshake issue, got %v", err)
@@ -124,8 +126,14 @@ func TestFromMCPServerHandshakeFailureMarksDegraded(t *testing.T) {
 	}
 
 	health, healthErr := ext.Health(context.Background())
+	adapter, ok := ext.(*Adapter)
+	if !ok {
+		t.Fatalf("expected *Adapter type, got %T", ext)
+	}
+	adapter.Invalidate()
+	health, healthErr = ext.Health(context.Background())
 	if healthErr == nil {
-		t.Fatal("expected health check to surface handshake error")
+		t.Fatal("expected health check to surface handshake error after invalidate")
 	}
 	if health.Status != extensionspkg.ExtensionStatusDegraded {
 		t.Fatalf("expected degraded health snapshot, got %q", health.Status)
@@ -137,10 +145,12 @@ type stubClient struct {
 	discoverErr      error
 	callOutput       string
 	callErr          error
+	discoverCount    int
 	callCount        int
 }
 
 func (s *stubClient) Discover(context.Context, ServerConfig) (ServerSnapshot, error) {
+	s.discoverCount++
 	if s.discoverErr != nil {
 		return ServerSnapshot{}, s.discoverErr
 	}

--- a/internal/extensions/mcp/adapter_test.go
+++ b/internal/extensions/mcp/adapter_test.go
@@ -1,0 +1,170 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	extensionspkg "bytemind/internal/extensions"
+	toolspkg "bytemind/internal/tools"
+)
+
+func TestFromMCPServerBuildsActiveExtensionAndMapsTools(t *testing.T) {
+	client := &stubClient{
+		discoverSnapshot: ServerSnapshot{
+			ID:      "github",
+			Name:    "GitHub MCP",
+			Version: "1.0.0",
+			Tools: []ToolDescriptor{
+				{
+					Name:        "list_prs",
+					Description: "List PRs",
+					InputSchema: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"repo": map[string]any{"type": "string"},
+						},
+					},
+				},
+				{
+					Name:        "",
+					Description: "invalid",
+				},
+			},
+		},
+		callOutput: "ok",
+	}
+
+	ext, err := FromMCPServer(ServerConfig{
+		ID:   "github",
+		Name: "GitHub MCP",
+	}, WithClient(client))
+	if err != nil {
+		t.Fatalf("FromMCPServer failed: %v", err)
+	}
+
+	info := ext.Info()
+	if info.ID != "mcp.github" {
+		t.Fatalf("unexpected extension id: %q", info.ID)
+	}
+	if info.Kind != extensionspkg.ExtensionMCP {
+		t.Fatalf("unexpected extension kind: %q", info.Kind)
+	}
+	if info.Status != extensionspkg.ExtensionStatusActive {
+		t.Fatalf("expected active status, got %q", info.Status)
+	}
+	if info.Capabilities.Tools != 1 {
+		t.Fatalf("expected 1 valid tool, got %d", info.Capabilities.Tools)
+	}
+
+	tools, err := ext.ResolveTools(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveTools failed: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 bridged tool, got %d", len(tools))
+	}
+	if tools[0].Source != extensionspkg.ExtensionMCP {
+		t.Fatalf("unexpected tool source: %q", tools[0].Source)
+	}
+	if tools[0].ExtensionID != "mcp.github" {
+		t.Fatalf("unexpected extension id: %q", tools[0].ExtensionID)
+	}
+
+	definition := tools[0].Tool.Definition()
+	if definition.Function.Name != "list_prs" {
+		t.Fatalf("unexpected tool definition name: %q", definition.Function.Name)
+	}
+
+	output, err := tools[0].Tool.Run(context.Background(), json.RawMessage(`{"repo":"openai/openai"}`), nil)
+	if err != nil {
+		t.Fatalf("tool run failed: %v", err)
+	}
+	if output != "ok" {
+		t.Fatalf("unexpected tool output: %q", output)
+	}
+	if client.callCount != 1 {
+		t.Fatalf("expected one mcp call, got %d", client.callCount)
+	}
+}
+
+func TestFromMCPServerHandshakeFailureMarksDegraded(t *testing.T) {
+	client := &stubClient{
+		discoverErr: &ClientError{
+			Code:    ClientErrorHandshakeFailed,
+			Message: "handshake failed",
+		},
+	}
+
+	ext, err := FromMCPServer(ServerConfig{
+		ID:   "broken",
+		Name: "Broken Server",
+	}, WithClient(client))
+	if err != nil {
+		t.Fatalf("FromMCPServer should not fail hard on handshake issue, got %v", err)
+	}
+
+	info := ext.Info()
+	if info.Status != extensionspkg.ExtensionStatusDegraded {
+		t.Fatalf("expected degraded status, got %q", info.Status)
+	}
+	if info.Health.Status != extensionspkg.ExtensionStatusDegraded {
+		t.Fatalf("expected degraded health status, got %q", info.Health.Status)
+	}
+	if info.Health.LastError != extensionspkg.ErrCodeLoadFailed {
+		t.Fatalf("expected mapped load_failed code, got %q", info.Health.LastError)
+	}
+
+	tools, err := ext.ResolveTools(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveTools should not fail hard when degraded, got %v", err)
+	}
+	if len(tools) != 0 {
+		t.Fatalf("expected no tools from degraded extension, got %d", len(tools))
+	}
+
+	health, healthErr := ext.Health(context.Background())
+	if healthErr == nil {
+		t.Fatal("expected health check to surface handshake error")
+	}
+	if health.Status != extensionspkg.ExtensionStatusDegraded {
+		t.Fatalf("expected degraded health snapshot, got %q", health.Status)
+	}
+}
+
+type stubClient struct {
+	discoverSnapshot ServerSnapshot
+	discoverErr      error
+	callOutput       string
+	callErr          error
+	callCount        int
+}
+
+func (s *stubClient) Discover(context.Context, ServerConfig) (ServerSnapshot, error) {
+	if s.discoverErr != nil {
+		return ServerSnapshot{}, s.discoverErr
+	}
+	return s.discoverSnapshot, nil
+}
+
+func (s *stubClient) CallTool(_ context.Context, _ ServerConfig, _ string, _ json.RawMessage) (string, error) {
+	s.callCount++
+	if s.callErr != nil {
+		return "", s.callErr
+	}
+	return s.callOutput, nil
+}
+
+func TestMapClientErrorToToolExecError(t *testing.T) {
+	err := mapClientErrorToToolExecError(&ClientError{Code: ClientErrorInvalidArgs, Message: "bad args"})
+	if err == nil {
+		t.Fatal("expected mapped error")
+	}
+	execErr, ok := toolspkg.AsToolExecError(err)
+	if !ok {
+		t.Fatalf("expected ToolExecError, got %T", err)
+	}
+	if execErr.Code != toolspkg.ToolErrorInvalidArgs {
+		t.Fatalf("expected invalid_args, got %q", execErr.Code)
+	}
+}

--- a/internal/extensions/mcp/client.go
+++ b/internal/extensions/mcp/client.go
@@ -136,6 +136,7 @@ func (c *StdioClient) Discover(ctx context.Context, cfg ServerConfig) (ServerSna
 	responses, err := c.runWithProtocolFallback(callCtx, cfg, func(protocolVersion string) []rpcRequest {
 		return []rpcRequest{
 			newRPCRequest(1, "initialize", initializeParams(protocolVersion)),
+			newRPCNotification("notifications/initialized", map[string]any{}),
 			newRPCRequest(2, "tools/list", map[string]any{}),
 		}
 	})
@@ -220,6 +221,7 @@ func (c *StdioClient) CallTool(ctx context.Context, cfg ServerConfig, toolName s
 	responses, err := c.runWithProtocolFallback(callCtx, cfg, func(protocolVersion string) []rpcRequest {
 		return []rpcRequest{
 			newRPCRequest(1, "initialize", initializeParams(protocolVersion)),
+			newRPCNotification("notifications/initialized", map[string]any{}),
 			newRPCRequest(2, "tools/call", map[string]any{
 				"name":      toolName,
 				"arguments": args,
@@ -298,7 +300,14 @@ func (c *StdioClient) runRPC(ctx context.Context, cfg ServerConfig, requests []r
 		if err := writeRPCRequest(writer, request); err != nil {
 			return nil, newClientError(ClientErrorTransport, "failed to write mcp request", err)
 		}
-		expectedID := strconv.Itoa(request.ID)
+		expectedID, hasRequestID, requestIDErr := normalizeRPCResponseID(request.ID)
+		if requestIDErr != nil {
+			return nil, newClientError(ClientErrorProtocol, "failed to encode mcp request id", requestIDErr)
+		}
+		if !hasRequestID {
+			// Notifications do not have ids and do not produce responses.
+			continue
+		}
 		for {
 			response, err := readRPCResponse(reader)
 			if err != nil {
@@ -465,7 +474,7 @@ func stopCommand(cmd *exec.Cmd, stdin io.WriteCloser) {
 
 type rpcRequest struct {
 	JSONRPC string `json:"jsonrpc"`
-	ID      int    `json:"id"`
+	ID      any    `json:"id,omitempty"`
 	Method  string `json:"method"`
 	Params  any    `json:"params,omitempty"`
 }
@@ -487,6 +496,14 @@ func newRPCRequest(id int, method string, params any) rpcRequest {
 	return rpcRequest{
 		JSONRPC: "2.0",
 		ID:      id,
+		Method:  method,
+		Params:  params,
+	}
+}
+
+func newRPCNotification(method string, params any) rpcRequest {
+	return rpcRequest{
+		JSONRPC: "2.0",
 		Method:  method,
 		Params:  params,
 	}

--- a/internal/extensions/mcp/client.go
+++ b/internal/extensions/mcp/client.go
@@ -20,6 +20,12 @@ const (
 	defaultCallTimeout    = 30 * time.Second
 )
 
+var defaultProtocolVersions = []string{
+	"2026-04-01",
+	"2025-03-26",
+	"2024-11-05",
+}
+
 var defaultEnvWhitelist = []string{
 	"PATH",
 	"Path",
@@ -36,15 +42,17 @@ var defaultEnvWhitelist = []string{
 }
 
 type ServerConfig struct {
-	ID             string
-	Name           string
-	Version        string
-	Command        string
-	Args           []string
-	Env            map[string]string
-	CWD            string
-	StartupTimeout time.Duration
-	CallTimeout    time.Duration
+	ID               string
+	Name             string
+	Version          string
+	ProtocolVersion  string
+	ProtocolVersions []string
+	Command          string
+	Args             []string
+	Env              map[string]string
+	CWD              string
+	StartupTimeout   time.Duration
+	CallTimeout      time.Duration
 }
 
 type ToolDescriptor struct {
@@ -125,15 +133,11 @@ func (c *StdioClient) Discover(ctx context.Context, cfg ServerConfig) (ServerSna
 	callCtx, cancel := withTimeoutIfMissing(ctx, cfg.StartupTimeout)
 	defer cancel()
 
-	responses, err := c.runRPC(callCtx, cfg, []rpcRequest{
-		newRPCRequest(1, "initialize", map[string]any{
-			"protocolVersion": "2026-04-01",
-			"clientInfo": map[string]any{
-				"name":    "bytemind",
-				"version": "dev",
-			},
-		}),
-		newRPCRequest(2, "tools/list", map[string]any{}),
+	responses, err := c.runWithProtocolFallback(callCtx, cfg, func(protocolVersion string) []rpcRequest {
+		return []rpcRequest{
+			newRPCRequest(1, "initialize", initializeParams(protocolVersion)),
+			newRPCRequest(2, "tools/list", map[string]any{}),
+		}
 	})
 	if err != nil {
 		return ServerSnapshot{}, err
@@ -213,18 +217,14 @@ func (c *StdioClient) CallTool(ctx context.Context, cfg ServerConfig, toolName s
 	callCtx, cancel := withTimeoutIfMissing(ctx, cfg.CallTimeout)
 	defer cancel()
 
-	responses, err := c.runRPC(callCtx, cfg, []rpcRequest{
-		newRPCRequest(1, "initialize", map[string]any{
-			"protocolVersion": "2026-04-01",
-			"clientInfo": map[string]any{
-				"name":    "bytemind",
-				"version": "dev",
-			},
-		}),
-		newRPCRequest(2, "tools/call", map[string]any{
-			"name":      toolName,
-			"arguments": args,
-		}),
+	responses, err := c.runWithProtocolFallback(callCtx, cfg, func(protocolVersion string) []rpcRequest {
+		return []rpcRequest{
+			newRPCRequest(1, "initialize", initializeParams(protocolVersion)),
+			newRPCRequest(2, "tools/call", map[string]any{
+				"name":      toolName,
+				"arguments": args,
+			}),
+		}
 	})
 	if err != nil {
 		return "", err
@@ -298,35 +298,81 @@ func (c *StdioClient) runRPC(ctx context.Context, cfg ServerConfig, requests []r
 		if err := writeRPCRequest(writer, request); err != nil {
 			return nil, newClientError(ClientErrorTransport, "failed to write mcp request", err)
 		}
-		response, err := readRPCResponse(reader)
-		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				return nil, newClientError(ClientErrorTimeout, "mcp request timed out", err)
-			}
-			if errors.Is(err, io.EOF) {
-				message := "mcp server closed stdout before replying"
-				if trimmed := strings.TrimSpace(stderr.String()); trimmed != "" {
-					message = fmt.Sprintf("%s: %s", message, trimmed)
+		expectedID := strconv.Itoa(request.ID)
+		for {
+			response, err := readRPCResponse(reader)
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					return nil, newClientError(ClientErrorTimeout, "mcp request timed out", err)
 				}
-				return nil, newClientError(ClientErrorTransport, message, err)
+				if errors.Is(err, io.EOF) {
+					message := "mcp server closed stdout before replying"
+					if trimmed := strings.TrimSpace(stderr.String()); trimmed != "" {
+						message = fmt.Sprintf("%s: %s", message, trimmed)
+					}
+					return nil, newClientError(ClientErrorTransport, message, err)
+				}
+				return nil, newClientError(ClientErrorProtocol, "failed to read mcp response", err)
 			}
-			return nil, newClientError(ClientErrorProtocol, "failed to read mcp response", err)
+
+			actualID, hasID, idErr := normalizeRPCResponseID(response.ID)
+			if idErr != nil {
+				return nil, newClientError(ClientErrorProtocol, "failed to decode mcp response id", idErr)
+			}
+			if !hasID {
+				// MCP servers may emit notifications before the response.
+				if strings.TrimSpace(response.Method) != "" {
+					continue
+				}
+				return nil, newClientError(ClientErrorProtocol, "mcp response missing id", nil)
+			}
+			if actualID != expectedID {
+				return nil, newClientError(ClientErrorProtocol, "mcp response id mismatch", nil)
+			}
+			if response.Error != nil {
+				return nil, mapRPCError(request.Method, response.Error)
+			}
+			responses = append(responses, response)
+			break
 		}
-		if response.ID != request.ID {
-			return nil, newClientError(ClientErrorProtocol, "mcp response id mismatch", nil)
-		}
-		if response.Error != nil {
-			return nil, mapRPCError(request.Method, response.Error)
-		}
-		responses = append(responses, response)
 	}
 	return responses, nil
+}
+
+func (c *StdioClient) runWithProtocolFallback(
+	ctx context.Context,
+	cfg ServerConfig,
+	buildRequests func(protocolVersion string) []rpcRequest,
+) ([]rpcResponse, error) {
+	protocolVersions := cloneStringSlice(cfg.ProtocolVersions)
+	if len(protocolVersions) == 0 {
+		protocolVersions = cloneStringSlice(defaultProtocolVersions)
+	}
+
+	for index, protocolVersion := range protocolVersions {
+		responses, err := c.runRPC(ctx, cfg, buildRequests(protocolVersion))
+		if err == nil {
+			return responses, nil
+		}
+		if isClientErrorCode(err, ClientErrorHandshakeFailed) && index < len(protocolVersions)-1 {
+			continue
+		}
+		if isClientErrorCode(err, ClientErrorHandshakeFailed) && len(protocolVersions) > 1 {
+			message := fmt.Sprintf("mcp initialize failed for protocol versions: %s", strings.Join(protocolVersions, ", "))
+			return nil, newClientError(ClientErrorHandshakeFailed, message, err)
+		}
+		return nil, err
+	}
+
+	message := fmt.Sprintf("mcp initialize failed for protocol versions: %s", strings.Join(protocolVersions, ", "))
+	return nil, newClientError(ClientErrorHandshakeFailed, message, nil)
 }
 
 func normalizeServerConfig(cfg ServerConfig) ServerConfig {
 	cfg.ID = normalizeID(cfg.ID)
 	cfg.Name = strings.TrimSpace(cfg.Name)
 	cfg.Version = strings.TrimSpace(cfg.Version)
+	cfg.ProtocolVersion = strings.TrimSpace(cfg.ProtocolVersion)
 	cfg.Command = strings.TrimSpace(cfg.Command)
 	cfg.CWD = strings.TrimSpace(cfg.CWD)
 	if cfg.Name == "" {
@@ -341,6 +387,7 @@ func normalizeServerConfig(cfg ServerConfig) ServerConfig {
 	if cfg.Args == nil {
 		cfg.Args = []string{}
 	}
+	cfg.ProtocolVersions = normalizeProtocolVersions(cfg.ProtocolVersion, cfg.ProtocolVersions)
 	cfg.Env = cloneStringMap(cfg.Env)
 	return cfg
 }
@@ -425,7 +472,8 @@ type rpcRequest struct {
 
 type rpcResponse struct {
 	JSONRPC string          `json:"jsonrpc"`
-	ID      int             `json:"id"`
+	ID      any             `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
 	Result  json.RawMessage `json:"result,omitempty"`
 	Error   *rpcError       `json:"error,omitempty"`
 }
@@ -444,6 +492,97 @@ func newRPCRequest(id int, method string, params any) rpcRequest {
 	}
 }
 
+func initializeParams(protocolVersion string) map[string]any {
+	return map[string]any{
+		"protocolVersion": strings.TrimSpace(protocolVersion),
+		"clientInfo": map[string]any{
+			"name":    "bytemind",
+			"version": "dev",
+		},
+	}
+}
+
+func isClientErrorCode(err error, code ClientErrorCode) bool {
+	if err == nil {
+		return false
+	}
+	var clientErr *ClientError
+	if !errors.As(err, &clientErr) {
+		return false
+	}
+	return clientErr.Code == code
+}
+
+func normalizeProtocolVersions(primary string, extras []string) []string {
+	versions := make([]string, 0, 1+len(extras))
+	if strings.TrimSpace(primary) != "" {
+		versions = append(versions, primary)
+	}
+	versions = append(versions, extras...)
+
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(versions))
+	for _, version := range versions {
+		version = strings.TrimSpace(version)
+		if version == "" {
+			continue
+		}
+		if _, ok := seen[version]; ok {
+			continue
+		}
+		seen[version] = struct{}{}
+		normalized = append(normalized, version)
+	}
+	if len(normalized) > 0 {
+		return normalized
+	}
+	return cloneStringSlice(defaultProtocolVersions)
+}
+
+func normalizeRPCResponseID(id any) (string, bool, error) {
+	switch value := id.(type) {
+	case nil:
+		return "", false, nil
+	case int:
+		return strconv.Itoa(value), true, nil
+	case int8:
+		return strconv.Itoa(int(value)), true, nil
+	case int16:
+		return strconv.Itoa(int(value)), true, nil
+	case int32:
+		return strconv.Itoa(int(value)), true, nil
+	case int64:
+		return strconv.FormatInt(value, 10), true, nil
+	case uint:
+		return strconv.FormatUint(uint64(value), 10), true, nil
+	case uint8:
+		return strconv.FormatUint(uint64(value), 10), true, nil
+	case uint16:
+		return strconv.FormatUint(uint64(value), 10), true, nil
+	case uint32:
+		return strconv.FormatUint(uint64(value), 10), true, nil
+	case uint64:
+		return strconv.FormatUint(value, 10), true, nil
+	case json.Number:
+		if integer, err := value.Int64(); err == nil {
+			return strconv.FormatInt(integer, 10), true, nil
+		}
+		if _, err := value.Float64(); err == nil {
+			return "", true, fmt.Errorf("response id must be an integer, got %q", value.String())
+		}
+		return "", true, fmt.Errorf("invalid numeric response id %q", value.String())
+	case float64:
+		if value != float64(int64(value)) {
+			return "", true, fmt.Errorf("response id must be an integer, got %v", value)
+		}
+		return strconv.FormatInt(int64(value), 10), true, nil
+	case string:
+		return strings.TrimSpace(value), true, nil
+	default:
+		return "", true, fmt.Errorf("unsupported response id type %T", id)
+	}
+}
+
 func writeRPCRequest(writer *bufio.Writer, request rpcRequest) error {
 	data, err := json.Marshal(request)
 	if err != nil {
@@ -458,7 +597,9 @@ func readRPCResponse(reader *bufio.Reader) (rpcResponse, error) {
 		return rpcResponse{}, err
 	}
 	var response rpcResponse
-	if err := json.Unmarshal(payload, &response); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	if err := decoder.Decode(&response); err != nil {
 		return rpcResponse{}, err
 	}
 	return response, nil
@@ -577,6 +718,15 @@ func cloneMap(input map[string]any) map[string]any {
 	for key, value := range input {
 		out[key] = value
 	}
+	return out
+}
+
+func cloneStringSlice(input []string) []string {
+	if input == nil {
+		return nil
+	}
+	out := make([]string, len(input))
+	copy(out, input)
 	return out
 }
 

--- a/internal/extensions/mcp/client.go
+++ b/internal/extensions/mcp/client.go
@@ -1,0 +1,530 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	defaultStartupTimeout = 5 * time.Second
+	defaultCallTimeout    = 30 * time.Second
+)
+
+type ServerConfig struct {
+	ID             string
+	Name           string
+	Version        string
+	Command        string
+	Args           []string
+	Env            map[string]string
+	CWD            string
+	StartupTimeout time.Duration
+	CallTimeout    time.Duration
+}
+
+type ToolDescriptor struct {
+	Name        string
+	Description string
+	InputSchema map[string]any
+}
+
+type ServerSnapshot struct {
+	ID      string
+	Name    string
+	Version string
+	Tools   []ToolDescriptor
+}
+
+type Client interface {
+	Discover(ctx context.Context, cfg ServerConfig) (ServerSnapshot, error)
+	CallTool(ctx context.Context, cfg ServerConfig, toolName string, raw json.RawMessage) (string, error)
+}
+
+type ClientErrorCode string
+
+const (
+	ClientErrorInvalidConfig   ClientErrorCode = "invalid_config"
+	ClientErrorTransport       ClientErrorCode = "transport_error"
+	ClientErrorProtocol        ClientErrorCode = "protocol_error"
+	ClientErrorTimeout         ClientErrorCode = "timeout"
+	ClientErrorHandshakeFailed ClientErrorCode = "handshake_failed"
+	ClientErrorListToolsFailed ClientErrorCode = "tools_list_failed"
+	ClientErrorCallFailed      ClientErrorCode = "call_failed"
+	ClientErrorPermission      ClientErrorCode = "permission_denied"
+	ClientErrorInvalidArgs     ClientErrorCode = "invalid_args"
+)
+
+type ClientError struct {
+	Code    ClientErrorCode
+	Message string
+	Err     error
+}
+
+func (e *ClientError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) == "" {
+		return string(e.Code)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func (e *ClientError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func newClientError(code ClientErrorCode, message string, err error) error {
+	return &ClientError{
+		Code:    code,
+		Message: strings.TrimSpace(message),
+		Err:     err,
+	}
+}
+
+type StdioClient struct{}
+
+func NewStdioClient() *StdioClient {
+	return &StdioClient{}
+}
+
+func (c *StdioClient) Discover(ctx context.Context, cfg ServerConfig) (ServerSnapshot, error) {
+	cfg = normalizeServerConfig(cfg)
+	if err := validateServerConfig(cfg, true); err != nil {
+		return ServerSnapshot{}, err
+	}
+
+	callCtx, cancel := withTimeoutIfMissing(ctx, cfg.StartupTimeout)
+	defer cancel()
+
+	responses, err := c.runRPC(callCtx, cfg, []rpcRequest{
+		newRPCRequest(1, "initialize", map[string]any{
+			"protocolVersion": "2026-04-01",
+			"clientInfo": map[string]any{
+				"name":    "bytemind",
+				"version": "dev",
+			},
+		}),
+		newRPCRequest(2, "tools/list", map[string]any{}),
+	})
+	if err != nil {
+		return ServerSnapshot{}, err
+	}
+	if len(responses) != 2 {
+		return ServerSnapshot{}, newClientError(ClientErrorProtocol, "mcp server returned incomplete discovery responses", nil)
+	}
+
+	initResult := struct {
+		ServerInfo struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"serverInfo"`
+	}{}
+	if err := json.Unmarshal(responses[0].Result, &initResult); err != nil {
+		return ServerSnapshot{}, newClientError(ClientErrorProtocol, "failed to decode initialize result", err)
+	}
+
+	toolsResult := struct {
+		Tools []struct {
+			Name        string         `json:"name"`
+			Description string         `json:"description"`
+			InputSchema map[string]any `json:"inputSchema"`
+			Parameters  map[string]any `json:"parameters"`
+		} `json:"tools"`
+	}{}
+	if err := json.Unmarshal(responses[1].Result, &toolsResult); err != nil {
+		return ServerSnapshot{}, newClientError(ClientErrorProtocol, "failed to decode tools/list result", err)
+	}
+
+	descriptors := make([]ToolDescriptor, 0, len(toolsResult.Tools))
+	for _, tool := range toolsResult.Tools {
+		schema := cloneMap(tool.InputSchema)
+		if len(schema) == 0 {
+			schema = cloneMap(tool.Parameters)
+		}
+		descriptors = append(descriptors, ToolDescriptor{
+			Name:        strings.TrimSpace(tool.Name),
+			Description: strings.TrimSpace(tool.Description),
+			InputSchema: schema,
+		})
+	}
+
+	name := strings.TrimSpace(initResult.ServerInfo.Name)
+	if name == "" {
+		name = cfg.Name
+	}
+	version := strings.TrimSpace(initResult.ServerInfo.Version)
+	if version == "" {
+		version = cfg.Version
+	}
+	return ServerSnapshot{
+		ID:      cfg.ID,
+		Name:    name,
+		Version: version,
+		Tools:   descriptors,
+	}, nil
+}
+
+func (c *StdioClient) CallTool(ctx context.Context, cfg ServerConfig, toolName string, raw json.RawMessage) (string, error) {
+	cfg = normalizeServerConfig(cfg)
+	if err := validateServerConfig(cfg, true); err != nil {
+		return "", err
+	}
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return "", newClientError(ClientErrorInvalidArgs, "tool name is required", nil)
+	}
+
+	args := map[string]any{}
+	if len(bytes.TrimSpace(raw)) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return "", newClientError(ClientErrorInvalidArgs, "tool arguments must be a JSON object", err)
+		}
+	}
+
+	callCtx, cancel := withTimeoutIfMissing(ctx, cfg.CallTimeout)
+	defer cancel()
+
+	responses, err := c.runRPC(callCtx, cfg, []rpcRequest{
+		newRPCRequest(1, "initialize", map[string]any{
+			"protocolVersion": "2026-04-01",
+			"clientInfo": map[string]any{
+				"name":    "bytemind",
+				"version": "dev",
+			},
+		}),
+		newRPCRequest(2, "tools/call", map[string]any{
+			"name":      toolName,
+			"arguments": args,
+		}),
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(responses) != 2 {
+		return "", newClientError(ClientErrorProtocol, "mcp server returned incomplete call responses", nil)
+	}
+
+	callResult := struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}{}
+	if err := json.Unmarshal(responses[1].Result, &callResult); err == nil {
+		if callResult.IsError {
+			return "", newClientError(ClientErrorCallFailed, fmt.Sprintf("mcp tool %q returned isError", toolName), nil)
+		}
+		parts := make([]string, 0, len(callResult.Content))
+		for _, item := range callResult.Content {
+			if strings.TrimSpace(item.Text) == "" {
+				continue
+			}
+			parts = append(parts, item.Text)
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, "\n"), nil
+		}
+	}
+
+	compact, err := compactJSON(responses[1].Result)
+	if err != nil {
+		return "", newClientError(ClientErrorProtocol, "failed to normalize tools/call result", err)
+	}
+	return compact, nil
+}
+
+func (c *StdioClient) runRPC(ctx context.Context, cfg ServerConfig, requests []rpcRequest) ([]rpcResponse, error) {
+	if len(requests) == 0 {
+		return nil, nil
+	}
+
+	cmd := exec.CommandContext(ctx, cfg.Command, cfg.Args...)
+	if strings.TrimSpace(cfg.CWD) != "" {
+		cmd.Dir = cfg.CWD
+	}
+	cmd.Env = mergeCommandEnv(cfg.Env)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, newClientError(ClientErrorTransport, "failed to open mcp stdin pipe", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, newClientError(ClientErrorTransport, "failed to open mcp stdout pipe", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, newClientError(ClientErrorTransport, "failed to start mcp server process", err)
+	}
+	defer stopCommand(cmd, stdin)
+
+	reader := bufio.NewReader(stdout)
+	writer := bufio.NewWriter(stdin)
+	responses := make([]rpcResponse, 0, len(requests))
+
+	for _, request := range requests {
+		if err := writeRPCRequest(writer, request); err != nil {
+			return nil, newClientError(ClientErrorTransport, "failed to write mcp request", err)
+		}
+		response, err := readRPCResponse(reader)
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, newClientError(ClientErrorTimeout, "mcp request timed out", err)
+			}
+			if errors.Is(err, io.EOF) {
+				message := "mcp server closed stdout before replying"
+				if trimmed := strings.TrimSpace(stderr.String()); trimmed != "" {
+					message = fmt.Sprintf("%s: %s", message, trimmed)
+				}
+				return nil, newClientError(ClientErrorTransport, message, err)
+			}
+			return nil, newClientError(ClientErrorProtocol, "failed to read mcp response", err)
+		}
+		if response.ID != request.ID {
+			return nil, newClientError(ClientErrorProtocol, "mcp response id mismatch", nil)
+		}
+		if response.Error != nil {
+			return nil, mapRPCError(request.Method, response.Error)
+		}
+		responses = append(responses, response)
+	}
+	return responses, nil
+}
+
+func normalizeServerConfig(cfg ServerConfig) ServerConfig {
+	cfg.ID = normalizeID(cfg.ID)
+	cfg.Name = strings.TrimSpace(cfg.Name)
+	cfg.Version = strings.TrimSpace(cfg.Version)
+	cfg.Command = strings.TrimSpace(cfg.Command)
+	cfg.CWD = strings.TrimSpace(cfg.CWD)
+	if cfg.Name == "" {
+		cfg.Name = cfg.ID
+	}
+	if cfg.StartupTimeout <= 0 {
+		cfg.StartupTimeout = defaultStartupTimeout
+	}
+	if cfg.CallTimeout <= 0 {
+		cfg.CallTimeout = defaultCallTimeout
+	}
+	if cfg.Args == nil {
+		cfg.Args = []string{}
+	}
+	cfg.Env = cloneStringMap(cfg.Env)
+	return cfg
+}
+
+func validateServerConfig(cfg ServerConfig, requireCommand bool) error {
+	if strings.TrimSpace(cfg.ID) == "" {
+		return newClientError(ClientErrorInvalidConfig, "mcp server id is required", nil)
+	}
+	if requireCommand && strings.TrimSpace(cfg.Command) == "" {
+		return newClientError(ClientErrorInvalidConfig, "mcp server command is required", nil)
+	}
+	if strings.TrimSpace(cfg.CWD) != "" {
+		if _, err := os.Stat(cfg.CWD); err != nil {
+			return newClientError(ClientErrorInvalidConfig, "mcp server cwd is not accessible", err)
+		}
+	}
+	return nil
+}
+
+func withTimeoutIfMissing(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	if _, has := ctx.Deadline(); has {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func mergeCommandEnv(extra map[string]string) []string {
+	base := map[string]string{}
+	for _, item := range os.Environ() {
+		parts := strings.SplitN(item, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		base[parts[0]] = parts[1]
+	}
+	for key, value := range extra {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		base[key] = value
+	}
+	env := make([]string, 0, len(base))
+	for key, value := range base {
+		env = append(env, fmt.Sprintf("%s=%s", key, value))
+	}
+	return env
+}
+
+func stopCommand(cmd *exec.Cmd, stdin io.WriteCloser) {
+	if stdin != nil {
+		_ = stdin.Close()
+	}
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return
+	case <-time.After(200 * time.Millisecond):
+	}
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+	<-done
+}
+
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func newRPCRequest(id int, method string, params any) rpcRequest {
+	return rpcRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  params,
+	}
+}
+
+func writeRPCRequest(writer *bufio.Writer, request rpcRequest) error {
+	data, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+	if _, err := writer.Write(data); err != nil {
+		return err
+	}
+	if err := writer.WriteByte('\n'); err != nil {
+		return err
+	}
+	return writer.Flush()
+}
+
+func readRPCResponse(reader *bufio.Reader) (rpcResponse, error) {
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		return rpcResponse{}, err
+	}
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 {
+		return rpcResponse{}, io.EOF
+	}
+	var response rpcResponse
+	if err := json.Unmarshal(line, &response); err != nil {
+		return rpcResponse{}, err
+	}
+	return response, nil
+}
+
+func mapRPCError(method string, rpcErr *rpcError) error {
+	if rpcErr == nil {
+		return nil
+	}
+	message := strings.TrimSpace(rpcErr.Message)
+	if message == "" {
+		message = "mcp server returned an unknown error"
+	}
+	switch strings.TrimSpace(method) {
+	case "initialize":
+		return newClientError(ClientErrorHandshakeFailed, message, nil)
+	case "tools/list":
+		return newClientError(ClientErrorListToolsFailed, message, nil)
+	case "tools/call":
+		switch rpcErr.Code {
+		case -32602:
+			return newClientError(ClientErrorInvalidArgs, message, nil)
+		case -32001:
+			return newClientError(ClientErrorPermission, message, nil)
+		default:
+			return newClientError(ClientErrorCallFailed, message, nil)
+		}
+	default:
+		return newClientError(ClientErrorProtocol, message, nil)
+	}
+}
+
+func compactJSON(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+	var out bytes.Buffer
+	if err := json.Compact(&out, raw); err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	out := make(map[string]any, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneStringMap(input map[string]string) map[string]string {
+	if input == nil {
+		return nil
+	}
+	out := make(map[string]string, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}
+
+func normalizeID(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	if raw == "" {
+		return ""
+	}
+	replacer := strings.NewReplacer(" ", "-", "/", "-", "\\", "-", ":", "-", ".", "-")
+	raw = replacer.Replace(raw)
+	raw = strings.Trim(raw, "-_")
+	if raw == "" {
+		return ""
+	}
+	return raw
+}

--- a/internal/extensions/mcp/client.go
+++ b/internal/extensions/mcp/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -18,6 +19,21 @@ const (
 	defaultStartupTimeout = 5 * time.Second
 	defaultCallTimeout    = 30 * time.Second
 )
+
+var defaultEnvWhitelist = []string{
+	"PATH",
+	"Path",
+	"SYSTEMROOT",
+	"SystemRoot",
+	"WINDIR",
+	"COMSPEC",
+	"ComSpec",
+	"PATHEXT",
+	"TEMP",
+	"TMP",
+	"HOME",
+	"USERPROFILE",
+}
 
 type ServerConfig struct {
 	ID             string
@@ -356,12 +372,15 @@ func withTimeoutIfMissing(ctx context.Context, timeout time.Duration) (context.C
 
 func mergeCommandEnv(extra map[string]string) []string {
 	base := map[string]string{}
-	for _, item := range os.Environ() {
-		parts := strings.SplitN(item, "=", 2)
-		if len(parts) != 2 {
+	for _, key := range defaultEnvWhitelist {
+		if key = strings.TrimSpace(key); key == "" {
 			continue
 		}
-		base[parts[0]] = parts[1]
+		value, ok := os.LookupEnv(key)
+		if !ok {
+			continue
+		}
+		base[key] = value
 	}
 	for key, value := range extra {
 		key = strings.TrimSpace(key)
@@ -430,29 +449,86 @@ func writeRPCRequest(writer *bufio.Writer, request rpcRequest) error {
 	if err != nil {
 		return err
 	}
-	if _, err := writer.Write(data); err != nil {
+	return writeFramedJSON(writer, data)
+}
+
+func readRPCResponse(reader *bufio.Reader) (rpcResponse, error) {
+	payload, err := readFramedJSON(reader)
+	if err != nil {
+		return rpcResponse{}, err
+	}
+	var response rpcResponse
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return rpcResponse{}, err
+	}
+	return response, nil
+}
+
+func writeRPCResponse(writer *bufio.Writer, response rpcResponse) error {
+	data, err := json.Marshal(response)
+	if err != nil {
 		return err
 	}
-	if err := writer.WriteByte('\n'); err != nil {
+	return writeFramedJSON(writer, data)
+}
+
+func readRPCRequest(reader *bufio.Reader) (rpcRequest, error) {
+	payload, err := readFramedJSON(reader)
+	if err != nil {
+		return rpcRequest{}, err
+	}
+	var request rpcRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		return rpcRequest{}, err
+	}
+	return request, nil
+}
+
+func writeFramedJSON(writer *bufio.Writer, payload []byte) error {
+	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(payload))
+	if _, err := writer.WriteString(header); err != nil {
+		return err
+	}
+	if _, err := writer.Write(payload); err != nil {
 		return err
 	}
 	return writer.Flush()
 }
 
-func readRPCResponse(reader *bufio.Reader) (rpcResponse, error) {
-	line, err := reader.ReadBytes('\n')
-	if err != nil {
-		return rpcResponse{}, err
+func readFramedJSON(reader *bufio.Reader) ([]byte, error) {
+	contentLength := -1
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid mcp frame header line %q", line)
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		value := strings.TrimSpace(parts[1])
+		if key != "content-length" {
+			continue
+		}
+		length, err := strconv.Atoi(value)
+		if err != nil || length < 0 {
+			return nil, fmt.Errorf("invalid content-length %q", value)
+		}
+		contentLength = length
 	}
-	line = bytes.TrimSpace(line)
-	if len(line) == 0 {
-		return rpcResponse{}, io.EOF
+	if contentLength < 0 {
+		return nil, errors.New("missing content-length header")
 	}
-	var response rpcResponse
-	if err := json.Unmarshal(line, &response); err != nil {
-		return rpcResponse{}, err
+	payload := make([]byte, contentLength)
+	if _, err := io.ReadFull(reader, payload); err != nil {
+		return nil, err
 	}
-	return response, nil
+	return payload, nil
 }
 
 func mapRPCError(method string, rpcErr *rpcError) error {

--- a/internal/extensions/mcp/client_extra_test.go
+++ b/internal/extensions/mcp/client_extra_test.go
@@ -266,8 +266,25 @@ func TestWriteRPCRequestAndReadRPCResponseErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("readRPCRequest failed: %v", err)
 	}
-	if decodedRequest.ID != 9 || decodedRequest.Method != "tools/list" {
+	decodedRequestID, hasDecodedRequestID, err := normalizeRPCResponseID(decodedRequest.ID)
+	if err != nil {
+		t.Fatalf("normalizeRPCResponseID(decoded request) failed: %v", err)
+	}
+	if !hasDecodedRequestID || decodedRequestID != "9" || decodedRequest.Method != "tools/list" {
 		t.Fatalf("unexpected decoded request: %#v", decodedRequest)
+	}
+
+	notificationRoundtrip := &strings.Builder{}
+	notificationWriter := bufio.NewWriter(notificationRoundtrip)
+	if err := writeRPCRequest(notificationWriter, newRPCNotification("notifications/initialized", map[string]any{})); err != nil {
+		t.Fatalf("writeRPCRequest for notification failed: %v", err)
+	}
+	decodedNotification, err := readRPCRequest(bufio.NewReader(strings.NewReader(notificationRoundtrip.String())))
+	if err != nil {
+		t.Fatalf("readRPCRequest for notification failed: %v", err)
+	}
+	if decodedNotification.ID != nil || decodedNotification.Method != "notifications/initialized" {
+		t.Fatalf("unexpected decoded notification: %#v", decodedNotification)
 	}
 }
 

--- a/internal/extensions/mcp/client_extra_test.go
+++ b/internal/extensions/mcp/client_extra_test.go
@@ -213,7 +213,11 @@ func TestWriteRPCRequestAndReadRPCResponseErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("readRPCResponse roundtrip failed: %v", err)
 	}
-	if response.ID != 1 {
+	id, hasID, err := normalizeRPCResponseID(response.ID)
+	if err != nil {
+		t.Fatalf("normalizeRPCResponseID failed: %v", err)
+	}
+	if !hasID || id != "1" {
 		t.Fatalf("unexpected response id: %#v", response)
 	}
 
@@ -245,7 +249,11 @@ func TestWriteRPCRequestAndReadRPCResponseErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("readRPCResponse for framed response failed: %v", err)
 	}
-	if decodedResponse.ID != 2 {
+	decodedID, hasDecodedID, err := normalizeRPCResponseID(decodedResponse.ID)
+	if err != nil {
+		t.Fatalf("normalizeRPCResponseID(decoded) failed: %v", err)
+	}
+	if !hasDecodedID || decodedID != "2" {
 		t.Fatalf("unexpected decoded response id: %#v", decodedResponse)
 	}
 
@@ -320,6 +328,10 @@ func TestCallToolErrorAndFallbackPaths(t *testing.T) {
 	_, err = client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{}`))
 	assertClientErrorCode(t, err, ClientErrorProtocol)
 
+	cfg = helperServerConfig(t, "non_integer_response_id")
+	_, err = client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{}`))
+	assertClientErrorCode(t, err, ClientErrorProtocol)
+
 	cfg = helperServerConfig(t, "invalid_json_line")
 	_, err = client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{}`))
 	assertClientErrorCode(t, err, ClientErrorProtocol)
@@ -385,6 +397,9 @@ func TestNormalizeIDAndCloneMapHelpers(t *testing.T) {
 	if cloneStringMap(nil) != nil {
 		t.Fatal("expected nil clone for nil string map")
 	}
+	if cloneStringSlice(nil) != nil {
+		t.Fatal("expected nil clone for nil string slice")
+	}
 
 	source := map[string]any{"a": 1}
 	cloned := cloneMap(source)
@@ -399,6 +414,12 @@ func TestNormalizeIDAndCloneMapHelpers(t *testing.T) {
 	if sourceEnv["A"] != "1" {
 		t.Fatal("cloneStringMap should not mutate source map")
 	}
+	protocolVersions := []string{"2026-04-01", "2025-03-26"}
+	clonedVersions := cloneStringSlice(protocolVersions)
+	clonedVersions[0] = "2024-11-05"
+	if protocolVersions[0] != "2026-04-01" {
+		t.Fatal("cloneStringSlice should not mutate source slice")
+	}
 
 	t.Setenv("BYTEMIND_MCP_SECRET", "top-secret")
 	envMap := envListToMap(mergeCommandEnv(nil))
@@ -411,6 +432,70 @@ func TestNormalizeIDAndCloneMapHelpers(t *testing.T) {
 	}))
 	if envMap["BYTEMIND_MCP_SECRET"] != "explicit" {
 		t.Fatalf("expected explicit env injection, got %#v", envMap["BYTEMIND_MCP_SECRET"])
+	}
+}
+
+func TestNormalizeProtocolVersions(t *testing.T) {
+	versions := normalizeProtocolVersions(" 2026-04-01 ", []string{"2025-03-26", "2026-04-01", "", "2024-11-05"})
+	expected := []string{"2026-04-01", "2025-03-26", "2024-11-05"}
+	if len(versions) != len(expected) {
+		t.Fatalf("unexpected protocol version count: got %d want %d", len(versions), len(expected))
+	}
+	for i := range expected {
+		if versions[i] != expected[i] {
+			t.Fatalf("unexpected version at %d: got %q want %q", i, versions[i], expected[i])
+		}
+	}
+
+	defaults := normalizeProtocolVersions("", nil)
+	if len(defaults) != len(defaultProtocolVersions) {
+		t.Fatalf("expected default protocol versions, got %#v", defaults)
+	}
+}
+
+func TestNormalizeRPCResponseID(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      any
+		wantID  string
+		wantHas bool
+		wantErr bool
+	}{
+		{name: "nil", id: nil, wantID: "", wantHas: false, wantErr: false},
+		{name: "int", id: 2, wantID: "2", wantHas: true, wantErr: false},
+		{name: "string", id: " 3 ", wantID: "3", wantHas: true, wantErr: false},
+		{name: "json number", id: json.Number("4"), wantID: "4", wantHas: true, wantErr: false},
+		{name: "decimal number", id: json.Number("1.5"), wantID: "", wantHas: true, wantErr: true},
+		{name: "unsupported", id: true, wantID: "", wantHas: true, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotHas, err := normalizeRPCResponseID(tc.id)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("did not expect error, got %v", err)
+			}
+			if gotHas != tc.wantHas {
+				t.Fatalf("unexpected has-id value: got %v want %v", gotHas, tc.wantHas)
+			}
+			if gotID != tc.wantID {
+				t.Fatalf("unexpected id: got %q want %q", gotID, tc.wantID)
+			}
+		})
+	}
+}
+
+func TestIsClientErrorCode(t *testing.T) {
+	if isClientErrorCode(nil, ClientErrorProtocol) {
+		t.Fatal("nil error should not match client error code")
+	}
+	if isClientErrorCode(errors.New("boom"), ClientErrorProtocol) {
+		t.Fatal("non-client error should not match client error code")
+	}
+	if !isClientErrorCode(newClientError(ClientErrorProtocol, "x", nil), ClientErrorProtocol) {
+		t.Fatal("expected client error code match")
 	}
 }
 

--- a/internal/extensions/mcp/client_extra_test.go
+++ b/internal/extensions/mcp/client_extra_test.go
@@ -222,14 +222,44 @@ func TestWriteRPCRequestAndReadRPCResponseErrors(t *testing.T) {
 		t.Fatal("expected write error")
 	}
 
-	if _, err := readRPCResponse(bufio.NewReader(strings.NewReader("\n"))); !errors.Is(err, io.EOF) {
-		t.Fatalf("expected EOF for blank line, got %v", err)
+	if _, err := readRPCResponse(bufio.NewReader(strings.NewReader("\n"))); err == nil || !strings.Contains(err.Error(), "content-length") {
+		t.Fatalf("expected missing content-length error for blank frame header, got %v", err)
 	}
 	if _, err := readRPCResponse(bufio.NewReader(strings.NewReader("{\n"))); err == nil {
 		t.Fatal("expected invalid json error")
 	}
 	if _, err := readRPCResponse(bufio.NewReader(alwaysFailReader{err: io.ErrUnexpectedEOF})); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("expected wrapped reader error, got %v", err)
+	}
+
+	responseRoundtrip := &strings.Builder{}
+	responseWriter := bufio.NewWriter(responseRoundtrip)
+	if err := writeRPCResponse(responseWriter, rpcResponse{
+		JSONRPC: "2.0",
+		ID:      2,
+		Result:  json.RawMessage(`{"ok":true}`),
+	}); err != nil {
+		t.Fatalf("writeRPCResponse failed: %v", err)
+	}
+	decodedResponse, err := readRPCResponse(bufio.NewReader(strings.NewReader(responseRoundtrip.String())))
+	if err != nil {
+		t.Fatalf("readRPCResponse for framed response failed: %v", err)
+	}
+	if decodedResponse.ID != 2 {
+		t.Fatalf("unexpected decoded response id: %#v", decodedResponse)
+	}
+
+	requestRoundtrip := &strings.Builder{}
+	requestWriter := bufio.NewWriter(requestRoundtrip)
+	if err := writeRPCRequest(requestWriter, newRPCRequest(9, "tools/list", map[string]any{})); err != nil {
+		t.Fatalf("writeRPCRequest for request roundtrip failed: %v", err)
+	}
+	decodedRequest, err := readRPCRequest(bufio.NewReader(strings.NewReader(requestRoundtrip.String())))
+	if err != nil {
+		t.Fatalf("readRPCRequest failed: %v", err)
+	}
+	if decodedRequest.ID != 9 || decodedRequest.Method != "tools/list" {
+		t.Fatalf("unexpected decoded request: %#v", decodedRequest)
 	}
 }
 
@@ -369,6 +399,19 @@ func TestNormalizeIDAndCloneMapHelpers(t *testing.T) {
 	if sourceEnv["A"] != "1" {
 		t.Fatal("cloneStringMap should not mutate source map")
 	}
+
+	t.Setenv("BYTEMIND_MCP_SECRET", "top-secret")
+	envMap := envListToMap(mergeCommandEnv(nil))
+	if _, ok := envMap["BYTEMIND_MCP_SECRET"]; ok {
+		t.Fatal("mergeCommandEnv should not inherit non-whitelisted variables by default")
+	}
+
+	envMap = envListToMap(mergeCommandEnv(map[string]string{
+		"BYTEMIND_MCP_SECRET": "explicit",
+	}))
+	if envMap["BYTEMIND_MCP_SECRET"] != "explicit" {
+		t.Fatalf("expected explicit env injection, got %#v", envMap["BYTEMIND_MCP_SECRET"])
+	}
 }
 
 func assertClientErrorCode(t *testing.T, err error, code ClientErrorCode) {
@@ -383,6 +426,18 @@ func assertClientErrorCode(t *testing.T, err error, code ClientErrorCode) {
 	if clientErr.Code != code {
 		t.Fatalf("expected code %q, got %q (err=%v)", code, clientErr.Code, err)
 	}
+}
+
+func envListToMap(items []string) map[string]string {
+	out := make(map[string]string, len(items))
+	for _, item := range items {
+		parts := strings.SplitN(item, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		out[parts[0]] = parts[1]
+	}
+	return out
 }
 
 type alwaysFailWriter struct {

--- a/internal/extensions/mcp/client_extra_test.go
+++ b/internal/extensions/mcp/client_extra_test.go
@@ -1,0 +1,402 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClientErrorHelpers(t *testing.T) {
+	var nilErr *ClientError
+	if nilErr.Error() != "" {
+		t.Fatalf("expected empty string for nil error, got %q", nilErr.Error())
+	}
+	if nilErr.Unwrap() != nil {
+		t.Fatal("expected nil unwrap for nil error")
+	}
+
+	cause := errors.New("boom")
+	err := &ClientError{Code: ClientErrorProtocol, Message: "  ", Err: cause}
+	if err.Error() != string(ClientErrorProtocol) {
+		t.Fatalf("unexpected message without text: %q", err.Error())
+	}
+	if !errors.Is(err, cause) {
+		t.Fatal("expected unwrap to include cause")
+	}
+
+	wrapped := newClientError(ClientErrorInvalidArgs, "  bad args  ", nil)
+	var clientErr *ClientError
+	if !errors.As(wrapped, &clientErr) {
+		t.Fatalf("expected ClientError, got %T", wrapped)
+	}
+	if clientErr.Message != "bad args" {
+		t.Fatalf("expected trimmed message, got %q", clientErr.Message)
+	}
+}
+
+func TestValidateServerConfig(t *testing.T) {
+	valid := ServerConfig{ID: "id", Command: "cmd"}
+	if err := validateServerConfig(valid, true); err != nil {
+		t.Fatalf("expected valid config, got %v", err)
+	}
+
+	cases := []struct {
+		name string
+		cfg  ServerConfig
+		req  bool
+		code ClientErrorCode
+	}{
+		{
+			name: "missing id",
+			cfg:  ServerConfig{Command: "cmd"},
+			req:  true,
+			code: ClientErrorInvalidConfig,
+		},
+		{
+			name: "missing command when required",
+			cfg:  ServerConfig{ID: "id"},
+			req:  true,
+			code: ClientErrorInvalidConfig,
+		},
+		{
+			name: "missing cwd",
+			cfg: ServerConfig{
+				ID:      "id",
+				Command: "cmd",
+				CWD:     filepath.Join(t.TempDir(), "missing"),
+			},
+			req:  true,
+			code: ClientErrorInvalidConfig,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateServerConfig(tc.cfg, tc.req)
+			assertClientErrorCode(t, err, tc.code)
+		})
+	}
+
+	if err := validateServerConfig(ServerConfig{ID: "id"}, false); err != nil {
+		t.Fatalf("command should be optional when not required, got %v", err)
+	}
+}
+
+func TestWithTimeoutIfMissing(t *testing.T) {
+	ctx := context.Background()
+	withoutTimeout, cancel := withTimeoutIfMissing(ctx, 0)
+	defer cancel()
+	if _, has := withoutTimeout.Deadline(); has {
+		t.Fatal("did not expect deadline when timeout <= 0")
+	}
+
+	parent, parentCancel := context.WithTimeout(context.Background(), time.Second)
+	defer parentCancel()
+	inherited, inheritedCancel := withTimeoutIfMissing(parent, 5*time.Second)
+	defer inheritedCancel()
+	parentDeadline, _ := parent.Deadline()
+	inheritedDeadline, hasDeadline := inherited.Deadline()
+	if !hasDeadline {
+		t.Fatal("expected inherited deadline")
+	}
+	if !inheritedDeadline.Equal(parentDeadline) {
+		t.Fatalf("expected inherited deadline %v, got %v", parentDeadline, inheritedDeadline)
+	}
+
+	withTimeout, withTimeoutCancel := withTimeoutIfMissing(context.Background(), 50*time.Millisecond)
+	defer withTimeoutCancel()
+	if _, has := withTimeout.Deadline(); !has {
+		t.Fatal("expected deadline when timeout is set")
+	}
+}
+
+func TestMapRPCError(t *testing.T) {
+	if err := mapRPCError("initialize", nil); err != nil {
+		t.Fatalf("expected nil rpc error to map to nil, got %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		method string
+		err    *rpcError
+		code   ClientErrorCode
+	}{
+		{
+			name:   "initialize maps handshake",
+			method: "initialize",
+			err:    &rpcError{Code: -32000, Message: "x"},
+			code:   ClientErrorHandshakeFailed,
+		},
+		{
+			name:   "tools list maps list error",
+			method: "tools/list",
+			err:    &rpcError{Code: -32000, Message: "x"},
+			code:   ClientErrorListToolsFailed,
+		},
+		{
+			name:   "tools call invalid args",
+			method: "tools/call",
+			err:    &rpcError{Code: -32602, Message: "x"},
+			code:   ClientErrorInvalidArgs,
+		},
+		{
+			name:   "tools call permission",
+			method: "tools/call",
+			err:    &rpcError{Code: -32001, Message: "x"},
+			code:   ClientErrorPermission,
+		},
+		{
+			name:   "tools call default",
+			method: "tools/call",
+			err:    &rpcError{Code: -32099, Message: "x"},
+			code:   ClientErrorCallFailed,
+		},
+		{
+			name:   "unknown method",
+			method: "unknown",
+			err:    &rpcError{Code: -32099, Message: "x"},
+			code:   ClientErrorProtocol,
+		},
+		{
+			name:   "empty message fallback",
+			method: "initialize",
+			err:    &rpcError{Code: -32000, Message: "   "},
+			code:   ClientErrorHandshakeFailed,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mapped := mapRPCError(tc.method, tc.err)
+			assertClientErrorCode(t, mapped, tc.code)
+		})
+	}
+}
+
+func TestCompactJSONHelpers(t *testing.T) {
+	output, err := compactJSON(nil)
+	if err != nil {
+		t.Fatalf("compactJSON(nil) failed: %v", err)
+	}
+	if output != "" {
+		t.Fatalf("expected empty output, got %q", output)
+	}
+
+	output, err = compactJSON(json.RawMessage(`{ "a": 1 }`))
+	if err != nil {
+		t.Fatalf("compactJSON(valid) failed: %v", err)
+	}
+	if output != `{"a":1}` {
+		t.Fatalf("unexpected compact output: %q", output)
+	}
+
+	if _, err := compactJSON(json.RawMessage(`{`)); err == nil {
+		t.Fatal("expected invalid json error")
+	}
+}
+
+func TestWriteRPCRequestAndReadRPCResponseErrors(t *testing.T) {
+	roundtrip := &strings.Builder{}
+	writer := bufio.NewWriter(roundtrip)
+	if err := writeRPCRequest(writer, newRPCRequest(1, "ping", map[string]any{"a": 1})); err != nil {
+		t.Fatalf("writeRPCRequest roundtrip failed: %v", err)
+	}
+	reader := bufio.NewReader(strings.NewReader(roundtrip.String()))
+	response, err := readRPCResponse(reader)
+	if err != nil {
+		t.Fatalf("readRPCResponse roundtrip failed: %v", err)
+	}
+	if response.ID != 1 {
+		t.Fatalf("unexpected response id: %#v", response)
+	}
+
+	errWriter := bufio.NewWriterSize(alwaysFailWriter{err: io.ErrClosedPipe}, 1)
+	if err := writeRPCRequest(errWriter, newRPCRequest(1, "ping", map[string]any{"a": 1})); err == nil {
+		t.Fatal("expected write error")
+	}
+
+	if _, err := readRPCResponse(bufio.NewReader(strings.NewReader("\n"))); !errors.Is(err, io.EOF) {
+		t.Fatalf("expected EOF for blank line, got %v", err)
+	}
+	if _, err := readRPCResponse(bufio.NewReader(strings.NewReader("{\n"))); err == nil {
+		t.Fatal("expected invalid json error")
+	}
+	if _, err := readRPCResponse(bufio.NewReader(alwaysFailReader{err: io.ErrUnexpectedEOF})); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected wrapped reader error, got %v", err)
+	}
+}
+
+func TestDiscoverFallbackAndDecodeErrorPaths(t *testing.T) {
+	client := NewStdioClient()
+
+	cfg := helperServerConfig(t, "discover_empty_server_info")
+	cfg.Name = "fallback-name"
+	cfg.Version = "9.9.9"
+	snapshot, err := client.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover fallback scenario failed: %v", err)
+	}
+	if snapshot.Name != "fallback-name" {
+		t.Fatalf("expected fallback name, got %q", snapshot.Name)
+	}
+	if snapshot.Version != "9.9.9" {
+		t.Fatalf("expected fallback version, got %q", snapshot.Version)
+	}
+
+	cfg = helperServerConfig(t, "discover_invalid_initialize_result")
+	_, err = client.Discover(context.Background(), cfg)
+	assertClientErrorCode(t, err, ClientErrorProtocol)
+
+	cfg = helperServerConfig(t, "discover_invalid_tools_result")
+	_, err = client.Discover(context.Background(), cfg)
+	assertClientErrorCode(t, err, ClientErrorProtocol)
+}
+
+func TestCallToolErrorAndFallbackPaths(t *testing.T) {
+	client := NewStdioClient()
+
+	cfg := helperServerConfig(t, "call_ok")
+	_, err := client.CallTool(context.Background(), cfg, "", json.RawMessage(`{}`))
+	assertClientErrorCode(t, err, ClientErrorInvalidArgs)
+
+	_, err = client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`[]`))
+	assertClientErrorCode(t, err, ClientErrorInvalidArgs)
+
+	cfg = helperServerConfig(t, "call_fail")
+	_, err = client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{}`))
+	assertClientErrorCode(t, err, ClientErrorCallFailed)
+
+	cfg = helperServerConfig(t, "call_is_error")
+	_, err = client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{}`))
+	assertClientErrorCode(t, err, ClientErrorCallFailed)
+
+	cfg = helperServerConfig(t, "call_compact_fallback")
+	output, err := client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("compact fallback call failed: %v", err)
+	}
+	if output != `{"foo":"bar"}` {
+		t.Fatalf("expected compact fallback output, got %q", output)
+	}
+
+	cfg = helperServerConfig(t, "bad_response_id")
+	_, err = client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{}`))
+	assertClientErrorCode(t, err, ClientErrorProtocol)
+
+	cfg = helperServerConfig(t, "invalid_json_line")
+	_, err = client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{}`))
+	assertClientErrorCode(t, err, ClientErrorProtocol)
+
+	cfg = helperServerConfig(t, "eof_with_stderr")
+	_, err = client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{}`))
+	assertClientErrorCode(t, err, ClientErrorTransport)
+
+	cfg = helperServerConfig(t, "sleep")
+	cfg.CallTimeout = 20 * time.Millisecond
+	_, err = client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{}`))
+	assertClientErrorCode(t, err, ClientErrorTimeout)
+}
+
+func TestRunRPCZeroRequestAndStopCommandBranches(t *testing.T) {
+	client := NewStdioClient()
+	responses, err := client.runRPC(context.Background(), ServerConfig{}, nil)
+	if err != nil {
+		t.Fatalf("runRPC with empty requests failed: %v", err)
+	}
+	if responses != nil {
+		t.Fatalf("expected nil responses for empty request list, got %#v", responses)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("failed to resolve test executable: %v", err)
+	}
+
+	quick := exec.Command(exe, "-test.run=^TestMCPHelperProcess$")
+	quick.Env = append(os.Environ(), "BYTEMIND_MCP_HELPER=1", "BYTEMIND_MCP_SCENARIO=eof_with_stderr")
+	quickIn, err := quick.StdinPipe()
+	if err != nil {
+		t.Fatalf("quick stdin pipe failed: %v", err)
+	}
+	if err := quick.Start(); err != nil {
+		t.Fatalf("quick start failed: %v", err)
+	}
+	stopCommand(quick, quickIn)
+
+	slow := exec.Command(exe, "-test.run=^TestMCPHelperProcess$")
+	slow.Env = append(os.Environ(), "BYTEMIND_MCP_HELPER=1", "BYTEMIND_MCP_SCENARIO=sleep")
+	if _, err := slow.StdinPipe(); err != nil {
+		t.Fatalf("slow stdin pipe failed: %v", err)
+	}
+	if err := slow.Start(); err != nil {
+		t.Fatalf("slow start failed: %v", err)
+	}
+	stopCommand(slow, nil)
+}
+
+func TestNormalizeIDAndCloneMapHelpers(t *testing.T) {
+	if got := normalizeID("  GitHub/Repo.Name  "); got != "github-repo-name" {
+		t.Fatalf("unexpected normalized id: %q", got)
+	}
+	if got := normalizeID("   "); got != "" {
+		t.Fatalf("expected empty id, got %q", got)
+	}
+
+	if cloneMap(nil) != nil {
+		t.Fatal("expected nil clone for nil map")
+	}
+	if cloneStringMap(nil) != nil {
+		t.Fatal("expected nil clone for nil string map")
+	}
+
+	source := map[string]any{"a": 1}
+	cloned := cloneMap(source)
+	cloned["a"] = 2
+	if source["a"].(int) != 1 {
+		t.Fatal("cloneMap should not mutate source map")
+	}
+
+	sourceEnv := map[string]string{"A": "1"}
+	clonedEnv := cloneStringMap(sourceEnv)
+	clonedEnv["A"] = "2"
+	if sourceEnv["A"] != "1" {
+		t.Fatal("cloneStringMap should not mutate source map")
+	}
+}
+
+func assertClientErrorCode(t *testing.T, err error, code ClientErrorCode) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected client error %q, got nil", code)
+	}
+	var clientErr *ClientError
+	if !errors.As(err, &clientErr) {
+		t.Fatalf("expected ClientError, got %T (%v)", err, err)
+	}
+	if clientErr.Code != code {
+		t.Fatalf("expected code %q, got %q (err=%v)", code, clientErr.Code, err)
+	}
+}
+
+type alwaysFailWriter struct {
+	err error
+}
+
+func (w alwaysFailWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
+
+type alwaysFailReader struct {
+	err error
+}
+
+func (r alwaysFailReader) Read(_ []byte) (int, error) {
+	return 0, r.err
+}

--- a/internal/extensions/mcp/client_test.go
+++ b/internal/extensions/mcp/client_test.go
@@ -98,6 +98,30 @@ func TestStdioClientDiscoverWithStringResponseID(t *testing.T) {
 	}
 }
 
+func TestStdioClientDiscoverRequiresInitializedNotification(t *testing.T) {
+	client := NewStdioClient()
+	cfg := helperServerConfig(t, "require_initialized")
+	snapshot, err := client.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover with required initialized notification failed: %v", err)
+	}
+	if len(snapshot.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(snapshot.Tools))
+	}
+}
+
+func TestStdioClientCallToolRequiresInitializedNotification(t *testing.T) {
+	client := NewStdioClient()
+	cfg := helperServerConfig(t, "require_initialized")
+	output, err := client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{"message":"hello"}`))
+	if err != nil {
+		t.Fatalf("CallTool with required initialized notification failed: %v", err)
+	}
+	if output != "ok-from-helper" {
+		t.Fatalf("unexpected call output: %q", output)
+	}
+}
+
 func TestMCPHelperProcess(t *testing.T) {
 	if os.Getenv("BYTEMIND_MCP_HELPER") != "1" {
 		return
@@ -109,6 +133,7 @@ func TestMCPHelperProcess(t *testing.T) {
 	}
 	reader := bufio.NewReader(os.Stdin)
 	writer := bufio.NewWriter(os.Stdout)
+	initialized := false
 	for {
 		if scenario == "invalid_json_line" {
 			_, _ = os.Stdout.WriteString("not-json\n")
@@ -132,12 +157,41 @@ func TestMCPHelperProcess(t *testing.T) {
 			})
 			continue
 		}
+		if request.Method == "notifications/initialized" {
+			initialized = true
+			continue
+		}
+		requestID, hasRequestID, requestIDErr := normalizeRPCResponseID(request.ID)
+		if requestIDErr != nil {
+			_ = writeRPCResponse(writer, rpcResponse{
+				JSONRPC: "2.0",
+				Error: &rpcError{
+					Code:    -32600,
+					Message: "invalid request id",
+				},
+			})
+			continue
+		}
+		if !hasRequestID {
+			_ = writeRPCResponse(writer, rpcResponse{
+				JSONRPC: "2.0",
+				Error: &rpcError{
+					Code:    -32600,
+					Message: "request id is required for this method",
+				},
+			})
+			continue
+		}
 		responseID := any(request.ID)
 		if scenario == "bad_response_id" {
-			responseID = request.ID + 1
+			if value, err := strconv.Atoi(requestID); err == nil {
+				responseID = value + 1
+			} else {
+				responseID = requestID + "-bad"
+			}
 		}
 		if scenario == "response_id_as_string" {
-			responseID = strconv.Itoa(request.ID)
+			responseID = requestID
 		}
 		if scenario == "non_integer_response_id" {
 			responseID = 1.5
@@ -177,13 +231,23 @@ func TestMCPHelperProcess(t *testing.T) {
 				response.Result = json.RawMessage(`{"serverInfo":{"name":"helper-mcp","version":"1.2.3"}}`)
 			}
 		case "tools/list":
-			if scenario == "discover_invalid_tools_result" {
+			if scenario == "require_initialized" && !initialized {
+				response.Error = &rpcError{
+					Code:    -32000,
+					Message: "server not initialized",
+				}
+			} else if scenario == "discover_invalid_tools_result" {
 				response.Result = json.RawMessage(`"oops"`)
 			} else {
 				response.Result = json.RawMessage(`{"tools":[{"name":"echo","description":"echo text","inputSchema":{"type":"object","properties":{"message":{"type":"string"}}}}]}`)
 			}
 		case "tools/call":
-			if scenario == "call_fail" {
+			if scenario == "require_initialized" && !initialized {
+				response.Error = &rpcError{
+					Code:    -32000,
+					Message: "server not initialized",
+				}
+			} else if scenario == "call_fail" {
 				response.Error = &rpcError{
 					Code:    -32000,
 					Message: "call failed",

--- a/internal/extensions/mcp/client_test.go
+++ b/internal/extensions/mcp/client_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -61,6 +62,42 @@ func TestStdioClientCallToolWithHelperServer(t *testing.T) {
 	}
 }
 
+func TestStdioClientHandlesNotificationBeforeResponse(t *testing.T) {
+	client := NewStdioClient()
+	cfg := helperServerConfig(t, "notification_before_response")
+	output, err := client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{"message":"hello"}`))
+	if err != nil {
+		t.Fatalf("CallTool with notification-before-response failed: %v", err)
+	}
+	if output != "ok-from-helper" {
+		t.Fatalf("unexpected call output: %q", output)
+	}
+}
+
+func TestStdioClientProtocolFallbackWithHelperServer(t *testing.T) {
+	client := NewStdioClient()
+	cfg := helperServerConfig(t, "protocol_fallback")
+	snapshot, err := client.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover with protocol fallback failed: %v", err)
+	}
+	if snapshot.Name != "helper-mcp" {
+		t.Fatalf("unexpected server name: %q", snapshot.Name)
+	}
+}
+
+func TestStdioClientDiscoverWithStringResponseID(t *testing.T) {
+	client := NewStdioClient()
+	cfg := helperServerConfig(t, "response_id_as_string")
+	snapshot, err := client.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover with string response id failed: %v", err)
+	}
+	if len(snapshot.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(snapshot.Tools))
+	}
+}
+
 func TestMCPHelperProcess(t *testing.T) {
 	if os.Getenv("BYTEMIND_MCP_HELPER") != "1" {
 		return
@@ -95,13 +132,25 @@ func TestMCPHelperProcess(t *testing.T) {
 			})
 			continue
 		}
-		responseID := request.ID
+		responseID := any(request.ID)
 		if scenario == "bad_response_id" {
-			responseID++
+			responseID = request.ID + 1
+		}
+		if scenario == "response_id_as_string" {
+			responseID = strconv.Itoa(request.ID)
+		}
+		if scenario == "non_integer_response_id" {
+			responseID = 1.5
 		}
 		response := rpcResponse{
 			JSONRPC: "2.0",
 			ID:      responseID,
+		}
+		if scenario == "notification_before_response" {
+			_ = writeRPCResponse(writer, rpcResponse{
+				JSONRPC: "2.0",
+				Method:  "notifications/progress",
+			})
 		}
 		switch request.Method {
 		case "initialize":
@@ -109,6 +158,16 @@ func TestMCPHelperProcess(t *testing.T) {
 				response.Error = &rpcError{
 					Code:    -32000,
 					Message: "handshake failed",
+				}
+			} else if scenario == "protocol_fallback" {
+				version := protocolVersionFromRequest(request)
+				if version == "2026-04-01" {
+					response.Error = &rpcError{
+						Code:    -32000,
+						Message: "unsupported protocol version",
+					}
+				} else {
+					response.Result = json.RawMessage(`{"serverInfo":{"name":"helper-mcp","version":"1.2.3"}}`)
 				}
 			} else if scenario == "discover_invalid_initialize_result" {
 				response.Result = json.RawMessage(`"oops"`)
@@ -145,6 +204,15 @@ func TestMCPHelperProcess(t *testing.T) {
 		_ = writeRPCResponse(writer, response)
 	}
 	os.Exit(0)
+}
+
+func protocolVersionFromRequest(request rpcRequest) string {
+	params, ok := request.Params.(map[string]any)
+	if !ok || params == nil {
+		return ""
+	}
+	protocolVersion, _ := params["protocolVersion"].(string)
+	return strings.TrimSpace(protocolVersion)
 }
 
 func helperServerConfig(t *testing.T, scenario string) ServerConfig {

--- a/internal/extensions/mcp/client_test.go
+++ b/internal/extensions/mcp/client_test.go
@@ -1,0 +1,137 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStdioClientDiscoverWithHelperServer(t *testing.T) {
+	client := NewStdioClient()
+	cfg := helperServerConfig(t, "discover_ok")
+	snapshot, err := client.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if snapshot.Name != "helper-mcp" {
+		t.Fatalf("unexpected server name: %q", snapshot.Name)
+	}
+	if snapshot.Version != "1.2.3" {
+		t.Fatalf("unexpected server version: %q", snapshot.Version)
+	}
+	if len(snapshot.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(snapshot.Tools))
+	}
+	if snapshot.Tools[0].Name != "echo" {
+		t.Fatalf("unexpected tool name: %q", snapshot.Tools[0].Name)
+	}
+}
+
+func TestStdioClientHandshakeFailureWithHelperServer(t *testing.T) {
+	client := NewStdioClient()
+	cfg := helperServerConfig(t, "handshake_fail")
+	_, err := client.Discover(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected handshake error")
+	}
+	var clientErr *ClientError
+	if !errors.As(err, &clientErr) {
+		t.Fatalf("expected ClientError, got %T", err)
+	}
+	if clientErr.Code != ClientErrorHandshakeFailed {
+		t.Fatalf("expected handshake_failed, got %q", clientErr.Code)
+	}
+}
+
+func TestStdioClientCallToolWithHelperServer(t *testing.T) {
+	client := NewStdioClient()
+	cfg := helperServerConfig(t, "call_ok")
+	output, err := client.CallTool(context.Background(), cfg, "echo", json.RawMessage(`{"message":"hello"}`))
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if output != "ok-from-helper" {
+		t.Fatalf("unexpected call output: %q", output)
+	}
+}
+
+func TestMCPHelperProcess(t *testing.T) {
+	if os.Getenv("BYTEMIND_MCP_HELPER") != "1" {
+		return
+	}
+	scenario := strings.TrimSpace(os.Getenv("BYTEMIND_MCP_SCENARIO"))
+	scanner := bufio.NewScanner(os.Stdin)
+	encoder := json.NewEncoder(os.Stdout)
+	for scanner.Scan() {
+		var request rpcRequest
+		if err := json.Unmarshal(scanner.Bytes(), &request); err != nil {
+			_ = encoder.Encode(rpcResponse{
+				JSONRPC: "2.0",
+				ID:      0,
+				Error: &rpcError{
+					Code:    -32700,
+					Message: "parse error",
+				},
+			})
+			continue
+		}
+		response := rpcResponse{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+		}
+		switch request.Method {
+		case "initialize":
+			if scenario == "handshake_fail" {
+				response.Error = &rpcError{
+					Code:    -32000,
+					Message: "handshake failed",
+				}
+			} else {
+				response.Result = json.RawMessage(`{"serverInfo":{"name":"helper-mcp","version":"1.2.3"}}`)
+			}
+		case "tools/list":
+			response.Result = json.RawMessage(`{"tools":[{"name":"echo","description":"echo text","inputSchema":{"type":"object","properties":{"message":{"type":"string"}}}}]}`)
+		case "tools/call":
+			if scenario == "call_fail" {
+				response.Error = &rpcError{
+					Code:    -32000,
+					Message: "call failed",
+				}
+			} else {
+				response.Result = json.RawMessage(`{"content":[{"type":"text","text":"ok-from-helper"}]}`)
+			}
+		default:
+			response.Error = &rpcError{
+				Code:    -32601,
+				Message: "method not found",
+			}
+		}
+		_ = encoder.Encode(response)
+	}
+	os.Exit(0)
+}
+
+func helperServerConfig(t *testing.T, scenario string) ServerConfig {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("failed to resolve test executable: %v", err)
+	}
+	return ServerConfig{
+		ID:      "helper",
+		Name:    "helper",
+		Command: exe,
+		Args:    []string{"-test.run=^TestMCPHelperProcess$"},
+		Env: map[string]string{
+			"BYTEMIND_MCP_HELPER":   "1",
+			"BYTEMIND_MCP_SCENARIO": scenario,
+		},
+		StartupTimeout: 3 * time.Second,
+		CallTimeout:    3 * time.Second,
+	}
+}

--- a/internal/extensions/mcp/client_test.go
+++ b/internal/extensions/mcp/client_test.go
@@ -65,9 +65,20 @@ func TestMCPHelperProcess(t *testing.T) {
 		return
 	}
 	scenario := strings.TrimSpace(os.Getenv("BYTEMIND_MCP_SCENARIO"))
+	if scenario == "eof_with_stderr" {
+		_, _ = os.Stderr.WriteString("helper exited early")
+		os.Exit(0)
+	}
 	scanner := bufio.NewScanner(os.Stdin)
 	encoder := json.NewEncoder(os.Stdout)
 	for scanner.Scan() {
+		if scenario == "invalid_json_line" {
+			_, _ = os.Stdout.WriteString("not-json\n")
+			os.Exit(0)
+		}
+		if scenario == "sleep" {
+			time.Sleep(250 * time.Millisecond)
+		}
 		var request rpcRequest
 		if err := json.Unmarshal(scanner.Bytes(), &request); err != nil {
 			_ = encoder.Encode(rpcResponse{
@@ -80,9 +91,13 @@ func TestMCPHelperProcess(t *testing.T) {
 			})
 			continue
 		}
+		responseID := request.ID
+		if scenario == "bad_response_id" {
+			responseID++
+		}
 		response := rpcResponse{
 			JSONRPC: "2.0",
-			ID:      request.ID,
+			ID:      responseID,
 		}
 		switch request.Method {
 		case "initialize":
@@ -91,17 +106,29 @@ func TestMCPHelperProcess(t *testing.T) {
 					Code:    -32000,
 					Message: "handshake failed",
 				}
+			} else if scenario == "discover_invalid_initialize_result" {
+				response.Result = json.RawMessage(`"oops"`)
+			} else if scenario == "discover_empty_server_info" {
+				response.Result = json.RawMessage(`{"serverInfo":{"name":"","version":""}}`)
 			} else {
 				response.Result = json.RawMessage(`{"serverInfo":{"name":"helper-mcp","version":"1.2.3"}}`)
 			}
 		case "tools/list":
-			response.Result = json.RawMessage(`{"tools":[{"name":"echo","description":"echo text","inputSchema":{"type":"object","properties":{"message":{"type":"string"}}}}]}`)
+			if scenario == "discover_invalid_tools_result" {
+				response.Result = json.RawMessage(`"oops"`)
+			} else {
+				response.Result = json.RawMessage(`{"tools":[{"name":"echo","description":"echo text","inputSchema":{"type":"object","properties":{"message":{"type":"string"}}}}]}`)
+			}
 		case "tools/call":
 			if scenario == "call_fail" {
 				response.Error = &rpcError{
 					Code:    -32000,
 					Message: "call failed",
 				}
+			} else if scenario == "call_is_error" {
+				response.Result = json.RawMessage(`{"isError":true,"content":[{"type":"text","text":"tool failed"}]}`)
+			} else if scenario == "call_compact_fallback" {
+				response.Result = json.RawMessage(`{"foo":"bar"}`)
 			} else {
 				response.Result = json.RawMessage(`{"content":[{"type":"text","text":"ok-from-helper"}]}`)
 			}

--- a/internal/extensions/mcp/client_test.go
+++ b/internal/extensions/mcp/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -69,9 +70,9 @@ func TestMCPHelperProcess(t *testing.T) {
 		_, _ = os.Stderr.WriteString("helper exited early")
 		os.Exit(0)
 	}
-	scanner := bufio.NewScanner(os.Stdin)
-	encoder := json.NewEncoder(os.Stdout)
-	for scanner.Scan() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	for {
 		if scenario == "invalid_json_line" {
 			_, _ = os.Stdout.WriteString("not-json\n")
 			os.Exit(0)
@@ -79,9 +80,12 @@ func TestMCPHelperProcess(t *testing.T) {
 		if scenario == "sleep" {
 			time.Sleep(250 * time.Millisecond)
 		}
-		var request rpcRequest
-		if err := json.Unmarshal(scanner.Bytes(), &request); err != nil {
-			_ = encoder.Encode(rpcResponse{
+		request, err := readRPCRequest(reader)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			_ = writeRPCResponse(writer, rpcResponse{
 				JSONRPC: "2.0",
 				ID:      0,
 				Error: &rpcError{
@@ -138,7 +142,7 @@ func TestMCPHelperProcess(t *testing.T) {
 				Message: "method not found",
 			}
 		}
-		_ = encoder.Encode(response)
+		_ = writeRPCResponse(writer, response)
 	}
 	os.Exit(0)
 }

--- a/internal/extensions/mcp/health.go
+++ b/internal/extensions/mcp/health.go
@@ -1,0 +1,163 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	extensionspkg "bytemind/internal/extensions"
+	toolspkg "bytemind/internal/tools"
+)
+
+func newExtensionError(code extensionspkg.ErrorCode, message string, err error) error {
+	return &extensionspkg.ExtensionError{
+		Code:    code,
+		Message: strings.TrimSpace(message),
+		Err:     err,
+	}
+}
+
+func toExtensionError(err error, fallbackCode extensionspkg.ErrorCode, fallbackMessage string) error {
+	if err == nil {
+		return nil
+	}
+	var extErr *extensionspkg.ExtensionError
+	if errors.As(err, &extErr) {
+		return err
+	}
+	message := strings.TrimSpace(err.Error())
+	if message == "" {
+		message = strings.TrimSpace(fallbackMessage)
+	}
+	return newExtensionError(fallbackCode, message, err)
+}
+
+func mapClientErrorToExtensionCode(err error) extensionspkg.ErrorCode {
+	var clientErr *ClientError
+	if !errors.As(err, &clientErr) || clientErr == nil {
+		return extensionspkg.ErrCodeLoadFailed
+	}
+	switch clientErr.Code {
+	case ClientErrorInvalidConfig, ClientErrorInvalidArgs:
+		return extensionspkg.ErrCodeInvalidManifest
+	case ClientErrorPermission:
+		return extensionspkg.ErrCodeConflict
+	case ClientErrorHandshakeFailed, ClientErrorListToolsFailed, ClientErrorCallFailed:
+		return extensionspkg.ErrCodeLoadFailed
+	case ClientErrorTimeout:
+		return extensionspkg.ErrCodeBusy
+	default:
+		return extensionspkg.ErrCodeLoadFailed
+	}
+}
+
+func mapClientErrorToToolExecError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var clientErr *ClientError
+	if !errors.As(err, &clientErr) || clientErr == nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return toolspkg.NewToolExecError(toolspkg.ToolErrorTimeout, "mcp tool request timed out", true, err)
+		}
+		return toolspkg.NewToolExecError(toolspkg.ToolErrorToolFailed, err.Error(), true, err)
+	}
+	switch clientErr.Code {
+	case ClientErrorTimeout:
+		return toolspkg.NewToolExecError(toolspkg.ToolErrorTimeout, clientErr.Error(), true, clientErr)
+	case ClientErrorPermission:
+		return toolspkg.NewToolExecError(toolspkg.ToolErrorPermissionDenied, clientErr.Error(), false, clientErr)
+	case ClientErrorInvalidArgs:
+		return toolspkg.NewToolExecError(toolspkg.ToolErrorInvalidArgs, clientErr.Error(), false, clientErr)
+	default:
+		return toolspkg.NewToolExecError(toolspkg.ToolErrorToolFailed, clientErr.Error(), true, clientErr)
+	}
+}
+
+func contextError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) {
+		return context.Canceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+
+func filterValidToolDescriptors(tools []ToolDescriptor) ([]ToolDescriptor, int) {
+	if len(tools) == 0 {
+		return nil, 0
+	}
+	valid := make([]ToolDescriptor, 0, len(tools))
+	skipped := 0
+	for _, descriptor := range tools {
+		name := strings.TrimSpace(descriptor.Name)
+		if name == "" {
+			skipped++
+			continue
+		}
+		item := ToolDescriptor{
+			Name:        name,
+			Description: strings.TrimSpace(descriptor.Description),
+			InputSchema: normalizedSchema(descriptor.InputSchema),
+		}
+		valid = append(valid, item)
+	}
+	return valid, skipped
+}
+
+func cloneToolDescriptors(items []ToolDescriptor) []ToolDescriptor {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]ToolDescriptor, 0, len(items))
+	for _, item := range items {
+		out = append(out, ToolDescriptor{
+			Name:        item.Name,
+			Description: item.Description,
+			InputSchema: cloneMap(item.InputSchema),
+		})
+	}
+	return out
+}
+
+func normalizedSchema(schema map[string]any) map[string]any {
+	if len(schema) == 0 {
+		return map[string]any{
+			"type":                 "object",
+			"additionalProperties": true,
+		}
+	}
+	cloned := cloneMap(schema)
+	if _, ok := cloned["type"]; !ok {
+		cloned["type"] = "object"
+	}
+	return cloned
+}
+
+func marshalJSONInline(value any) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func formatHealthMessage(prefix string, payload any) string {
+	prefix = strings.TrimSpace(prefix)
+	if payload == nil {
+		return prefix
+	}
+	if encoded := strings.TrimSpace(marshalJSONInline(payload)); encoded != "" {
+		if prefix == "" {
+			return encoded
+		}
+		return fmt.Sprintf("%s: %s", prefix, encoded)
+	}
+	return prefix
+}

--- a/internal/extensions/mcp/health_test.go
+++ b/internal/extensions/mcp/health_test.go
@@ -1,0 +1,201 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	extensionspkg "bytemind/internal/extensions"
+	toolspkg "bytemind/internal/tools"
+)
+
+type emptyErr struct{}
+
+func (emptyErr) Error() string { return "" }
+
+func TestToExtensionError(t *testing.T) {
+	if toExtensionError(nil, extensionspkg.ErrCodeLoadFailed, "fallback") != nil {
+		t.Fatal("expected nil error when input is nil")
+	}
+
+	original := &extensionspkg.ExtensionError{
+		Code:    extensionspkg.ErrCodeLoadFailed,
+		Message: "existing",
+	}
+	if got := toExtensionError(original, extensionspkg.ErrCodeInvalidSource, "fallback"); got != original {
+		t.Fatal("expected extension error to be returned as-is")
+	}
+
+	wrapped := toExtensionError(emptyErr{}, extensionspkg.ErrCodeInvalidSource, "  fallback message  ")
+	var extErr *extensionspkg.ExtensionError
+	if !errors.As(wrapped, &extErr) {
+		t.Fatalf("expected ExtensionError, got %T", wrapped)
+	}
+	if extErr.Code != extensionspkg.ErrCodeInvalidSource {
+		t.Fatalf("unexpected code: %q", extErr.Code)
+	}
+	if extErr.Message != "fallback message" {
+		t.Fatalf("unexpected fallback message: %q", extErr.Message)
+	}
+}
+
+func TestMapClientErrorToExtensionCode(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		code extensionspkg.ErrorCode
+	}{
+		{
+			name: "non client error",
+			err:  errors.New("x"),
+			code: extensionspkg.ErrCodeLoadFailed,
+		},
+		{
+			name: "invalid config",
+			err:  &ClientError{Code: ClientErrorInvalidConfig},
+			code: extensionspkg.ErrCodeInvalidManifest,
+		},
+		{
+			name: "invalid args",
+			err:  &ClientError{Code: ClientErrorInvalidArgs},
+			code: extensionspkg.ErrCodeInvalidManifest,
+		},
+		{
+			name: "permission",
+			err:  &ClientError{Code: ClientErrorPermission},
+			code: extensionspkg.ErrCodeConflict,
+		},
+		{
+			name: "timeout",
+			err:  &ClientError{Code: ClientErrorTimeout},
+			code: extensionspkg.ErrCodeBusy,
+		},
+		{
+			name: "default",
+			err:  &ClientError{Code: ClientErrorProtocol},
+			code: extensionspkg.ErrCodeLoadFailed,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mapClientErrorToExtensionCode(tc.err); got != tc.code {
+				t.Fatalf("expected %q, got %q", tc.code, got)
+			}
+		})
+	}
+}
+
+func TestMapClientErrorToToolExecErrorTable(t *testing.T) {
+	if mapClientErrorToToolExecError(nil) != nil {
+		t.Fatal("expected nil output for nil input")
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		code toolspkg.ToolErrorCode
+	}{
+		{
+			name: "deadline exceeded",
+			err:  context.DeadlineExceeded,
+			code: toolspkg.ToolErrorTimeout,
+		},
+		{
+			name: "non client error",
+			err:  errors.New("boom"),
+			code: toolspkg.ToolErrorToolFailed,
+		},
+		{
+			name: "client timeout",
+			err:  &ClientError{Code: ClientErrorTimeout, Message: "timeout"},
+			code: toolspkg.ToolErrorTimeout,
+		},
+		{
+			name: "client permission",
+			err:  &ClientError{Code: ClientErrorPermission, Message: "denied"},
+			code: toolspkg.ToolErrorPermissionDenied,
+		},
+		{
+			name: "client invalid args",
+			err:  &ClientError{Code: ClientErrorInvalidArgs, Message: "bad"},
+			code: toolspkg.ToolErrorInvalidArgs,
+		},
+		{
+			name: "client default",
+			err:  &ClientError{Code: ClientErrorProtocol, Message: "bad"},
+			code: toolspkg.ToolErrorToolFailed,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mapped := mapClientErrorToToolExecError(tc.err)
+			execErr, ok := toolspkg.AsToolExecError(mapped)
+			if !ok {
+				t.Fatalf("expected ToolExecError, got %T", mapped)
+			}
+			if execErr.Code != tc.code {
+				t.Fatalf("expected %q, got %q", tc.code, execErr.Code)
+			}
+		})
+	}
+}
+
+func TestContextError(t *testing.T) {
+	if contextError(nil) != nil {
+		t.Fatal("expected nil for nil input")
+	}
+	if got := contextError(context.Canceled); !errors.Is(got, context.Canceled) {
+		t.Fatalf("expected canceled, got %v", got)
+	}
+	if got := contextError(context.DeadlineExceeded); !errors.Is(got, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline, got %v", got)
+	}
+	if got := contextError(errors.New("x")); got != nil {
+		t.Fatalf("expected nil for unknown error, got %v", got)
+	}
+}
+
+func TestSchemaAndFormattingHelpers(t *testing.T) {
+	defaultSchema := normalizedSchema(nil)
+	if defaultSchema["type"] != "object" {
+		t.Fatalf("expected object schema, got %#v", defaultSchema)
+	}
+	if defaultSchema["additionalProperties"] != true {
+		t.Fatalf("expected additionalProperties=true, got %#v", defaultSchema)
+	}
+
+	schema := normalizedSchema(map[string]any{
+		"properties": map[string]any{"repo": map[string]any{"type": "string"}},
+	})
+	if schema["type"] != "object" {
+		t.Fatalf("expected injected type=object, got %#v", schema)
+	}
+
+	schema = normalizedSchema(map[string]any{
+		"type": "array",
+	})
+	if schema["type"] != "array" {
+		t.Fatalf("expected existing type to be preserved, got %#v", schema)
+	}
+
+	if marshalJSONInline(map[string]any{"a": 1}) == "" {
+		t.Fatal("expected marshalJSONInline to serialize map")
+	}
+	if marshalJSONInline(chan int(nil)) != "" {
+		t.Fatal("expected marshalJSONInline to return empty string on marshal error")
+	}
+
+	if got := formatHealthMessage("  ok  ", nil); got != "ok" {
+		t.Fatalf("unexpected format with nil payload: %q", got)
+	}
+	if got := formatHealthMessage("", map[string]any{"a": 1}); got == "" || got == " " {
+		t.Fatalf("expected formatted payload, got %q", got)
+	}
+	if got := formatHealthMessage("status", map[string]any{"a": 1}); !strings.HasPrefix(got, "status") {
+		t.Fatalf("expected prefixed message, got %q", got)
+	}
+	if got := formatHealthMessage("status", chan int(nil)); got != "status" {
+		t.Fatalf("expected prefix fallback when payload is not marshalable, got %q", got)
+	}
+}


### PR DESCRIPTION
## 背景

根据 `extension-iteration-plan.md` 的阶段七和 `prd-extension.md` 的 MCP Adapter 要求，先落地最小可用的 MCP 适配能力，为后续 manager/config/CLI 接线做准备。

## 本次变更

- 新增 `internal/extensions/mcp/client.go`
- 新增 `internal/extensions/mcp/adapter.go`
- 新增 `internal/extensions/mcp/health.go`
- 新增 `internal/extensions/mcp/client_test.go`
- 新增 `internal/extensions/mcp/adapter_test.go`
- 修改 `internal/extensions/interface.go`，补充 `Extension` 接口（`Info/ResolveTools/Health`）

## 主要实现点

- 增加 MCP server 配置与能力模型（`ServerConfig`、`ToolDescriptor`、`ServerSnapshot`）
- 增加最小 stdio JSON-RPC 客户端，支持 `initialize`、`tools/list`、`tools/call`
- 实现 `FromMCPServer(cfg)`，可构建 MCP Extension 并在初始化时做 discover
- 实现 `ResolveTools`，将 MCP tool 映射为 `extensions.ExtensionTool`
- 实现 `Health` 与错误映射，握手失败时标记 `degraded`
- 工具声明缺字段（例如空 name）时仅跳过该工具，不拖垮整个 server

## 测试

已通过：

- `go test ./internal/extensions/mcp -v`
- `go test ./internal/extensions/... -v`

覆盖点：

- fake MCP server 握手成功/失败
- tools/call 成功路径
- 非法工具声明跳过
- degraded 状态可见
- client error -> extension/tool error 映射

## 影响与边界

- 不改 `executor` 主链路，不引入 MCP 特判分支
- 目前是阶段七最小闭环，尚未接入 manager 全流程、配置持久化、CLI/TUI 管理入口
- 未引入 `resources/*`、`prompts/*` 或 HTTP/SSE transport（按当前范围控制）
