### PR TITLE
fix(tui): show five slash commands per page

### DIFF
--- a/tui/component_palettes.go
+++ b/tui/component_palettes.go
@@ -83,8 +83,8 @@ func (m model) renderCommandPalette() string {
 	}
 
 	selected, _ := m.selectedCommandItem()
-	nameWidth := min(26, max(14, width/4))
-	descWidth := max(12, width-commandPaletteStyle.GetHorizontalFrameSize()-nameWidth-4)
+	nameWidth := min(22, max(12, width/5))
+	descWidth := max(12, width-commandPaletteStyle.GetHorizontalFrameSize()-nameWidth-3)
 	rows := make([]string, 0, commandPageSize+1)
 	for _, item := range m.visibleCommandItemsPage() {
 		rowStyle := commandPaletteRowStyle
@@ -99,7 +99,7 @@ func (m model) renderCommandPalette() string {
 		name := nameStyle.Width(nameWidth).Render(item.Usage)
 		desc := descStyle.Width(descWidth).Render(compact(item.Description, max(12, descWidth)))
 		rows = append(rows, rowStyle.Width(max(1, width-commandPaletteStyle.GetHorizontalFrameSize())).Render(
-			lipgloss.JoinHorizontal(lipgloss.Top, name, "  ", desc),
+			lipgloss.JoinHorizontal(lipgloss.Top, name, " ", desc),
 		))
 	}
 	for len(rows) < commandPageSize {

--- a/tui/model.go
+++ b/tui/model.go
@@ -35,7 +35,7 @@ const (
 	scrollStep                 = 3
 	scrollbarWidth             = 1
 	mouseZoneAutoProbeMaxDelta = 4
-	commandPageSize            = 3
+	commandPageSize            = 5
 	mentionPageSize            = 5
 	maxPendingBTW              = 5
 	promptSearchPageSize       = 5

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -3839,7 +3839,7 @@ func TestLandingViewRendersCommandPaletteAboveInput(t *testing.T) {
 	}
 }
 
-func TestCommandPaletteUsesCompactThreeRowList(t *testing.T) {
+func TestCommandPaletteUsesCompactFiveRowList(t *testing.T) {
 	input := textarea.New()
 	input.SetValue("/")
 	m := model{
@@ -3852,8 +3852,8 @@ func TestCommandPaletteUsesCompactThreeRowList(t *testing.T) {
 
 	m.syncCommandPalette()
 
-	if len(m.visibleCommandItemsPage()) != 3 {
-		t.Fatalf("expected command palette list height 3, got %d", len(m.visibleCommandItemsPage()))
+	if len(m.visibleCommandItemsPage()) != 5 {
+		t.Fatalf("expected command palette list height 5, got %d", len(m.visibleCommandItemsPage()))
 	}
 }
 
@@ -3865,6 +3865,7 @@ func TestCommandPaletteSupportsPageNavigation(t *testing.T) {
 		{Name: "/c", Usage: "/c", Description: "c"},
 		{Name: "/d", Usage: "/d", Description: "d"},
 		{Name: "/e", Usage: "/e", Description: "e"},
+		{Name: "/f", Usage: "/f", Description: "f"},
 	}
 	defer func() { commandItems = original }()
 
@@ -3880,12 +3881,12 @@ func TestCommandPaletteSupportsPageNavigation(t *testing.T) {
 
 	afterDown, _ := m.handleCommandPaletteKey(tea.KeyMsg{Type: tea.KeyPgDown})
 	downModel := afterDown.(model)
-	if downModel.commandCursor != 3 {
+	if downModel.commandCursor != 5 {
 		t.Fatalf("expected pgdown to move to next command page, got cursor %d", downModel.commandCursor)
 	}
 	page := downModel.visibleCommandItemsPage()
-	if len(page) == 0 || page[0].Name != "/d" {
-		t.Fatalf("expected second page to start with /d, got %+v", page)
+	if len(page) == 0 || page[0].Name != "/f" {
+		t.Fatalf("expected second page to start with /f, got %+v", page)
 	}
 
 	afterUp, _ := downModel.handleCommandPaletteKey(tea.KeyMsg{Type: tea.KeyPgUp})


### PR DESCRIPTION
## 背景

slash 命令选择框当前每页只展示 3 条，列表留白偏大，导致同一屏里能看到的命令偏少，浏览效率不高。

## 本次修改

- 将 slash 命令选择框的分页数量从 3 条调整为 5 条
- 收紧命令名与描述之间的横向间距，让列表更紧凑
- 同步更新相关 TUI 分页测试

## 验证

- `go test ./tui -run "TestCommandPaletteUsesCompactFiveRowList|TestCommandPaletteSupportsPageNavigation|TestComponentCommandAndMentionPaletteRenderStates" -v`
