### PR TITLE
refactor(tui): slim tool cards into tag-line display

### DIFF
--- a/tui/component_conversation.go
+++ b/tui/component_conversation.go
@@ -225,7 +225,7 @@ func renderChatSection(item chatEntry, width int) string {
 	headContent := title.Render(displayTitle)
 	if item.Kind == "tool" {
 		label, _ := toolDisplayParts(displayTitle)
-		headContent = renderPillBadge(label, "info")
+		headContent = renderToolTag(label, "info")
 	}
 	if item.Kind == "user" && strings.TrimSpace(item.Meta) != "" {
 		headContent = chatHeaderMetaStyle.Render(item.Meta)
@@ -242,7 +242,7 @@ func renderChatSection(item chatEntry, width int) string {
 			lipgloss.Left,
 			headContent,
 			"  ",
-			renderPillBadge(statusBadgeText, status),
+			renderToolTag(statusBadgeText, status),
 		)
 	}
 	if item.Kind == "assistant" {
@@ -384,6 +384,27 @@ func renderAssistantPhaseBadge(status string) string {
 	default:
 		return ""
 	}
+}
+
+func renderToolTag(text, tagType string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	style := lipgloss.NewStyle().Bold(true)
+	switch strings.TrimSpace(strings.ToLower(tagType)) {
+	case "active", "running", "accent", "info":
+		style = style.Foreground(semanticColors.AccentSoft)
+	case "success", "done":
+		style = style.Foreground(semanticColors.Success)
+	case "warning", "pending", "warn":
+		style = style.Foreground(semanticColors.Warning)
+	case "error", "failed", "danger":
+		style = style.Foreground(semanticColors.Danger)
+	default:
+		style = style.Foreground(semanticColors.TextMuted)
+	}
+	return style.Render(text)
 }
 
 func resolveRunCardStyle(items []chatEntry) lipgloss.Style {

--- a/tui/component_conversation.go
+++ b/tui/component_conversation.go
@@ -224,21 +224,25 @@ func renderChatSection(item chatEntry, width int) string {
 	}
 	headContent := title.Render(displayTitle)
 	if item.Kind == "tool" {
-		label, name := toolDisplayParts(displayTitle)
+		label, _ := toolDisplayParts(displayTitle)
 		headContent = renderPillBadge(label, "info")
-		if strings.TrimSpace(name) != "" {
-			headContent = lipgloss.JoinHorizontal(lipgloss.Left, headContent, " ", toolNameStyle.Render(name))
-		}
 	}
 	if item.Kind == "user" && strings.TrimSpace(item.Meta) != "" {
 		headContent = chatHeaderMetaStyle.Render(item.Meta)
 	}
 	if status != "" {
+		statusBadgeText := status
+		if item.Kind == "tool" {
+			switch strings.TrimSpace(strings.ToLower(status)) {
+			case "done", "success":
+				statusBadgeText = "✓"
+			}
+		}
 		headContent = lipgloss.JoinHorizontal(
 			lipgloss.Left,
 			headContent,
 			"  ",
-			renderPillBadge(status, status),
+			renderPillBadge(statusBadgeText, status),
 		)
 	}
 	if item.Kind == "assistant" {

--- a/tui/component_footer.go
+++ b/tui/component_footer.go
@@ -11,10 +11,14 @@ import (
 )
 
 func (m model) renderFooter() string {
+	return m.footerComponent().Render(m)
+}
+
+func renderFooterDefault(m model) string {
 	ensureZoneManager()
 	inputBorder := m.inputBorderStyle().
 		Width(m.chatPanelInnerWidth()).
-		Render(zone.Mark(inputEditorZoneID, m.renderInputEditorView()))
+		Render(zone.Mark(inputEditorZoneID, m.inputEditorViewComponent().Render(m)))
 	parts := make([]string, 0, 4)
 	if m.approval != nil {
 		parts = append(parts, m.renderApprovalBanner())

--- a/tui/component_status_scroll.go
+++ b/tui/component_status_scroll.go
@@ -25,6 +25,10 @@ func (m model) renderTokenBadge(width int) string {
 }
 
 func (m model) renderScrollbar(viewHeight, contentHeight, currentOffset int) string {
+	return m.scrollbarComponent().Render(m, viewHeight, contentHeight, currentOffset)
+}
+
+func renderScrollbarDefault(m model, viewHeight, contentHeight, currentOffset int) string {
 	thumbTop, thumbHeight, _, visible := m.scrollbarLayout(viewHeight, contentHeight, currentOffset)
 	if !visible {
 		return ""
@@ -122,10 +126,14 @@ func stripANSIText(value string) string {
 }
 
 func (m model) renderStatusBar() string {
-	return m.renderStatusBarWithWidth(max(24, m.chatPanelInnerWidth()))
+	return m.statusBarComponent().Render(m, max(24, m.chatPanelInnerWidth()))
 }
 
 func (m model) renderStatusBarWithWidth(width int) string {
+	return m.statusBarComponent().Render(m, width)
+}
+
+func renderStatusBarWithWidthDefault(m model, width int) string {
 	stepTitle := currentOrNextStepTitle(m.plan)
 	if stepTitle == "" {
 		stepTitle = "-"

--- a/tui/component_text_render.go
+++ b/tui/component_text_render.go
@@ -22,6 +22,9 @@ func formatChatBodyMode(item chatEntry, width int, copyMode bool) string {
 		return strings.TrimRight(wrapPlainText(text, width), "\n")
 	}
 	if item.Kind == "tool" {
+		if !copyMode {
+			text = firstNonEmptyLine(text)
+		}
 		if copyMode {
 			return strings.TrimRight(renderToolCopyBody(text, width), "\n")
 		}
@@ -138,6 +141,16 @@ func renderToolBodyLegacy(text string, width int) string {
 		prevBlank = false
 	}
 	return strings.Join(out, "\n")
+}
+
+func firstNonEmptyLine(text string) string {
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			return line
+		}
+	}
+	return ""
 }
 
 func renderToolLine(line string, width int, first bool) string {

--- a/tui/component_view_shell.go
+++ b/tui/component_view_shell.go
@@ -18,39 +18,30 @@ func (m model) View() string {
 			m.syncInputStyle()
 		}
 	}
-	base := m.renderLanding()
-	if m.screen == screenChat {
-		chatContent := lipgloss.JoinVertical(lipgloss.Left, m.renderMainPanel(), m.renderFooter())
-		base = panelStyle.Width(m.chatPanelWidth()).Render(chatContent)
-	}
-
-	rendered := base
-	switch {
-	case m.helpOpen:
-		rendered = renderModal(m.width, m.height, m.renderHelpModal())
-	case m.sessionsOpen:
-		rendered = renderModal(m.width, m.height, m.renderSessionsModal())
-	case m.skillsOpen:
-		rendered = renderModal(m.width, m.height, m.renderSkillsModal())
-	}
+	base := m.activePage().Render(m)
+	rendered := m.viewOverlayComponent().Apply(m, base)
 	return zone.Scan(rendered)
 }
 
 func (m model) renderMainPanel() string {
+	return m.mainPanelComponent().Render(m)
+}
+
+func renderMainPanelDefault(m model) string {
 	width := max(24, m.chatPanelInnerWidth())
 	badge := strings.TrimSpace(m.renderTopRightCluster(width))
 	conversation := lipgloss.JoinHorizontal(
 		lipgloss.Top,
-		m.renderConversationViewport(),
-		m.renderScrollbar(m.viewport.Height, m.viewport.TotalLineCount(), m.viewport.YOffset),
+		m.conversationViewportComponent().Render(m),
+		m.scrollbarComponent().Render(m, m.viewport.Height, m.viewport.TotalLineCount(), m.viewport.YOffset),
 	)
 	if badge == "" {
-		return lipgloss.JoinVertical(lipgloss.Left, m.renderStatusBar(), "", conversation)
+		return lipgloss.JoinVertical(lipgloss.Left, m.statusBarComponent().Render(m, max(24, m.chatPanelInnerWidth())), "", conversation)
 	}
 
 	badgeW := lipgloss.Width(badge)
 	statusW := max(12, width-badgeW-2)
-	status := m.renderStatusBarWithWidth(statusW)
+	status := m.statusBarComponent().Render(m, statusW)
 	header := lipgloss.JoinHorizontal(lipgloss.Top, status, "  ", badge)
 
 	parts := []string{header}
@@ -62,6 +53,10 @@ func (m model) renderMainPanel() string {
 }
 
 func (m model) renderLanding() string {
+	return m.landingComponent().Render(m)
+}
+
+func renderLandingDefault(m model) string {
 	ensureZoneManager()
 	logo := landingLogoStyle.Render(strings.Join([]string{
 		"    ____        __                      _           __",
@@ -74,7 +69,7 @@ func (m model) renderLanding() string {
 	inputBox := landingInputStyle.Copy().
 		BorderForeground(m.modeAccentColor()).
 		Width(m.landingInputShellWidth()).
-		Render(zone.Mark(inputEditorZoneID, m.renderInputEditorView()))
+		Render(zone.Mark(inputEditorZoneID, m.inputEditorViewComponent().Render(m)))
 	parts := []string{logo, "", m.renderModeTabs(), ""}
 	if m.startupGuide.Active {
 		parts = append(parts, m.renderStartupGuidePanel(), "")

--- a/tui/model.go
+++ b/tui/model.go
@@ -725,14 +725,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if !m.sessionsOpen && !m.helpOpen && !m.commandOpen && m.approval == nil {
-		before := m.input.Value()
-		var cmd tea.Cmd
-		m.input, cmd = m.input.Update(msg)
-		if m.input.Value() != before {
-			m.handleInputMutation(before, m.input.Value(), "")
-			m.syncInputOverlays()
-		}
-		return m, cmd
+		return m.defaultInputComponent().Update(m, msg)
 	}
 
 	return m, nil

--- a/tui/model_mouse_selection.go
+++ b/tui/model_mouse_selection.go
@@ -423,6 +423,10 @@ func (m model) hasCopyableViewportSelection() bool {
 }
 
 func (m model) renderConversationViewport() string {
+	return m.conversationViewportComponent().Render(m)
+}
+
+func renderConversationViewportDefault(m model) string {
 	content := ""
 	if m.hasCopyableViewportSelection() {
 		if preview := m.renderActiveSelectionPreview(); strings.TrimSpace(preview) != "" {
@@ -436,6 +440,10 @@ func (m model) renderConversationViewport() string {
 }
 
 func (m model) renderInputEditorView() string {
+	return m.inputEditorViewComponent().Render(m)
+}
+
+func renderInputEditorViewDefault(m model) string {
 	raw := m.input.View()
 	if !m.hasCopyableInputSelection() {
 		return raw

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -3576,11 +3576,17 @@ func TestRenderConversationIncludesToolEntries(t *testing.T) {
 	}
 
 	got := m.renderConversation()
-	if !strings.Contains(got, "READ") || !strings.Contains(got, "read_file") {
+	if !strings.Contains(got, "READ") {
 		t.Fatalf("expected conversation to show tool entry, got %q", got)
 	}
-	if !strings.Contains(got, "Read model.go") || !strings.Contains(got, "range: 1-20") {
+	if strings.Contains(got, "read_file") {
+		t.Fatalf("expected conversation to hide raw tool name in header, got %q", got)
+	}
+	if !strings.Contains(got, "Read model.go") {
 		t.Fatalf("expected conversation to show tool summary, got %q", got)
+	}
+	if strings.Contains(got, "range: 1-20") || strings.Contains(got, "path: tui/model.go") {
+		t.Fatalf("expected conversation to collapse tool body to one summary line, got %q", got)
 	}
 }
 
@@ -3901,8 +3907,11 @@ func TestRenderChatSectionToolHeaderOmitsStatusWords(t *testing.T) {
 	if !strings.Contains(got, "running") {
 		t.Fatalf("expected tool header to show status badge text, got %q", got)
 	}
-	if !strings.Contains(got, "LIST") || !strings.Contains(got, "list_files") {
-		t.Fatalf("expected tool header to show structured label and tool name, got %q", got)
+	if !strings.Contains(got, "LIST") {
+		t.Fatalf("expected tool header to show structured label, got %q", got)
+	}
+	if strings.Contains(got, "list_files") {
+		t.Fatalf("expected tool header to hide raw tool name, got %q", got)
 	}
 	if strings.Contains(got, "params:") || strings.Contains(got, "{\"") {
 		t.Fatalf("expected tool section to hide params content, got %q", got)
@@ -3922,11 +3931,8 @@ func TestFormatChatBodyHighlightsSearchToolSummaryAndMatches(t *testing.T) {
 	if !strings.Contains(got, toolSearchSummaryStyle.Render("12 matches for \"func main() {\"")) {
 		t.Fatalf("expected search summary line to be highlighted, got %q", got)
 	}
-	if !strings.Contains(got, toolSearchMatchStyle.Render("bytemind/opencode-go/main.go:14 func main() {")) {
-		t.Fatalf("expected first search match line to be highlighted, got %q", got)
-	}
-	if !strings.Contains(got, toolSearchMatchStyle.Render("cmd/bytemind/main.go:11 func main() {")) {
-		t.Fatalf("expected second search match line to be highlighted, got %q", got)
+	if strings.Contains(got, "bytemind/opencode-go/main.go:14") || strings.Contains(got, "cmd/bytemind/main.go:11") {
+		t.Fatalf("expected tool body to render only summary line, got %q", got)
 	}
 }
 
@@ -4453,8 +4459,17 @@ func TestRenderChatCardToolUsesVisualSeparator(t *testing.T) {
 	if !strings.Contains(got, "\u2502") && !strings.Contains(got, "|") {
 		t.Fatalf("expected tool card to include a left border separator, got %q", got)
 	}
-	if !strings.Contains(got, "READ") || !strings.Contains(got, "read_file") {
+	if !strings.Contains(got, "READ") {
 		t.Fatalf("expected tool card title to render, got %q", got)
+	}
+	if strings.Contains(got, "read_file") {
+		t.Fatalf("expected tool card to hide raw tool name, got %q", got)
+	}
+	if !strings.Contains(got, "✓") {
+		t.Fatalf("expected done status to render as checkmark, got %q", got)
+	}
+	if strings.Contains(got, "range: 1-20") || strings.Contains(got, "path: tui/model.go") {
+		t.Fatalf("expected tool card body to collapse to one summary line, got %q", got)
 	}
 }
 

--- a/tui/ui_component_defaults.go
+++ b/tui/ui_component_defaults.go
@@ -1,0 +1,136 @@
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type landingPage struct{}
+
+func (landingPage) Render(m model) string {
+	return m.landingComponent().Render(m)
+}
+
+type chatPage struct{}
+
+func (chatPage) Render(m model) string {
+	chatContent := lipgloss.JoinVertical(
+		lipgloss.Left,
+		m.mainPanelComponent().Render(m),
+		m.footerComponent().Render(m),
+	)
+	return panelStyle.Width(m.chatPanelWidth()).Render(chatContent)
+}
+
+func (m model) activePage() pageRenderer {
+	if m.screen == screenChat {
+		return chatPage{}
+	}
+	return landingPage{}
+}
+
+type defaultViewOverlayComponent struct{}
+
+func (defaultViewOverlayComponent) Apply(m model, base string) string {
+	switch {
+	case m.helpOpen:
+		return renderModal(m.width, m.height, m.renderHelpModal())
+	case m.sessionsOpen:
+		return renderModal(m.width, m.height, m.renderSessionsModal())
+	case m.skillsOpen:
+		return renderModal(m.width, m.height, m.renderSkillsModal())
+	default:
+		return base
+	}
+}
+
+func (m model) viewOverlayComponent() viewOverlayComponent {
+	return defaultViewOverlayComponent{}
+}
+
+type defaultMainPanelComponent struct{}
+
+func (defaultMainPanelComponent) Render(m model) string {
+	return renderMainPanelDefault(m)
+}
+
+func (m model) mainPanelComponent() mainPanelComponent {
+	return defaultMainPanelComponent{}
+}
+
+type defaultLandingComponent struct{}
+
+func (defaultLandingComponent) Render(m model) string {
+	return renderLandingDefault(m)
+}
+
+func (m model) landingComponent() landingComponent {
+	return defaultLandingComponent{}
+}
+
+type defaultFooterComponent struct{}
+
+func (defaultFooterComponent) Render(m model) string {
+	return renderFooterDefault(m)
+}
+
+func (m model) footerComponent() footerComponent {
+	return defaultFooterComponent{}
+}
+
+type defaultStatusBarComponent struct{}
+
+func (defaultStatusBarComponent) Render(m model, width int) string {
+	return renderStatusBarWithWidthDefault(m, width)
+}
+
+func (m model) statusBarComponent() statusBarComponent {
+	return defaultStatusBarComponent{}
+}
+
+type defaultScrollbarComponent struct{}
+
+func (defaultScrollbarComponent) Render(m model, viewHeight, contentHeight, currentOffset int) string {
+	return renderScrollbarDefault(m, viewHeight, contentHeight, currentOffset)
+}
+
+func (m model) scrollbarComponent() scrollbarComponent {
+	return defaultScrollbarComponent{}
+}
+
+type defaultConversationViewportComponent struct{}
+
+func (defaultConversationViewportComponent) Render(m model) string {
+	return renderConversationViewportDefault(m)
+}
+
+func (m model) conversationViewportComponent() conversationViewportComponent {
+	return defaultConversationViewportComponent{}
+}
+
+type defaultInputEditorViewComponent struct{}
+
+func (defaultInputEditorViewComponent) Render(m model) string {
+	return renderInputEditorViewDefault(m)
+}
+
+func (m model) inputEditorViewComponent() inputEditorViewComponent {
+	return defaultInputEditorViewComponent{}
+}
+
+type textAreaInputComponent struct{}
+
+func (textAreaInputComponent) Update(m model, msg tea.Msg) (model, tea.Cmd) {
+	before := m.input.Value()
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	if m.input.Value() != before {
+		m.handleInputMutation(before, m.input.Value(), "")
+		m.syncInputOverlays()
+	}
+	return m, cmd
+}
+
+func (m model) defaultInputComponent() inputComponent {
+	return textAreaInputComponent{}
+}

--- a/tui/ui_component_types.go
+++ b/tui/ui_component_types.go
@@ -1,0 +1,45 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// pageRenderer renders one top-level screen in the TUI.
+type pageRenderer interface {
+	Render(m model) string
+}
+
+type viewOverlayComponent interface {
+	Apply(m model, base string) string
+}
+
+type mainPanelComponent interface {
+	Render(m model) string
+}
+
+type landingComponent interface {
+	Render(m model) string
+}
+
+type footerComponent interface {
+	Render(m model) string
+}
+
+type statusBarComponent interface {
+	Render(m model, width int) string
+}
+
+type scrollbarComponent interface {
+	Render(m model, viewHeight, contentHeight, currentOffset int) string
+}
+
+type conversationViewportComponent interface {
+	Render(m model) string
+}
+
+type inputEditorViewComponent interface {
+	Render(m model) string
+}
+
+// inputComponent owns input-editor update behavior.
+type inputComponent interface {
+	Update(m model, msg tea.Msg) (model, tea.Cmd)
+}


### PR DESCRIPTION
背景
当前工具执行区同时展示动作标签和工具名，并在正文展示多行细节，信息密度偏高，更像 description card，不够轻量。

本次改动
工具头部去重：仅保留动作标签（如 LIST / READ / SHELL），不再并排显示原始工具名（如 read_file）。
成功状态轻量化：工具 done/success 状态显示为 ✓。
工具正文单行化：显示层仅保留第一条摘要行，不再展开 range/path/stdout/stderr 等附加行。
保持边界：不改 run 分组、不改 thinking 区块、不改 tool 事件流和底层结果结构，仅做展示层减法。
测试
已通过 tui 相关测试，包括：

工具头部显示与去重
done -> ✓ 状态显示
工具正文单行摘要
工具开始时参数正文仍隐藏（回归行为保持）
影响
工具执行区信息更聚焦，视觉噪音降低，整体更接近 tag line 风格。