### PR TITLE
refactor(ui): 对主界面进行优化

### DIFF
--- a/internal/app/tui_run_test.go
+++ b/internal/app/tui_run_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestRunTUIBuildsOptionsAndInvokesProgram(t *testing.T) {
+	withAppVersion(t, "v7.8.9", "")
 	workspace := t.TempDir()
 	t.Chdir(workspace)
 	writeTUIRunTestConfig(t, workspace, map[string]any{
@@ -37,6 +38,9 @@ func TestRunTUIBuildsOptionsAndInvokesProgram(t *testing.T) {
 		}
 		if opts.Workspace != workspace {
 			t.Fatalf("expected workspace %q, got %q", workspace, opts.Workspace)
+		}
+		if opts.Version != "v7.8.9" {
+			t.Fatalf("expected app version to pass through, got %q", opts.Version)
 		}
 		if opts.Config.Provider.Model != "gpt-5.4" {
 			t.Fatalf("expected model override to apply, got %q", opts.Config.Provider.Model)

--- a/internal/app/tui_runtime.go
+++ b/internal/app/tui_runtime.go
@@ -109,6 +109,7 @@ func BuildTUIRuntime(req TUIRequest) (TUIRuntime, error) {
 			ImageStore:   imageStore,
 			Config:       cfg,
 			Workspace:    runtimeBundle.Session.Workspace,
+			Version:      CurrentVersion(),
 			StartupGuide: guide,
 		},
 		close: runner.Close,

--- a/tui/app.go
+++ b/tui/app.go
@@ -20,6 +20,7 @@ type Options struct {
 	ImageStore   assets.ImageStore
 	Config       config.Config
 	Workspace    string
+	Version      string
 	StartupGuide StartupGuide
 }
 

--- a/tui/component_input.go
+++ b/tui/component_input.go
@@ -26,9 +26,9 @@ func (m model) landingInputShellWidth() int {
 func (m model) modeAccentColor() lipgloss.Color {
 	if m.screen == screenLanding {
 		if m.mode == modePlan {
-			return lipgloss.Color("#A9C6E8")
+			return lipgloss.Color(landingPlanAccent)
 		}
-		return lipgloss.Color("#4CB7FF")
+		return lipgloss.Color(landingBuildAccent)
 	}
 	if m.mode == modePlan {
 		return colorThinking

--- a/tui/component_input.go
+++ b/tui/component_input.go
@@ -8,13 +8,15 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+const landingInputPlaceholder = "Ask anything, or type / for commands..."
+
 func (m model) landingInputShellWidth() int {
 	if m.width <= 0 {
 		return 52
 	}
 	maxFit := max(1, m.width-16)
-	preferred := max(58, (m.width*2)/3)
-	maxPreferred := 104
+	preferred := max(landingStableHeroWidth(), (m.width*2)/3)
+	maxPreferred := max(104, landingStableHeroWidth())
 	if maxFit < 52 {
 		return maxFit
 	}
@@ -53,7 +55,7 @@ func (m *model) syncInputStyle() {
 	if m.startupGuide.Active {
 		m.input.Placeholder = startupGuideInputPlaceholder(m.startupGuide.CurrentField)
 	} else if m.screen == screenLanding {
-		m.input.Placeholder = "Let's get started..."
+		m.input.Placeholder = landingInputPlaceholder
 	} else {
 		m.input.Placeholder = "Ask Bytemind to inspect, change, or verify this workspace..."
 	}

--- a/tui/component_landing.go
+++ b/tui/component_landing.go
@@ -28,7 +28,7 @@ func (m model) renderLandingHero() string {
 	dotMutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#455C71"))
 	dotActiveStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#64DF69"))
 
-	headerHost := headerHostStyle.Render("bytemind@localhost:~")
+	headerHost := headerHostStyle.Render(landingWorkspaceName(m.workspace))
 	dots := strings.Join([]string{
 		dotMutedStyle.Render("●"),
 		dotMutedStyle.Render("●"),
@@ -37,7 +37,7 @@ func (m model) renderLandingHero() string {
 	headerGap := max(1, innerWidth-lipgloss.Width(headerHost)-lipgloss.Width(dots))
 	headerRow := headerBgStyle.Render(padLandingANSI(headerHost+strings.Repeat(" ", headerGap)+dots, innerWidth))
 
-	promptRow := padLandingANSI("  "+promptSigilStyle.Render(">_")+"  "+promptLabelStyle.Render("launching bytemind"), innerWidth)
+	promptRow := padLandingANSI("  "+promptSigilStyle.Render(">_")+"  "+promptLabelStyle.Render("Your AI assistant"), innerWidth)
 	pixelRows := landingPixelLogoRows("BYTEMIND", pixelStyle, pixelGlowStyle, m.landingGlowStep, innerWidth-2)
 	logoRows := make([]string, 0, len(pixelRows))
 	for _, row := range pixelRows {
@@ -63,8 +63,28 @@ func (m model) renderLandingHero() string {
 	)
 	frame := strings.Join(frameRows, "\n")
 
-	subtitle := landingSubtitleStyle.Render("Your AI assistant")
+	subtitle := " "
 	return frame + "\n\n" + subtitle
+}
+
+func landingWorkspaceName(workspace string) string {
+	workspace = strings.TrimSpace(workspace)
+	if workspace == "" {
+		return "workspace"
+	}
+	normalized := strings.ReplaceAll(workspace, "\\", "/")
+	normalized = strings.TrimRight(normalized, "/")
+	if normalized == "" || normalized == "." {
+		return "workspace"
+	}
+	if idx := strings.LastIndex(normalized, "/"); idx >= 0 {
+		normalized = normalized[idx+1:]
+	}
+	name := strings.TrimSpace(normalized)
+	if name == "" || name == "." {
+		return "workspace"
+	}
+	return name
 }
 
 func (m model) landingPromptHeroWidth() int {

--- a/tui/component_landing.go
+++ b/tui/component_landing.go
@@ -11,7 +11,7 @@ import (
 
 var landingShortcutHints = []footerShortcutHint{
 	{Key: "Enter", Label: "send"},
-	{Key: "Shift+Enter", Label: "newline"},
+	{Key: "Ctrl+J", Label: "newline"},
 	{Key: "/", Label: "commands"},
 	{Key: "Ctrl+L", Label: "sessions"},
 	{Key: "Ctrl+C", Label: "quit"},

--- a/tui/component_landing.go
+++ b/tui/component_landing.go
@@ -10,10 +10,14 @@ import (
 )
 
 var landingShortcutHints = []footerShortcutHint{
+	{Key: "Enter", Label: "send"},
+	{Key: "Shift+Enter", Label: "newline"},
 	{Key: "/", Label: "commands"},
 	{Key: "Ctrl+L", Label: "sessions"},
 	{Key: "Ctrl+C", Label: "quit"},
 }
+
+const landingLogoText = "BYTEMIND"
 
 func (m model) renderLandingHero() string {
 	innerWidth := m.landingPromptHeroWidth()
@@ -25,20 +29,14 @@ func (m model) renderLandingHero() string {
 	brandStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#E6F2FF")).Bold(true)
 	pixelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#2BE8FF"))
 	pixelGlowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#91CFD5"))
-	dotMutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#455C71"))
-	dotActiveStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#64DF69"))
 
 	headerHost := headerHostStyle.Render(landingWorkspaceName(m.workspace))
-	dots := strings.Join([]string{
-		dotMutedStyle.Render("●"),
-		dotMutedStyle.Render("●"),
-		dotActiveStyle.Render("●"),
-	}, " ")
-	headerGap := max(1, innerWidth-lipgloss.Width(headerHost)-lipgloss.Width(dots))
-	headerRow := headerBgStyle.Render(padLandingANSI(headerHost+strings.Repeat(" ", headerGap)+dots, innerWidth))
+	headerMeta := m.landingHeaderVersion(innerWidth - lipgloss.Width(headerHost) - 1)
+	headerGap := max(0, innerWidth-lipgloss.Width(headerHost)-lipgloss.Width(headerMeta))
+	headerRow := headerBgStyle.Render(padLandingANSI(headerHost+strings.Repeat(" ", headerGap)+headerMeta, innerWidth))
 
 	promptRow := padLandingANSI("  "+promptSigilStyle.Render(">_")+"  "+promptLabelStyle.Render("Your AI assistant"), innerWidth)
-	pixelRows := landingPixelLogoRows("BYTEMIND", pixelStyle, pixelGlowStyle, m.landingGlowStep, innerWidth-2)
+	pixelRows := landingPixelLogoRows(landingLogoText, pixelStyle, pixelGlowStyle, m.landingGlowStep, innerWidth-2)
 	logoRows := make([]string, 0, len(pixelRows))
 	for _, row := range pixelRows {
 		left := max(0, (innerWidth-lipgloss.Width(row))/2)
@@ -92,8 +90,34 @@ func (m model) landingPromptHeroWidth() int {
 		return 74
 	}
 	maxFit := max(24, m.width-8)
-	preferred := min(118, max(74, (m.width*5)/6))
+	preferred := max(landingStableHeroWidth(), m.landingInputShellWidth())
 	return clamp(preferred, 62, maxFit)
+}
+
+func landingStableHeroWidth() int {
+	return landingPreferredLogoWidth(landingLogoText) + 2
+}
+
+func landingPreferredLogoWidth(text string) int {
+	const (
+		glyphWidth = 5
+		cellWidth  = 2
+		gapWidth   = 2
+	)
+	runeCount := len([]rune(text))
+	if runeCount == 0 {
+		return 0
+	}
+	return runeCount*glyphWidth*cellWidth + (runeCount-1)*gapWidth
+}
+
+func (m model) landingHeaderVersion(maxWidth int) string {
+	version := strings.TrimSpace(m.version)
+	if version == "" || maxWidth <= 0 {
+		return ""
+	}
+	version = xansi.Cut(version, 0, maxWidth)
+	return landingVersionStyle.Render(version)
 }
 
 func padLandingANSI(text string, width int) string {
@@ -318,25 +342,18 @@ func ensureMinRows(text string, rows int) string {
 	return strings.Join(lines, "\n")
 }
 
-func (m model) renderLandingInputActions() string {
-	actions := landingActionKeyStyle.Render("Enter") + " " + landingActionLabelStyle.Render("send") +
-		landingActionDividerStyle.Render(" | ") +
-		landingActionKeyStyle.Render("Shift+Enter") + " " + landingActionLabelStyle.Render("newline")
-	return landingHintStyle.Render(actions)
-}
-
 func (m model) renderLandingModeTabs() string {
-	buildStyle := landingModeInactiveStyle
-	planStyle := landingModeInactiveStyle
+	buildLabel := landingModeInactiveStyle.Render("Build")
+	planLabel := landingModeInactiveStyle.Render("Plan")
 	if m.mode == modeBuild {
-		buildStyle = landingModeBuildActiveStyle
+		buildLabel = landingModeBuildActiveStyle.Render("[ Build ]")
 	} else {
-		planStyle = landingModePlanActiveStyle
+		planLabel = landingModePlanActiveStyle.Render("[ Plan ]")
 	}
-	sep := landingModeInactiveStyle.Render("   ")
-	tabs := buildStyle.Render("Build") +
+	sep := landingModeInactiveStyle.Render("    ")
+	tabs := buildLabel +
 		sep +
-		planStyle.Render("Plan")
+		planLabel
 	modelLabel := m.currentModelLabel()
 	if strings.TrimSpace(modelLabel) == "" || modelLabel == "-" {
 		return tabs
@@ -347,9 +364,10 @@ func (m model) renderLandingModeTabs() string {
 func renderLandingShortcutHints() string {
 	parts := make([]string, 0, len(landingShortcutHints))
 	for _, hint := range landingShortcutHints {
-		parts = append(parts, landingShortcutKeyStyle.Render(hint.Key)+" "+landingShortcutLabelStyle.Render(hint.Label))
+		key := landingShortcutKeyStyle.Render("[" + hint.Key + "]")
+		parts = append(parts, key+" "+landingShortcutLabelStyle.Render(hint.Label))
 	}
-	return strings.Join(parts, landingShortcutDividerStyle.Render("  |  "))
+	return strings.Join(parts, landingShortcutDividerStyle.Render("   "))
 }
 
 func (m model) renderLandingContent(markInputZone bool) string {
@@ -365,8 +383,6 @@ func (m model) renderLandingContent(markInputZone bool) string {
 		parts,
 		"",
 		m.renderLandingInputBox(markInputZone),
-		m.renderLandingInputActions(),
-		"",
 		renderLandingShortcutHints(),
 	)
 	return strings.Join(parts, "\n")
@@ -407,26 +423,7 @@ func (m model) renderLandingCanvas(content string) string {
 	for len(rows) < m.height {
 		rows = append(rows, m.renderLandingCanvasRow("", len(rows)))
 	}
-	if versionRow, ok := m.renderLandingVersionRow(m.height - 1); ok {
-		rows[m.height-1] = versionRow
-	}
 	return strings.Join(rows, "\n")
-}
-
-func (m model) renderLandingVersionRow(row int) (string, bool) {
-	version := strings.TrimSpace(m.version)
-	if version == "" || m.width <= 0 {
-		return "", false
-	}
-	rowStyle := lipgloss.NewStyle().Background(m.landingGradientColor(row))
-	label := landingVersionStyle.Render(version)
-	labelWidth := lipgloss.Width(label)
-	if labelWidth >= m.width {
-		return xansi.Cut(label, 0, m.width), true
-	}
-	left := max(0, m.width-labelWidth-2)
-	right := max(0, m.width-left-labelWidth)
-	return rowStyle.Width(left).Render("") + rowStyle.Render(label) + rowStyle.Width(right).Render(""), true
 }
 
 func (m model) renderLandingCanvasRow(line string, row int) string {

--- a/tui/component_landing.go
+++ b/tui/component_landing.go
@@ -70,21 +70,21 @@ func (m model) renderLandingHero() string {
 func landingWorkspaceName(workspace string) string {
 	workspace = strings.TrimSpace(workspace)
 	if workspace == "" {
-		return "workspace"
+		return "./workspace"
 	}
 	normalized := strings.ReplaceAll(workspace, "\\", "/")
 	normalized = strings.TrimRight(normalized, "/")
 	if normalized == "" || normalized == "." {
-		return "workspace"
+		return "./workspace"
 	}
 	if idx := strings.LastIndex(normalized, "/"); idx >= 0 {
 		normalized = normalized[idx+1:]
 	}
 	name := strings.TrimSpace(normalized)
 	if name == "" || name == "." {
-		return "workspace"
+		return "./workspace"
 	}
-	return name
+	return "./" + name
 }
 
 func (m model) landingPromptHeroWidth() int {
@@ -334,9 +334,14 @@ func (m model) renderLandingModeTabs() string {
 		planStyle = landingModePlanActiveStyle
 	}
 	sep := landingModeInactiveStyle.Render("   ")
-	return buildStyle.Render("Build") +
+	tabs := buildStyle.Render("Build") +
 		sep +
 		planStyle.Render("Plan")
+	modelLabel := m.currentModelLabel()
+	if strings.TrimSpace(modelLabel) == "" || modelLabel == "-" {
+		return tabs
+	}
+	return tabs + sep + landingModelStyle.Render(modelLabel)
 }
 
 func renderLandingShortcutHints() string {
@@ -402,7 +407,26 @@ func (m model) renderLandingCanvas(content string) string {
 	for len(rows) < m.height {
 		rows = append(rows, m.renderLandingCanvasRow("", len(rows)))
 	}
+	if versionRow, ok := m.renderLandingVersionRow(m.height - 1); ok {
+		rows[m.height-1] = versionRow
+	}
 	return strings.Join(rows, "\n")
+}
+
+func (m model) renderLandingVersionRow(row int) (string, bool) {
+	version := strings.TrimSpace(m.version)
+	if version == "" || m.width <= 0 {
+		return "", false
+	}
+	rowStyle := lipgloss.NewStyle().Background(m.landingGradientColor(row))
+	label := landingVersionStyle.Render(version)
+	labelWidth := lipgloss.Width(label)
+	if labelWidth >= m.width {
+		return xansi.Cut(label, 0, m.width), true
+	}
+	left := max(0, m.width-labelWidth-2)
+	right := max(0, m.width-left-labelWidth)
+	return rowStyle.Width(left).Render("") + rowStyle.Render(label) + rowStyle.Width(right).Render(""), true
 }
 
 func (m model) renderLandingCanvasRow(line string, row int) string {

--- a/tui/component_view_shell_test.go
+++ b/tui/component_view_shell_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/1024XEngineer/bytemind/internal/config"
+
 	"github.com/charmbracelet/bubbles/textarea"
 	xansi "github.com/charmbracelet/x/ansi"
 )
@@ -19,6 +21,10 @@ func TestRenderLandingProducesContent(t *testing.T) {
 		mode:      modeBuild,
 		input:     input,
 		workspace: `D:\happycoding\lzy1\byte-lab`,
+		version:   "v1.2.3",
+		cfg: config.Config{
+			Provider: config.ProviderConfig{Model: "gpt-5.4-mini"},
+		},
 	}
 	m.syncInputStyle()
 
@@ -30,8 +36,14 @@ func TestRenderLandingProducesContent(t *testing.T) {
 	if got := strings.Count(plain, "Your AI assistant"); got != 1 {
 		t.Fatalf("expected landing assistant label once in rendered content, got %d in %q", got, plain)
 	}
-	if !strings.Contains(plain, "byte-lab") {
+	if !strings.Contains(plain, "./byte-lab") {
 		t.Fatalf("expected workspace name in prompt hero header, got %q", plain)
+	}
+	if !strings.Contains(plain, "gpt-5.4-mini") {
+		t.Fatalf("expected current model in landing mode row, got %q", plain)
+	}
+	if !strings.Contains(plain, "v1.2.3") {
+		t.Fatalf("expected version in landing canvas, got %q", plain)
 	}
 	if strings.Contains(plain, "bytemind@localhost") {
 		t.Fatalf("expected prompt hero header not to use localhost label, got %q", plain)
@@ -89,9 +101,9 @@ func TestLandingPromptHelpers(t *testing.T) {
 		workspace string
 		want      string
 	}{
-		{workspace: `D:\happycoding\lzy1\bytemind`, want: "bytemind"},
-		{workspace: "/home/me/byte-lab/", want: "byte-lab"},
-		{workspace: "", want: "workspace"},
+		{workspace: `D:\happycoding\lzy1\bytemind`, want: "./bytemind"},
+		{workspace: "/home/me/byte-lab/", want: "./byte-lab"},
+		{workspace: "", want: "./workspace"},
 	} {
 		if got := landingWorkspaceName(tc.workspace); got != tc.want {
 			t.Fatalf("expected workspace name %q for %q, got %q", tc.want, tc.workspace, got)
@@ -135,6 +147,26 @@ func TestRenderLandingCanvasUsesLandingContentTop(t *testing.T) {
 	want := m.landingContentTop(2)
 	if got != want {
 		t.Fatalf("expected first content row at %d, got %d", want, got)
+	}
+}
+
+func TestRenderLandingCanvasPlacesVersionBottomRight(t *testing.T) {
+	m := model{
+		width:   30,
+		height:  5,
+		version: "v1.2.3",
+	}
+	rendered := m.renderLandingCanvas("A")
+	lines := strings.Split(strings.ReplaceAll(rendered, "\r\n", "\n"), "\n")
+	if len(lines) != m.height {
+		t.Fatalf("expected %d canvas rows, got %d", m.height, len(lines))
+	}
+	bottom := xansi.Strip(lines[len(lines)-1])
+	if got := xansi.StringWidth(lines[len(lines)-1]); got != m.width {
+		t.Fatalf("expected version row width %d, got %d", m.width, got)
+	}
+	if !strings.HasSuffix(strings.TrimRight(bottom, " "), "v1.2.3") {
+		t.Fatalf("expected version to be bottom-right aligned, got %q", bottom)
 	}
 }
 

--- a/tui/component_view_shell_test.go
+++ b/tui/component_view_shell_test.go
@@ -52,7 +52,7 @@ func TestRenderLandingProducesContent(t *testing.T) {
 	if !strings.Contains(plain, landingInputPlaceholder) {
 		t.Fatalf("expected action-oriented landing placeholder, got %q", plain)
 	}
-	for _, want := range []string{"[Enter] send", "[Shift+Enter] newline", "[/] commands", "[Ctrl+L] sessions", "[Ctrl+C] quit"} {
+	for _, want := range []string{"[Enter] send", "[Ctrl+J] newline", "[/] commands", "[Ctrl+L] sessions", "[Ctrl+C] quit"} {
 		if !strings.Contains(plain, want) {
 			t.Fatalf("expected landing shortcut hint %q, got %q", want, plain)
 		}

--- a/tui/component_view_shell_test.go
+++ b/tui/component_view_shell_test.go
@@ -13,11 +13,12 @@ func TestRenderLandingProducesContent(t *testing.T) {
 	input.Focus()
 
 	m := model{
-		screen: screenLanding,
-		width:  120,
-		height: 36,
-		mode:   modeBuild,
-		input:  input,
+		screen:    screenLanding,
+		width:     120,
+		height:    36,
+		mode:      modeBuild,
+		input:     input,
+		workspace: `D:\happycoding\lzy1\byte-lab`,
 	}
 	m.syncInputStyle()
 
@@ -26,14 +27,17 @@ func TestRenderLandingProducesContent(t *testing.T) {
 		t.Fatalf("expected landing view to render non-empty content")
 	}
 	plain := xansi.Strip(rendered)
-	if !strings.Contains(plain, "Your AI assistant") {
-		t.Fatalf("expected landing subtitle in rendered content, got %q", plain)
+	if got := strings.Count(plain, "Your AI assistant"); got != 1 {
+		t.Fatalf("expected landing assistant label once in rendered content, got %d in %q", got, plain)
 	}
-	if !strings.Contains(plain, "bytemind@localhost:~") {
-		t.Fatalf("expected prompt hero header in rendered content, got %q", plain)
+	if !strings.Contains(plain, "byte-lab") {
+		t.Fatalf("expected workspace name in prompt hero header, got %q", plain)
 	}
-	if !strings.Contains(plain, "launching bytemind") {
-		t.Fatalf("expected prompt hero launch line in rendered content, got %q", plain)
+	if strings.Contains(plain, "bytemind@localhost") {
+		t.Fatalf("expected prompt hero header not to use localhost label, got %q", plain)
+	}
+	if strings.Contains(plain, "launching bytemind") {
+		t.Fatalf("expected prompt hero launch line to use assistant label, got %q", plain)
 	}
 	if !strings.Contains(plain, "█") {
 		t.Fatalf("expected prompt hero pixel matrix logo in rendered content, got %q", plain)
@@ -80,6 +84,18 @@ func TestLandingPromptHelpers(t *testing.T) {
 	m := model{width: 0}
 	if got := m.landingPromptHeroWidth(); got != 74 {
 		t.Fatalf("expected default prompt hero width 74, got %d", got)
+	}
+	for _, tc := range []struct {
+		workspace string
+		want      string
+	}{
+		{workspace: `D:\happycoding\lzy1\bytemind`, want: "bytemind"},
+		{workspace: "/home/me/byte-lab/", want: "byte-lab"},
+		{workspace: "", want: "workspace"},
+	} {
+		if got := landingWorkspaceName(tc.workspace); got != tc.want {
+			t.Fatalf("expected workspace name %q for %q, got %q", tc.want, tc.workspace, got)
+		}
 	}
 
 	rows := landingPixelLogoRows("BY", landingModeStyle, landingModeStyle, 0, 120)

--- a/tui/component_view_shell_test.go
+++ b/tui/component_view_shell_test.go
@@ -45,11 +45,25 @@ func TestRenderLandingProducesContent(t *testing.T) {
 	if !strings.Contains(plain, "v1.2.3") {
 		t.Fatalf("expected version in landing canvas, got %q", plain)
 	}
+	if !strings.Contains(plain, "[ Build ]") {
+		t.Fatalf("expected active build tab in landing mode row, got %q", plain)
+	}
+	if !strings.Contains(plain, landingInputPlaceholder) {
+		t.Fatalf("expected action-oriented landing placeholder, got %q", plain)
+	}
+	for _, want := range []string{"[Enter] send", "[Shift+Enter] newline", "[/] commands", "[Ctrl+L] sessions", "[Ctrl+C] quit"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("expected landing shortcut hint %q, got %q", want, plain)
+		}
+	}
 	if strings.Contains(plain, "bytemind@localhost") {
 		t.Fatalf("expected prompt hero header not to use localhost label, got %q", plain)
 	}
 	if strings.Contains(plain, "launching bytemind") {
 		t.Fatalf("expected prompt hero launch line to use assistant label, got %q", plain)
+	}
+	if strings.Contains(plain, "Let's get started") {
+		t.Fatalf("expected old landing placeholder to be removed, got %q", plain)
 	}
 	if !strings.Contains(plain, "█") {
 		t.Fatalf("expected prompt hero pixel matrix logo in rendered content, got %q", plain)
@@ -96,6 +110,14 @@ func TestLandingPromptHelpers(t *testing.T) {
 	m := model{width: 0}
 	if got := m.landingPromptHeroWidth(); got != 74 {
 		t.Fatalf("expected default prompt hero width 74, got %d", got)
+	}
+	wide := model{width: 120}
+	if got, want := wide.landingPromptHeroWidth(), wide.landingInputShellWidth(); got != want {
+		t.Fatalf("expected landing hero width to align with input width %d, got %d", want, got)
+	}
+	restoredRows := landingPixelLogoRows(landingLogoText, landingModeStyle, landingModeStyle, 0, wide.landingPromptHeroWidth()-2)
+	if got, want := xansi.StringWidth(restoredRows[0]), landingPreferredLogoWidth(landingLogoText); got != want {
+		t.Fatalf("expected restored-width logo to keep stable pixel width %d, got %d", want, got)
 	}
 	for _, tc := range []struct {
 		workspace string
@@ -150,23 +172,18 @@ func TestRenderLandingCanvasUsesLandingContentTop(t *testing.T) {
 	}
 }
 
-func TestRenderLandingCanvasPlacesVersionBottomRight(t *testing.T) {
+func TestRenderLandingHeroPlacesVersionInHeader(t *testing.T) {
 	m := model{
 		width:   30,
 		height:  5,
 		version: "v1.2.3",
 	}
-	rendered := m.renderLandingCanvas("A")
-	lines := strings.Split(strings.ReplaceAll(rendered, "\r\n", "\n"), "\n")
-	if len(lines) != m.height {
-		t.Fatalf("expected %d canvas rows, got %d", m.height, len(lines))
+	hero := xansi.Strip(m.renderLandingHero())
+	if !strings.Contains(hero, "v1.2.3") {
+		t.Fatalf("expected landing hero header to contain version, got %q", hero)
 	}
-	bottom := xansi.Strip(lines[len(lines)-1])
-	if got := xansi.StringWidth(lines[len(lines)-1]); got != m.width {
-		t.Fatalf("expected version row width %d, got %d", m.width, got)
-	}
-	if !strings.HasSuffix(strings.TrimRight(bottom, " "), "v1.2.3") {
-		t.Fatalf("expected version to be bottom-right aligned, got %q", bottom)
+	if strings.Contains(hero, "●") {
+		t.Fatalf("expected landing hero header to replace mac-style dots with version, got %q", hero)
 	}
 }
 

--- a/tui/component_view_shell_test.go
+++ b/tui/component_view_shell_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/config"
 
 	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/lipgloss"
 	xansi "github.com/charmbracelet/x/ansi"
 )
 
@@ -184,6 +185,27 @@ func TestRenderLandingHeroPlacesVersionInHeader(t *testing.T) {
 	}
 	if strings.Contains(hero, "●") {
 		t.Fatalf("expected landing hero header to replace mac-style dots with version, got %q", hero)
+	}
+}
+
+func TestLandingModeAccentColors(t *testing.T) {
+	build := model{screen: screenLanding, mode: modeBuild}
+	if got, want := build.modeAccentColor(), lipgloss.Color(landingBuildAccent); got != want {
+		t.Fatalf("expected landing build input accent %q, got %q", want, got)
+	}
+	if got, want := landingModeBuildActiveStyle.GetForeground(), lipgloss.Color(landingBuildAccent); got != want {
+		t.Fatalf("expected landing build tab accent %q, got %q", want, got)
+	}
+
+	plan := model{screen: screenLanding, mode: modePlan}
+	if got, want := plan.modeAccentColor(), lipgloss.Color(landingPlanAccent); got != want {
+		t.Fatalf("expected landing plan input accent %q, got %q", want, got)
+	}
+	if got, want := landingModePlanActiveStyle.GetForeground(), lipgloss.Color(landingPlanAccent); got != want {
+		t.Fatalf("expected landing plan tab accent %q, got %q", want, got)
+	}
+	if got, want := landingModePlanActiveStyle.GetBackground(), lipgloss.Color(landingPlanBg); got != want {
+		t.Fatalf("expected landing plan tab background %q, got %q", want, got)
 	}
 }
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -336,6 +336,7 @@ type model struct {
 	imageStore assets.ImageStore
 	cfg        config.Config
 	workspace  string
+	version    string
 
 	width  int
 	height int
@@ -507,6 +508,7 @@ func newModel(opts Options) model {
 		imageStore:           opts.ImageStore,
 		cfg:                  opts.Config,
 		workspace:            opts.Workspace,
+		version:              opts.Version,
 		async:                async,
 		viewport:             vp,
 		copyView:             copyVP,

--- a/tui/model_mouse_selection.go
+++ b/tui/model_mouse_selection.go
@@ -466,7 +466,7 @@ func (m model) renderLandingInputEditorView() string {
 	if value == "" {
 		placeholder := m.input.Placeholder
 		if strings.TrimSpace(placeholder) == "" {
-			placeholder = "Let's get started..."
+			placeholder = landingInputPlaceholder
 		}
 		if !showCaret || !m.input.Focused() {
 			return landingPlaceholderStyle.Render(placeholder)

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -5385,6 +5385,9 @@ func TestLandingModeTabsHideAccessLabel(t *testing.T) {
 	if strings.Contains(tabs, "Access:") || strings.Contains(tabs, "Full Access") {
 		t.Fatalf("expected landing mode tabs to hide access label, got %q", tabs)
 	}
+	if !strings.Contains(stripANSI(tabs), "[ Build ]") {
+		t.Fatalf("expected active build tab to use bracket style, got %q", tabs)
+	}
 }
 
 func TestApprovalBannerForFullAccessConfirmation(t *testing.T) {

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -2,6 +2,12 @@ package tui
 
 import "github.com/charmbracelet/lipgloss"
 
+const (
+	landingBuildAccent = "#4CB7FF"
+	landingPlanAccent  = "#D86BFF"
+	landingPlanBg      = "#2C123D"
+)
+
 type semanticColorTokens struct {
 	Panel         lipgloss.Color
 	PanelMuted    lipgloss.Color
@@ -163,7 +169,7 @@ var (
 					Underline(true)
 
 	landingModeStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#4CB7FF")).
+				Foreground(lipgloss.Color(landingBuildAccent)).
 				Bold(true)
 
 	landingModelStyle = lipgloss.NewStyle().
@@ -176,13 +182,13 @@ var (
 				Faint(true)
 
 	landingModeBuildActiveStyle = lipgloss.NewStyle().
-					Foreground(lipgloss.Color("#4CB7FF")).
+					Foreground(lipgloss.Color(landingBuildAccent)).
 					Background(lipgloss.Color("#06233A")).
 					Bold(true)
 
 	landingModePlanActiveStyle = lipgloss.NewStyle().
-					Foreground(lipgloss.Color("#A9C6E8")).
-					Background(lipgloss.Color("#162036")).
+					Foreground(lipgloss.Color(landingPlanAccent)).
+					Background(lipgloss.Color(landingPlanBg)).
 					Bold(true)
 
 	landingModeInactiveStyle = lipgloss.NewStyle().

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -167,7 +167,13 @@ var (
 				Bold(true)
 
 	landingModelStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#A9C6E8"))
+				Foreground(lipgloss.Color("#A9C6E8")).
+				Background(colorLandingPanel)
+
+	landingVersionStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#DDE6F0")).
+				Background(colorLandingPanel).
+				Faint(true)
 
 	landingHintStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#7FA4CC")).

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -172,34 +172,17 @@ var (
 
 	landingVersionStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#DDE6F0")).
-				Background(colorLandingPanel).
+				Background(lipgloss.Color("#020A14")).
 				Faint(true)
-
-	landingHintStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#7FA4CC")).
-				Background(colorLandingPanel)
-
-	landingActionKeyStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#DCEBFF")).
-				Background(colorLandingPanel).
-				Bold(true)
-
-	landingActionLabelStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#A9C6E8")).
-				Background(colorLandingPanel)
-
-	landingActionDividerStyle = lipgloss.NewStyle().
-					Foreground(lipgloss.Color("#5E7DA4")).
-					Background(colorLandingPanel)
 
 	landingModeBuildActiveStyle = lipgloss.NewStyle().
 					Foreground(lipgloss.Color("#4CB7FF")).
-					Background(colorLandingPanel).
+					Background(lipgloss.Color("#06233A")).
 					Bold(true)
 
 	landingModePlanActiveStyle = lipgloss.NewStyle().
 					Foreground(lipgloss.Color("#A9C6E8")).
-					Background(colorLandingPanel).
+					Background(lipgloss.Color("#162036")).
 					Bold(true)
 
 	landingModeInactiveStyle = lipgloss.NewStyle().


### PR DESCRIPTION
修改内容：
- 顶部终端框左上角从 bytemind@localhost:~ 改成当前 workspace 名称，格式是 ./workspaceName，例如 ./bytemind。
- 顶部终端框里的提示文案从 launching bytemind 改成 Your AI assistant。
- 原本主 logo 下方居中的 Your AI assistant 文本被移除，改成空白占位，保留原有垂直间距。
- Build / Plan 模式切换行右侧新增当前模型名显示，例如 gpt-5.4-mini。
- 主页面新增版本号显示，已 push 版本里是放在右下角，样式是低透明度白色。
- 版本号从应用运行时传入 TUI：Options 和 model 增加了 Version 字段，运行时用 CurrentVersion() 注入。- 
- 补了主页面渲染测试，覆盖 workspace 名称、模型显示、版本号显示、旧文案移除等行为。


修改前
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/e9007ac3-8335-4a21-b192-d0a777894a14" />

修改后
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/7cbc3b33-b504-416c-ac6b-f2dedf9bf80e" />
