### PR TITLE
fix: 修复 bytemind 在大目录中无法启动的问题

### DIFF
--- a/internal/app/entrypoint_test.go
+++ b/internal/app/entrypoint_test.go
@@ -77,8 +77,8 @@ func TestBootstrapCreatesSessionInWorkspace(t *testing.T) {
 		t.Fatal("expected bootstrap to return runner, store, and session")
 	}
 	sess := runtimeBundle.Session
-	if sess.Workspace != workspace {
-		t.Fatalf("expected workspace %q, got %q", workspace, sess.Workspace)
+	if normalizeExistingPath(sess.Workspace) != normalizeExistingPath(workspace) {
+		t.Fatalf("expected workspace %q, got %q", normalizeExistingPath(workspace), normalizeExistingPath(sess.Workspace))
 	}
 	if strings.TrimSpace(sess.ID) == "" {
 		t.Fatal("expected session id to be created")
@@ -107,8 +107,8 @@ func TestBootstrapEntrypointAllowsBroadWorkspaceWithoutOverride(t *testing.T) {
 	if runtimeBundle.Session == nil {
 		t.Fatal("expected session to be created")
 	}
-	if runtimeBundle.Session.Workspace != workspace {
-		t.Fatalf("expected workspace %q, got %q", workspace, runtimeBundle.Session.Workspace)
+	if normalizeExistingPath(runtimeBundle.Session.Workspace) != normalizeExistingPath(workspace) {
+		t.Fatalf("expected workspace %q, got %q", normalizeExistingPath(workspace), normalizeExistingPath(runtimeBundle.Session.Workspace))
 	}
 }
 

--- a/internal/app/entrypoint_test.go
+++ b/internal/app/entrypoint_test.go
@@ -85,7 +85,7 @@ func TestBootstrapCreatesSessionInWorkspace(t *testing.T) {
 	}
 }
 
-func TestBootstrapEntrypointRejectsBroadWorkspaceWithoutOverride(t *testing.T) {
+func TestBootstrapEntrypointAllowsBroadWorkspaceWithoutOverride(t *testing.T) {
 	workspace := t.TempDir()
 	for i := 0; i < DefaultBroadWorkspaceEntryThreshold; i++ {
 		path := filepath.Join(workspace, fmt.Sprintf("entry-%03d.tmp", i))
@@ -94,17 +94,21 @@ func TestBootstrapEntrypointRejectsBroadWorkspaceWithoutOverride(t *testing.T) {
 		}
 	}
 	t.Chdir(workspace)
+	t.Setenv("BYTEMIND_HOME", filepath.Join(workspace, ".bytemind-home"))
 
-	_, err := BootstrapEntrypoint(EntrypointRequest{
+	runtimeBundle, err := BootstrapEntrypoint(EntrypointRequest{
 		RequireAPIKey: false,
 		Stdin:         strings.NewReader(""),
 		Stdout:        &bytes.Buffer{},
 	})
-	if err == nil {
-		t.Fatal("expected broad workspace error")
+	if err != nil {
+		t.Fatalf("expected broad workspace to be allowed, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "too broad for default workspace") {
-		t.Fatalf("unexpected error: %v", err)
+	if runtimeBundle.Session == nil {
+		t.Fatal("expected session to be created")
+	}
+	if runtimeBundle.Session.Workspace != workspace {
+		t.Fatalf("expected workspace %q, got %q", workspace, runtimeBundle.Session.Workspace)
 	}
 }
 

--- a/internal/app/workspace.go
+++ b/internal/app/workspace.go
@@ -51,9 +51,6 @@ func ResolveWorkspace(workspaceOverride string) (string, error) {
 	if projectRoot := DetectProjectRoot(cwd); projectRoot != "" {
 		return projectRoot, nil
 	}
-	if IsBroadWorkspacePath(cwd) {
-		return "", fmt.Errorf("current directory %s is too broad for default workspace; rerun with -workspace <project-dir> (or set BYTEMIND_ALLOW_BROAD_WORKSPACE=true)", cwd)
-	}
 	return cwd, nil
 }
 

--- a/internal/app/workspace_test.go
+++ b/internal/app/workspace_test.go
@@ -87,8 +87,8 @@ func TestResolveWorkspaceUsesCurrentDirectoryWhenBroadAndNoProjectMarker(t *test
 	if err != nil {
 		t.Fatalf("expected broad current directory to be allowed, got %v", err)
 	}
-	if got != dir {
-		t.Fatalf("expected workspace %q, got %q", dir, got)
+	if normalizeExistingPath(got) != normalizeExistingPath(dir) {
+		t.Fatalf("expected workspace %q, got %q", normalizeExistingPath(dir), normalizeExistingPath(got))
 	}
 }
 

--- a/internal/app/workspace_test.go
+++ b/internal/app/workspace_test.go
@@ -65,6 +65,33 @@ func TestResolveWorkspaceAutoDetectsProjectRoot(t *testing.T) {
 	}
 }
 
+func TestResolveWorkspaceUsesCurrentDirectoryWhenBroadAndNoProjectMarker(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < DefaultBroadWorkspaceEntryThreshold; i++ {
+		if err := os.Mkdir(filepath.Join(dir, fmt.Sprintf("entry-%03d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveWorkspace("")
+	if err != nil {
+		t.Fatalf("expected broad current directory to be allowed, got %v", err)
+	}
+	if got != dir {
+		t.Fatalf("expected workspace %q, got %q", dir, got)
+	}
+}
+
 func TestIsBroadWorkspacePathWithHomeFlagsKnownBroadRoots(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "home")
 	for _, dir := range []string{


### PR DESCRIPTION
﻿## 背景

当前 `bytemind` 在未显式传入 `-workspace` 时，会先尝试自动推断 workspace。若当前目录被判定为 "broad workspace"（例如盘符根目录、用户主目录，或目录项较多的目录），程序会直接报错退出：

```text
current directory ... is too broad for default workspace
```

这会导致用户在一些常见目录下甚至无法正常启动 `bytemind`，启动阶段的阻塞感会明显高于它带来的保护价值。

## 本次修改

- 保留现有的项目根自动探测逻辑
- 如果当前目录向上可以探测到项目根，仍然优先使用项目根作为 workspace
- 如果探测不到项目根，则直接使用当前目录作为默认 workspace
- 不再因为目录被判定为 broad workspace 而在启动阶段直接拒绝运行

## 预期收益

- 修复 `bytemind` 在大目录中无法启动的问题
- 让 CLI/TUI 的默认行为更符合用户直觉：从哪里启动，就默认以哪里作为工作区
- 保留项目目录下的自动收敛能力，不影响已有的项目根识别体验

## 测试

已运行：

```bash
go test ./internal/app -v
```

并进行了冒烟验证：

- 在 `E:\` 目录下执行 `bytemind mcp list`，不再出现 `too broad for default workspace` 报错
- 在大目录场景下可以正常进入启动流程
