### PR TITLE
fix(tui): collapse parallel read tool cards

### DIFF
--- a/tui/component_conversation.go
+++ b/tui/component_conversation.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -283,14 +284,75 @@ func renderBytemindRunRow(items []chatEntry, width int) string {
 func renderBytemindRunCard(items []chatEntry, width int) string {
 	outer := resolveRunCardStyle(items)
 	contentWidth := max(8, width-outer.GetHorizontalFrameSize())
-	sections := make([]string, 0, len(items))
-	for i, item := range items {
+	sectionGroups := collapseRunSectionGroups(items)
+	sections := make([]string, 0, len(sectionGroups))
+	for i, group := range sectionGroups {
 		if i > 0 {
 			sections = append(sections, renderRunSectionDivider(contentWidth))
 		}
-		sections = append(sections, renderRunSection(item, contentWidth))
+		sections = append(sections, renderRunSectionGroup(group, contentWidth))
 	}
 	return outer.Width(contentWidth).Render(strings.Join(sections, "\n"))
+}
+
+func collapseRunSectionGroups(items []chatEntry) [][]chatEntry {
+	groups := make([][]chatEntry, 0, len(items))
+	for i := 0; i < len(items); {
+		item := items[i]
+		name, ok := collapsibleParallelToolName(item)
+		if !ok {
+			groups = append(groups, []chatEntry{item})
+			i++
+			continue
+		}
+
+		j := i + 1
+		group := []chatEntry{item}
+		for j < len(items) {
+			nextName, nextOK := collapsibleParallelToolName(items[j])
+			if !nextOK || nextName != name {
+				break
+			}
+			group = append(group, items[j])
+			j++
+		}
+		groups = append(groups, group)
+		i = j
+	}
+	return groups
+}
+
+func collapsibleParallelToolName(item chatEntry) (string, bool) {
+	if item.Kind != "tool" {
+		return "", false
+	}
+	_, name := toolDisplayParts(item.Title)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+	if toolDisplayLabel(name) != "READ" {
+		return "", false
+	}
+	return name, true
+}
+
+func renderRunSectionGroup(group []chatEntry, width int) string {
+	if len(group) == 0 {
+		return ""
+	}
+	if len(group) == 1 {
+		return renderRunSection(group[0], width)
+	}
+
+	_, name := toolDisplayParts(group[0].Title)
+	synthetic := chatEntry{
+		Kind:   "tool",
+		Title:  fmt.Sprintf("%s x %d | %s", toolDisplayLabel(name), len(group), name),
+		Body:   summarizeParallelToolGroup(group, name),
+		Status: aggregateToolGroupStatus(group),
+	}
+	return renderRunSection(synthetic, width)
 }
 
 func renderRunSection(item chatEntry, width int) string {
@@ -306,7 +368,76 @@ func renderRunSection(item chatEntry, width int) string {
 	return renderChatSection(item, width)
 }
 
+func summarizeParallelToolGroup(group []chatEntry, name string) string {
+	if len(group) == 0 {
+		return ""
+	}
+	if toolDisplayLabel(name) == "READ" {
+		return summarizeParallelReadGroup(group)
+	}
+	return fmt.Sprintf("%d parallel %s calls", len(group), strings.ToLower(toolDisplayLabel(name)))
+}
+
+func summarizeParallelReadGroup(group []chatEntry) string {
+	fileNames := make([]string, 0, len(group))
+	for _, item := range group {
+		summary := strings.TrimSpace(firstNonEmptyLine(item.Body))
+		if summary == "" {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(summary, "Read "))
+		if name == "" {
+			name = summary
+		}
+		fileNames = append(fileNames, name)
+	}
+	if len(fileNames) == 0 {
+		return fmt.Sprintf("Read %d files", len(group))
+	}
+	previewCount := min(3, len(fileNames))
+	preview := strings.Join(fileNames[:previewCount], ", ")
+	if len(fileNames) > previewCount {
+		return fmt.Sprintf("Read %d files: %s +%d", len(fileNames), preview, len(fileNames)-previewCount)
+	}
+	return fmt.Sprintf("Read %d files: %s", len(fileNames), preview)
+}
+
+func aggregateToolGroupStatus(group []chatEntry) string {
+	hasDone := false
+	hasRunning := false
+	hasWarn := false
+	for _, item := range group {
+		switch strings.TrimSpace(strings.ToLower(item.Status)) {
+		case "error", "failed":
+			return "error"
+		case "warn", "warning", "pending":
+			hasWarn = true
+		case "running", "active":
+			hasRunning = true
+		case "done", "success":
+			hasDone = true
+		}
+	}
+	switch {
+	case hasWarn:
+		return "warn"
+	case hasRunning:
+		return "running"
+	case hasDone:
+		return "done"
+	default:
+		return strings.TrimSpace(group[0].Status)
+	}
+}
+
 func renderRunSectionDivider(width int) string {
+	if width <= 0 {
+		return ""
+	}
+	return runSectionDividerStyle.Width(width).Render(strings.Repeat("-", width))
+}
+
+func renderRunSectionDividerLegacy(width int) string {
 	if width <= 0 {
 		return ""
 	}

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -198,3 +198,171 @@ func TestRenderBytemindRunCardDoesNotCollapseSeparatedReadTools(t *testing.T) {
 		t.Fatalf("expected separated read tools to remain distinct, got %q", view)
 	}
 }
+
+func TestCollapseRunSectionGroupsKeepsNonReadAndSplitsReadRuns(t *testing.T) {
+	items := []chatEntry{
+		{Kind: "assistant", Title: assistantLabel, Body: "Thinking", Status: "final"},
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read a.go", Status: "done"},
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read b.go", Status: "done"},
+		{Kind: "tool", Title: toolEntryTitle("list_files"), Body: "Listed files", Status: "done"},
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read c.go", Status: "done"},
+	}
+
+	groups := collapseRunSectionGroups(items)
+	if len(groups) != 4 {
+		t.Fatalf("expected 4 groups, got %d: %#v", len(groups), groups)
+	}
+	if len(groups[0]) != 1 || groups[0][0].Kind != "assistant" {
+		t.Fatalf("expected first group to keep non-tool item intact, got %#v", groups[0])
+	}
+	if len(groups[1]) != 2 {
+		t.Fatalf("expected adjacent read tools to collapse together, got %#v", groups[1])
+	}
+	if len(groups[2]) != 1 || !strings.Contains(groups[2][0].Title, "list_files") {
+		t.Fatalf("expected non-read tool to stay separate, got %#v", groups[2])
+	}
+	if len(groups[3]) != 1 || !strings.Contains(groups[3][0].Body, "Read c.go") {
+		t.Fatalf("expected trailing read tool to become its own group, got %#v", groups[3])
+	}
+}
+
+func TestCollapsibleParallelToolNameOnlyAcceptsReadTools(t *testing.T) {
+	tests := []struct {
+		name string
+		item chatEntry
+		ok   bool
+		want string
+	}{
+		{
+			name: "read tool",
+			item: chatEntry{Kind: "tool", Title: toolEntryTitle("read_file")},
+			ok:   true,
+			want: "read_file",
+		},
+		{
+			name: "non tool",
+			item: chatEntry{Kind: "assistant", Title: toolEntryTitle("read_file")},
+			ok:   false,
+		},
+		{
+			name: "empty tool name",
+			item: chatEntry{Kind: "tool", Title: "READ | "},
+			ok:   false,
+		},
+		{
+			name: "non read tool",
+			item: chatEntry{Kind: "tool", Title: toolEntryTitle("list_files")},
+			ok:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := collapsibleParallelToolName(tc.item)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("expected (%q, %v), got (%q, %v)", tc.want, tc.ok, got, ok)
+			}
+		})
+	}
+}
+
+func TestRenderRunSectionGroupSummariesAndStatuses(t *testing.T) {
+	if got := renderRunSectionGroup(nil, 60); got != "" {
+		t.Fatalf("expected empty group to render empty string, got %q", got)
+	}
+
+	single := renderRunSectionGroup([]chatEntry{
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read one.go", Status: "done"},
+	}, 60)
+	if !strings.Contains(stripANSI(single), "Read one.go") {
+		t.Fatalf("expected single group to render original section, got %q", single)
+	}
+
+	multiRead := stripANSI(renderRunSectionGroup([]chatEntry{
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read one.go", Status: "done"},
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read two.go", Status: "running"},
+	}, 80))
+	for _, want := range []string{"READ x 2", "Read 2 files: one.go, two.go", "running"} {
+		if !strings.Contains(strings.ToLower(multiRead), strings.ToLower(want)) {
+			t.Fatalf("expected grouped read render to contain %q, got %q", want, multiRead)
+		}
+	}
+
+	multiOther := stripANSI(renderRunSectionGroup([]chatEntry{
+		{Kind: "tool", Title: toolEntryTitle("list_files"), Body: "files", Status: "warn"},
+		{Kind: "tool", Title: toolEntryTitle("list_files"), Body: "more files", Status: "done"},
+	}, 80))
+	if !strings.Contains(multiOther, "2 parallel list calls") {
+		t.Fatalf("expected generic parallel summary, got %q", multiOther)
+	}
+	if !strings.Contains(strings.ToLower(multiOther), "warn") {
+		t.Fatalf("expected grouped status to prefer warn, got %q", multiOther)
+	}
+}
+
+func TestSummarizeParallelReadGroupAndAggregateStatusFallbacks(t *testing.T) {
+	if got := summarizeParallelReadGroup([]chatEntry{
+		{Kind: "tool", Body: ""},
+		{Kind: "tool", Body: "   "},
+	}); got != "Read 2 files" {
+		t.Fatalf("expected fallback read summary, got %q", got)
+	}
+
+	if got := summarizeParallelReadGroup([]chatEntry{
+		{Kind: "tool", Body: "Read a.go"},
+		{Kind: "tool", Body: "Read b.go"},
+		{Kind: "tool", Body: "Read c.go"},
+		{Kind: "tool", Body: "Read d.go"},
+	}); got != "Read 4 files: a.go, b.go, c.go +1" {
+		t.Fatalf("expected preview read summary, got %q", got)
+	}
+
+	if got := summarizeParallelToolGroup(nil, "read_file"); got != "" {
+		t.Fatalf("expected empty group summary to be empty, got %q", got)
+	}
+
+	if got := aggregateToolGroupStatus([]chatEntry{
+		{Status: "done"},
+		{Status: "failed"},
+	}); got != "error" {
+		t.Fatalf("expected failed tool group to map to error, got %q", got)
+	}
+
+	if got := aggregateToolGroupStatus([]chatEntry{
+		{Status: "active"},
+		{Status: "done"},
+	}); got != "running" {
+		t.Fatalf("expected active tool group to map to running, got %q", got)
+	}
+
+	if got := aggregateToolGroupStatus([]chatEntry{
+		{Status: "custom"},
+	}); got != "custom" {
+		t.Fatalf("expected unknown status to fall back to first entry status, got %q", got)
+	}
+}
+
+func TestRenderRunSectionDividerUsesAsciiHyphen(t *testing.T) {
+	if got := renderRunSectionDivider(0); got != "" {
+		t.Fatalf("expected zero-width divider to be empty, got %q", got)
+	}
+
+	got := stripANSI(renderRunSectionDivider(5))
+	if !strings.Contains(got, "-----") {
+		t.Fatalf("expected divider to use ascii hyphens, got %q", got)
+	}
+	if strings.Contains(got, "鈹€") {
+		t.Fatalf("expected divider not to use box-drawing glyphs, got %q", got)
+	}
+}
+
+func TestRenderRunSectionDividerLegacyUsesPreviousGlyph(t *testing.T) {
+	if got := renderRunSectionDividerLegacy(0); got != "" {
+		t.Fatalf("expected zero-width legacy divider to be empty, got %q", got)
+	}
+
+	got := stripANSI(renderRunSectionDividerLegacy(5))
+	if strings.Contains(got, "-----") {
+		t.Fatalf("expected legacy divider to differ from ascii fallback, got %q", got)
+	}
+}

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -166,3 +166,35 @@ func TestRenderConversationKeepsProgressBlueAndFinalNeutral(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderBytemindRunCardCollapsesConsecutiveReadTools(t *testing.T) {
+	view := stripANSI(renderBytemindRunCard([]chatEntry{
+		{Kind: "assistant", Title: thinkingLabel, Body: "Inspecting files", Status: "thinking"},
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read server.py\nrange: 1-20", Status: "done"},
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read index.html\nrange: 1-40", Status: "done"},
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read README.md\nrange: 1-80", Status: "done"},
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read faq.md\nrange: 1-50", Status: "done"},
+	}, 80))
+
+	if strings.Count(view, "READ x") != 1 {
+		t.Fatalf("expected consecutive read tools to collapse into one section, got %q", view)
+	}
+	if !strings.Contains(view, "READ x 4") {
+		t.Fatalf("expected collapsed read header with count, got %q", view)
+	}
+	if !strings.Contains(view, "Read 4 files: server.py, index.html, README.md +1") {
+		t.Fatalf("expected collapsed read summary, got %q", view)
+	}
+}
+
+func TestRenderBytemindRunCardDoesNotCollapseSeparatedReadTools(t *testing.T) {
+	view := stripANSI(renderBytemindRunCard([]chatEntry{
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read server.py", Status: "done"},
+		{Kind: "assistant", Title: assistantLabel, Body: "Using that result first", Status: "final"},
+		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read index.html", Status: "done"},
+	}, 80))
+
+	if strings.Count(view, "READ  ") != 2 {
+		t.Fatalf("expected separated read tools to remain distinct, got %q", view)
+	}
+}

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -366,7 +366,7 @@ var (
 				Background(semanticColors.Surface).
 				BorderLeft(true).
 				BorderForeground(semanticColors.Border).
-				Padding(0, 1)
+				Padding(0, 0)
 
 	runToolSuccessSectionStyle = runToolSectionStyle.Copy().
 					BorderForeground(semanticColors.Success)


### PR DESCRIPTION
## 变更说明
- 收紧 run card 内工具调用 section 的间距，减少连续工具卡片之间的空白感
- 将同一段 run 中连续出现的 `read_file` 工具调用收纳为一条聚合展示
- 聚合后的标题展示为 `READ x N`，正文展示读取文件数量和文件名摘要
- 保持串行场景不收纳：如果中间穿插 assistant 回复或其他工具调用，仍按原样逐条展示
- 补充 TUI 渲染测试，覆盖“连续 read 会收纳”和“隔开的 read 不会收纳”两种情况

## 测试
- `go test ./tui`
