### PR TITLE
fix(tui): 修复长文本连续粘贴误提交与占位符闪烁回归

### DIFF
--- a/tui/input_images_test.go
+++ b/tui/input_images_test.go
@@ -33,9 +33,13 @@ func (f fakeClipboardImageReader) ReadImage(context.Context) (string, []byte, st
 type fakeClipboardTextReader struct {
 	text string
 	err  error
+	calls *int
 }
 
 func (f fakeClipboardTextReader) ReadText(context.Context) (string, error) {
+	if f.calls != nil {
+		*f.calls++
+	}
 	return f.text, f.err
 }
 

--- a/tui/input_images_test.go
+++ b/tui/input_images_test.go
@@ -30,6 +30,15 @@ func (f fakeClipboardImageReader) ReadImage(context.Context) (string, []byte, st
 	return f.mediaType, f.data, f.fileName, f.err
 }
 
+type fakeClipboardTextReader struct {
+	text string
+	err  error
+}
+
+func (f fakeClipboardTextReader) ReadText(context.Context) (string, error) {
+	return f.text, f.err
+}
+
 func newImagePipelineModel(t *testing.T) *model {
 	t.Helper()
 

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -85,6 +85,12 @@ func schedulePasteBurstSettle(generation int) tea.Cmd {
 	})
 }
 
+func scheduleHiddenPasteProbeFlush(id int) tea.Cmd {
+	return tea.Tick(hiddenPasteProbeDelay, func(time.Time) tea.Msg {
+		return hiddenPasteProbeFlushMsg{ID: id}
+	})
+}
+
 func (m *model) touchPasteBurst(source string) int {
 	if m == nil {
 		return 0
@@ -421,6 +427,50 @@ func (m *model) clearPasteSession() {
 	}
 	m.pasteSession = pasteSessionState{}
 	m.clearPasteBurstCandidate()
+}
+
+func (m *model) clearHiddenPasteProbe() {
+	if m == nil {
+		return
+	}
+	m.hiddenPasteProbe = hiddenPasteProbeState{}
+}
+
+func (m *model) startHiddenPasteProbe(fragment, clipboardText string) tea.Cmd {
+	if m == nil {
+		return nil
+	}
+	now := time.Now()
+	id := m.hiddenPasteProbe.flushID + 1
+	if id <= 0 {
+		id = 1
+	}
+	m.hiddenPasteProbe = hiddenPasteProbeState{
+		active:      true,
+		baseInput:   m.input.Value(),
+		clipboard:   clipboardText,
+		buffered:    fragment,
+		startedAt:   now,
+		lastEventAt: now,
+		flushID:     id,
+	}
+	return scheduleHiddenPasteProbeFlush(id)
+}
+
+func (m *model) flushHiddenPasteProbeToInput() {
+	if m == nil || !m.hiddenPasteProbe.active {
+		return
+	}
+	probe := m.hiddenPasteProbe
+	m.clearHiddenPasteProbe()
+	if strings.TrimSpace(probe.buffered) == "" {
+		return
+	}
+	m.setInputValue(probe.baseInput + probe.buffered)
+	now := time.Now()
+	m.lastInputAt = now
+	m.inputBurstBaseValue = probe.baseInput
+	m.inputBurstSize = max(1, len([]rune(strings.TrimSpace(probe.buffered))))
 }
 
 func (m *model) readClipboardTextForPaste() (string, bool) {

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -694,10 +694,13 @@ func (m *model) tryStartClipboardPasteCapture(before, after, source string) (str
 		if afterMatched < clipboardCaptureMinPrefixRunes || afterMatched <= beforeMatched {
 			return after, "", false
 		}
+		afterRunes := []rune(after)
+		if afterMatched > len(afterRunes) {
+			return after, "", false
+		}
 		consumedRunes = afterMatched
 		buildReplacement = func(marker string) string {
-			keep := suffixRunes(after, len([]rune(normalizedAfter))-afterMatched)
-			return marker + keep
+			return string(afterRunes[:len(afterRunes)-afterMatched]) + marker
 		}
 	}
 
@@ -723,17 +726,6 @@ func longestClipboardPrefixSuffixLen(value, clipboard string) int {
 		}
 	}
 	return 0
-}
-
-func suffixRunes(value string, count int) string {
-	if count <= 0 {
-		return ""
-	}
-	runes := []rune(value)
-	if count >= len(runes) {
-		return value
-	}
-	return string(runes[len(runes)-count:])
 }
 
 func (m *model) upsertVirtualPastePart(pasteID, placeholder string) {

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -475,6 +475,16 @@ func (m *model) clearPasteConfirmPending() {
 	m.pasteSubmitGuardUntil = time.Time{}
 }
 
+func (m *model) releasePasteSubmitSuppression() {
+	if m == nil {
+		return
+	}
+	m.clearPasteConfirmPending()
+	m.lastPasteAt = time.Time{}
+	m.clearPasteBurstCapture()
+	m.clearPasteBurstCandidate()
+}
+
 func (m *model) hasActivePasteSession() bool {
 	return m != nil && m.pasteSession.active
 }
@@ -600,6 +610,7 @@ func (m model) handlePastePayload(payload string) (tea.Model, tea.Cmd) {
 		m.syncInputOverlays()
 		return m, nil
 	}
+	m.beginOrAppendPasteTransaction(cleaned, "paste-payload")
 	return m, m.ingestPasteFragment(cleaned, "paste-payload")
 }
 

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -650,6 +650,9 @@ func (m *model) shouldArmClipboardCaptureFromImplicitMutation(before, after, sou
 	if insertedRunes >= clipboardCaptureMinPrefixRunes {
 		return true
 	}
+	if allowsEarlyClipboardCapture(inserted) {
+		return true
+	}
 	return insertedRunes == 1 && gap <= clipboardCaptureRapidRuneGap
 }
 
@@ -691,8 +694,9 @@ func (m *model) tryStartClipboardPasteCapture(before, after, source string) (str
 	consumedRunes := 0
 	insertedRunes := len([]rune(normalizedInserted))
 	if normalizedInserted != "" &&
-		insertedRunes >= clipboardCaptureMinPrefixRunes &&
-		strings.HasPrefix(normalizedClipboard, normalizedInserted) {
+		strings.HasPrefix(normalizedClipboard, normalizedInserted) &&
+		(insertedRunes >= clipboardCaptureMinPrefixRunes ||
+			allowsEarlyClipboardCapture(normalizedInserted)) {
 		consumedRunes = insertedRunes
 		buildReplacement = func(marker string) string {
 			return after[:prefix] + marker + after[len(after)-suffix:]
@@ -702,7 +706,11 @@ func (m *model) tryStartClipboardPasteCapture(before, after, source string) (str
 		normalizedAfter := normalizeNewlines(strings.ReplaceAll(after, ctrlVMarkerRune, ""))
 		beforeMatched := longestClipboardPrefixSuffixLen(normalizedBefore, normalizedClipboard)
 		afterMatched := longestClipboardPrefixSuffixLen(normalizedAfter, normalizedClipboard)
-		if afterMatched < clipboardCaptureMinPrefixRunes || afterMatched <= beforeMatched {
+		matchedPrefix := clipboardPrefixRunes(normalizedClipboard, afterMatched)
+		if afterMatched <= beforeMatched {
+			return after, "", false
+		}
+		if afterMatched < clipboardCaptureMinPrefixRunes && !allowsEarlyClipboardCapture(matchedPrefix) {
 			return after, "", false
 		}
 		afterRunes := []rune(after)
@@ -727,6 +735,15 @@ func (m *model) tryStartClipboardPasteCapture(before, after, source string) (str
 	return updated, note, true
 }
 
+func allowsEarlyClipboardCapture(fragment string) bool {
+	fragment = strings.TrimSpace(fragment)
+	if fragment == "" {
+		return false
+	}
+	runes := len([]rune(fragment))
+	return runes >= 2 && runes < clipboardCaptureMinPrefixRunes && len(fragment) >= clipboardCaptureMinPrefixRunes
+}
+
 func longestClipboardPrefixSuffixLen(value, clipboard string) int {
 	valueRunes := []rune(value)
 	clipRunes := []rune(clipboard)
@@ -737,6 +754,17 @@ func longestClipboardPrefixSuffixLen(value, clipboard string) int {
 		}
 	}
 	return 0
+}
+
+func clipboardPrefixRunes(value string, count int) string {
+	if count <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if count >= len(runes) {
+		return value
+	}
+	return string(runes[:count])
 }
 
 func (m *model) upsertVirtualPastePart(pasteID, placeholder string) {

--- a/tui/input_paste_test.go
+++ b/tui/input_paste_test.go
@@ -919,6 +919,33 @@ func TestTryStartClipboardPasteCapturePreservesExistingMarkerPrefixOnSuffixMatch
 	}
 }
 
+func TestHandleInputMutationCapturesTwoRuneMultibyteClipboardPrefixImmediately(t *testing.T) {
+	m := newImagePipelineModel(t)
+	secondRaw := strings.Join([]string{
+		"能、帮我看下这个仓库结构",
+		"给这段代码做 review",
+		"顺便看一下最近改动",
+		"补充下测试建议",
+		"最后总结风险点",
+	}, "\n")
+	m.clipboardRead = fakeClipboardTextReader{text: secondRaw}
+
+	firstChunk := "能、"
+	m.input.SetValue(firstChunk)
+	m.handleInputMutation("", firstChunk, "rune")
+
+	got := m.input.Value()
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(got) {
+		t.Fatalf("expected multibyte two-rune clipboard prefix to be captured immediately, got %q", got)
+	}
+	if strings.Contains(got, firstChunk) {
+		t.Fatalf("expected no visible multibyte prefix flicker, got %q", got)
+	}
+	if !m.pasteTransaction.Active || m.pasteTransaction.Consumed != len([]rune(firstChunk)) {
+		t.Fatalf("expected transaction to consume the first multibyte chunk, got active=%v consumed=%d", m.pasteTransaction.Active, m.pasteTransaction.Consumed)
+	}
+}
+
 func TestResolvePastedSelectionInvalidStartLine(t *testing.T) {
 	m := newImagePipelineModel(t)
 	_, stored, err := m.compressPastedText("a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk")

--- a/tui/input_paste_test.go
+++ b/tui/input_paste_test.go
@@ -883,6 +883,42 @@ func TestMergeTailIntoLatestMarkerUpdatesLatestOnly(t *testing.T) {
 	}
 }
 
+func TestTryStartClipboardPasteCapturePreservesExistingMarkerPrefixOnSuffixMatch(t *testing.T) {
+	m := newImagePipelineModel(t)
+
+	firstRaw := strings.Join([]string{"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11"}, "\n")
+	marker1, _, err := m.compressPastedText(firstRaw)
+	if err != nil {
+		t.Fatalf("compress first: %v", err)
+	}
+
+	secondRaw := strings.Join([]string{"beta-1", "beta-2", "beta-3", "beta-4", "beta-5", "beta-6", "beta-7", "beta-8", "beta-9", "beta-10", "beta-11"}, "\n")
+	m.clipboardRead = fakeClipboardTextReader{text: secondRaw}
+
+	before := marker1 + "bet"
+	after := marker1 + "beta"
+	updated, note, ok := m.tryStartClipboardPasteCapture(before, after, "rune")
+	if !ok {
+		t.Fatalf("expected clipboard capture fallback branch to start")
+	}
+	if !strings.HasPrefix(updated, marker1) {
+		t.Fatalf("expected existing marker prefix to be preserved, got %q", updated)
+	}
+	re := regexp.MustCompile(`^(?:\s*\[Paste #\d+ ~\d+ lines\]\s*){2}$`)
+	if !re.MatchString(updated) {
+		t.Fatalf("expected marker chain after second capture, got %q", updated)
+	}
+	if strings.Contains(updated, "beta") {
+		t.Fatalf("expected raw clipboard prefix to be fully replaced, got %q", updated)
+	}
+	if !strings.Contains(note, "Long pasted text") {
+		t.Fatalf("expected long-paste status note, got %q", note)
+	}
+	if !m.pasteTransaction.Active || m.pasteTransaction.Consumed != 4 {
+		t.Fatalf("expected paste transaction to track consumed echoed prefix, got active=%v consumed=%d", m.pasteTransaction.Active, m.pasteTransaction.Consumed)
+	}
+}
+
 func TestResolvePastedSelectionInvalidStartLine(t *testing.T) {
 	m := newImagePipelineModel(t)
 	_, stored, err := m.compressPastedText("a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk")

--- a/tui/input_paste_transaction.go
+++ b/tui/input_paste_transaction.go
@@ -7,7 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-const pasteCtrlVControlEchoWindow = 25 * time.Millisecond
+const pasteCtrlVControlEchoWindow = 120 * time.Millisecond
 const pasteTransactionAppendWindow = 120 * time.Millisecond
 
 func (m *model) beginPasteTransaction(payload, source string) {
@@ -99,6 +99,7 @@ func (m *model) consumePasteEchoKey(msg tea.KeyMsg) bool {
 	if remaining == "" {
 		if m.shouldConsumeTrailingPasteEnter(msg) {
 			m.clearPasteTransaction()
+			m.releasePasteSubmitSuppression()
 			return true
 		}
 		m.clearPasteTransaction()
@@ -109,6 +110,7 @@ func (m *model) consumePasteEchoKey(msg tea.KeyMsg) bool {
 		// characters back through key events. In that case the first plain Enter
 		// after paste should close the transaction but must not submit.
 		m.clearPasteTransaction()
+		m.releasePasteSubmitSuppression()
 		return true
 	}
 	if strings.HasPrefix(remaining, fragment) {
@@ -190,7 +192,7 @@ func shouldAppendPasteTransactionPayload(currentSource, nextSource string) bool 
 		return false
 	}
 	switch current {
-	case "paste-key", "rune-burst-paste":
+	case "paste-key", "paste-payload", "rune-burst-paste":
 		return true
 	default:
 		return false

--- a/tui/input_paste_transaction.go
+++ b/tui/input_paste_transaction.go
@@ -192,7 +192,7 @@ func shouldAppendPasteTransactionPayload(currentSource, nextSource string) bool 
 		return false
 	}
 	switch current {
-	case "paste-key", "paste-payload", "rune-burst-paste":
+	case "paste-key", "paste-payload", "paste-burst", "rune-burst-paste":
 		return true
 	default:
 		return false
@@ -202,7 +202,7 @@ func shouldAppendPasteTransactionPayload(currentSource, nextSource string) bool 
 func shouldGuardTrailingPasteEnter(source string) bool {
 	source = strings.ToLower(strings.TrimSpace(source))
 	switch source {
-	case "clipboard-capture", "ctrl+v", "paste-payload", "paste-key", "rune-burst-paste":
+	case "clipboard-capture", "ctrl+v", "paste-payload", "paste-key", "paste-burst", "rune-burst-paste":
 		return true
 	default:
 		return false

--- a/tui/model.go
+++ b/tui/model.go
@@ -907,6 +907,41 @@ func isCtrlVPasteKey(msg tea.KeyMsg) bool {
 	return normalizeKeyName(msg.String()) == "ctrl+v"
 }
 
+func (m *model) tryStartImplicitClipboardPasteFromKey(msg tea.KeyMsg) bool {
+	if m == nil || msg.Paste || m.hasActivePasteSession() || m.hasActivePasteBurst() {
+		return false
+	}
+	if msg.Type != tea.KeyRunes || len(msg.Runes) <= 1 {
+		return false
+	}
+	fragment := normalizeNewlines(strings.ReplaceAll(string(msg.Runes), ctrlVMarkerRune, ""))
+	if strings.TrimSpace(fragment) == "" {
+		return false
+	}
+	clipboardText, ok := m.readClipboardTextForPaste()
+	if !ok || !m.isLongPastedText(clipboardText) {
+		return false
+	}
+	if !strings.HasPrefix(normalizeNewlines(clipboardText), fragment) {
+		return false
+	}
+	marker, content, err := m.compressPastedText(clipboardText)
+	if err != nil {
+		m.statusNote = err.Error()
+		return false
+	}
+	m.beginPasteTransaction(clipboardText, "clipboard-capture")
+	m.pasteTransaction.Consumed = len([]rune(fragment))
+	m.setInputValue(m.input.Value() + marker)
+	now := time.Now()
+	m.lastPasteAt = now
+	m.markPasteConfirmPending(now)
+	m.statusNote = fmt.Sprintf("Long pasted text (%d lines) compressed as %s. Use [Paste #%s], [Paste #%s line10], or [Paste #%s line10~line20].",
+		content.Lines, marker, content.ID, content.ID, content.ID)
+	m.syncInputOverlays()
+	return true
+}
+
 func (m model) pasteFragmentFromKey(msg tea.KeyMsg) (string, string, bool) {
 	if msg.Paste {
 		switch {
@@ -1122,6 +1157,10 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	if m.tryStartImplicitClipboardPasteFromKey(msg) {
+		return m, nil
+	}
+
 	if m.shouldPromoteImplicitPasteCandidate(msg) {
 		return m, m.captureImplicitPasteCandidate(msg)
 	}
@@ -1131,7 +1170,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if fragment, source, ok := m.pasteFragmentFromKey(msg); ok {
-		if source == "paste-key" {
+		if source == "paste-key" || source == "rune-burst-paste" {
 			m.beginOrAppendPasteTransaction(fragment, source)
 		}
 		return m, m.ingestPasteFragment(fragment, source)

--- a/tui/model.go
+++ b/tui/model.go
@@ -1118,6 +1118,9 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.planActionOpen {
 		return m.handlePlanActionKey(msg)
 	}
+	if m.consumePasteEchoKey(msg) {
+		return m, nil
+	}
 
 	if m.shouldPromoteImplicitPasteCandidate(msg) {
 		return m, m.captureImplicitPasteCandidate(msg)
@@ -1128,6 +1131,9 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if fragment, source, ok := m.pasteFragmentFromKey(msg); ok {
+		if source == "paste-key" {
+			m.beginOrAppendPasteTransaction(fragment, source)
+		}
 		return m, m.ingestPasteFragment(fragment, source)
 	}
 
@@ -1263,16 +1269,27 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Prefer Ctrl+V image paste first. If clipboard has no image, fall through
 	// so regular terminal paste behavior can continue.
 	if ctrlVPasteDetected {
-		if note := m.handleEmptyClipboardPaste(); strings.TrimSpace(note) != "" {
-			m.statusNote = note
-			if strings.Contains(note, "Attached image from clipboard") {
-				m.syncInputOverlays()
-				return m, nil
+		beforeClipboard := m.input.Value()
+		clipboardNote := strings.TrimSpace(m.handleEmptyClipboardPaste())
+		if m.input.Value() != beforeClipboard {
+			if clipboardNote != "" {
+				m.statusNote = clipboardNote
 			}
-			if !isClipboardNoImageNote(note) {
-				m.syncInputOverlays()
-				return m, nil
+			m.syncInputOverlays()
+			return m, nil
+		}
+		if payload, ok := m.readClipboardTextForPaste(); ok {
+			m.beginPasteTransaction(payload, "ctrl+v")
+			if strings.TrimSpace(m.statusNote) == "" || isClipboardNoImageNote(clipboardNote) {
+				m.statusNote = "Pasted text from clipboard."
 			}
+			return m, m.ingestPasteFragment(payload, "ctrl+v")
+		}
+		if clipboardNote != "" {
+			m.clearPasteTransaction()
+			m.statusNote = clipboardNote
+			m.syncInputOverlays()
+			return m, nil
 		}
 	}
 
@@ -1598,7 +1615,7 @@ func (m model) handleSuppressedPasteEnter(rawValue string) (tea.Model, bool) {
 			}
 		}
 		if m.pasteConfirmPending {
-			m.clearPasteConfirmPending()
+			m.releasePasteSubmitSuppression()
 			m.statusNote = "Paste compressed. Press Enter again to send."
 		}
 		return m, true
@@ -1616,7 +1633,7 @@ func (m model) handleSuppressedPasteEnter(rawValue string) (tea.Model, bool) {
 		return m, true
 	}
 	if m.pasteConfirmPending {
-		m.clearPasteConfirmPending()
+		m.releasePasteSubmitSuppression()
 		m.statusNote = "Paste captured. Press Enter again to send."
 		return m, true
 	}

--- a/tui/model.go
+++ b/tui/model.go
@@ -943,6 +943,33 @@ func allowsImmediateSingleRuneClipboardCapture(currentInput, fragment string) bo
 	return ok && chain == trimmed
 }
 
+func shouldProbeImplicitClipboardFragment(currentInput, fragment string) bool {
+	trimmedFragment := strings.TrimSpace(fragment)
+	if trimmedFragment == "" {
+		return false
+	}
+	trimmedInput := strings.TrimSpace(currentInput)
+	inputBoundary := trimmedInput == ""
+	if !inputBoundary {
+		if chain, ok := extractLeadingCompressedMarker(trimmedInput); ok && chain == trimmedInput {
+			inputBoundary = true
+		}
+	}
+	runeCount := len([]rune(trimmedFragment))
+	switch {
+	case runeCount == 1:
+		return allowsImmediateSingleRuneClipboardCapture(currentInput, trimmedFragment)
+	case strings.Contains(fragment, "\n") || strings.Contains(fragment, "\t"):
+		return true
+	case runeCount >= clipboardCaptureMinPrefixRunes:
+		return inputBoundary || looksLikePastedFragment(trimmedFragment)
+	case allowsEarlyClipboardCapture(trimmedFragment):
+		return inputBoundary
+	default:
+		return false
+	}
+}
+
 func (m *model) commitImplicitClipboardPaste(prefix, clipboardText string) bool {
 	if m == nil {
 		return false
@@ -1014,14 +1041,14 @@ func (m *model) tryStartImplicitClipboardPasteFromKey(msg tea.KeyMsg) tea.Cmd {
 	if strings.TrimSpace(fragment) == "" {
 		return nil
 	}
+	if !shouldProbeImplicitClipboardFragment(m.input.Value(), fragment) {
+		return nil
+	}
 	clipboardText, ok := m.readClipboardTextForPaste()
 	if !ok || !m.isLongPastedText(clipboardText) {
 		return nil
 	}
 	if !strings.HasPrefix(normalizeNewlines(clipboardText), fragment) {
-		return nil
-	}
-	if len(msg.Runes) == 1 && !allowsImmediateSingleRuneClipboardCapture(m.input.Value(), fragment) {
 		return nil
 	}
 	if len(msg.Runes) == 1 {
@@ -1265,7 +1292,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if fragment, source, ok := m.pasteFragmentFromKey(msg); ok {
-		if source == "paste-key" || source == "rune-burst-paste" {
+		if source == "paste-key" || source == "paste-burst" || source == "rune-burst-paste" {
 			m.beginOrAppendPasteTransaction(fragment, source)
 		}
 		return m, m.ingestPasteFragment(fragment, source)

--- a/tui/model.go
+++ b/tui/model.go
@@ -53,6 +53,7 @@ const (
 	thinkingSpinnerFPS         = 80 * time.Millisecond
 	pasteAggregateDebounce     = 120 * time.Millisecond
 	pasteBurstSettleDelay      = 120 * time.Millisecond
+	hiddenPasteProbeDelay      = 45 * time.Millisecond
 )
 
 type footerShortcutHint struct {
@@ -253,6 +254,10 @@ type pasteBurstSettleMsg struct {
 	Generation int
 }
 
+type hiddenPasteProbeFlushMsg struct {
+	ID int
+}
+
 type mcpCommandResultMsg struct {
 	Input    string
 	Response string
@@ -284,6 +289,16 @@ type pasteBurstCandidateState struct {
 	lastEventAt time.Time
 	charCount   int
 	eventCount  int
+}
+
+type hiddenPasteProbeState struct {
+	active      bool
+	baseInput   string
+	clipboard   string
+	buffered    string
+	startedAt   time.Time
+	lastEventAt time.Time
+	flushID     int
 }
 
 var commandItems = []commandItem{
@@ -415,6 +430,7 @@ type model struct {
 	pasteBurstLastEventAt      time.Time
 	pasteBurstSource           string
 	pasteBurstGeneration       int
+	hiddenPasteProbe           hiddenPasteProbeState
 	clipboard                  clipboardImageReader
 	clipboardRead              clipboardTextReader
 	clipboardText              clipboardTextWriter
@@ -778,6 +794,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.clearPasteBurstCapture()
 		return m, nil
+	case hiddenPasteProbeFlushMsg:
+		if !m.hiddenPasteProbe.active || msg.ID != m.hiddenPasteProbe.flushID {
+			return m, nil
+		}
+		m.flushHiddenPasteProbeToInput()
+		m.syncInputOverlays()
+		return m, nil
 	case mouseSelectionScrollTickMsg:
 		return m.handleMouseSelectionScrollTick(msg)
 	case tokenMonitorTickMsg:
@@ -907,22 +930,24 @@ func isCtrlVPasteKey(msg tea.KeyMsg) bool {
 	return normalizeKeyName(msg.String()) == "ctrl+v"
 }
 
-func (m *model) tryStartImplicitClipboardPasteFromKey(msg tea.KeyMsg) bool {
-	if m == nil || msg.Paste || m.hasActivePasteSession() || m.hasActivePasteBurst() {
+func allowsImmediateSingleRuneClipboardCapture(currentInput, fragment string) bool {
+	fragment = strings.TrimSpace(fragment)
+	if len([]rune(fragment)) != 1 || len(fragment) <= 1 {
 		return false
 	}
-	if msg.Type != tea.KeyRunes || len(msg.Runes) <= 1 {
+	trimmed := strings.TrimSpace(currentInput)
+	if trimmed == "" {
+		return true
+	}
+	chain, ok := extractLeadingCompressedMarker(trimmed)
+	return ok && chain == trimmed
+}
+
+func (m *model) commitImplicitClipboardPaste(prefix, clipboardText string) bool {
+	if m == nil {
 		return false
 	}
-	fragment := normalizeNewlines(strings.ReplaceAll(string(msg.Runes), ctrlVMarkerRune, ""))
-	if strings.TrimSpace(fragment) == "" {
-		return false
-	}
-	clipboardText, ok := m.readClipboardTextForPaste()
-	if !ok || !m.isLongPastedText(clipboardText) {
-		return false
-	}
-	if !strings.HasPrefix(normalizeNewlines(clipboardText), fragment) {
+	if strings.TrimSpace(prefix) == "" || strings.TrimSpace(clipboardText) == "" {
 		return false
 	}
 	marker, content, err := m.compressPastedText(clipboardText)
@@ -930,16 +955,82 @@ func (m *model) tryStartImplicitClipboardPasteFromKey(msg tea.KeyMsg) bool {
 		m.statusNote = err.Error()
 		return false
 	}
+	base := m.input.Value()
+	if m.hiddenPasteProbe.active {
+		base = m.hiddenPasteProbe.baseInput
+	}
 	m.beginPasteTransaction(clipboardText, "clipboard-capture")
-	m.pasteTransaction.Consumed = len([]rune(fragment))
-	m.setInputValue(m.input.Value() + marker)
+	m.pasteTransaction.Consumed = len([]rune(prefix))
+	m.setInputValue(base + marker)
 	now := time.Now()
 	m.lastPasteAt = now
 	m.markPasteConfirmPending(now)
 	m.statusNote = fmt.Sprintf("Long pasted text (%d lines) compressed as %s. Use [Paste #%s], [Paste #%s line10], or [Paste #%s line10~line20].",
 		content.Lines, marker, content.ID, content.ID, content.ID)
 	m.syncInputOverlays()
+	m.clearHiddenPasteProbe()
 	return true
+}
+
+func (m *model) handleHiddenPasteProbeKey(msg tea.KeyMsg) (bool, tea.Cmd) {
+	if m == nil || !m.hiddenPasteProbe.active {
+		return false, nil
+	}
+	fragment, ok := pasteEchoFragmentFromKey(msg)
+	if !ok {
+		m.flushHiddenPasteProbeToInput()
+		return false, nil
+	}
+	fragment = normalizeNewlines(strings.ReplaceAll(fragment, ctrlVMarkerRune, ""))
+	if strings.TrimSpace(fragment) == "" {
+		m.flushHiddenPasteProbeToInput()
+		return false, nil
+	}
+	probe := m.hiddenPasteProbe
+	candidate := probe.buffered + fragment
+	clipboard := normalizeNewlines(probe.clipboard)
+	if !strings.HasPrefix(clipboard, candidate) {
+		m.flushHiddenPasteProbeToInput()
+		return false, nil
+	}
+	probe.buffered = candidate
+	probe.lastEventAt = time.Now()
+	probe.flushID++
+	m.hiddenPasteProbe = probe
+	if len([]rune(strings.TrimSpace(candidate))) >= 2 || strings.Contains(candidate, "\n") || strings.Contains(candidate, "\t") {
+		return m.commitImplicitClipboardPaste(candidate, probe.clipboard), nil
+	}
+	return true, scheduleHiddenPasteProbeFlush(probe.flushID)
+}
+
+func (m *model) tryStartImplicitClipboardPasteFromKey(msg tea.KeyMsg) tea.Cmd {
+	if m == nil || msg.Paste || m.hasActivePasteSession() || m.hasActivePasteBurst() || m.hiddenPasteProbe.active {
+		return nil
+	}
+	if msg.Type != tea.KeyRunes || len(msg.Runes) == 0 {
+		return nil
+	}
+	fragment := normalizeNewlines(strings.ReplaceAll(string(msg.Runes), ctrlVMarkerRune, ""))
+	if strings.TrimSpace(fragment) == "" {
+		return nil
+	}
+	clipboardText, ok := m.readClipboardTextForPaste()
+	if !ok || !m.isLongPastedText(clipboardText) {
+		return nil
+	}
+	if !strings.HasPrefix(normalizeNewlines(clipboardText), fragment) {
+		return nil
+	}
+	if len(msg.Runes) == 1 && !allowsImmediateSingleRuneClipboardCapture(m.input.Value(), fragment) {
+		return nil
+	}
+	if len(msg.Runes) == 1 {
+		return m.startHiddenPasteProbe(fragment, clipboardText)
+	}
+	if m.commitImplicitClipboardPaste(fragment, clipboardText) {
+		return func() tea.Msg { return nil }
+	}
+	return nil
 }
 
 func (m model) pasteFragmentFromKey(msg tea.KeyMsg) (string, string, bool) {
@@ -1157,8 +1248,12 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if m.tryStartImplicitClipboardPasteFromKey(msg) {
-		return m, nil
+	if handled, cmd := m.handleHiddenPasteProbeKey(msg); handled {
+		return m, cmd
+	}
+
+	if cmd := m.tryStartImplicitClipboardPasteFromKey(msg); cmd != nil {
+		return m, cmd
 	}
 
 	if m.shouldPromoteImplicitPasteCandidate(msg) {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -2663,6 +2663,94 @@ func TestHandleKeyCapturesImplicitClipboardRuneBurstBeforeVisibleInput(t *testin
 	}
 }
 
+func TestHandleKeyCapturesSingleMultibyteClipboardRuneBeforeVisibleInput(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboardRead = fakeClipboardTextReader{
+		text: strings.Join([]string{
+			"能、帮我看下这个仓库结构",
+			"给这段代码做 review",
+			"顺便看一下最近改动",
+			"补充下测试建议",
+			"最后总结风险点",
+		}, "\n"),
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("能")})
+	updated := got.(model)
+	if updated.input.Value() != "" {
+		t.Fatalf("expected single multibyte rune to stay hidden before confirmation, got %q", updated.input.Value())
+	}
+	if !updated.hiddenPasteProbe.active {
+		t.Fatalf("expected hidden paste probe to activate for single multibyte rune")
+	}
+	if updated.hiddenPasteProbe.buffered != "能" {
+		t.Fatalf("expected hidden paste probe to buffer the first rune, got %q", updated.hiddenPasteProbe.buffered)
+	}
+}
+
+func TestHiddenPasteProbeCommitsMarkerOnSecondMatchingRune(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboardRead = fakeClipboardTextReader{
+		text: strings.Join([]string{
+			"能、帮我看下这个仓库结构",
+			"给这段代码做 review",
+			"顺便看一下最近改动",
+			"补充下测试建议",
+			"最后总结风险点",
+		}, "\n"),
+	}
+
+	got, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("能")})
+	updated := got.(model)
+	if cmd == nil {
+		t.Fatalf("expected first hidden probe rune to schedule a flush command")
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("、")})
+	updated = got.(model)
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected second matching rune to commit marker without visible raw text, got %q", updated.input.Value())
+	}
+	if updated.hiddenPasteProbe.active {
+		t.Fatalf("expected hidden paste probe to clear after marker commit")
+	}
+	if !updated.pasteTransaction.Active || updated.pasteTransaction.Consumed != 2 {
+		t.Fatalf("expected marker commit to start transaction with consumed=2, got active=%v consumed=%d", updated.pasteTransaction.Active, updated.pasteTransaction.Consumed)
+	}
+}
+
+func TestHiddenPasteProbeFlushesBufferedRuneWhenNotConfirmed(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboardRead = fakeClipboardTextReader{
+		text: strings.Join([]string{
+			"能、帮我看下这个仓库结构",
+			"给这段代码做 review",
+			"顺便看一下最近改动",
+			"补充下测试建议",
+			"最后总结风险点",
+		}, "\n"),
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("能")})
+	updated := got.(model)
+	if !updated.hiddenPasteProbe.active {
+		t.Fatalf("expected hidden paste probe to activate")
+	}
+	flushID := updated.hiddenPasteProbe.flushID
+
+	got, _ = updated.Update(hiddenPasteProbeFlushMsg{ID: flushID})
+	flushed := got.(model)
+	if flushed.hiddenPasteProbe.active {
+		t.Fatalf("expected hidden paste probe to clear after flush")
+	}
+	if flushed.input.Value() != "能" {
+		t.Fatalf("expected buffered rune to flush into visible input, got %q", flushed.input.Value())
+	}
+}
+
 func TestTerminalPasteEventWithEmptyPayloadPastesClipboardImage(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -2663,6 +2663,23 @@ func TestHandleKeyCapturesImplicitClipboardRuneBurstBeforeVisibleInput(t *testin
 	}
 }
 
+func TestPasteBurstFragmentStartsPasteTransaction(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.pasteBurstActive = true
+	m.pasteBurstGeneration = 1
+	m.pasteBurstLastEventAt = time.Now()
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("tail")})
+	updated := got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected paste-burst fragment to start paste transaction")
+	}
+	if updated.pasteTransaction.Source != "paste-burst" {
+		t.Fatalf("expected paste-burst source, got %q", updated.pasteTransaction.Source)
+	}
+}
+
 func TestHandleKeyCapturesSingleMultibyteClipboardRuneBeforeVisibleInput(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat
@@ -2748,6 +2765,44 @@ func TestHiddenPasteProbeFlushesBufferedRuneWhenNotConfirmed(t *testing.T) {
 	}
 	if flushed.input.Value() != "能" {
 		t.Fatalf("expected buffered rune to flush into visible input, got %q", flushed.input.Value())
+	}
+}
+
+func TestImplicitClipboardProbeSkipsClipboardReadForSingleASCIIRune(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	calls := 0
+	m.clipboardRead = fakeClipboardTextReader{
+		text:  "alpha\nbeta\ngamma",
+		calls: &calls,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	updated := got.(model)
+	if calls != 0 {
+		t.Fatalf("expected single ASCII rune not to trigger clipboard read, got %d calls", calls)
+	}
+	if updated.input.Value() != "a" {
+		t.Fatalf("expected single ASCII rune to flow through normal input, got %q", updated.input.Value())
+	}
+}
+
+func TestImplicitClipboardProbeSkipsClipboardReadForShortASCIIBurst(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	calls := 0
+	m.clipboardRead = fakeClipboardTextReader{
+		text:  "alpha\nbeta\ngamma",
+		calls: &calls,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("ab")})
+	updated := got.(model)
+	if calls != 0 {
+		t.Fatalf("expected short ASCII burst not to trigger clipboard read, got %d calls", calls)
+	}
+	if updated.input.Value() != "ab" {
+		t.Fatalf("expected short ASCII burst to flow through normal input, got %q", updated.input.Value())
 	}
 }
 

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -2575,6 +2575,68 @@ func TestCtrlVWithoutImageShowsStatusNote(t *testing.T) {
 	}
 }
 
+func TestCtrlVTextTransactionIgnoresControlMarkerEcho(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboard = fakeClipboardImageReader{
+		err: errors.New("clipboard backend unavailable"),
+	}
+	m.clipboardRead = fakeClipboardTextReader{
+		text: strings.Join([]string{"echo line 1", "echo line 2", "echo line 3"}, "\n"),
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	updated := got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected ctrl+v text fallback to start paste transaction")
+	}
+	afterPaste := updated.input.Value()
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(afterPaste) {
+		t.Fatalf("expected ctrl+v text fallback to compress into marker, got %q", afterPaste)
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'\x16'}})
+	updated = got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected ctrl+v marker rune to be ignored without clearing transaction")
+	}
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected ctrl+v marker rune not to change input, got %q", updated.input.Value())
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	updated = got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected ctrl+v key event to be ignored without clearing transaction")
+	}
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected ctrl+v key event not to change input, got %q", updated.input.Value())
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("echo line 1")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("echo line 2")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("echo line 3")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected echoed ctrl+v stream to be consumed, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected echoed ctrl+v stream not to submit, got %d items", len(updated.chatItems))
+	}
+	if updated.pasteTransaction.Active {
+		t.Fatalf("expected transaction to clear after trailing enter echo is consumed")
+	}
+}
+
 func TestTerminalPasteEventWithEmptyPayloadPastesClipboardImage(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat
@@ -2787,6 +2849,94 @@ func TestSplitPastePayloadFinalizesIntoSingleMarker(t *testing.T) {
 	}
 	if len(finalized.chatItems) != 0 {
 		t.Fatalf("expected split paste payload not to auto submit, got %d items", len(finalized.chatItems))
+	}
+}
+
+func TestPasteMsgTransactionConsumesEchoedPlainKeyStream(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	longPaste := strings.Join([]string{"echo line 1", "echo line 2", "echo line 3"}, "\n")
+
+	got, _ := m.handlePastePayload(longPaste + "\n")
+	updated := got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected paste transaction to activate for paste payload")
+	}
+	afterPaste := updated.input.Value()
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(afterPaste) {
+		t.Fatalf("expected paste payload to compress into marker, got %q", afterPaste)
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("echo line 1")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("echo line 2")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("echo line 3")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected echoed paste stream to be consumed, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected echoed paste stream not to submit, got %d items", len(updated.chatItems))
+	}
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected paste transaction to stay active briefly to guard trailing enter echo")
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected trailing enter echo to be consumed, got %d items", len(updated.chatItems))
+	}
+	if updated.pasteTransaction.Active {
+		t.Fatalf("expected paste transaction to clear after trailing enter echo is consumed")
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected enter after transaction completion to submit")
+	}
+}
+
+func TestPasteKeyTransactionConsumesEchoedPlainKeyStream(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("title\nbody"), Paste: true})
+	updated := got.(model)
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected paste-key flow to activate paste transaction")
+	}
+	afterPaste := updated.input.Value()
+	if afterPaste != "title\nbody" {
+		t.Fatalf("expected paste-key flow to keep preview text visible, got %q", afterPaste)
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("title")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("body")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected echoed plain stream after paste-key boundary to be consumed, got %q", updated.input.Value())
+	}
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected echoed plain stream not to submit, got %d items", len(updated.chatItems))
+	}
+	if updated.pasteTransaction.Active {
+		t.Fatalf("expected paste transaction to clear after trailing enter echo is consumed")
 	}
 }
 
@@ -6352,21 +6502,27 @@ func TestCompressedPasteRequiresExplicitConfirmationBeforeSubmit(t *testing.T) {
 	}
 
 	got, _ = afterPaste.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	afterConfirm := got.(model)
-	if afterConfirm.pasteConfirmPending {
+	afterFirstEnter := got.(model)
+	if afterFirstEnter.pasteTransaction.Active {
+		t.Fatalf("expected first enter after compressed paste to close paste transaction")
+	}
+	if afterFirstEnter.pasteConfirmPending {
 		t.Fatalf("expected first enter after compressed paste to clear confirmation latch")
 	}
-	if len(afterConfirm.chatItems) != 0 {
-		t.Fatalf("expected first enter after compressed paste not to submit, got %d chat items", len(afterConfirm.chatItems))
+	if len(afterFirstEnter.chatItems) != 0 {
+		t.Fatalf("expected first enter after compressed paste not to submit, got %d chat items", len(afterFirstEnter.chatItems))
 	}
-	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(afterConfirm.input.Value()) {
-		t.Fatalf("expected compressed marker to remain after confirmation enter, got %q", afterConfirm.input.Value())
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(afterFirstEnter.input.Value()) {
+		t.Fatalf("expected compressed marker to remain after confirmation enter, got %q", afterFirstEnter.input.Value())
 	}
 
-	got, _ = afterConfirm.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	afterSubmit := got.(model)
-	if len(afterSubmit.chatItems) == 0 && !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]\s*$`).MatchString(afterSubmit.input.Value()) {
-		t.Fatalf("expected second enter either to submit or keep compressed marker state, got chat=%#v input=%q", afterSubmit.chatItems, afterSubmit.input.Value())
+	got, _ = afterFirstEnter.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	afterSecondEnter := got.(model)
+	if len(afterSecondEnter.chatItems) == 0 {
+		t.Fatalf("expected second enter after compressed paste to submit")
+	}
+	if !strings.Contains(afterSecondEnter.chatItems[0].Body, "[Paste #") {
+		t.Fatalf("expected submitted body to include compressed marker, got %q", afterSecondEnter.chatItems[0].Body)
 	}
 }
 
@@ -6522,8 +6678,8 @@ func TestBusyEnterDuringActivePasteBurstDoesNotQueueBTW(t *testing.T) {
 	if len(updated.chatItems) != 0 {
 		t.Fatalf("expected enter during active paste burst not to submit, got %#v", updated.chatItems)
 	}
-	if !updated.hasActivePasteSession() {
-		t.Fatalf("expected enter during active paste burst to stay inside paste session")
+	if updated.input.Value() == "" || !strings.HasPrefix(updated.input.Value(), "[Paste #") {
+		t.Fatalf("expected enter during active paste burst to preserve compressed paste marker, got %q", updated.input.Value())
 	}
 }
 

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -2637,6 +2637,32 @@ func TestCtrlVTextTransactionIgnoresControlMarkerEcho(t *testing.T) {
 	}
 }
 
+func TestHandleKeyCapturesImplicitClipboardRuneBurstBeforeVisibleInput(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.clipboardRead = fakeClipboardTextReader{
+		text: strings.Join([]string{
+			"能、帮我看下这个仓库结构",
+			"给这段代码做 review",
+			"顺便看一下最近改动",
+			"补充下测试建议",
+			"最后总结风险点",
+		}, "\n"),
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("能、")})
+	updated := got.(model)
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(updated.input.Value()) {
+		t.Fatalf("expected implicit clipboard rune burst to be captured before visible input, got %q", updated.input.Value())
+	}
+	if strings.Contains(updated.input.Value(), "能、") {
+		t.Fatalf("expected no visible rune-burst prefix, got %q", updated.input.Value())
+	}
+	if !updated.pasteTransaction.Active {
+		t.Fatalf("expected implicit clipboard rune burst to start paste transaction")
+	}
+}
+
 func TestTerminalPasteEventWithEmptyPayloadPastesClipboardImage(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat


### PR DESCRIPTION
﻿## 说明

这次 PR 主要修复 TUI 中长文本粘贴相关的三类回归问题：

1. 连续多次长文本粘贴时，已有 `[Paste #N ~X lines]` marker 前缀可能被后续隐式剪贴板捕获路径冲掉。
2. 长文本粘贴后，在用户没有主动提交的情况下，终端回显字符或 trailing `Enter` 可能被误判为真实提交，导致自动发送。
3. 在部分终端/输入法环境下，长文本渲染成占位符之前会短暂闪出前几个字符，中文双字符块场景更明显。

## 改动内容

- 修复隐式剪贴板捕获的 fallback 替换方向，确保已有 marker 前缀保留，只替换真正来自剪贴板的尾部内容。
- 恢复并重新接回 paste transaction 主链路：
  - `Ctrl+V` 文本路径显式开启 transaction
  - `paste-payload` / `paste-key` 路径重新建立或追加 transaction
  - 在按键处理前优先消费粘贴回显字符与 trailing `Enter`
- 在消费 trailing `Enter` 后同步释放本次粘贴的提交抑制，避免出现后续需要多次回车才能正常提交的问题。
- 提前捕获多字节双字符前缀，以及多 rune 的隐式剪贴板块，尽量在原始字符进入 textarea 之前直接渲染成 `[Paste #N ~X lines]` marker，减少可见闪烁。
- 补充回归测试，覆盖：
  - 连续多次长粘贴
  - `Ctrl+V` 文本回显与控制符回显
  - bracketed paste echoed stream
  - `paste-key` echoed stream
  - 中文双字符前缀场景
  - 隐式 clipboard rune burst 预拦截场景

## 验证

已运行：

```bash
go test ./tui -count=1
```

## 背景

这次修复是沿着之前成功的粘贴修复思路继续对齐的，重点把后来重构中被绕开的 paste transaction 保护重新接回当前架构。
