### PR TITLE
runtime: 将同步工具执行从 runtime task 中抽离

### DIFF
--- a/internal/agent/tool_execution.go
+++ b/internal/agent/tool_execution.go
@@ -313,7 +313,8 @@ func (e *defaultEngine) toolSafetyClass(name string) tools.SafetyClass {
 
 func shouldExecuteToolDirectly(name string) bool {
 	switch strings.TrimSpace(name) {
-	case "list_files", "read_file", "search_text", "web_search", "web_fetch":
+	case "list_files", "read_file", "search_text", "web_search", "web_fetch",
+		"write_file", "replace_in_file", "apply_patch", "update_plan":
 		return true
 	default:
 		return false

--- a/internal/agent/tool_execution.go
+++ b/internal/agent/tool_execution.go
@@ -56,7 +56,8 @@ func (e *defaultEngine) executeToolCall(
 	if runner.policyGateway == nil {
 		return fmt.Errorf("policy gateway is unavailable")
 	}
-	if runner.runtime == nil {
+	executeDirectly := shouldExecuteToolDirectly(call.Function.Name)
+	if !executeDirectly && runner.runtime == nil {
 		return fmt.Errorf("runtime gateway is unavailable")
 	}
 
@@ -126,69 +127,85 @@ func (e *defaultEngine) executeToolCall(
 	}
 
 	execStartedAt := time.Now()
-	runtimeMetadata := map[string]string{
-		"tool_name": call.Function.Name,
+	executeTool := func(execCtx context.Context) (string, error) {
+		sandboxRoots := buildSandboxRoots(runner.workspace, runner.config.WritableRoots)
+		return runner.executor.ExecuteForMode(execCtx, runMode, call.Function.Name, call.Function.Arguments, &tools.ExecutionContext{
+			Workspace:         runner.workspace,
+			WritableRoots:     runner.config.WritableRoots,
+			ApprovalPolicy:    runner.config.ApprovalPolicy,
+			ApprovalMode:      runner.config.ApprovalMode,
+			AwayPolicy:        runner.config.AwayPolicy,
+			SandboxEnabled:    runner.config.SandboxEnabled,
+			SystemSandboxMode: runner.config.SystemSandboxMode,
+			LeaseID:           sandboxLeaseID,
+			RunID:             sandboxRunID,
+			FSRead:            append([]string(nil), sandboxRoots...),
+			FSWrite:           append([]string(nil), sandboxRoots...),
+			ExecAllowlist:     toSandboxExecRules(runner.config.ExecAllowlist),
+			NetworkAllowlist:  toSandboxNetworkRules(runner.config.NetworkAllowlist),
+			Approval:          approval,
+			Session:           sess,
+			TaskManager:       runner.taskManager,
+			Extensions:        runner.extensions,
+			Mode:              runMode,
+			Stdin:             runner.stdin,
+			Stdout:            runner.stdout,
+			AllowedTools:      allowedTools,
+			DeniedTools:       deniedTools,
+		})
 	}
-	appendSandboxAuditContext(runtimeMetadata, sandboxAudit)
-	execution, runtimeErr := runner.runtime.RunSync(ctx, RuntimeTaskRequest{
-		SessionID: sessionID,
-		TraceID:   traceID,
-		Name:      call.Function.Name,
-		Kind:      "tool",
-		Metadata:  runtimeMetadata,
-		Execute: func(execCtx context.Context) ([]byte, error) {
-			sandboxRoots := buildSandboxRoots(runner.workspace, runner.config.WritableRoots)
-			output, err := runner.executor.ExecuteForMode(execCtx, runMode, call.Function.Name, call.Function.Arguments, &tools.ExecutionContext{
-				Workspace:         runner.workspace,
-				WritableRoots:     runner.config.WritableRoots,
-				ApprovalPolicy:    runner.config.ApprovalPolicy,
-				ApprovalMode:      runner.config.ApprovalMode,
-				AwayPolicy:        runner.config.AwayPolicy,
-				SandboxEnabled:    runner.config.SandboxEnabled,
-				SystemSandboxMode: runner.config.SystemSandboxMode,
-				LeaseID:           sandboxLeaseID,
-				RunID:             sandboxRunID,
-				FSRead:            append([]string(nil), sandboxRoots...),
-				FSWrite:           append([]string(nil), sandboxRoots...),
-				ExecAllowlist:     toSandboxExecRules(runner.config.ExecAllowlist),
-				NetworkAllowlist:  toSandboxNetworkRules(runner.config.NetworkAllowlist),
-				Approval:          approval,
-				Session:           sess,
-				TaskManager:       runner.taskManager,
-				Extensions:        runner.extensions,
-				Mode:              runMode,
-				Stdin:             runner.stdin,
-				Stdout:            runner.stdout,
-				AllowedTools:      allowedTools,
-				DeniedTools:       deniedTools,
-			})
-			return []byte(output), err
-		},
-		OnTaskStateChanged: func(task runtimepkg.Task) {
-			runner.appendTaskStateAudit(
-				ctx,
-				sessionID,
-				traceID,
-				call.Function.Name,
-				sandboxAudit,
-				task,
-			)
-		},
-	})
 
-	result := string(execution.Result.Output)
-	execErr := execution.ExecutionError
-	if runtimeErr != nil && execution.Result.TaskID == "" {
-		execErr = runtimeErr
-	}
-	if execErr == nil && execution.Result.TaskID != "" && execution.Result.Status != corepkg.TaskCompleted {
-		execErr = runtimeTaskResultError{
-			status:    execution.Result.Status,
-			errorCode: execution.Result.ErrorCode,
+	var (
+		result    string
+		execErr   error
+		taskID    corepkg.TaskID
+		errorCode string
+	)
+	if executeDirectly {
+		result, execErr = executeTool(ctx)
+	} else {
+		runtimeMetadata := map[string]string{
+			"tool_name": call.Function.Name,
 		}
-	}
-	if execErr == nil && runtimeErr != nil {
-		execErr = runtimeErr
+		appendSandboxAuditContext(runtimeMetadata, sandboxAudit)
+		execution, runtimeErr := runner.runtime.RunSync(ctx, RuntimeTaskRequest{
+			SessionID: sessionID,
+			TraceID:   traceID,
+			Name:      call.Function.Name,
+			Kind:      "tool",
+			Metadata:  runtimeMetadata,
+			Execute: func(execCtx context.Context) ([]byte, error) {
+				output, err := executeTool(execCtx)
+				return []byte(output), err
+			},
+			OnTaskStateChanged: func(task runtimepkg.Task) {
+				runner.appendTaskStateAudit(
+					ctx,
+					sessionID,
+					traceID,
+					call.Function.Name,
+					sandboxAudit,
+					task,
+				)
+			},
+		})
+
+		taskID = execution.TaskID
+		errorCode = execution.Result.ErrorCode
+		result = string(execution.Result.Output)
+		execErr = execution.ExecutionError
+		if runtimeErr != nil && execution.Result.TaskID == "" {
+			execErr = runtimeErr
+		}
+		if execErr == nil && execution.Result.TaskID != "" && execution.Result.Status != corepkg.TaskCompleted {
+			execErr = runtimeTaskResultError{
+				status:    execution.Result.Status,
+				errorCode: execution.Result.ErrorCode,
+			}
+		}
+		if execErr == nil && runtimeErr != nil {
+			execErr = runtimeErr
+		}
 	}
 
 	if execErr != nil {
@@ -239,13 +256,13 @@ func (e *defaultEngine) executeToolCall(
 		"sandbox_run_id":   sandboxRunID,
 	})
 	appendSandboxAuditContext(metadata, sandboxAudit)
-	if execution.Result.ErrorCode != "" {
-		metadata["error_code"] = execution.Result.ErrorCode
+	if errorCode != "" {
+		metadata["error_code"] = errorCode
 	}
 	appendSystemSandboxAuditMetadata(metadata, result)
 	runner.appendAudit(ctx, storagepkg.AuditEvent{
 		SessionID: sessionID,
-		TaskID:    execution.TaskID,
+		TaskID:    taskID,
 		TraceID:   traceID,
 		Actor:     "agent",
 		Action:    "tool_execute_result",
@@ -292,6 +309,15 @@ func (e *defaultEngine) toolSafetyClass(name string) tools.SafetyClass {
 		return tools.SafetyClassModerate
 	}
 	return spec.SafetyClass
+}
+
+func shouldExecuteToolDirectly(name string) bool {
+	switch strings.TrimSpace(name) {
+	case "list_files", "read_file", "search_text", "web_search", "web_fetch":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e *defaultEngine) handleRejectedToolCall(

--- a/internal/agent/tool_execution_audit_test.go
+++ b/internal/agent/tool_execution_audit_test.go
@@ -36,7 +36,7 @@ func (s *toolExecutionAuditStore) snapshot() []storagepkg.AuditEvent {
 	return copied
 }
 
-func TestRunPromptRecordsTaskStateChangedAuditWithSessionTaskTrace(t *testing.T) {
+func TestRunPromptRecordsTaskStateChangedAuditForRuntimeBackedTool(t *testing.T) {
 	workspace := t.TempDir()
 	store, err := session.NewStore(t.TempDir())
 	if err != nil {
@@ -44,15 +44,20 @@ func TestRunPromptRecordsTaskStateChangedAuditWithSessionTaskTrace(t *testing.T)
 	}
 	sess := session.New(workspace)
 	auditStore := &toolExecutionAuditStore{}
+	probe := &managerProbeTool{}
+	registry := tools.DefaultRegistry()
+	if err := registry.Register(probe, tools.RegisterOptions{Source: tools.RegistrationSourceBuiltin}); err != nil {
+		t.Fatal(err)
+	}
 
 	client := &fakeClient{replies: []llm.Message{
 		{
 			Role: llm.RoleAssistant,
 			ToolCalls: []llm.ToolCall{{
-				ID:   "trace-tool-1",
+				ID:   "trace-runtime-tool-1",
 				Type: "function",
 				Function: llm.ToolFunctionCall{
-					Name:      "list_files",
+					Name:      "manager_probe",
 					Arguments: `{}`,
 				},
 			}},
@@ -74,13 +79,13 @@ func TestRunPromptRecordsTaskStateChangedAuditWithSessionTaskTrace(t *testing.T)
 		},
 		Client:     client,
 		Store:      store,
-		Registry:   tools.DefaultRegistry(),
+		Registry:   registry,
 		AuditStore: auditStore,
 		Stdin:      strings.NewReader(""),
 		Stdout:     io.Discard,
 	})
 
-	answer, err := runner.RunPrompt(context.Background(), sess, "list files", "build", io.Discard)
+	answer, err := runner.RunPrompt(context.Background(), sess, "probe managers", "build", io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,8 +113,8 @@ func TestRunPromptRecordsTaskStateChangedAuditWithSessionTaskTrace(t *testing.T)
 		if event.TaskID == "" {
 			t.Fatalf("expected non-empty task id, got %+v", event)
 		}
-		if event.TraceID != corepkg.TraceID("trace-tool-1") {
-			t.Fatalf("expected trace id %q, got %q", "trace-tool-1", event.TraceID)
+		if event.TraceID != corepkg.TraceID("trace-runtime-tool-1") {
+			t.Fatalf("expected trace id %q, got %q", "trace-runtime-tool-1", event.TraceID)
 		}
 		if got := event.Metadata["sandbox_enabled"]; got != "true" {
 			t.Fatalf("expected task_state_changed sandbox_enabled=true, got %q", got)
@@ -161,19 +166,33 @@ func (g *stubRuntimeGateway) RunSync(_ context.Context, request RuntimeTaskReque
 	}, nil
 }
 
-func TestRunPromptExecutesToolThroughRuntimeGatewayBoundary(t *testing.T) {
+func TestShouldExecuteToolDirectlyRoutesOnlyReadOnlyBuiltins(t *testing.T) {
+	for _, name := range []string{"list_files", "read_file", "search_text", "web_search", "web_fetch"} {
+		if !shouldExecuteToolDirectly(name) {
+			t.Fatalf("expected %s to execute directly", name)
+		}
+	}
+	for _, name := range []string{"write_file", "replace_in_file", "apply_patch", "update_plan", "run_shell", "manager_probe"} {
+		if shouldExecuteToolDirectly(name) {
+			t.Fatalf("expected %s to remain runtime-backed", name)
+		}
+	}
+}
+
+func TestRunPromptExecutesReadOnlyToolDirectly(t *testing.T) {
 	workspace := t.TempDir()
 	store, err := session.NewStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
 	sess := session.New(workspace)
+	auditStore := &toolExecutionAuditStore{}
 
 	client := &fakeClient{replies: []llm.Message{
 		{
 			Role: llm.RoleAssistant,
 			ToolCalls: []llm.ToolCall{{
-				ID:   "tool-via-runtime",
+				ID:   "tool-direct-read",
 				Type: "function",
 				Function: llm.ToolFunctionCall{
 					Name:      "list_files",
@@ -197,9 +216,105 @@ func TestRunPromptExecutesToolThroughRuntimeGatewayBoundary(t *testing.T) {
 			SandboxEnabled:    true,
 			SystemSandboxMode: "best_effort",
 		},
+		Client:     client,
+		Store:      store,
+		Registry:   tools.DefaultRegistry(),
+		Runtime:    gateway,
+		AuditStore: auditStore,
+		Stdin:      strings.NewReader(""),
+		Stdout:     io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "run tool", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "done" {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+
+	gateway.mu.Lock()
+	callCount := len(gateway.calls)
+	gateway.mu.Unlock()
+	if callCount != 0 {
+		t.Fatalf("expected read-only tool to bypass runtime gateway, got %d calls", callCount)
+	}
+
+	if len(sess.Messages) < 3 {
+		t.Fatalf("expected tool result message to be persisted, got %#v", sess.Messages)
+	}
+	toolResult := sess.Messages[2].Content
+	if strings.Contains(toolResult, `"via":"runtime_gateway"`) {
+		t.Fatalf("expected direct tool result, got %q", toolResult)
+	}
+
+	events := auditStore.snapshot()
+	for _, event := range events {
+		if event.Action == "task_state_changed" {
+			t.Fatalf("did not expect task_state_changed for direct tool, got %+v", event)
+		}
+	}
+	var resultEvent *storagepkg.AuditEvent
+	for i := range events {
+		if events[i].Action == "tool_execute_result" && events[i].Metadata["tool_name"] == "list_files" {
+			resultEvent = &events[i]
+		}
+	}
+	if resultEvent == nil {
+		t.Fatalf("expected tool_execute_result audit event, got %+v", events)
+	}
+	if resultEvent.TaskID != "" {
+		t.Fatalf("expected direct tool audit to omit task id, got %+v", resultEvent)
+	}
+	if resultEvent.TraceID != corepkg.TraceID("tool-direct-read") {
+		t.Fatalf("expected trace id %q, got %q", "tool-direct-read", resultEvent.TraceID)
+	}
+}
+
+func TestRunPromptKeepsNonDirectToolOnRuntimeGateway(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	probe := &managerProbeTool{}
+	registry := tools.DefaultRegistry()
+	if err := registry.Register(probe, tools.RegisterOptions{Source: tools.RegistrationSourceBuiltin}); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "tool-via-runtime",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "manager_probe",
+					Arguments: `{}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "done",
+		},
+	}}
+	gateway := &stubRuntimeGateway{}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:          config.ProviderConfig{Model: "test-model"},
+			MaxIterations:     4,
+			Stream:            false,
+			SandboxEnabled:    true,
+			SystemSandboxMode: "best_effort",
+		},
 		Client:   client,
 		Store:    store,
-		Registry: tools.DefaultRegistry(),
+		Registry: registry,
 		Runtime:  gateway,
 		Stdin:    strings.NewReader(""),
 		Stdout:   io.Discard,
@@ -223,7 +338,7 @@ func TestRunPromptExecutesToolThroughRuntimeGatewayBoundary(t *testing.T) {
 	if callCount != 1 {
 		t.Fatalf("expected exactly 1 runtime gateway call, got %d", callCount)
 	}
-	if call.Name != "list_files" || call.Kind != "tool" {
+	if call.Name != "manager_probe" || call.Kind != "tool" {
 		t.Fatalf("expected runtime gateway tool request, got %+v", call)
 	}
 	if got := call.Metadata["sandbox_enabled"]; got != "true" {

--- a/internal/agent/tool_execution_audit_test.go
+++ b/internal/agent/tool_execution_audit_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -166,13 +168,23 @@ func (g *stubRuntimeGateway) RunSync(_ context.Context, request RuntimeTaskReque
 	}, nil
 }
 
-func TestShouldExecuteToolDirectlyRoutesOnlyReadOnlyBuiltins(t *testing.T) {
-	for _, name := range []string{"list_files", "read_file", "search_text", "web_search", "web_fetch"} {
+func TestShouldExecuteToolDirectlyRoutesSynchronousBuiltins(t *testing.T) {
+	for _, name := range []string{
+		"list_files",
+		"read_file",
+		"search_text",
+		"web_search",
+		"web_fetch",
+		"write_file",
+		"replace_in_file",
+		"apply_patch",
+		"update_plan",
+	} {
 		if !shouldExecuteToolDirectly(name) {
 			t.Fatalf("expected %s to execute directly", name)
 		}
 	}
-	for _, name := range []string{"write_file", "replace_in_file", "apply_patch", "update_plan", "run_shell", "manager_probe"} {
+	for _, name := range []string{"run_shell", "manager_probe"} {
 		if shouldExecuteToolDirectly(name) {
 			t.Fatalf("expected %s to remain runtime-backed", name)
 		}
@@ -268,6 +280,195 @@ func TestRunPromptExecutesReadOnlyToolDirectly(t *testing.T) {
 	}
 	if resultEvent.TraceID != corepkg.TraceID("tool-direct-read") {
 		t.Fatalf("expected trace id %q, got %q", "tool-direct-read", resultEvent.TraceID)
+	}
+}
+
+func TestRunPromptExecutesWriteFileDirectly(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	auditStore := &toolExecutionAuditStore{}
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "tool-direct-write",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "write_file",
+					Arguments: `{"path":"x.txt","content":"hello"}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "done",
+		},
+	}}
+	gateway := &stubRuntimeGateway{}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:       config.ProviderConfig{Model: "test-model"},
+			MaxIterations:  4,
+			Stream:         false,
+			ApprovalPolicy: "on-request",
+		},
+		Client:     client,
+		Store:      store,
+		Registry:   tools.DefaultRegistry(),
+		Runtime:    gateway,
+		AuditStore: auditStore,
+		Stdin:      strings.NewReader("y\n"),
+		Stdout:     io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "write file", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "done" {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+
+	gateway.mu.Lock()
+	callCount := len(gateway.calls)
+	gateway.mu.Unlock()
+	if callCount != 0 {
+		t.Fatalf("expected write_file to bypass runtime gateway, got %d calls", callCount)
+	}
+	data, err := os.ReadFile(filepath.Join(workspace, "x.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("unexpected file content: %q", string(data))
+	}
+
+	events := auditStore.snapshot()
+	for _, event := range events {
+		if event.Action == "task_state_changed" {
+			t.Fatalf("did not expect task_state_changed for direct write tool, got %+v", event)
+		}
+	}
+	var resultEvent *storagepkg.AuditEvent
+	for i := range events {
+		if events[i].Action == "tool_execute_result" && events[i].Metadata["tool_name"] == "write_file" {
+			resultEvent = &events[i]
+		}
+	}
+	if resultEvent == nil {
+		t.Fatalf("expected tool_execute_result audit event, got %+v", events)
+	}
+	if resultEvent.TaskID != "" {
+		t.Fatalf("expected direct write audit to omit task id, got %+v", resultEvent)
+	}
+	if resultEvent.TraceID != corepkg.TraceID("tool-direct-write") {
+		t.Fatalf("expected trace id %q, got %q", "tool-direct-write", resultEvent.TraceID)
+	}
+}
+
+func TestRunPromptExecutesUpdatePlanDirectly(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	auditStore := &toolExecutionAuditStore{}
+	events := make([]Event, 0, 6)
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "tool-direct-plan",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "update_plan",
+					Arguments: `{"explanation":"starting","plan":[{"step":"Inspect provider","status":"completed"},{"step":"Add tests","status":"in_progress"}]}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "done",
+		},
+	}}
+	gateway := &stubRuntimeGateway{}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 4,
+			Stream:        false,
+		},
+		Client:     client,
+		Store:      store,
+		Registry:   tools.DefaultRegistry(),
+		Runtime:    gateway,
+		AuditStore: auditStore,
+		Observer: ObserverFunc(func(event Event) {
+			events = append(events, event)
+		}),
+		Stdin:  strings.NewReader(""),
+		Stdout: io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "update plan", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "done" {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+
+	gateway.mu.Lock()
+	callCount := len(gateway.calls)
+	gateway.mu.Unlock()
+	if callCount != 0 {
+		t.Fatalf("expected update_plan to bypass runtime gateway, got %d calls", callCount)
+	}
+	if len(sess.Plan.Steps) != 2 || sess.Plan.Steps[1].Title != "Add tests" {
+		t.Fatalf("unexpected session plan: %#v", sess.Plan)
+	}
+	seenPlanUpdated := false
+	for _, event := range events {
+		if event.Type == EventPlanUpdated {
+			seenPlanUpdated = true
+			break
+		}
+	}
+	if !seenPlanUpdated {
+		t.Fatalf("expected EventPlanUpdated, got %+v", events)
+	}
+
+	auditEvents := auditStore.snapshot()
+	for _, event := range auditEvents {
+		if event.Action == "task_state_changed" {
+			t.Fatalf("did not expect task_state_changed for direct update_plan, got %+v", event)
+		}
+	}
+	var resultEvent *storagepkg.AuditEvent
+	for i := range auditEvents {
+		if auditEvents[i].Action == "tool_execute_result" && auditEvents[i].Metadata["tool_name"] == "update_plan" {
+			resultEvent = &auditEvents[i]
+		}
+	}
+	if resultEvent == nil {
+		t.Fatalf("expected tool_execute_result audit event, got %+v", auditEvents)
+	}
+	if resultEvent.TaskID != "" {
+		t.Fatalf("expected direct update_plan audit to omit task id, got %+v", resultEvent)
+	}
+	if resultEvent.TraceID != corepkg.TraceID("tool-direct-plan") {
+		t.Fatalf("expected trace id %q, got %q", "tool-direct-plan", resultEvent.TraceID)
 	}
 }
 


### PR DESCRIPTION
## 背景

当前工具调用默认都会先进入 `RuntimeGateway.RunSync(...)`，即使是普通同步工具也会被包装成 runtime task。这样会让 `runtime` 同时承担“同步工具执行”和“长生命周期 job 编排”两类语义，增加后续 SubAgent / background task 演进时的耦合成本。

这个 PR 先完成第一步边界收缩：把普通同步工具从 runtime task 包装里抽离出来，但保留现有 runtime/job 基础设施，不影响后续 SubAgent 引入。

## 变更内容

- 在 `internal/agent/tool_execution.go` 中引入 direct 路由分支。
- 将以下同步工具改为 direct execution，不再经过 `RuntimeGateway.RunSync(...)`：
  - `list_files`
  - `read_file`
  - `search_text`
  - `web_search`
  - `web_fetch`
  - `write_file`
  - `replace_in_file`
  - `apply_patch`
  - `update_plan`
- direct 工具仍继续走现有 `tools.Executor` 链路，保留：
  - 参数解析
  - 权限检查
  - destructive approval
  - sandbox 相关上下文
  - `tool_execute_start` / `tool_execute_result` audit
  - `TraceID`
  - tool result message 写回 session
- 非 direct 工具仍保持 runtime-backed 行为，当前包括：
  - `run_shell`
  - 其他未纳入 direct allowlist 的工具
- 保留 `update_plan` 完成后的 `EventPlanUpdated` 语义不变。

## 行为变化

- direct 工具不再创建 runtime task。
- direct 工具不再产生 `task_state_changed` audit。
- direct 工具的 `tool_execute_result` audit 中 `TaskID` 为空，但 `TraceID` 保持存在。
- runtime-backed 工具的行为保持不变。

## 测试

补充并调整了 `internal/agent/tool_execution_audit_test.go`，覆盖：

- runtime-backed 工具仍产生 `task_state_changed`
- 同步工具路由规则正确
- 只读工具 direct 执行且绕过 runtime gateway
- `write_file` direct 执行且真实写入文件
- `update_plan` direct 执行且仍更新 session plan 并发出 `EventPlanUpdated`
- 非 direct 工具仍走 runtime gateway

已验证：

```bash
go test ./internal/agent -v
```