### PR TITLE
refactor(tui): polish approval banner layout and spacing

### DIFF
--- a/tui/component_overlays.go
+++ b/tui/component_overlays.go
@@ -49,15 +49,42 @@ func (m model) renderHelpModal() string {
 }
 
 func (m model) renderApprovalBanner() string {
-	width := max(24, m.chatPanelInnerWidth())
-	commandWidth := max(20, width-4)
-	lines := []string{
-		accentStyle.Render("Approval required"),
-		mutedStyle.Render("Reason: " + trimPreview(m.approval.Reason, commandWidth)),
-		codeStyle.Width(commandWidth).Render(m.approval.Command),
-		mutedStyle.Render("Y / Enter approve    N / Esc reject"),
+	bannerWidth := max(24, m.chatPanelInnerWidth())
+	innerWidth := max(20, bannerWidth-approvalBannerStyle.GetHorizontalFrameSize())
+	command := strings.TrimSpace(m.approval.Command)
+	if command == "" {
+		command = "-"
 	}
-	return approvalBannerStyle.Width(width).Render(strings.Join(lines, "\n"))
+
+	title := "Approval required"
+	reasonBudget := max(0, innerWidth-lipgloss.Width(title)-2)
+	reason := trimPreview(m.approval.Reason, reasonBudget)
+	line1 := approvalTitleStyle.Render(title)
+	if reason != "" {
+		line1 += "  " + approvalReasonStyle.Render(reason)
+	}
+
+	toolPrefix := "Tool: "
+	hint := "Approve [Y/Enter]  Reject [N/Esc]"
+	minGap := 2
+	toolBudget := innerWidth - lipgloss.Width(toolPrefix) - lipgloss.Width(hint) - minGap
+	if toolBudget < 6 {
+		toolBudget = 6
+	}
+	tool := trimPreview(command, toolBudget)
+	leftPlain := toolPrefix + tool
+	gap := innerWidth - lipgloss.Width(leftPlain) - lipgloss.Width(hint)
+	if gap < 1 {
+		tool = trimPreview(command, max(1, innerWidth-lipgloss.Width(toolPrefix)-lipgloss.Width(hint)-1))
+		leftPlain = toolPrefix + tool
+		gap = max(1, innerWidth-lipgloss.Width(leftPlain)-lipgloss.Width(hint))
+	}
+	line2 := approvalCommandStyle.Render(leftPlain) + strings.Repeat(" ", gap) + approvalHintStyle.Render(hint)
+
+	body := lipgloss.NewStyle().
+		Width(innerWidth).
+		Render(strings.Join([]string{line1, line2}, "\n"))
+	return approvalBannerStyle.Render(body)
 }
 
 func (m model) renderActiveSkillBanner() string {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -3992,10 +3992,11 @@ func TestApprovalBannerRendersAboveInput(t *testing.T) {
 
 	footer := m.renderFooter()
 	for _, want := range []string{
+		"Approval required",
 		"go test ./tui",
 		"run tests",
-		"Y / Enter",
-		"N / Esc",
+		"Approve [Y/Enter]",
+		"Reject [N/Esc]",
 	} {
 		if !strings.Contains(footer, want) {
 			t.Fatalf("expected approval banner to contain %q", want)
@@ -4003,6 +4004,38 @@ func TestApprovalBannerRendersAboveInput(t *testing.T) {
 	}
 	if strings.Contains(footer, "Approval Request") {
 		t.Fatalf("did not expect old centered approval modal title in footer")
+	}
+}
+
+func TestApprovalBannerUsesCompactSingleNormalBorder(t *testing.T) {
+	input := textarea.New()
+	m := model{
+		width: 64,
+		input: input,
+		approval: &approvalPrompt{
+			Command: "write_file_with_a_very_long_tool_name_to_force_truncation",
+			Reason:  "destructive tool may modify workspace files: write_file_with_a_very_long_tool_name_to_force_truncation",
+		},
+	}
+
+	banner := m.renderApprovalBanner()
+	if strings.ContainsAny(banner, "╭╮╰╯") {
+		t.Fatalf("expected normal single border without rounded corners, got %q", banner)
+	}
+	lines := strings.Split(banner, "\n")
+	if len(lines) != 6 {
+		t.Fatalf("expected medium-height boxed approval banner with top/bottom padding, got %d lines: %q", len(lines), banner)
+	}
+	expectedWidth := max(24, m.chatPanelInnerWidth())
+	for i, line := range lines {
+		if got := lipgloss.Width(line); got != expectedWidth {
+			t.Fatalf("expected banner line %d width %d, got %d (%q)", i, expectedWidth, got, line)
+		}
+	}
+	for _, want := range []string{"Tool:", "Approve [Y/Enter]", "Reject [N/Esc]"} {
+		if !strings.Contains(banner, want) {
+			t.Fatalf("expected compact approval banner to contain %q", want)
+		}
 	}
 }
 

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -4039,6 +4039,55 @@ func TestApprovalBannerUsesCompactSingleNormalBorder(t *testing.T) {
 	}
 }
 
+func TestApprovalBannerDefaultsWhenCommandAndReasonEmpty(t *testing.T) {
+	input := textarea.New()
+	m := model{
+		width: 80,
+		input: input,
+		approval: &approvalPrompt{
+			Command: "   ",
+			Reason:  "   ",
+		},
+	}
+
+	banner := m.renderApprovalBanner()
+	if !strings.Contains(banner, "Approval required") {
+		t.Fatalf("expected approval title in banner, got %q", banner)
+	}
+	if !strings.Contains(banner, "Tool: -") {
+		t.Fatalf("expected empty command to fallback to '-', got %q", banner)
+	}
+	if !strings.Contains(banner, "Approve [Y/Enter]") || !strings.Contains(banner, "Reject [N/Esc]") {
+		t.Fatalf("expected approval actions to render, got %q", banner)
+	}
+}
+
+func TestApprovalBannerNarrowWidthFallbackKeepsAlignedHint(t *testing.T) {
+	input := textarea.New()
+	m := model{
+		width: 24,
+		input: input,
+		approval: &approvalPrompt{
+			Command: "very_long_destructive_tool_name_for_narrow_layout",
+			Reason:  "destructive tool may modify workspace files: very_long_destructive_tool_name_for_narrow_layout",
+		},
+	}
+
+	banner := m.renderApprovalBanner()
+	lines := strings.Split(banner, "\n")
+	expectedWidth := max(24, m.chatPanelInnerWidth())
+	for i, line := range lines {
+		if got := lipgloss.Width(line); got != expectedWidth {
+			t.Fatalf("expected banner line %d width %d under narrow layout, got %d (%q)", i, expectedWidth, got, line)
+		}
+	}
+	for _, want := range []string{"Approve", "[Y/Enter]", "Reject", "[N/Esc]"} {
+		if !strings.Contains(banner, want) {
+			t.Fatalf("expected narrow-layout fallback to keep action hint token %q, got %q", want, banner)
+		}
+	}
+}
+
 func TestRenderFooterShowsActiveSkillBanner(t *testing.T) {
 	input := textarea.New()
 	m := model{

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -392,8 +392,22 @@ var (
 	approvalBannerStyle = lipgloss.NewStyle().
 				BorderStyle(lipgloss.NormalBorder()).
 				BorderForeground(semanticColors.Warning).
-				Background(semanticColors.WarningSoft).
-				Padding(0, 1)
+				Background(lipgloss.Color("#000000")).
+				Padding(1, 0)
+
+	approvalTitleStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.Warning).
+				Bold(true)
+
+	approvalReasonStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextMuted)
+
+	approvalCommandStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextBase).
+				Background(lipgloss.Color("#000000"))
+
+	approvalHintStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextMuted)
 
 	activeSkillBannerStyle = lipgloss.NewStyle().
 				BorderStyle(lipgloss.NormalBorder()).


### PR DESCRIPTION
这次改动把权限审批框重构成了更简约的卡片样式：保留单层完整边框和黑色背景，去掉了旧版的杂乱视觉元素，并修复了边框宽度计算带来的左侧残影/错位问题。内容布局压缩为两行，第一行展示 Approval required 和原因，第二行左侧是 Tool，右侧是 Approve/Reject 操作提示；在窄宽度下会优先保留操作提示并对工具名做截断，保证始终对齐整洁。最后又按你的反馈把卡片高度做了“中等加高”（上下各 1 行留白），让视觉更舒展但不臃肿。测试也同步更新，新增了边框形态和高度回归校验，go test ./tui 已通过。