### PR TITLE
refactor: 解决大目录下打开遍历目录卡死问题

### DIFF
--- a/internal/app/entrypoint_test.go
+++ b/internal/app/entrypoint_test.go
@@ -77,15 +77,15 @@ func TestBootstrapCreatesSessionInWorkspace(t *testing.T) {
 		t.Fatal("expected bootstrap to return runner, store, and session")
 	}
 	sess := runtimeBundle.Session
-	if sess.Workspace != workspace {
-		t.Fatalf("expected workspace %q, got %q", workspace, sess.Workspace)
+	if normalizeExistingPath(sess.Workspace) != normalizeExistingPath(workspace) {
+		t.Fatalf("expected workspace %q, got %q", normalizeExistingPath(workspace), normalizeExistingPath(sess.Workspace))
 	}
 	if strings.TrimSpace(sess.ID) == "" {
 		t.Fatal("expected session id to be created")
 	}
 }
 
-func TestBootstrapEntrypointRejectsBroadWorkspaceWithoutOverride(t *testing.T) {
+func TestBootstrapEntrypointAllowsBroadWorkspaceWithoutOverride(t *testing.T) {
 	workspace := t.TempDir()
 	for i := 0; i < DefaultBroadWorkspaceEntryThreshold; i++ {
 		path := filepath.Join(workspace, fmt.Sprintf("entry-%03d.tmp", i))
@@ -94,6 +94,32 @@ func TestBootstrapEntrypointRejectsBroadWorkspaceWithoutOverride(t *testing.T) {
 		}
 	}
 	t.Chdir(workspace)
+	t.Setenv("BYTEMIND_HOME", filepath.Join(workspace, ".bytemind-home"))
+
+	runtimeBundle, err := BootstrapEntrypoint(EntrypointRequest{
+		RequireAPIKey: false,
+		Stdin:         strings.NewReader(""),
+		Stdout:        &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatalf("expected broad workspace to be allowed, got %v", err)
+	}
+	if runtimeBundle.Session == nil {
+		t.Fatal("expected session to be created")
+	}
+	if normalizeExistingPath(runtimeBundle.Session.Workspace) != normalizeExistingPath(workspace) {
+		t.Fatalf("expected workspace %q, got %q", normalizeExistingPath(workspace), normalizeExistingPath(runtimeBundle.Session.Workspace))
+	}
+}
+
+func TestBootstrapEntrypointRejectsHighRiskHomeWithoutOverride(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "home")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(workspace)
+	t.Setenv("HOME", workspace)
+	t.Setenv("USERPROFILE", "")
 
 	_, err := BootstrapEntrypoint(EntrypointRequest{
 		RequireAPIKey: false,
@@ -101,7 +127,7 @@ func TestBootstrapEntrypointRejectsBroadWorkspaceWithoutOverride(t *testing.T) {
 		Stdout:        &bytes.Buffer{},
 	})
 	if err == nil {
-		t.Fatal("expected broad workspace error")
+		t.Fatal("expected high-risk workspace error")
 	}
 	if !strings.Contains(err.Error(), "too broad for default workspace") {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/app/workspace.go
+++ b/internal/app/workspace.go
@@ -51,7 +51,7 @@ func ResolveWorkspace(workspaceOverride string) (string, error) {
 	if projectRoot := DetectProjectRoot(cwd); projectRoot != "" {
 		return projectRoot, nil
 	}
-	if IsBroadWorkspacePath(cwd) {
+	if IsHighRiskWorkspacePath(cwd) {
 		return "", fmt.Errorf("current directory %s is too broad for default workspace; rerun with -workspace <project-dir> (or set BYTEMIND_ALLOW_BROAD_WORKSPACE=true)", cwd)
 	}
 	return cwd, nil
@@ -88,11 +88,29 @@ func hasProjectMarker(dir string) bool {
 }
 
 func IsBroadWorkspacePath(dir string) bool {
-	if value := strings.TrimSpace(os.Getenv("BYTEMIND_ALLOW_BROAD_WORKSPACE")); value != "" {
-		if parsed, err := strconv.ParseBool(value); err == nil && parsed {
-			return false
-		}
+	if allowBroadWorkspace() {
+		return false
 	}
+	return IsBroadWorkspacePathWithHome(dir, workspaceRiskHome())
+}
+
+func IsHighRiskWorkspacePath(dir string) bool {
+	if allowBroadWorkspace() {
+		return false
+	}
+	return IsHighRiskWorkspacePathWithHome(dir, workspaceRiskHome())
+}
+
+func allowBroadWorkspace() bool {
+	value := strings.TrimSpace(os.Getenv("BYTEMIND_ALLOW_BROAD_WORKSPACE"))
+	if value == "" {
+		return false
+	}
+	parsed, err := strconv.ParseBool(value)
+	return err == nil && parsed
+}
+
+func workspaceRiskHome() string {
 	home := strings.TrimSpace(os.Getenv("HOME"))
 	if home == "" {
 		home = strings.TrimSpace(os.Getenv("USERPROFILE"))
@@ -100,10 +118,22 @@ func IsBroadWorkspacePath(dir string) bool {
 	if home == "" {
 		home, _ = os.UserHomeDir()
 	}
-	return IsBroadWorkspacePathWithHome(dir, home)
+	return home
 }
 
 func IsBroadWorkspacePathWithHome(dir, home string) bool {
+	if IsHighRiskWorkspacePathWithHome(dir, home) {
+		return true
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	return len(entries) >= DefaultBroadWorkspaceEntryThreshold
+}
+
+func IsHighRiskWorkspacePathWithHome(dir, home string) bool {
 	dir = filepath.Clean(strings.TrimSpace(dir))
 	if dir == "" {
 		return false
@@ -126,11 +156,7 @@ func IsBroadWorkspacePathWithHome(dir, home string) bool {
 		}
 	}
 
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	return len(entries) >= DefaultBroadWorkspaceEntryThreshold
+	return false
 }
 
 func IsFilesystemRoot(path string) bool {

--- a/internal/app/workspace_test.go
+++ b/internal/app/workspace_test.go
@@ -65,6 +65,88 @@ func TestResolveWorkspaceAutoDetectsProjectRoot(t *testing.T) {
 	}
 }
 
+func TestResolveWorkspaceUsesCurrentDirectoryWhenBroadAndNoProjectMarker(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < DefaultBroadWorkspaceEntryThreshold; i++ {
+		if err := os.Mkdir(filepath.Join(dir, fmt.Sprintf("entry-%03d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveWorkspace("")
+	if err != nil {
+		t.Fatalf("expected broad current directory to be allowed, got %v", err)
+	}
+	if normalizeExistingPath(got) != normalizeExistingPath(dir) {
+		t.Fatalf("expected workspace %q, got %q", normalizeExistingPath(dir), normalizeExistingPath(got))
+	}
+}
+
+func TestResolveWorkspaceRejectsHighRiskHomeWithoutOverride(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", "")
+	if err := os.Chdir(home); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ResolveWorkspace("")
+	if err == nil {
+		t.Fatal("expected high-risk home workspace to be rejected")
+	}
+	if !strings.Contains(err.Error(), "too broad for default workspace") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveWorkspaceAllowsHighRiskHomeWithEnvOptIn(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("BYTEMIND_ALLOW_BROAD_WORKSPACE", "true")
+	if err := os.Chdir(home); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveWorkspace("")
+	if err != nil {
+		t.Fatalf("expected opt-in to allow high-risk workspace, got %v", err)
+	}
+	if normalizeExistingPath(got) != normalizeExistingPath(home) {
+		t.Fatalf("expected workspace %q, got %q", normalizeExistingPath(home), normalizeExistingPath(got))
+	}
+}
+
 func TestIsBroadWorkspacePathWithHomeFlagsKnownBroadRoots(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "home")
 	for _, dir := range []string{
@@ -82,6 +164,24 @@ func TestIsBroadWorkspacePathWithHomeFlagsKnownBroadRoots(t *testing.T) {
 	}
 }
 
+func TestIsHighRiskWorkspacePathWithHomeFlagsKnownRoots(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	for _, dir := range []string{
+		filesystemRootForTest(home),
+		home,
+		filepath.Join(home, "Desktop"),
+		filepath.Join(home, "Documents"),
+		filepath.Join(home, "Downloads"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if !IsHighRiskWorkspacePathWithHome(dir, home) {
+			t.Fatalf("expected %q to be treated as high-risk workspace", dir)
+		}
+	}
+}
+
 func TestIsBroadWorkspacePathWithHomeFlagsLargeDirectory(t *testing.T) {
 	dir := t.TempDir()
 	for i := 0; i < DefaultBroadWorkspaceEntryThreshold; i++ {
@@ -91,6 +191,18 @@ func TestIsBroadWorkspacePathWithHomeFlagsLargeDirectory(t *testing.T) {
 	}
 	if !IsBroadWorkspacePathWithHome(dir, "") {
 		t.Fatalf("expected directory with %d entries to be broad", DefaultBroadWorkspaceEntryThreshold)
+	}
+}
+
+func TestIsHighRiskWorkspacePathWithHomeAllowsOrdinaryLargeDirectory(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < DefaultBroadWorkspaceEntryThreshold; i++ {
+		if err := os.Mkdir(filepath.Join(dir, fmt.Sprintf("entry-%03d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if IsHighRiskWorkspacePathWithHome(dir, "") {
+		t.Fatalf("did not expect ordinary large directory %q to be high-risk", dir)
 	}
 }
 
@@ -142,4 +254,12 @@ func pathWithinRoot(path, root string) bool {
 		return true
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func filesystemRootForTest(path string) string {
+	volume := filepath.VolumeName(path)
+	if volume == "" {
+		return string(filepath.Separator)
+	}
+	return volume + string(filepath.Separator)
 }

--- a/internal/mention/index.go
+++ b/internal/mention/index.go
@@ -23,8 +23,11 @@ const (
 )
 
 var (
-	mentionIndexRefreshInterval = 10 * time.Second
-	mentionIndexDefaultMaxFiles = 6000
+	mentionIndexRefreshInterval    = 10 * time.Second
+	mentionIndexDefaultMaxFiles    = 6000
+	mentionIndexDefaultMaxVisits   = 25000
+	mentionIndexDefaultMaxDirs     = 5000
+	mentionIndexDefaultMaxDuration = 750 * time.Millisecond
 )
 
 type Token struct {
@@ -287,9 +290,15 @@ func buildMentionIndex(root string, maxFiles int, matcher mentionIgnoreMatcher) 
 	if maxFiles <= 0 {
 		maxFiles = mentionIndexDefaultMaxFiles
 	}
+	maxVisits := mentionMaxVisitsFromEnv()
+	maxDirs := mentionMaxDirsFromEnv()
+	maxDuration := mentionMaxDurationFromEnv()
+	started := time.Now()
 
 	files := make([]Candidate, 0, minInt(maxFiles, 512))
 	truncated := false
+	visits := 0
+	dirs := 0
 	_ = filepath.WalkDir(root, func(pathAbs string, d fs.DirEntry, err error) error {
 		if err != nil {
 			if d != nil && d.IsDir() {
@@ -299,6 +308,15 @@ func buildMentionIndex(root string, maxFiles int, matcher mentionIgnoreMatcher) 
 		}
 		if pathAbs == root {
 			return nil
+		}
+		visits++
+		if visits > maxVisits {
+			truncated = true
+			return fs.SkipAll
+		}
+		if maxDuration > 0 && time.Since(started) > maxDuration {
+			truncated = true
+			return fs.SkipAll
 		}
 
 		rel, relErr := filepath.Rel(root, pathAbs)
@@ -312,6 +330,11 @@ func buildMentionIndex(root string, maxFiles int, matcher mentionIgnoreMatcher) 
 		name := d.Name()
 
 		if d.IsDir() {
+			dirs++
+			if dirs > maxDirs {
+				truncated = true
+				return fs.SkipAll
+			}
 			if shouldSkipMentionDir(name) || matcher.SkipDir(name, rel) {
 				return filepath.SkipDir
 			}
@@ -718,6 +741,42 @@ func mentionMaxFilesFromEnv() int {
 		return mentionIndexDefaultMaxFiles
 	}
 	return n
+}
+
+func mentionMaxVisitsFromEnv() int {
+	raw := strings.TrimSpace(os.Getenv("BYTEMIND_MENTION_MAX_VISITS"))
+	if raw == "" {
+		return mentionIndexDefaultMaxVisits
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return mentionIndexDefaultMaxVisits
+	}
+	return n
+}
+
+func mentionMaxDirsFromEnv() int {
+	raw := strings.TrimSpace(os.Getenv("BYTEMIND_MENTION_MAX_DIRS"))
+	if raw == "" {
+		return mentionIndexDefaultMaxDirs
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return mentionIndexDefaultMaxDirs
+	}
+	return n
+}
+
+func mentionMaxDurationFromEnv() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("BYTEMIND_MENTION_MAX_DURATION_MS"))
+	if raw == "" {
+		return mentionIndexDefaultMaxDuration
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return mentionIndexDefaultMaxDuration
+	}
+	return time.Duration(n) * time.Millisecond
 }
 
 func FindActiveToken(input string) (Token, bool) {

--- a/internal/mention/index_test.go
+++ b/internal/mention/index_test.go
@@ -286,6 +286,38 @@ func TestWorkspaceFileIndexRespectsMaxFilesLimitFromEnv(t *testing.T) {
 	}
 }
 
+func TestWorkspaceFileIndexStopsWhenVisitBudgetExceeded(t *testing.T) {
+	workspace := t.TempDir()
+	for i := 0; i < 5; i++ {
+		mustWriteMentionFile(t, filepath.Join(workspace, string(rune('a'+i))+".go"), "package main")
+	}
+	t.Setenv("BYTEMIND_MENTION_MAX_VISITS", "2")
+
+	index := NewWorkspaceFileIndex(workspace)
+	results := index.Search("", 50)
+	if len(results) != 2 {
+		t.Fatalf("expected visit-limited result count 2, got %d (%#v)", len(results), results)
+	}
+	stats := index.Stats()
+	if !stats.Truncated {
+		t.Fatalf("expected stats to mark index as truncated")
+	}
+}
+
+func TestWorkspaceFileIndexStopsWhenDirectoryBudgetExceeded(t *testing.T) {
+	workspace := t.TempDir()
+	mustWriteMentionFile(t, filepath.Join(workspace, "a", "one.go"), "package main")
+	mustWriteMentionFile(t, filepath.Join(workspace, "b", "two.go"), "package main")
+	t.Setenv("BYTEMIND_MENTION_MAX_DIRS", "1")
+
+	index := NewWorkspaceFileIndex(workspace)
+	_ = index.Search("", 50)
+	stats := index.Stats()
+	if !stats.Truncated {
+		t.Fatalf("expected directory budget to truncate index")
+	}
+}
+
 func TestWorkspaceFileIndexRebuildsAfterRefreshInterval(t *testing.T) {
 	workspace := t.TempDir()
 	mustWriteMentionFile(t, filepath.Join(workspace, "a.txt"), "a")
@@ -337,6 +369,23 @@ func TestMentionMaxFilesFromEnvFallbacks(t *testing.T) {
 	t.Setenv("BYTEMIND_MENTION_MAX_FILES", "0")
 	if got := mentionMaxFilesFromEnv(); got != mentionIndexDefaultMaxFiles {
 		t.Fatalf("expected non-positive env to use default max files, got %d", got)
+	}
+}
+
+func TestMentionBudgetEnvFallbacks(t *testing.T) {
+	t.Setenv("BYTEMIND_MENTION_MAX_VISITS", "abc")
+	if got := mentionMaxVisitsFromEnv(); got != mentionIndexDefaultMaxVisits {
+		t.Fatalf("expected invalid visit budget to use default, got %d", got)
+	}
+
+	t.Setenv("BYTEMIND_MENTION_MAX_DIRS", "0")
+	if got := mentionMaxDirsFromEnv(); got != mentionIndexDefaultMaxDirs {
+		t.Fatalf("expected non-positive dir budget to use default, got %d", got)
+	}
+
+	t.Setenv("BYTEMIND_MENTION_MAX_DURATION_MS", "-1")
+	if got := mentionMaxDurationFromEnv(); got != mentionIndexDefaultMaxDuration {
+		t.Fatalf("expected invalid duration budget to use default, got %s", got)
 	}
 }
 

--- a/internal/tools/search_text.go
+++ b/internal/tools/search_text.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/1024XEngineer/bytemind/internal/llm"
 )
@@ -42,6 +43,8 @@ type searchTextScanStats struct {
 
 var searchTextLookPath = exec.LookPath
 var searchTextCommand = exec.CommandContext
+
+const defaultSearchTextRipgrepTimeout = 5 * time.Second
 
 func (SearchTextTool) Definition() llm.ToolDefinition {
 	return llm.ToolDefinition{
@@ -151,7 +154,7 @@ func searchTextWithRipgrep(ctx context.Context, args searchTextArgs, workspace, 
 		searchBase = filepath.Dir(root)
 	}
 
-	rgCtx, cancel := context.WithCancel(ctx)
+	rgCtx, cancel := context.WithTimeout(ctx, searchTextRipgrepTimeout())
 	defer cancel()
 
 	commandArgs := []string{
@@ -238,11 +241,14 @@ func searchTextWithRipgrep(ctx context.Context, args searchTextArgs, workspace, 
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, false, "", true, ctxErr
 	}
-	if scanErr != nil {
-		return nil, false, "", false, nil
-	}
 	if truncated {
 		return matches, true, reason, true, nil
+	}
+	if errors.Is(rgCtx.Err(), context.DeadlineExceeded) {
+		return matches, true, "timeout", true, nil
+	}
+	if scanErr != nil {
+		return nil, false, "", false, nil
 	}
 	if waitErr != nil {
 		var exitErr *exec.ExitError
@@ -359,6 +365,11 @@ func searchTextCanUseRipgrepBudgets() bool {
 		maxSearchTextFiles() == defaultSearchTextMaxFiles &&
 		maxSearchTextBytes() == defaultSearchTextMaxBytes &&
 		maxSearchTextFileBytes() == defaultSearchTextMaxFileBytes
+}
+
+func searchTextRipgrepTimeout() time.Duration {
+	timeoutMS := positiveEnvInt("BYTEMIND_SEARCH_RG_TIMEOUT_MS", int(defaultSearchTextRipgrepTimeout/time.Millisecond))
+	return time.Duration(timeoutMS) * time.Millisecond
 }
 
 func normalizeRipgrepPath(workspace, base, raw string) string {

--- a/internal/tools/search_text_test.go
+++ b/internal/tools/search_text_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+	"time"
 )
 
 func TestSearchTextToolFindsMatchesCaseInsensitiveAndSkipsHiddenDirsAndBinary(t *testing.T) {
@@ -175,6 +176,18 @@ func TestSearchTextCanUseRipgrepBudgetsDisabledByEnvOverride(t *testing.T) {
 	t.Setenv("BYTEMIND_SEARCH_MAX_FILES", "1")
 	if searchTextCanUseRipgrepBudgets() {
 		t.Fatal("expected ripgrep path to be disabled when custom budgets are configured")
+	}
+}
+
+func TestSearchTextRipgrepTimeoutFromEnv(t *testing.T) {
+	t.Setenv("BYTEMIND_SEARCH_RG_TIMEOUT_MS", "25")
+	if got := searchTextRipgrepTimeout(); got != 25*time.Millisecond {
+		t.Fatalf("expected 25ms timeout, got %s", got)
+	}
+
+	t.Setenv("BYTEMIND_SEARCH_RG_TIMEOUT_MS", "invalid")
+	if got := searchTextRipgrepTimeout(); got != defaultSearchTextRipgrepTimeout {
+		t.Fatalf("expected invalid timeout to use default, got %s", got)
 	}
 }
 


### PR DESCRIPTION
**继续解决 #328问题**
## 解决思路
### 继续拦截高风险目录
C:\、/、用户 HOME、Desktop、Downloads、Documents 这类目录默认仍然拒绝，除非用户显式 opt-in：
if IsHighRiskWorkspacePath(cwd) {
    return "", fmt.Errorf("current directory %s is too broad; rerun with -workspace <project-dir> or set BYTEMIND_ALLOW_BROAD_WORKSPACE=true", cwd)
}
### 普通“大目录”允许启动
以前 len(os.ReadDir(dir)) >= 300 这种 entry-count 判断不要作为启动失败条件，只作为 warning / stats。这样能解决“在大目录无法启动”的问题，又不会默认把 C 盘作为 workspace。

### 把保护下沉到扫描操作
重点优化 internal/mention/index.go：
现在 mention 索引用 WalkDir，只有 maxFiles=6000，缺少 maxVisits/maxDirs/maxDuration。建议加：

BYTEMIND_MENTION_MAX_VISITS
BYTEMIND_MENTION_MAX_DIRS
BYTEMIND_MENTION_MAX_DURATION_MS
超预算就 truncated=true，返回部分索引，不阻塞启动
### 给搜索加超时
internal/tools/search_text.go fallback walk 已经有预算，但 ripgrep 分支如果在大根目录且无匹配，仍可能扫很久。给 rg 加默认 timeout，例如 3-5 秒，超时返回 partial/truncated。

## 具体做法：
- internal/app/workspace.go：普通“大目录”不再启动失败，但盘符根目录、HOME、Desktop/Documents/Downloads 这类高风险目录仍默认拒绝，可用 BYTEMIND_ALLOW_BROAD_WORKSPACE=true 显式放开。
- internal/mention/index.go：mention 文件索引增加 max visits / max dirs / max duration 预算，避免类似 C 盘遍历卡死。
- internal/tools/search_text.go：ripgrep 搜索增加默认 5s 超时，可用 BYTEMIND_SEARCH_RG_TIMEOUT_MS 调整。
补了对应测试，覆盖普通大目录允许、高风险目录拒绝、mention 预算截断、rg 超时配置。