### PR TITLE
Codex/repr pr 329 upstream main

### DIFF
--- a/internal/agent/approval_precheck.go
+++ b/internal/agent/approval_precheck.go
@@ -59,42 +59,50 @@ func (r *Runner) prepareRunApprovalHandler(setup runPromptSetup, out io.Writer) 
 
 	grants := runApprovalGrants{}
 	if requestShell {
-		approved, err := base(tools.ApprovalRequest{
-			Command: "run_shell (session pre-approval)",
-			Reason:  "pre-approve approval-required run_shell commands for this run",
+		decision, err := base(tools.ApprovalRequest{
+			ToolName: "run_shell",
+			Command:  "run_shell (session pre-approval)",
+			Reason:   "pre-approve approval-required run_shell commands for this run",
 		})
+		approved := tools.NormalizeApprovalDecision(decision).Approved()
 		writePreapprovalResult(out, "run_shell", approved, err)
 		if err == nil && approved {
 			grants.Shell = true
 		}
 	}
 	if requestDestructive {
-		approved, err := base(tools.ApprovalRequest{
-			Command: "workspace-modifying tools (session pre-approval)",
-			Reason:  fmt.Sprintf("pre-approve destructive tool calls for this run: %s", strings.Join(destructive, ", ")),
+		decision, err := base(tools.ApprovalRequest{
+			ToolName: "destructive_tools",
+			Command:  "workspace-modifying tools (session pre-approval)",
+			Reason:   fmt.Sprintf("pre-approve destructive tool calls for this run: %s", strings.Join(destructive, ", ")),
 		})
+		approved := tools.NormalizeApprovalDecision(decision).Approved()
 		writePreapprovalResult(out, "workspace-modifying tools", approved, err)
 		if err == nil && approved {
 			grants.Destructive = true
 		}
 	}
-	return func(req tools.ApprovalRequest) (bool, error) {
+	return func(req tools.ApprovalRequest) (tools.ApprovalDecision, error) {
 		if grants.Destructive && isDestructiveToolApprovalRequest(req) {
-			return true, nil
+			return tools.ApprovalDecision{Disposition: tools.ApprovalApproveOnce}, nil
 		}
 		if grants.Shell && isRunShellApprovalRequest(req) {
-			return true, nil
+			return tools.ApprovalDecision{Disposition: tools.ApprovalApproveOnce}, nil
 		}
-		approved, err := base(req)
-		if err != nil || !approved {
-			return approved, err
+		decision, err := base(req)
+		normalized := tools.NormalizeApprovalDecision(decision)
+		if err != nil || !normalized.Approved() {
+			return normalized, err
 		}
-		if isDestructiveToolApprovalRequest(req) {
+		if normalized.ReusableForAllTools() {
 			grants.Destructive = true
-		} else if isRunShellApprovalRequest(req) {
+			grants.Shell = true
+		} else if normalized.ReusableForSameTool() && isDestructiveToolApprovalRequest(req) {
+			grants.Destructive = true
+		} else if normalized.ReusableForSameTool() && isRunShellApprovalRequest(req) {
 			grants.Shell = true
 		}
-		return true, nil
+		return normalized, nil
 	}
 }
 
@@ -109,7 +117,7 @@ func (r *Runner) resolveRunApprovalBaseHandler() (tools.ApprovalHandler, bool) {
 		return unavailableRunApprovalHandler(), false
 	}
 	reader := bufio.NewReader(r.stdin)
-	return func(req tools.ApprovalRequest) (bool, error) {
+	return func(req tools.ApprovalRequest) (tools.ApprovalDecision, error) {
 		command := strings.TrimSpace(req.Command)
 		if command == "" {
 			command = "unknown action"
@@ -124,20 +132,23 @@ func (r *Runner) resolveRunApprovalBaseHandler() (tools.ApprovalHandler, bool) {
 		}
 		line, err := reader.ReadString('\n')
 		if err != nil && err != io.EOF {
-			return false, err
+			return tools.ApprovalDecision{Disposition: tools.ApprovalDeny}, err
 		}
 		answer := strings.ToLower(strings.TrimSpace(line))
-		return answer == "y" || answer == "yes", nil
+		if answer == "y" || answer == "yes" {
+			return tools.ApprovalDecision{Disposition: tools.ApprovalApproveOnce}, nil
+		}
+		return tools.ApprovalDecision{Disposition: tools.ApprovalDeny}, nil
 	}, true
 }
 
 func unavailableRunApprovalHandler() tools.ApprovalHandler {
-	return func(req tools.ApprovalRequest) (bool, error) {
+	return func(req tools.ApprovalRequest) (tools.ApprovalDecision, error) {
 		command := strings.TrimSpace(req.Command)
 		if command == "" {
 			command = "unknown action"
 		}
-		return false, fmt.Errorf("approval channel unavailable for %q: missing TUI approval bridge and stdin fallback", command)
+		return tools.ApprovalDecision{Disposition: tools.ApprovalDeny}, fmt.Errorf("approval channel unavailable for %q: missing TUI approval bridge and stdin fallback", command)
 	}
 }
 

--- a/internal/agent/approval_precheck_test.go
+++ b/internal/agent/approval_precheck_test.go
@@ -145,9 +145,9 @@ func TestPrepareRunApprovalHandlerPreApprovesRunShellAndDestructive(t *testing.T
 			ApprovalMode:   "interactive",
 		},
 		registry: tools.DefaultRegistry(),
-		approval: func(req tools.ApprovalRequest) (bool, error) {
+		approval: func(req tools.ApprovalRequest) (tools.ApprovalDecision, error) {
 			requests = append(requests, req)
-			return true, nil
+			return tools.ApprovalDecision{Disposition: tools.ApprovalApproveOnce}, nil
 		},
 	}
 
@@ -168,23 +168,25 @@ func TestPrepareRunApprovalHandlerPreApprovesRunShellAndDestructive(t *testing.T
 		t.Fatalf("unexpected destructive pre-approval request: %+v", requests[1])
 	}
 
-	approved, err := handler(tools.ApprovalRequest{
-		Command: "go test ./...",
-		Reason:  "may modify files or environment: go",
+	decision, err := handler(tools.ApprovalRequest{
+		ToolName: "run_shell",
+		Command:  "go test ./...",
+		Reason:   "may modify files or environment: go",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected pre-approved run_shell request, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected pre-approved run_shell request, decision=%+v err=%v", decision, err)
 	}
 	if len(requests) != 2 {
 		t.Fatalf("expected run_shell request to skip runtime approval prompt, got %d calls", len(requests))
 	}
 
-	approved, err = handler(tools.ApprovalRequest{
-		Command: "write_file",
-		Reason:  "destructive tool may modify workspace files: write_file",
+	decision, err = handler(tools.ApprovalRequest{
+		ToolName: "write_file",
+		Command:  "write_file",
+		Reason:   "destructive tool may modify workspace files: write_file",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected pre-approved destructive request, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected pre-approved destructive request, decision=%+v err=%v", decision, err)
 	}
 	if len(requests) != 2 {
 		t.Fatalf("expected destructive request to skip runtime approval prompt, got %d calls", len(requests))
@@ -199,12 +201,12 @@ func TestPrepareRunApprovalHandlerFallsBackWhenPreApprovalDenied(t *testing.T) {
 			ApprovalMode:   "interactive",
 		},
 		registry: tools.DefaultRegistry(),
-		approval: func(req tools.ApprovalRequest) (bool, error) {
+		approval: func(req tools.ApprovalRequest) (tools.ApprovalDecision, error) {
 			requests = append(requests, req)
 			if strings.Contains(req.Reason, "pre-approve") {
-				return false, nil
+				return tools.ApprovalDecision{Disposition: tools.ApprovalDeny}, nil
 			}
-			return true, nil
+			return tools.ApprovalDecision{Disposition: tools.ApprovalApproveOnce}, nil
 		},
 	}
 
@@ -219,23 +221,25 @@ func TestPrepareRunApprovalHandlerFallsBackWhenPreApprovalDenied(t *testing.T) {
 		t.Fatalf("expected two pre-approval requests, got %d (%+v)", len(requests), requests)
 	}
 
-	approved, err := handler(tools.ApprovalRequest{
-		Command: "go test ./...",
-		Reason:  "may modify files or environment: go",
+	decision, err := handler(tools.ApprovalRequest{
+		ToolName: "run_shell",
+		Command:  "go test ./...",
+		Reason:   "may modify files or environment: go",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected runtime run_shell approval fallback, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected runtime run_shell approval fallback, decision=%+v err=%v", decision, err)
 	}
 	if len(requests) != 3 {
 		t.Fatalf("expected runtime run_shell request to call base handler after pre-approval denial, got %d calls", len(requests))
 	}
 
-	approved, err = handler(tools.ApprovalRequest{
-		Command: "write_file",
-		Reason:  "destructive tool may modify workspace files: write_file",
+	decision, err = handler(tools.ApprovalRequest{
+		ToolName: "write_file",
+		Command:  "write_file",
+		Reason:   "destructive tool may modify workspace files: write_file",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected runtime destructive approval fallback, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected runtime destructive approval fallback, decision=%+v err=%v", decision, err)
 	}
 	if len(requests) != 4 {
 		t.Fatalf("expected runtime destructive request to call base handler after pre-approval denial, got %d calls", len(requests))
@@ -265,20 +269,22 @@ func TestPrepareRunApprovalHandlerUsesStdinFallbackAndPreApproves(t *testing.T) 
 		t.Fatalf("expected two pre-approval prompts from stdin fallback, got %d (%q)", prompts, approvalOut.String())
 	}
 
-	approved, err := handler(tools.ApprovalRequest{
-		Command: "go test ./...",
-		Reason:  "may modify files or environment: go",
+	decision, err := handler(tools.ApprovalRequest{
+		ToolName: "run_shell",
+		Command:  "go test ./...",
+		Reason:   "may modify files or environment: go",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected run_shell request to be auto-approved after pre-approval, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected run_shell request to be auto-approved after pre-approval, decision=%+v err=%v", decision, err)
 	}
 
-	approved, err = handler(tools.ApprovalRequest{
-		Command: "write_file",
-		Reason:  "destructive tool may modify workspace files: write_file",
+	decision, err = handler(tools.ApprovalRequest{
+		ToolName: "write_file",
+		Command:  "write_file",
+		Reason:   "destructive tool may modify workspace files: write_file",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected destructive request to be auto-approved after pre-approval, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected destructive request to be auto-approved after pre-approval, decision=%+v err=%v", decision, err)
 	}
 
 	if prompts := strings.Count(approvalOut.String(), "Approve action"); prompts != 2 {
@@ -309,12 +315,13 @@ func TestPrepareRunApprovalHandlerStdinFallbackPromptsAtRuntimeAfterDeniedPreApp
 		t.Fatalf("expected two pre-approval prompts, got %d (%q)", prompts, approvalOut.String())
 	}
 
-	approved, err := handler(tools.ApprovalRequest{
-		Command: "go test ./...",
-		Reason:  "may modify files or environment: go",
+	decision, err := handler(tools.ApprovalRequest{
+		ToolName: "run_shell",
+		Command:  "go test ./...",
+		Reason:   "may modify files or environment: go",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected runtime prompt fallback to approve run_shell request, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected runtime prompt fallback to approve run_shell request, decision=%+v err=%v", decision, err)
 	}
 	if prompts := strings.Count(approvalOut.String(), "Approve action"); prompts != 3 {
 		t.Fatalf("expected one extra runtime prompt after denied pre-approval, got %d (%q)", prompts, approvalOut.String())
@@ -329,9 +336,9 @@ func TestPrepareRunApprovalHandlerSkipsPreapprovalWhenIntentUnclear(t *testing.T
 			ApprovalMode:   "interactive",
 		},
 		registry: tools.DefaultRegistry(),
-		approval: func(req tools.ApprovalRequest) (bool, error) {
+		approval: func(req tools.ApprovalRequest) (tools.ApprovalDecision, error) {
 			requests = append(requests, req)
-			return true, nil
+			return tools.ApprovalDecision{Disposition: tools.ApprovalApproveOnce}, nil
 		},
 	}
 
@@ -346,12 +353,13 @@ func TestPrepareRunApprovalHandlerSkipsPreapprovalWhenIntentUnclear(t *testing.T
 		t.Fatalf("expected no pre-approval requests for low-risk intent, got %+v", requests)
 	}
 
-	approved, err := handler(tools.ApprovalRequest{
-		Command: "go test ./...",
-		Reason:  "may modify files or environment: go",
+	decision, err := handler(tools.ApprovalRequest{
+		ToolName: "run_shell",
+		Command:  "go test ./...",
+		Reason:   "may modify files or environment: go",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected runtime approval handler to remain available, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected runtime approval handler to remain available, decision=%+v err=%v", decision, err)
 	}
 	if len(requests) != 1 {
 		t.Fatalf("expected runtime call to use base handler, got %d requests", len(requests))
@@ -366,9 +374,9 @@ func TestPrepareRunApprovalHandlerLearnsRuntimeApprovalsWithinRun(t *testing.T) 
 			ApprovalMode:   "interactive",
 		},
 		registry: tools.DefaultRegistry(),
-		approval: func(req tools.ApprovalRequest) (bool, error) {
+		approval: func(req tools.ApprovalRequest) (tools.ApprovalDecision, error) {
 			requests = append(requests, req)
-			return true, nil
+			return tools.ApprovalDecision{Disposition: tools.ApprovalApproveSameToolSession}, nil
 		},
 	}
 
@@ -383,45 +391,49 @@ func TestPrepareRunApprovalHandlerLearnsRuntimeApprovalsWithinRun(t *testing.T) 
 		t.Fatalf("expected no eager pre-approval requests, got %+v", requests)
 	}
 
-	approved, err := handler(tools.ApprovalRequest{
-		Command: "go test ./...",
-		Reason:  "may modify files or environment: go",
+	decision, err := handler(tools.ApprovalRequest{
+		ToolName: "run_shell",
+		Command:  "go test ./...",
+		Reason:   "may modify files or environment: go",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected first shell approval to pass, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected first shell approval to pass, decision=%+v err=%v", decision, err)
 	}
 	if len(requests) != 1 {
 		t.Fatalf("expected one runtime shell approval request, got %d", len(requests))
 	}
 
-	approved, err = handler(tools.ApprovalRequest{
-		Command: "go test ./...",
-		Reason:  "may modify files or environment: go",
+	decision, err = handler(tools.ApprovalRequest{
+		ToolName: "run_shell",
+		Command:  "go test ./...",
+		Reason:   "may modify files or environment: go",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected learned shell approval to pass, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected learned shell approval to pass, decision=%+v err=%v", decision, err)
 	}
 	if len(requests) != 1 {
 		t.Fatalf("expected learned shell approval not to reprompt, got %d requests", len(requests))
 	}
 
-	approved, err = handler(tools.ApprovalRequest{
-		Command: "write_file",
-		Reason:  "destructive tool may modify workspace files: write_file",
+	decision, err = handler(tools.ApprovalRequest{
+		ToolName: "write_file",
+		Command:  "write_file",
+		Reason:   "destructive tool may modify workspace files: write_file",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected first destructive approval to pass, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected first destructive approval to pass, decision=%+v err=%v", decision, err)
 	}
 	if len(requests) != 2 {
 		t.Fatalf("expected one runtime destructive approval request, got %d", len(requests))
 	}
 
-	approved, err = handler(tools.ApprovalRequest{
-		Command: "write_file",
-		Reason:  "destructive tool may modify workspace files: write_file",
+	decision, err = handler(tools.ApprovalRequest{
+		ToolName: "write_file",
+		Command:  "write_file",
+		Reason:   "destructive tool may modify workspace files: write_file",
 	})
-	if err != nil || !approved {
-		t.Fatalf("expected learned destructive approval to pass, approved=%v err=%v", approved, err)
+	if err != nil || !decision.Approved() {
+		t.Fatalf("expected learned destructive approval to pass, decision=%+v err=%v", decision, err)
 	}
 	if len(requests) != 2 {
 		t.Fatalf("expected learned destructive approval not to reprompt, got %d requests", len(requests))
@@ -448,14 +460,15 @@ func TestPrepareRunApprovalHandlerReportsUnavailableApprovalChannel(t *testing.T
 		t.Fatal("expected fallback approval handler when channel is unavailable")
 	}
 
-	approved, err := handler(tools.ApprovalRequest{
-		Command: "write_file",
-		Reason:  "destructive tool may modify workspace files: write_file",
+	decision, err := handler(tools.ApprovalRequest{
+		ToolName: "write_file",
+		Command:  "write_file",
+		Reason:   "destructive tool may modify workspace files: write_file",
 	})
 	if err == nil {
 		t.Fatal("expected unavailable approval channel error")
 	}
-	if approved {
+	if decision.Approved() {
 		t.Fatal("expected approval to be denied when channel is unavailable")
 	}
 	if !strings.Contains(err.Error(), "approval channel unavailable") {

--- a/internal/agent/runner_branches_test.go
+++ b/internal/agent/runner_branches_test.go
@@ -81,7 +81,9 @@ func TestRunnerSetters(t *testing.T) {
 	if runner.approval != nil {
 		t.Fatal("expected nil approval handler by default")
 	}
-	runner.SetApprovalHandler(func(tools.ApprovalRequest) (bool, error) { return true, nil })
+	runner.SetApprovalHandler(func(tools.ApprovalRequest) (tools.ApprovalDecision, error) {
+		return tools.ApprovalDecision{Disposition: tools.ApprovalApproveOnce}, nil
+	})
 	if runner.approval == nil {
 		t.Fatal("expected approval handler to be set")
 	}

--- a/internal/agent/runner_policy_test.go
+++ b/internal/agent/runner_policy_test.go
@@ -195,15 +195,16 @@ func TestRunPromptPolicyGatewayAskRequestsApprovalAndExecutesTool(t *testing.T) 
 			if execCtx == nil || execCtx.Approval == nil {
 				t.Fatal("expected approval handler in execution context")
 			}
-			approved, approvalErr := execCtx.Approval(tools.ApprovalRequest{
-				Command: "ask_tool",
-				Reason:  "high-risk tool requires approval",
+			decision, approvalErr := execCtx.Approval(tools.ApprovalRequest{
+				ToolName: "ask_tool",
+				Command:  "ask_tool",
+				Reason:   "high-risk tool requires approval",
 			})
 			if approvalErr != nil {
 				t.Fatalf("unexpected approval error: %v", approvalErr)
 			}
 			approvalRequested = true
-			if !approved {
+			if !decision.Approved() {
 				t.Fatal("expected approval handler to approve execution")
 			}
 			executed = true
@@ -260,11 +261,11 @@ func TestRunPromptPolicyGatewayAskRequestsApprovalAndExecutesTool(t *testing.T) 
 			}, nil
 		}),
 		AuditStore: auditStore,
-		Approval: func(req tools.ApprovalRequest) (bool, error) {
+		Approval: func(req tools.ApprovalRequest) (tools.ApprovalDecision, error) {
 			if req.Command != "ask_tool" {
 				t.Fatalf("unexpected approval command: %q", req.Command)
 			}
-			return true, nil
+			return tools.ApprovalDecision{Disposition: tools.ApprovalApproveOnce}, nil
 		},
 		Stdin:  strings.NewReader(""),
 		Stdout: io.Discard,

--- a/internal/app/tui_adapter.go
+++ b/internal/app/tui_adapter.go
@@ -52,14 +52,19 @@ func (a *tuiRunnerAdapter) SetApprovalHandler(handler tui.ApprovalHandler) {
 	if a == nil || a.runner == nil {
 		return
 	}
-	a.runner.SetApprovalHandler(func(req tools.ApprovalRequest) (bool, error) {
+	a.runner.SetApprovalHandler(func(req tools.ApprovalRequest) (tools.ApprovalDecision, error) {
 		if handler == nil {
-			return false, nil
+			return tools.ApprovalDecision{Disposition: tools.ApprovalDeny}, nil
 		}
-		return handler(tui.ApprovalRequest{
-			Command: req.Command,
-			Reason:  req.Reason,
+		decision, err := handler(tui.ApprovalRequest{
+			ToolName: req.ToolName,
+			Command:  req.Command,
+			Reason:   req.Reason,
 		})
+		if err != nil {
+			return tools.ApprovalDecision{}, err
+		}
+		return tools.ApprovalDecision{Disposition: tools.ApprovalDisposition(decision.Disposition)}, nil
 	})
 }
 

--- a/internal/tools/approval.go
+++ b/internal/tools/approval.go
@@ -1,8 +1,48 @@
 package tools
 
 type ApprovalRequest struct {
-	Command string
-	Reason  string
+	ToolName string
+	Command  string
+	Reason   string
 }
 
-type ApprovalHandler func(ApprovalRequest) (bool, error)
+type ApprovalDisposition string
+
+const (
+	ApprovalApproveOnce            ApprovalDisposition = "approve_once"
+	ApprovalApproveSameToolSession ApprovalDisposition = "approve_same_tool_session"
+	ApprovalApproveAllSession      ApprovalDisposition = "approve_all_session"
+	ApprovalDeny                   ApprovalDisposition = "deny"
+)
+
+type ApprovalDecision struct {
+	Disposition ApprovalDisposition
+}
+
+func (d ApprovalDecision) Approved() bool {
+	switch d.Disposition {
+	case ApprovalApproveOnce, ApprovalApproveSameToolSession, ApprovalApproveAllSession:
+		return true
+	default:
+		return false
+	}
+}
+
+func (d ApprovalDecision) ReusableForSameTool() bool {
+	return d.Disposition == ApprovalApproveSameToolSession || d.Disposition == ApprovalApproveAllSession
+}
+
+func (d ApprovalDecision) ReusableForAllTools() bool {
+	return d.Disposition == ApprovalApproveAllSession
+}
+
+func NormalizeApprovalDecision(d ApprovalDecision) ApprovalDecision {
+	switch d.Disposition {
+	case ApprovalApproveOnce, ApprovalApproveSameToolSession, ApprovalApproveAllSession, ApprovalDeny:
+		return d
+	default:
+		return ApprovalDecision{Disposition: ApprovalDeny}
+	}
+}
+
+type ApprovalHandler func(ApprovalRequest) (ApprovalDecision, error)

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -303,14 +303,15 @@ func promptDestructiveApproval(toolName string, execCtx *ExecutionContext) error
 	}
 	reason := fmt.Sprintf("destructive tool may modify workspace files: %s", toolName)
 	if execCtx.Approval != nil {
-		approved, err := execCtx.Approval(ApprovalRequest{
-			Command: toolName,
-			Reason:  reason,
+		decision, err := execCtx.Approval(ApprovalRequest{
+			ToolName: toolName,
+			Command:  toolName,
+			Reason:   reason,
 		})
 		if err != nil {
 			return NewToolExecError(ToolErrorPermissionDenied, err.Error(), false, err)
 		}
-		if !approved {
+		if !NormalizeApprovalDecision(decision).Approved() {
 			return NewToolExecError(ToolErrorPermissionDenied, fmt.Sprintf("tool %q was not run because approval was denied", toolName), false, nil)
 		}
 		return nil

--- a/internal/tools/executor_test.go
+++ b/internal/tools/executor_test.go
@@ -326,14 +326,14 @@ func TestExecutorAllowsDestructiveToolWhenApprovalGranted(t *testing.T) {
 
 	got, err := executor.Execute(context.Background(), "write_file", `{"path":"a.txt"}`, &ExecutionContext{
 		ApprovalPolicy: "on-request",
-		Approval: func(req ApprovalRequest) (bool, error) {
+		Approval: func(req ApprovalRequest) (ApprovalDecision, error) {
 			if req.Command != "write_file" {
 				t.Fatalf("unexpected approval command: %q", req.Command)
 			}
 			if !strings.Contains(req.Reason, "destructive tool") {
 				t.Fatalf("unexpected approval reason: %q", req.Reason)
 			}
-			return true, nil
+			return ApprovalDecision{Disposition: ApprovalApproveOnce}, nil
 		},
 	})
 	if err != nil {
@@ -370,9 +370,9 @@ func TestExecutorAwayModeAutoDenySkipsDestructiveApprovalPrompt(t *testing.T) {
 		ApprovalPolicy: "on-request",
 		ApprovalMode:   "away",
 		AwayPolicy:     "auto_deny_continue",
-		Approval: func(req ApprovalRequest) (bool, error) {
+		Approval: func(req ApprovalRequest) (ApprovalDecision, error) {
 			asked = true
-			return true, nil
+			return ApprovalDecision{Disposition: ApprovalApproveOnce}, nil
 		},
 	})
 	if err == nil {

--- a/internal/tools/run_shell.go
+++ b/internal/tools/run_shell.go
@@ -225,14 +225,15 @@ func promptForApproval(command, reason string, execCtx *ExecutionContext) error 
 		return approvalChannelUnavailableError("shell command", command)
 	}
 	if execCtx.Approval != nil {
-		approved, err := execCtx.Approval(ApprovalRequest{
-			Command: command,
-			Reason:  reason,
+		decision, err := execCtx.Approval(ApprovalRequest{
+			ToolName: "run_shell",
+			Command:  command,
+			Reason:   reason,
 		})
 		if err != nil {
 			return err
 		}
-		if !approved {
+		if !NormalizeApprovalDecision(decision).Approved() {
 			return errors.New("shell command was not run because approval was denied")
 		}
 		return nil

--- a/internal/tools/worker.go
+++ b/internal/tools/worker.go
@@ -848,14 +848,15 @@ func escalateWorkerApproval(toolName string, decision sandboxpkg.DecisionResult,
 		}
 		return nil
 	}
-	approved, err := execCtx.Approval(ApprovalRequest{
-		Command: toolName,
-		Reason:  decision.Message,
+	decisionResult, err := execCtx.Approval(ApprovalRequest{
+		ToolName: toolName,
+		Command:  toolName,
+		Reason:   decision.Message,
 	})
 	if err != nil {
 		return NewToolExecError(ToolErrorPermissionDenied, err.Error(), false, err)
 	}
-	if !approved {
+	if !NormalizeApprovalDecision(decisionResult).Approved() {
 		return NewToolExecError(ToolErrorPermissionDenied, fmt.Sprintf("tool %q was not run because approval was denied", toolName), false, nil)
 	}
 	return nil

--- a/internal/tools/worker_process_test.go
+++ b/internal/tools/worker_process_test.go
@@ -250,12 +250,12 @@ func TestSubprocessWorkerPreApprovesInteractiveEscalation(t *testing.T) {
 			ExecAllowlist: []sandboxpkg.ExecRule{
 				{Command: "go run", ArgsPattern: []string{"./cmd/app"}},
 			},
-			Approval: func(req ApprovalRequest) (bool, error) {
+			Approval: func(req ApprovalRequest) (ApprovalDecision, error) {
 				approvalCalls++
 				if !strings.Contains(strings.ToLower(req.Reason), "outside lease scope") {
 					t.Fatalf("unexpected escalation reason: %q", req.Reason)
 				}
-				return true, nil
+				return ApprovalDecision{Disposition: ApprovalApproveOnce}, nil
 			},
 		},
 	})
@@ -296,12 +296,12 @@ func TestSubprocessWorkerPreApprovesInteractiveShellRiskOnce(t *testing.T) {
 			ExecAllowlist: []sandboxpkg.ExecRule{
 				{Command: "go test", ArgsPattern: []string{"./..."}},
 			},
-			Approval: func(req ApprovalRequest) (bool, error) {
+			Approval: func(req ApprovalRequest) (ApprovalDecision, error) {
 				approvalCalls++
 				if !strings.Contains(strings.ToLower(req.Command), "go test") {
 					t.Fatalf("unexpected approval command: %q", req.Command)
 				}
-				return true, nil
+				return ApprovalDecision{Disposition: ApprovalApproveOnce}, nil
 			},
 		},
 	})

--- a/internal/tools/worker_test.go
+++ b/internal/tools/worker_test.go
@@ -199,12 +199,12 @@ func TestInProcessWorkerEscalatesRunShellWhenCommandNotInAllowlist(t *testing.T)
 			},
 			ApprovalPolicy: "on-request",
 			ApprovalMode:   "interactive",
-			Approval: func(req ApprovalRequest) (bool, error) {
+			Approval: func(req ApprovalRequest) (ApprovalDecision, error) {
 				approvalCalls++
 				if !strings.Contains(strings.ToLower(req.Reason), "outside lease scope") {
 					t.Fatalf("expected escalation reason to explain outside lease scope, got %q", req.Reason)
 				}
-				return true, nil
+				return ApprovalDecision{Disposition: ApprovalApproveOnce}, nil
 			},
 		},
 	})

--- a/tui/approval_bridge_test.go
+++ b/tui/approval_bridge_test.go
@@ -62,12 +62,13 @@ func TestInstallApprovalBridgeRoutesRunnerApprovalsToAsyncChannel(t *testing.T) 
 	}
 
 	done := make(chan struct{})
-	var approved bool
+	var approved ApprovalDecision
 	var callErr error
 	go func() {
 		approved, callErr = runner.handler(ApprovalRequest{
-			Command: "go test ./...",
-			Reason:  "outside lease scope",
+			ToolName: "run_shell",
+			Command:  "go test ./...",
+			Reason:   "outside lease scope",
 		})
 		close(done)
 	}()
@@ -81,7 +82,7 @@ func TestInstallApprovalBridgeRoutesRunnerApprovalsToAsyncChannel(t *testing.T) 
 		if req.Request.Command != "go test ./..." {
 			t.Fatalf("unexpected approval command: %#v", req.Request)
 		}
-		req.Reply <- approvalDecision{Approved: true}
+		req.Reply <- approvalDecision{Decision: ApprovalDecision{Disposition: ApprovalApproveOnce}}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for approval request message")
 	}
@@ -94,7 +95,7 @@ func TestInstallApprovalBridgeRoutesRunnerApprovalsToAsyncChannel(t *testing.T) 
 	if callErr != nil {
 		t.Fatalf("unexpected approval handler error: %v", callErr)
 	}
-	if !approved {
+	if !approved.Approved() {
 		t.Fatal("expected approval decision to propagate back to runner handler")
 	}
 }

--- a/tui/approval_logic_test.go
+++ b/tui/approval_logic_test.go
@@ -1,0 +1,159 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestApprovalDecisionHelpers(t *testing.T) {
+	for _, decision := range []ApprovalDecision{
+		{Disposition: ApprovalApproveOnce},
+		{Disposition: ApprovalApproveSameToolSession},
+		{Disposition: ApprovalApproveAllSession},
+	} {
+		if !decision.Approved() {
+			t.Fatalf("expected %+v to count as approved", decision)
+		}
+	}
+
+	denied := ApprovalDecision{Disposition: ApprovalDeny}
+	if denied.Approved() {
+		t.Fatalf("expected %+v not to count as approved", denied)
+	}
+
+	normalized := NormalizeApprovalDecision(ApprovalDecision{Disposition: ApprovalDisposition("mystery")})
+	if normalized.Disposition != ApprovalDeny {
+		t.Fatalf("expected unknown approval disposition to normalize to deny, got %+v", normalized)
+	}
+}
+
+func TestApprovalToolKeyAndOptionCatalog(t *testing.T) {
+	if got := approvalToolKey("  Run_Shell  "); got != "run_shell" {
+		t.Fatalf("expected normalized tool key, got %q", got)
+	}
+
+	options := model{}.approvalOptions()
+	if len(options) != 3 {
+		t.Fatalf("expected 3 approval options, got %d", len(options))
+	}
+	if options[0].Decision != ApprovalApproveOnce || options[1].Decision != ApprovalApproveSameToolSession || options[2].Decision != ApprovalApproveAllSession {
+		t.Fatalf("unexpected approval options ordering: %+v", options)
+	}
+}
+
+func TestApprovalStateHelpers(t *testing.T) {
+	m := &model{
+		sessionApprovalAll:   true,
+		sessionApprovedTools: map[string]struct{}{"run_shell": {}},
+	}
+
+	if decision, ok := m.cachedApprovalDecision(ApprovalRequest{ToolName: "anything"}); !ok || decision.Disposition != ApprovalApproveAllSession {
+		t.Fatalf("expected global session approval cache, got ok=%v decision=%+v", ok, decision)
+	}
+
+	m.resetSessionApprovalState()
+	if m.sessionApprovalAll {
+		t.Fatal("expected reset to clear global session approval")
+	}
+	if len(m.sessionApprovedTools) != 0 {
+		t.Fatalf("expected reset to clear approved tools, got %#v", m.sessionApprovedTools)
+	}
+
+	m.rememberApprovalDecision(ApprovalRequest{ToolName: "Run_Shell"}, ApprovalDecision{Disposition: ApprovalApproveSameToolSession})
+	if _, ok := m.sessionApprovedTools["run_shell"]; !ok {
+		t.Fatalf("expected same-tool approval to be remembered, got %#v", m.sessionApprovedTools)
+	}
+
+	if decision, ok := m.cachedApprovalDecision(ApprovalRequest{ToolName: "run_shell"}); !ok || decision.Disposition != ApprovalApproveSameToolSession {
+		t.Fatalf("expected same-tool cached approval, got ok=%v decision=%+v", ok, decision)
+	}
+
+	if decision, ok := m.cachedApprovalDecision(ApprovalRequest{}); ok || decision.Disposition != "" {
+		t.Fatalf("expected empty tool name not to hit cache, got ok=%v decision=%+v", ok, decision)
+	}
+}
+
+func TestApprovalKeyNavigationAndApproveAllSession(t *testing.T) {
+	reply := make(chan approvalDecision, 1)
+	m := model{
+		approval: &approvalPrompt{
+			ToolName: "run_shell",
+			Command:  "go test ./tui",
+			Reason:   "run focused tests",
+			Reply:    reply,
+		},
+		sessionApprovedTools: make(map[string]struct{}),
+		phase:                "approval",
+		async:                make(chan tea.Msg, 1),
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	updated := got.(model)
+	if updated.approval.Cursor != 1 {
+		t.Fatalf("expected down to move approval cursor to 1, got %d", updated.approval.Cursor)
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	updated = got.(model)
+	if updated.approval.Cursor != 2 {
+		t.Fatalf("expected second down to move approval cursor to 2, got %d", updated.approval.Cursor)
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	updated = got.(model)
+	if updated.approval.Cursor != 1 {
+		t.Fatalf("expected up to move approval cursor back to 1, got %d", updated.approval.Cursor)
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	updated = got.(model)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	updated = got.(model)
+	if updated.approval.Cursor != 2 {
+		t.Fatalf("expected j navigation to reach final option, got %d", updated.approval.Cursor)
+	}
+
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = got.(model)
+	if updated.approval != nil {
+		t.Fatal("expected approval prompt to close after confirm")
+	}
+	if !updated.sessionApprovalAll {
+		t.Fatal("expected approve-all-session to persist on the model")
+	}
+	if updated.statusNote != "Session approvals disabled for this TUI session." {
+		t.Fatalf("unexpected status note after approve-all-session: %q", updated.statusNote)
+	}
+
+	select {
+	case decision := <-reply:
+		if decision.Decision.Disposition != ApprovalApproveAllSession {
+			t.Fatalf("expected approve-all-session decision, got %+v", decision)
+		}
+	default:
+		t.Fatal("expected approval decision to be sent")
+	}
+
+	reply2 := make(chan approvalDecision, 1)
+	got, cmd := updated.Update(approvalRequestMsg{
+		Request: ApprovalRequest{ToolName: "different_tool", Command: "echo hi", Reason: "cached globally"},
+		Reply:   reply2,
+	})
+	updated = got.(model)
+	if cmd == nil {
+		t.Fatal("expected async wait command after cached global approval")
+	}
+	if updated.approval != nil {
+		t.Fatalf("expected cached global approval to skip prompt, got %+v", updated.approval)
+	}
+
+	select {
+	case decision := <-reply2:
+		if decision.Decision.Disposition != ApprovalApproveAllSession {
+			t.Fatalf("expected cached global approval decision, got %+v", decision)
+		}
+	default:
+		t.Fatal("expected cached global approval reply")
+	}
+}

--- a/tui/component_conversation.go
+++ b/tui/component_conversation.go
@@ -20,7 +20,11 @@ func (m model) renderConversation() string {
 	for i := 0; i < len(m.chatItems); {
 		item := m.chatItems[i]
 		if item.Kind == "user" {
-			blocks = append(blocks, renderChatRow(item, width))
+			resolvedItem := item
+			if strings.Contains(item.Body, "[Paste #") || strings.Contains(item.Body, "[Pasted #") {
+				resolvedItem.Body = m.resolveUserBodyPastes(item.Body)
+			}
+			blocks = append(blocks, renderChatRow(resolvedItem, width))
 			i++
 			continue
 		}

--- a/tui/component_overlays.go
+++ b/tui/component_overlays.go
@@ -51,6 +51,10 @@ func (m model) renderHelpModal() string {
 func (m model) renderApprovalBanner() string {
 	bannerWidth := max(24, m.chatPanelInnerWidth())
 	innerWidth := max(20, bannerWidth-approvalBannerStyle.GetHorizontalFrameSize())
+	toolName := strings.TrimSpace(m.approval.ToolName)
+	if toolName == "" {
+		toolName = "unknown"
+	}
 	command := strings.TrimSpace(m.approval.Command)
 	if command == "" {
 		command = "-"
@@ -58,41 +62,62 @@ func (m model) renderApprovalBanner() string {
 
 	isFullAccessConfirm := strings.EqualFold(strings.TrimSpace(m.approval.Kind), approvalPromptKindEnableFullAccess)
 	title := "Approval required"
-	toolPrefix := "Tool: "
-	confirmLabel := "Approve"
-	rejectLabel := "Reject"
-	confirmTone := "success"
 	if isFullAccessConfirm {
+		toolPrefix := "Action: "
+		confirmLabel := "Enable"
+		rejectLabel := "Cancel"
+		confirmTone := "warning"
 		title = "Enable full access?"
-		toolPrefix = "Action: "
-		confirmLabel = "Enable"
-		rejectLabel = "Cancel"
-		confirmTone = "warning"
+
+		reasonBudget := max(0, innerWidth-lipgloss.Width(title)-2)
+		reason := trimPreview(m.approval.Reason, reasonBudget)
+		line1 := approvalTitleStyle.Render(title)
+		if reason != "" {
+			line1 += "  " + approvalReasonStyle.Render(reason)
+		}
+
+		actionLine := approvalCommandStyle.Render(toolPrefix + trimPreview(command, max(6, innerWidth-lipgloss.Width(toolPrefix))))
+		choice := m.currentApprovalChoice()
+		confirmChoice := renderApprovalChoice(confirmLabel, confirmTone, choice == approvalChoiceApprove)
+		rejectChoice := renderApprovalChoice(rejectLabel, "error", choice == approvalChoiceReject)
+		choiceLine := lipgloss.JoinHorizontal(lipgloss.Left, confirmChoice, "  ", rejectChoice)
+
+		hintLine := approvalHintStyle.Render("Use Left/Right to choose, Enter to confirm, Esc to cancel")
+		if lipgloss.Width(choiceLine)+2+lipgloss.Width(hintLine) <= innerWidth {
+			choiceLine += strings.Repeat(" ", innerWidth-lipgloss.Width(choiceLine)-lipgloss.Width(hintLine)) + hintLine
+			hintLine = ""
+		}
+
+		lines := []string{line1, actionLine, choiceLine}
+		if strings.TrimSpace(hintLine) != "" {
+			lines = append(lines, hintLine)
+		}
+		body := lipgloss.NewStyle().
+			Width(innerWidth).
+			Render(strings.Join(lines, "\n"))
+		return approvalBannerStyle.Render(body)
 	}
 
-	reasonBudget := max(0, innerWidth-lipgloss.Width(title)-2)
-	reason := trimPreview(m.approval.Reason, reasonBudget)
-	line1 := approvalTitleStyle.Render(title)
-	if reason != "" {
-		line1 += "  " + approvalReasonStyle.Render(reason)
+	lines := []string{
+		approvalTitleStyle.Render(title),
+		approvalReasonStyle.Render("Tool: " + trimPreview(toolName, innerWidth-6)),
+		approvalCommandStyle.Render("Command: " + trimPreview(command, innerWidth-9)),
 	}
-
-	actionLine := approvalCommandStyle.Render(toolPrefix + trimPreview(command, max(6, innerWidth-lipgloss.Width(toolPrefix))))
-
-	choice := m.currentApprovalChoice()
-	confirmChoice := renderApprovalChoice(confirmLabel, confirmTone, choice == approvalChoiceApprove)
-	rejectChoice := renderApprovalChoice(rejectLabel, "error", choice == approvalChoiceReject)
-	choiceLine := lipgloss.JoinHorizontal(lipgloss.Left, confirmChoice, "  ", rejectChoice)
-
-	hintLine := approvalHintStyle.Render("Use Left/Right to choose, Enter to confirm, Esc to cancel")
-	if lipgloss.Width(choiceLine)+2+lipgloss.Width(hintLine) <= innerWidth {
-		choiceLine += strings.Repeat(" ", innerWidth-lipgloss.Width(choiceLine)-lipgloss.Width(hintLine)) + hintLine
-		hintLine = ""
+	if reason := strings.TrimSpace(m.approval.Reason); reason != "" {
+		lines = append(lines, approvalReasonStyle.Render(wrapPlainText(reason, innerWidth)))
 	}
-	lines := []string{line1, actionLine, choiceLine}
-	if strings.TrimSpace(hintLine) != "" {
-		lines = append(lines, hintLine)
+	lines = append(lines, "")
+	for i, option := range m.approvalOptions() {
+		prefix := "  "
+		style := approvalOptionStyle
+		if i == clamp(m.approval.Cursor, 0, len(m.approvalOptions())-1) {
+			prefix = "> "
+			style = approvalOptionSelectedStyle
+		}
+		lines = append(lines, style.Render(prefix+option.Label))
+		lines = append(lines, approvalOptionDescriptionStyle.Render("  "+wrapPlainText(option.Description, max(8, innerWidth-2))))
 	}
+	lines = append(lines, "", approvalHintStyle.Render("Up/Down or J/K to select  Enter confirm  Y approve once  N/Esc reject"))
 
 	body := lipgloss.NewStyle().
 		Width(innerWidth).

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -167,6 +167,49 @@ func TestRenderConversationKeepsProgressBlueAndFinalNeutral(t *testing.T) {
 	}
 }
 
+func TestRenderConversationRendersExpandableUserPasteBlocks(t *testing.T) {
+	m := model{
+		pastedContents: map[string]pastedContent{
+			"1": {
+				ID:      "1",
+				Content: "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12",
+				Lines:   12,
+			},
+		},
+		pastedOrder:      []string{"1"},
+		pasteExpandLevel: map[string]int{},
+	}
+	m.viewport.Width = 100
+	m.chatItems = []chatEntry{{Kind: "user", Title: "You", Body: "inspect [Paste #1 ~12 lines]"}}
+
+	collapsed := stripANSI(m.renderConversation())
+	if !strings.Contains(collapsed, "[Paste #1 ~12 lines]") {
+		t.Fatalf("expected collapsed paste marker in conversation, got %q", collapsed)
+	}
+	if !strings.Contains(collapsed, "[click]") {
+		t.Fatalf("expected collapsed paste marker hint, got %q", collapsed)
+	}
+
+	m.pasteExpandLevel["1"] = 1
+	preview := stripANSI(m.renderConversation())
+	for _, want := range []string{"[Paste #1 ~12 lines] [preview]", "line1", "line10", "... (2 more lines, click again for full, Ctrl+E expand all)"} {
+		if !strings.Contains(preview, want) {
+			t.Fatalf("expected preview conversation to contain %q, got %q", want, preview)
+		}
+	}
+	if strings.Contains(preview, "line11") || strings.Contains(preview, "line12") {
+		t.Fatalf("expected preview not to show remaining lines, got %q", preview)
+	}
+
+	m.pasteExpandLevel["1"] = 2
+	full := stripANSI(m.renderConversation())
+	for _, want := range []string{"[Paste #1 ~12 lines] [full]", "line12", "click again to collapse"} {
+		if !strings.Contains(full, want) {
+			t.Fatalf("expected full conversation to contain %q, got %q", want, full)
+		}
+	}
+}
+
 func TestRenderBytemindRunCardCollapsesConsecutiveReadTools(t *testing.T) {
 	view := stripANSI(renderBytemindRunCard([]chatEntry{
 		{Kind: "assistant", Title: thinkingLabel, Body: "Inspecting files", Status: "thinking"},
@@ -351,7 +394,7 @@ func TestRenderRunSectionDividerUsesAsciiHyphen(t *testing.T) {
 	if !strings.Contains(got, "-----") {
 		t.Fatalf("expected divider to use ascii hyphens, got %q", got)
 	}
-	if strings.Contains(got, "鈹€") {
+	if strings.Contains(got, "─") {
 		t.Fatalf("expected divider not to use box-drawing glyphs, got %q", got)
 	}
 }

--- a/tui/component_sessions.go
+++ b/tui/component_sessions.go
@@ -124,6 +124,7 @@ func (m *model) newSession() error {
 		return err
 	}
 	m.sess = next
+	m.resetSessionApprovalState()
 	m.screen = screenLanding
 	m.plan = planpkg.State{}
 	m.mode = modeBuild
@@ -182,6 +183,7 @@ func (m *model) resumeSession(prefix string) error {
 		return fmt.Errorf("session %s belongs to workspace %s", next.ID, next.Workspace)
 	}
 	m.sess = next
+	m.resetSessionApprovalState()
 	m.screen = screenChat
 	m.plan = copyPlanState(next.Plan)
 	m.mode = toAgentMode(next.Mode)

--- a/tui/component_text_render.go
+++ b/tui/component_text_render.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 
@@ -19,6 +20,9 @@ func formatChatCopyBody(item chatEntry, width int) string {
 func formatChatBodyMode(item chatEntry, width int, copyMode bool) string {
 	text := strings.ReplaceAll(item.Body, "\r\n", "\n")
 	if item.Kind == "user" {
+		if strings.Contains(text, "[Paste #") || strings.Contains(text, "[Pasted #") {
+			return strings.TrimRight(renderUserPasteAwareBody(text, width, copyMode), "\n")
+		}
 		return strings.TrimRight(wrapPlainText(text, width), "\n")
 	}
 	if item.Kind == "tool" {
@@ -43,6 +47,86 @@ func formatChatBodyMode(item chatEntry, width int, copyMode bool) string {
 		return strings.TrimRight(renderAssistantCopyBody(text, width), "\n")
 	}
 	return strings.TrimRight(renderAssistantBody(text, width), "\n")
+}
+
+func renderUserPasteAwareBody(text string, width int, copyMode bool) string {
+	if !strings.Contains(text, "[Paste #") && !strings.Contains(text, "[Pasted #") {
+		return wrapPlainText(text, width)
+	}
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	rendered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		rendered = append(rendered, renderUserPasteAwareLine(line, width, copyMode)...)
+	}
+	return strings.Join(rendered, "\n")
+}
+
+func renderUserPasteAwareLine(line string, width int, copyMode bool) []string {
+	if strings.TrimSpace(line) == "" {
+		return []string{""}
+	}
+	matches := pastedRefPattern.FindAllStringSubmatchIndex(line, -1)
+	if len(matches) == 0 {
+		return strings.Split(wrapPlainText(line, width), "\n")
+	}
+
+	out := make([]string, 0, len(matches)+1)
+	last := 0
+	for i, idx := range matches {
+		start, end := idx[0], idx[1]
+		prefix := line[last:start]
+		if strings.TrimSpace(prefix) != "" {
+			out = append(out, strings.Split(wrapPlainText(prefix, width), "\n")...)
+		}
+		nextStart := len(line)
+		if i+1 < len(matches) {
+			nextStart = matches[i+1][0]
+		}
+		markerSuffix := line[end:nextStart]
+		if strings.HasPrefix(strings.TrimSpace(markerSuffix), "[preview]") || strings.HasPrefix(strings.TrimSpace(markerSuffix), "[full]") {
+			out = append(out, renderWrappedPasteMarker(line[start:end]+markerSuffix, width, copyMode, false)...)
+			last = nextStart
+			continue
+		}
+		out = append(out, renderWrappedPasteMarker(line[start:end], width, copyMode, true)...)
+		last = end
+	}
+	suffix := line[last:]
+	if strings.TrimSpace(suffix) != "" {
+		out = append(out, strings.Split(wrapPlainText(suffix, width), "\n")...)
+	}
+	if len(out) == 0 {
+		return []string{""}
+	}
+	return out
+}
+
+func renderWrappedPasteMarker(marker string, width int, copyMode bool, showClickHint bool) []string {
+	if strings.TrimSpace(marker) == "" {
+		return nil
+	}
+	if copyMode {
+		return strings.Split(wrapPlainText(marker, width), "\n")
+	}
+	if width <= 0 {
+		width = 72
+	}
+	renderedMarker := pasteMarkerStyle.Render(marker)
+	if !showClickHint {
+		return []string{renderedMarker}
+	}
+	hintText := "[click]"
+	renderedHint := pasteExpandIconStyle.Render(hintText)
+	plainWidth := runewidth.StringWidth(marker) + 1 + runewidth.StringWidth(hintText)
+	if plainWidth <= width {
+		return []string{renderedMarker + " " + renderedHint}
+	}
+	wrapped := strings.Split(wrapPlainText(marker, width), "\n")
+	if len(wrapped) == 0 {
+		return []string{renderedMarker}
+	}
+	wrapped[len(wrapped)-1] = wrapped[len(wrapped)-1] + " " + renderedHint
+	return wrapped
 }
 
 func isHelpMarkdownText(text string) bool {
@@ -484,6 +568,7 @@ func renderSemanticAssistantLine(line string, width int) string {
 	if core == "" {
 		core = trimmed
 	}
+	intent := semanticIntent(core)
 
 	if isDocumentTitleLine(core) {
 		wrapped := strings.Split(wrapPlainText(core, width), "\n")
@@ -512,7 +597,7 @@ func renderSemanticAssistantLine(line string, width int) string {
 	}
 
 	label, rest, ok := splitSemanticLabel(core)
-	if !ok {
+	if !ok || intent == "" {
 		wrapped := strings.Split(wrapPlainText(core, max(8, width-runewidth.StringWidth(listPrefix))), "\n")
 		wrapped = applyIntentStyleToLines(core, wrapped)
 		return joinWithListPrefix(listPrefix, wrapped, isList)
@@ -957,4 +1042,123 @@ func renderMarkdownQuote(line string, width int) string {
 
 func looksLikeMarkdownTable(line string) bool {
 	return strings.Count(line, "|") >= 2
+}
+
+//
+// paste expansion rendering (in-conversation expand/collapse of compressed pastes)
+//
+
+const pastePreviewLineCount = 10
+
+func (m model) resolveUserBodyPastes(body string) string {
+	if !strings.Contains(body, "[Paste #") && !strings.Contains(body, "[Pasted #") {
+		return body
+	}
+	matches := pastedRefPattern.FindAllStringSubmatchIndex(body, -1)
+	if len(matches) == 0 {
+		return body
+	}
+
+	var out strings.Builder
+	last := 0
+	for _, idx := range matches {
+		start, end := idx[0], idx[1]
+		if start > last {
+			out.WriteString(body[last:start])
+		}
+
+		full := body[start:end]
+		pasteID := submatchString(body, idx, pasteRefGroupID)
+		if pasteID == "" {
+			out.WriteString(full)
+			last = end
+			continue
+		}
+
+		content, ok := m.pastedContents[pasteID]
+		if !ok {
+			out.WriteString(full)
+			last = end
+			continue
+		}
+
+		out.WriteString(renderResolvedPasteBlockPlain(content, m.pasteExpandLevel[pasteID]))
+		last = end
+	}
+	if last < len(body) {
+		out.WriteString(body[last:])
+	}
+	return out.String()
+}
+
+func resolvePasteBlockPlain(content pastedContent, level int) string {
+	switch level {
+	case 1:
+		return resolvePastePreviewPlain(content)
+	case 2:
+		return content.Content
+	default:
+		return fmt.Sprintf("▶ [Paste #%s ~%d lines]", content.ID, content.Lines)
+	}
+}
+
+func resolvePastePreviewPlain(content pastedContent) string {
+	lines := strings.Split(content.Content, "\n")
+	n := pastePreviewLineCount
+	if len(lines) < n {
+		n = len(lines)
+	}
+	var out strings.Builder
+	for i := 0; i < n; i++ {
+		out.WriteString(lines[i])
+		if i < n-1 {
+			out.WriteString("\n")
+		}
+	}
+	if len(lines) > pastePreviewLineCount {
+		out.WriteString(fmt.Sprintf("\n... (%d more lines, click or Ctrl+E to expand all)", len(lines)-pastePreviewLineCount))
+	}
+	return out.String()
+}
+
+func renderResolvedPasteBlockPlain(content pastedContent, level int) string {
+	header := fmt.Sprintf("[Paste #%s ~%d lines]", content.ID, content.Lines)
+	switch level {
+	case 1:
+		return renderResolvedPastePreviewPlain(content, header)
+	case 2:
+		return renderResolvedPasteExpandedPlain(content, header)
+	default:
+		return header
+	}
+}
+
+func renderResolvedPastePreviewPlain(content pastedContent, header string) string {
+	lines := strings.Split(content.Content, "\n")
+	n := pastePreviewLineCount
+	if len(lines) < n {
+		n = len(lines)
+	}
+	framed := make([]string, 0, n+2)
+	framed = append(framed, header+" [preview]")
+	for i := 0; i < n; i++ {
+		framed = append(framed, pasteExpandedFrameStyle.Render(lines[i]))
+	}
+	if len(lines) > pastePreviewLineCount {
+		framed = append(framed, pastePreviewStyle.Render(fmt.Sprintf("... (%d more lines, click again for full, Ctrl+E expand all)", len(lines)-pastePreviewLineCount)))
+	} else {
+		framed = append(framed, pastePreviewStyle.Render("click again to show full content"))
+	}
+	return strings.Join(framed, "\n")
+}
+
+func renderResolvedPasteExpandedPlain(content pastedContent, header string) string {
+	lines := strings.Split(content.Content, "\n")
+	framed := make([]string, 0, len(lines)+2)
+	framed = append(framed, header+" [full]")
+	for _, line := range lines {
+		framed = append(framed, pasteExpandedFrameStyle.Render(line))
+	}
+	framed = append(framed, pasteExpandAllHintStyle.Render("click again to collapse"))
+	return strings.Join(framed, "\n")
 }

--- a/tui/component_text_render_semantic_test.go
+++ b/tui/component_text_render_semantic_test.go
@@ -62,3 +62,28 @@ func TestApplyLineIntentStyleColorsInfoWarningAndError(t *testing.T) {
 		t.Fatalf("expected error styling to preserve text, got %q", errText)
 	}
 }
+
+func TestRenderSemanticAssistantLineDoesNotAccentGenericColonLabels(t *testing.T) {
+	got := renderSemanticAssistantLine("- 工具调用: 读写文件、搜索、打补丁", 80)
+	plain := stripANSI(got)
+	if !strings.Contains(plain, "- 工具调用: 读写文件、搜索、打补丁") {
+		t.Fatalf("expected generic label text to be preserved, got %q", plain)
+	}
+	if got != plain {
+		t.Fatalf("expected generic colon label not to receive standalone semantic highlighting, got %q", got)
+	}
+}
+
+func TestRenderSemanticAssistantLineKeepsIntentLabelsStyled(t *testing.T) {
+	got := stripANSI(renderSemanticAssistantLine("Tip: remember this detail", 12))
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected intent label rendering to wrap with semantic indentation, got %q", got)
+	}
+	if !strings.HasPrefix(lines[0], "Tip: ") {
+		t.Fatalf("expected first line to keep intent label prefix, got %q", got)
+	}
+	if !strings.HasPrefix(lines[1], strings.Repeat(" ", len("Tip: "))) {
+		t.Fatalf("expected wrapped intent label body to align after label prefix, got %q", got)
+	}
+}

--- a/tui/model.go
+++ b/tui/model.go
@@ -164,15 +164,17 @@ type toolRun struct {
 }
 
 type approvalPrompt struct {
-	Command string
-	Reason  string
-	Reply   chan approvalDecision
-	Kind    string
-	Choice  int
+	ToolName string
+	Command  string
+	Reason   string
+	Reply    chan approvalDecision
+	Kind     string
+	Choice   int
+	Cursor   int
 }
 
 type approvalDecision struct {
-	Approved bool
+	Decision ApprovalDecision
 	Err      error
 }
 
@@ -218,6 +220,12 @@ const (
 type approvalRequestMsg struct {
 	Request ApprovalRequest
 	Reply   chan approvalDecision
+}
+
+type approvalOption struct {
+	Label       string
+	Description string
+	Decision    ApprovalDisposition
 }
 
 type promptHistoryLoadedMsg struct {
@@ -378,6 +386,8 @@ type model struct {
 	phase                      string
 	llmConnected               bool
 	approval                   *approvalPrompt
+	sessionApprovalAll         bool
+	sessionApprovedTools       map[string]struct{}
 	mentionQuery               string
 	mentionToken               mention.Token
 	mentionResults             []mention.Candidate
@@ -492,11 +502,11 @@ func newModel(opts Options) model {
 		opts.Runner.SetObserver(func(event Event) {
 			async <- agentEventMsg{Event: event}
 		})
-		opts.Runner.SetApprovalHandler(func(req ApprovalRequest) (bool, error) {
+		opts.Runner.SetApprovalHandler(func(req ApprovalRequest) (ApprovalDecision, error) {
 			reply := make(chan approvalDecision, 1)
 			async <- approvalRequestMsg{Request: req, Reply: reply}
 			decision := <-reply
-			return decision.Approved, decision.Err
+			return NormalizeApprovalDecision(decision.Decision), decision.Err
 		})
 	}
 
@@ -527,6 +537,7 @@ func newModel(opts Options) model {
 		statusNote:           "Ready.",
 		phase:                "idle",
 		llmConnected:         true,
+		sessionApprovedTools: make(map[string]struct{}),
 		chatAutoFollow:       true,
 		mentionIndex:         mention.NewWorkspaceFileIndex(opts.Workspace),
 		tokenUsage:           newTokenUsageComponent(),
@@ -573,11 +584,11 @@ func (m *model) installApprovalBridge() {
 		return
 	}
 	async := m.async
-	m.runner.SetApprovalHandler(func(req ApprovalRequest) (bool, error) {
+	m.runner.SetApprovalHandler(func(req ApprovalRequest) (ApprovalDecision, error) {
 		reply := make(chan approvalDecision, 1)
 		async <- approvalRequestMsg{Request: req, Reply: reply}
 		decision := <-reply
-		return decision.Approved, decision.Err
+		return NormalizeApprovalDecision(decision.Decision), decision.Err
 	})
 }
 
@@ -597,6 +608,75 @@ func resolveMouseYOffset() int {
 		return 0
 	}
 	return clamp(value, -10, 10)
+}
+
+func approvalToolKey(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func (m model) approvalOptions() []approvalOption {
+	return []approvalOption{
+		{
+			Label:       "Approve this operation only",
+			Description: "Allow just the current request; the same tool will ask again the next time approval is needed.",
+			Decision:    ApprovalApproveOnce,
+		},
+		{
+			Label:       "Approve later requests from this tool",
+			Description: "Auto-approve later approval requests from the same tool for the rest of this TUI session.",
+			Decision:    ApprovalApproveSameToolSession,
+		},
+		{
+			Label:       "Disable approvals for this TUI session",
+			Description: "Auto-approve all later approval requests in this TUI session without changing global config.",
+			Decision:    ApprovalApproveAllSession,
+		},
+	}
+}
+
+func (m *model) resetSessionApprovalState() {
+	if m == nil {
+		return
+	}
+	m.sessionApprovalAll = false
+	m.sessionApprovedTools = make(map[string]struct{})
+}
+
+func (m *model) cachedApprovalDecision(req ApprovalRequest) (ApprovalDecision, bool) {
+	if m == nil {
+		return ApprovalDecision{}, false
+	}
+	if m.sessionApprovalAll {
+		return ApprovalDecision{Disposition: ApprovalApproveAllSession}, true
+	}
+	toolKey := approvalToolKey(req.ToolName)
+	if toolKey == "" {
+		return ApprovalDecision{}, false
+	}
+	if _, ok := m.sessionApprovedTools[toolKey]; ok {
+		return ApprovalDecision{Disposition: ApprovalApproveSameToolSession}, true
+	}
+	return ApprovalDecision{}, false
+}
+
+func (m *model) rememberApprovalDecision(req ApprovalRequest, decision ApprovalDecision) {
+	if m == nil {
+		return
+	}
+	decision = NormalizeApprovalDecision(decision)
+	switch decision.Disposition {
+	case ApprovalApproveAllSession:
+		m.sessionApprovalAll = true
+	case ApprovalApproveSameToolSession:
+		toolKey := approvalToolKey(req.ToolName)
+		if toolKey == "" {
+			return
+		}
+		if m.sessionApprovedTools == nil {
+			m.sessionApprovedTools = make(map[string]struct{})
+		}
+		m.sessionApprovedTools[toolKey] = struct{}{}
+	}
 }
 
 func (m model) Init() tea.Cmd {
@@ -741,12 +821,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refreshViewport()
 		return m, tea.Batch(waitForAsync(m.async), m.loadSessionsCmd())
 	case approvalRequestMsg:
+		if decision, ok := m.cachedApprovalDecision(msg.Request); ok {
+			msg.Reply <- approvalDecision{Decision: decision}
+			return m, waitForAsync(m.async)
+		}
 		m.approval = &approvalPrompt{
-			Command: msg.Request.Command,
-			Reason:  msg.Request.Reason,
-			Reply:   msg.Reply,
-			Kind:    approvalPromptKindTool,
-			Choice:  approvalChoiceApprove,
+			ToolName: msg.Request.ToolName,
+			Command:  msg.Request.Command,
+			Reason:   msg.Request.Reason,
+			Reply:    msg.Reply,
+			Kind:     approvalPromptKindTool,
+			Choice:   approvalChoiceApprove,
+			Cursor:   0,
 		}
 		m.statusNote = "Approval required."
 		m.phase = "approval"
@@ -1353,17 +1439,63 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.approval != nil {
+		if m.approval.Kind == approvalPromptKindEnableFullAccess {
+			switch msg.String() {
+			case "left", "h", "up", "k", "shift+tab", "backtab":
+				m.setApprovalChoice(approvalChoiceApprove)
+			case "right", "l", "down", "j", "tab":
+				m.setApprovalChoice(approvalChoiceReject)
+			case "enter":
+				m.resolveApprovalDecision(m.currentApprovalChoice() == approvalChoiceApprove)
+			case "y", "Y":
+				m.resolveApprovalDecision(true)
+			case "n", "N", "esc":
+				m.resolveApprovalDecision(false)
+			}
+			return m, nil
+		}
+
 		switch msg.String() {
-		case "left", "h", "up", "k", "shift+tab", "backtab":
-			m.setApprovalChoice(approvalChoiceApprove)
-		case "right", "l", "down", "j", "tab":
-			m.setApprovalChoice(approvalChoiceReject)
-		case "enter":
-			m.resolveApprovalDecision(m.currentApprovalChoice() == approvalChoiceApprove)
+		case "up", "k":
+			m.approval.Cursor = clamp(m.approval.Cursor-1, 0, len(m.approvalOptions())-1)
+		case "down", "j":
+			m.approval.Cursor = clamp(m.approval.Cursor+1, 0, len(m.approvalOptions())-1)
 		case "y", "Y":
-			m.resolveApprovalDecision(true)
+			req := ApprovalRequest{ToolName: m.approval.ToolName, Command: m.approval.Command, Reason: m.approval.Reason}
+			decision := ApprovalDecision{Disposition: ApprovalApproveOnce}
+			m.rememberApprovalDecision(req, decision)
+			if m.approval.Reply != nil {
+				m.approval.Reply <- approvalDecision{Decision: decision}
+			}
+			m.statusNote = "Approved current operation."
+			m.phase = "tool"
+			m.approval = nil
+		case "enter":
+			options := m.approvalOptions()
+			selected := options[clamp(m.approval.Cursor, 0, len(options)-1)]
+			req := ApprovalRequest{ToolName: m.approval.ToolName, Command: m.approval.Command, Reason: m.approval.Reason}
+			decision := ApprovalDecision{Disposition: selected.Decision}
+			m.rememberApprovalDecision(req, decision)
+			if m.approval.Reply != nil {
+				m.approval.Reply <- approvalDecision{Decision: decision}
+			}
+			switch selected.Decision {
+			case ApprovalApproveAllSession:
+				m.statusNote = "Session approvals disabled for this TUI session."
+			case ApprovalApproveSameToolSession:
+				m.statusNote = "Future approvals for this tool will auto-pass in this session."
+			default:
+				m.statusNote = "Approved current operation."
+			}
+			m.phase = "tool"
+			m.approval = nil
 		case "n", "N", "esc":
-			m.resolveApprovalDecision(false)
+			if m.approval.Reply != nil {
+				m.approval.Reply <- approvalDecision{Decision: ApprovalDecision{Disposition: ApprovalDeny}}
+			}
+			m.statusNote = "Operation rejected."
+			m.phase = "thinking"
+			m.approval = nil
 		}
 		return m, nil
 	}
@@ -2769,8 +2901,12 @@ func (m *model) resolveApprovalDecision(approved bool) {
 		return
 	}
 	current := m.approval
+	decision := ApprovalDecision{Disposition: ApprovalDeny}
+	if approved {
+		decision = ApprovalDecision{Disposition: ApprovalApproveOnce}
+	}
 	if current.Reply != nil {
-		current.Reply <- approvalDecision{Approved: approved}
+		current.Reply <- approvalDecision{Decision: decision}
 	}
 	switch current.Kind {
 	case approvalPromptKindEnableFullAccess:
@@ -2783,10 +2919,10 @@ func (m *model) resolveApprovalDecision(approved bool) {
 		m.phase = "idle"
 	case approvalPromptKindTool, "":
 		if approved {
-			m.statusNote = "Shell command approved."
+			m.statusNote = "Approved current operation."
 			m.phase = "tool"
 		} else {
-			m.statusNote = "Shell command rejected."
+			m.statusNote = "Operation rejected."
 			m.phase = "thinking"
 		}
 	default:

--- a/tui/model.go
+++ b/tui/model.go
@@ -278,6 +278,12 @@ type hiddenPasteProbeFlushMsg struct {
 	ID int
 }
 
+type togglePasteExpandMsg struct {
+	PasteID string
+}
+
+type togglePasteExpandAllMsg struct{}
+
 type mcpCommandResultMsg struct {
 	Input    string
 	Response string
@@ -443,6 +449,7 @@ type model struct {
 	pastedOrder                []string
 	nextPasteID                int
 	pastedStateLoaded          bool
+	pasteExpandLevel           map[string]int // 0=collapsed, 1=preview (first 10 lines), 2=full
 	lastCompressedPasteAt      time.Time
 	virtualPasteParts          []virtualPastePart
 	nextVirtualPastePart       int
@@ -549,6 +556,7 @@ func newModel(opts Options) model {
 		nextImageID:          nextSessionImageID(opts.Session),
 		pastedContents:       make(map[string]pastedContent, maxStoredPastedContents),
 		pastedOrder:          make([]string, 0, maxStoredPastedContents),
+		pasteExpandLevel:     make(map[string]int),
 		nextPasteID:          1,
 		virtualPasteParts:    make([]virtualPastePart, 0, maxStoredPastedContents),
 		nextVirtualPastePart: 1,
@@ -921,6 +929,33 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.flushHiddenPasteProbeToInput()
 		m.syncInputOverlays()
+		return m, nil
+	case togglePasteExpandMsg:
+		if m.pasteExpandLevel == nil {
+			m.pasteExpandLevel = make(map[string]int)
+		}
+		m.pasteExpandLevel[msg.PasteID] = (m.pasteExpandLevel[msg.PasteID] + 1) % 3
+		m.refreshViewport()
+		return m, nil
+	case togglePasteExpandAllMsg:
+		if m.pasteExpandLevel == nil {
+			m.pasteExpandLevel = make(map[string]int)
+		}
+		allFull := true
+		for _, id := range m.pastedOrder {
+			if m.pasteExpandLevel[id] != 2 {
+				allFull = false
+				break
+			}
+		}
+		newLevel := 2
+		if allFull {
+			newLevel = 0
+		}
+		for _, id := range m.pastedOrder {
+			m.pasteExpandLevel[id] = newLevel
+		}
+		m.refreshViewport()
 		return m, nil
 	case mouseSelectionScrollTickMsg:
 		return m.handleMouseSelectionScrollTick(msg)
@@ -1436,6 +1471,17 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.toggleApprovalMode()
 		return m, nil
+	case "ctrl+e":
+		if m.screen != screenChat {
+			return m, nil
+		}
+		if m.approval != nil || m.helpOpen || m.sessionsOpen || m.skillsOpen || m.commandOpen || m.mentionOpen || m.planActionOpen {
+			return m, nil
+		}
+		if len(m.pastedOrder) == 0 {
+			return m, nil
+		}
+		return m, func() tea.Msg { return togglePasteExpandAllMsg{} }
 	}
 
 	if m.approval != nil {

--- a/tui/model.go
+++ b/tui/model.go
@@ -2889,6 +2889,10 @@ func (m model) autoFollowLabel() string {
 
 func (m model) currentModelLabel() string {
 	if model := strings.TrimSpace(m.cfg.Provider.Model); model != "" {
+		lower := strings.ToLower(model)
+		if strings.HasSuffix(lower, " (bytemind)") {
+			return strings.TrimSpace(strings.TrimSuffix(lower, " (bytemind)"))
+		}
 		return model
 	}
 	return "-"

--- a/tui/model_mouse_selection.go
+++ b/tui/model_mouse_selection.go
@@ -99,10 +99,23 @@ func (m model) handleViewportMouseEvent(msg tea.MouseMsg) (tea.Model, tea.Cmd, b
 		}
 		return m, nil, true
 	case tea.MouseActionRelease:
-		if point, ok := m.viewportPointFromMouseWithAutoScroll(msg.X, msg.Y); ok && selectionHasRange(m.mouseSelectionStart, point) {
-			m.mouseSelectionEnd = point
-			m.mouseSelectionActive = true
-			m.statusNote = "Selection ready. Press Ctrl+C to copy."
+		if point, ok := m.viewportPointFromMouseWithAutoScroll(msg.X, msg.Y); ok {
+			if !selectionHasRange(m.mouseSelectionStart, point) {
+				if pasteID := m.pasteIDAtViewportPoint(point); pasteID != "" {
+					m.clearMouseSelection()
+					m.mouseSelecting = false
+					m.stopMouseSelectionScrollTicker()
+					m.draggingScrollbar = false
+					return m, func() tea.Msg { return togglePasteExpandMsg{PasteID: pasteID} }, true
+				}
+			}
+			if selectionHasRange(m.mouseSelectionStart, point) {
+				m.mouseSelectionEnd = point
+				m.mouseSelectionActive = true
+				m.statusNote = "Selection ready. Press Ctrl+C to copy."
+			} else {
+				m.clearMouseSelection()
+			}
 		} else {
 			m.clearMouseSelection()
 		}
@@ -879,4 +892,26 @@ func highlightVisibleLineByCells(line string, startCol, endCol int) string {
 
 func selectionHasRange(start, end viewportSelectionPoint) bool {
 	return start.Row != end.Row || start.Col != end.Col
+}
+
+func (m model) pasteIDAtViewportPoint(point viewportSelectionPoint) string {
+	lines := m.selectionSourceLines()
+	if point.Row < 0 || point.Row >= len(lines) {
+		return ""
+	}
+	for row := point.Row; row >= 0; row-- {
+		line := lines[row]
+		match := compressedPasteMarkerAnyPattern.FindString(line)
+		if match != "" {
+			details := compressedPasteMarkerDetailsPattern.FindStringSubmatch(match)
+			if len(details) >= 2 {
+				return details[1]
+			}
+			return ""
+		}
+		if row != point.Row && strings.TrimSpace(stripANSI(line)) == "" {
+			break
+		}
+	}
+	return ""
 }

--- a/tui/model_mouse_selection_test.go
+++ b/tui/model_mouse_selection_test.go
@@ -76,6 +76,25 @@ func TestHandleMouseDragSelectionAutoScrollsBeyondViewport(t *testing.T) {
 	}
 }
 
+func TestPasteIDAtViewportPointFindsExpandedPasteBodyRows(t *testing.T) {
+	m := model{
+		viewportContentCache: strings.Join([]string{
+			"You",
+			"[Paste #1 ~12 lines] [preview]",
+			"│ line1",
+			"│ line2",
+			"... (10 more lines, click again for full, Ctrl+E expand all)",
+		}, "\n"),
+	}
+
+	for _, row := range []int{1, 2, 3, 4} {
+		got := m.pasteIDAtViewportPoint(viewportSelectionPoint{Row: row, Col: 2})
+		if got != "1" {
+			t.Fatalf("expected row %d to resolve to paste 1, got %q", row, got)
+		}
+	}
+}
+
 func TestMouseSelectionScrollTickAutoScrollsWhileHoldingAtBottomEdge(t *testing.T) {
 	input := textarea.New()
 	input.Focus()

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -116,14 +116,19 @@ func (a testRunnerAdapter) SetObserver(observer Observer) {
 }
 
 func (a testRunnerAdapter) SetApprovalHandler(handler ApprovalHandler) {
-	a.Runner.SetApprovalHandler(func(req tools.ApprovalRequest) (bool, error) {
+	a.Runner.SetApprovalHandler(func(req tools.ApprovalRequest) (tools.ApprovalDecision, error) {
 		if handler == nil {
-			return false, nil
+			return tools.ApprovalDecision{Disposition: tools.ApprovalDeny}, nil
 		}
-		return handler(ApprovalRequest{
-			Command: req.Command,
-			Reason:  req.Reason,
+		decision, err := handler(ApprovalRequest{
+			ToolName: req.ToolName,
+			Command:  req.Command,
+			Reason:   req.Reason,
 		})
+		if err != nil {
+			return tools.ApprovalDecision{}, err
+		}
+		return tools.ApprovalDecision{Disposition: tools.ApprovalDisposition(decision.Disposition)}, nil
 	})
 }
 
@@ -5090,9 +5095,8 @@ func TestApprovalBannerRendersAboveInput(t *testing.T) {
 		"Approval required",
 		"go test ./tui",
 		"run tests",
-		"Approve",
-		"Reject",
-		"Enter to confirm",
+		"Approve this operation only",
+		"Disable approvals for this TUI session",
 	} {
 		if !strings.Contains(footer, want) {
 			t.Fatalf("expected approval banner to contain %q", want)
@@ -5109,15 +5113,16 @@ func TestApprovalBannerUsesCompactSingleNormalBorder(t *testing.T) {
 		width: 64,
 		input: input,
 		approval: &approvalPrompt{
-			Command: "write_file_with_a_very_long_tool_name_to_force_truncation",
-			Reason:  "destructive tool may modify workspace files: write_file_with_a_very_long_tool_name_to_force_truncation",
+			ToolName: "write_file",
+			Command:  "write_file_with_a_very_long_tool_name_to_force_truncation",
+			Reason:   "destructive tool may modify workspace files: write_file_with_a_very_long_tool_name_to_force_truncation",
 		},
 	}
 
 	banner := m.renderApprovalBanner()
 	lines := strings.Split(banner, "\n")
-	if len(lines) < 6 {
-		t.Fatalf("expected boxed approval banner with action buttons and hint lines, got %d lines: %q", len(lines), banner)
+	if len(lines) < 10 {
+		t.Fatalf("expected taller boxed approval panel with selectable options, got %d lines: %q", len(lines), banner)
 	}
 	expectedWidth := max(24, m.chatPanelInnerWidth())
 	for i, line := range lines {
@@ -5125,7 +5130,7 @@ func TestApprovalBannerUsesCompactSingleNormalBorder(t *testing.T) {
 			t.Fatalf("expected banner line %d width %d, got %d (%q)", i, expectedWidth, got, line)
 		}
 	}
-	for _, want := range []string{"Tool:", "Approve", "Reject", "Enter to confirm"} {
+	for _, want := range []string{"Tool: write_file", "Approve later requests from this tool", "Disable approvals for this TUI session"} {
 		if !strings.Contains(banner, want) {
 			t.Fatalf("expected compact approval banner to contain %q", want)
 		}
@@ -5147,10 +5152,10 @@ func TestApprovalBannerDefaultsWhenCommandAndReasonEmpty(t *testing.T) {
 	if !strings.Contains(banner, "Approval required") {
 		t.Fatalf("expected approval title in banner, got %q", banner)
 	}
-	if !strings.Contains(banner, "Tool: -") {
-		t.Fatalf("expected empty command to fallback to '-', got %q", banner)
+	if !strings.Contains(banner, "Tool: unknown") {
+		t.Fatalf("expected empty tool name to fallback to 'unknown', got %q", banner)
 	}
-	if !strings.Contains(banner, "Approve") || !strings.Contains(banner, "Reject") {
+	if !strings.Contains(banner, "Command: -") || !strings.Contains(banner, "Enter confirm") {
 		t.Fatalf("expected approval actions to render, got %q", banner)
 	}
 }
@@ -5174,7 +5179,7 @@ func TestApprovalBannerNarrowWidthFallbackKeepsAlignedHint(t *testing.T) {
 			t.Fatalf("expected banner line %d width %d under narrow layout, got %d (%q)", i, expectedWidth, got, line)
 		}
 	}
-	for _, want := range []string{"Approve", "Reject", "Enter to", "confirm"} {
+	for _, want := range []string{"Up/Down", "Enter confirm", "Y approve once", "N/Esc", "reject"} {
 		if !strings.Contains(banner, want) {
 			t.Fatalf("expected narrow-layout fallback to keep action hint token %q, got %q", want, banner)
 		}
@@ -5209,8 +5214,9 @@ func TestUpdateApprovalRequestMsgSetsApprovalPhase(t *testing.T) {
 
 	got, cmd := m.Update(approvalRequestMsg{
 		Request: ApprovalRequest{
-			Command: "go test ./tui",
-			Reason:  "run focused tests",
+			ToolName: "run_shell",
+			Command:  "go test ./tui",
+			Reason:   "run focused tests",
 		},
 		Reply: reply,
 	})
@@ -5225,11 +5231,11 @@ func TestUpdateApprovalRequestMsgSetsApprovalPhase(t *testing.T) {
 	if updated.approval.Command != "go test ./tui" || updated.approval.Reason != "run focused tests" {
 		t.Fatalf("expected approval prompt contents to be preserved, got %+v", updated.approval)
 	}
-	if updated.approval.Kind != approvalPromptKindTool {
-		t.Fatalf("expected tool approval kind, got %q", updated.approval.Kind)
+	if updated.approval.ToolName != "run_shell" || updated.approval.Cursor != 0 {
+		t.Fatalf("expected approval prompt metadata to be initialized, got %+v", updated.approval)
 	}
-	if updated.approval.Choice != approvalChoiceApprove {
-		t.Fatalf("expected default tool approval choice to be approve, got %d", updated.approval.Choice)
+	if updated.approval.Kind != approvalPromptKindTool || updated.approval.Choice != approvalChoiceApprove {
+		t.Fatalf("expected tool approval defaults to be initialized, got %+v", updated.approval)
 	}
 	if updated.phase != "approval" || updated.statusNote != "Approval required." {
 		t.Fatalf("expected approval request to switch UI into approval state, got phase=%q note=%q", updated.phase, updated.statusNote)
@@ -5254,14 +5260,14 @@ func TestApprovalKeysTransitionStateAndSendDecision(t *testing.T) {
 		if updated.approval != nil {
 			t.Fatalf("expected approval prompt to clear after approval")
 		}
-		if updated.phase != "tool" || updated.statusNote != "Shell command approved." {
+		if updated.phase != "tool" || updated.statusNote != "Approved current operation." {
 			t.Fatalf("expected approval to move UI into tool phase, got phase=%q note=%q", updated.phase, updated.statusNote)
 		}
 
 		select {
 		case decision := <-reply:
-			if !decision.Approved {
-				t.Fatalf("expected approval decision to be true")
+			if !decision.Decision.Approved() || decision.Decision.Disposition != ApprovalApproveOnce {
+				t.Fatalf("expected approve-once decision, got %+v", decision)
 			}
 		default:
 			t.Fatalf("expected approval decision to be sent")
@@ -5285,14 +5291,14 @@ func TestApprovalKeysTransitionStateAndSendDecision(t *testing.T) {
 		if updated.approval != nil {
 			t.Fatalf("expected approval prompt to clear after rejection")
 		}
-		if updated.phase != "thinking" || updated.statusNote != "Shell command rejected." {
+		if updated.phase != "thinking" || updated.statusNote != "Operation rejected." {
 			t.Fatalf("expected rejection to return UI to thinking phase, got phase=%q note=%q", updated.phase, updated.statusNote)
 		}
 
 		select {
 		case decision := <-reply:
-			if decision.Approved {
-				t.Fatalf("expected rejection decision to be false")
+			if decision.Decision.Approved() || decision.Decision.Disposition != ApprovalDeny {
+				t.Fatalf("expected rejection decision, got %+v", decision)
 			}
 		default:
 			t.Fatalf("expected rejection decision to be sent")
@@ -5303,19 +5309,20 @@ func TestApprovalKeysTransitionStateAndSendDecision(t *testing.T) {
 		reply := make(chan approvalDecision, 1)
 		m := model{
 			approval: &approvalPrompt{
+				ToolName: "run_shell",
 				Command: "go test ./tui",
 				Reason:  "run focused tests",
 				Reply:   reply,
 				Kind:    approvalPromptKindTool,
-				Choice:  approvalChoiceApprove,
+				Cursor:  0,
 			},
 			phase: "approval",
 		}
 
-		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRight})
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyDown})
 		updated := got.(model)
-		if updated.approval == nil || updated.approval.Choice != approvalChoiceReject {
-			t.Fatalf("expected right key to move selection to reject, got %+v", updated.approval)
+		if updated.approval == nil || updated.approval.Cursor != 1 {
+			t.Fatalf("expected down key to move selection to second approval option, got %+v", updated.approval)
 		}
 
 		got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
@@ -5323,17 +5330,68 @@ func TestApprovalKeysTransitionStateAndSendDecision(t *testing.T) {
 		if updated.approval != nil {
 			t.Fatalf("expected approval prompt to clear after confirming selection")
 		}
-		if updated.phase != "thinking" || updated.statusNote != "Shell command rejected." {
+		if updated.phase != "tool" || updated.statusNote != "Future approvals for this tool will auto-pass in this session." {
 			t.Fatalf("expected selected rejection to return to thinking phase, got phase=%q note=%q", updated.phase, updated.statusNote)
 		}
 
 		select {
 		case decision := <-reply:
-			if decision.Approved {
-				t.Fatalf("expected rejection decision to be false")
+			if decision.Decision.Disposition != ApprovalApproveSameToolSession {
+				t.Fatalf("expected same-tool session approval decision, got %+v", decision)
 			}
 		default:
-			t.Fatalf("expected rejection decision to be sent")
+			t.Fatalf("expected approval decision to be sent")
+		}
+	})
+	t.Run("approve same tool session caches future requests", func(t *testing.T) {
+		reply := make(chan approvalDecision, 1)
+		m := model{
+			approval: &approvalPrompt{
+				ToolName: "run_shell",
+				Command:  "go test ./tui",
+				Reason:   "run focused tests",
+				Cursor:   1,
+				Reply:    reply,
+				Kind:     approvalPromptKindTool,
+			},
+			sessionApprovedTools: make(map[string]struct{}),
+			phase:                "approval",
+			async:                make(chan tea.Msg, 1),
+		}
+
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+		updated := got.(model)
+		if _, ok := updated.sessionApprovedTools["run_shell"]; !ok {
+			t.Fatalf("expected same-tool approval to be cached, got %#v", updated.sessionApprovedTools)
+		}
+		select {
+		case decision := <-reply:
+			if decision.Decision.Disposition != ApprovalApproveSameToolSession {
+				t.Fatalf("expected same-tool session decision, got %+v", decision)
+			}
+		default:
+			t.Fatal("expected approval decision to be sent")
+		}
+
+		reply2 := make(chan approvalDecision, 1)
+		got, cmd := updated.Update(approvalRequestMsg{
+			Request: ApprovalRequest{ToolName: "run_shell", Command: "go test ./...", Reason: "same tool"},
+			Reply:   reply2,
+		})
+		updated = got.(model)
+		if cmd == nil {
+			t.Fatal("expected async wait command after cached approval")
+		}
+		if updated.approval != nil {
+			t.Fatalf("expected cached same-tool request to skip prompt, got %+v", updated.approval)
+		}
+		select {
+		case decision := <-reply2:
+			if decision.Decision.Disposition != ApprovalApproveSameToolSession {
+				t.Fatalf("expected cached same-tool decision, got %+v", decision)
+			}
+		default:
+			t.Fatal("expected cached approval reply")
 		}
 	})
 }

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -5531,6 +5531,36 @@ func TestFullAccessConfirmationRejectKeepsInteractiveMode(t *testing.T) {
 	}
 }
 
+func TestCurrentModelLabelCompactsBytemindPSeriesName(t *testing.T) {
+	m := model{
+		cfg: config.Config{
+			Provider: config.ProviderConfig{Model: "P1 (bytemind)"},
+		},
+	}
+
+	if got := m.currentModelLabel(); got != "p1" {
+		t.Fatalf("expected compact bytemind model label, got %q", got)
+	}
+}
+
+func TestRenderStatusBarUsesCompactBytemindModelLabel(t *testing.T) {
+	m := model{
+		width: 120,
+		mode:  modeBuild,
+		cfg: config.Config{
+			Provider: config.ProviderConfig{Model: "P1 (bytemind)"},
+		},
+	}
+
+	bar := m.renderStatusBar()
+	if !strings.Contains(bar, "Model: p1") {
+		t.Fatalf("expected status bar to show compact model label, got %q", bar)
+	}
+	if strings.Contains(bar, "bytemind") {
+		t.Fatalf("expected status bar to omit verbose provider suffix, got %q", bar)
+	}
+}
+
 func TestUpdateRunFinishedMsgResetsBusyState(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := model{

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -5179,7 +5179,7 @@ func TestApprovalBannerNarrowWidthFallbackKeepsAlignedHint(t *testing.T) {
 			t.Fatalf("expected banner line %d width %d under narrow layout, got %d (%q)", i, expectedWidth, got, line)
 		}
 	}
-	for _, want := range []string{"Up/Down", "Enter confirm", "Y approve once", "N/Esc", "reject"} {
+	for _, want := range []string{"Up/Down", "Enter", "confirm", "Y approve", "once", "N/Esc", "reject"} {
 		if !strings.Contains(banner, want) {
 			t.Fatalf("expected narrow-layout fallback to keep action hint token %q, got %q", want, banner)
 		}
@@ -5310,11 +5310,11 @@ func TestApprovalKeysTransitionStateAndSendDecision(t *testing.T) {
 		m := model{
 			approval: &approvalPrompt{
 				ToolName: "run_shell",
-				Command: "go test ./tui",
-				Reason:  "run focused tests",
-				Reply:   reply,
-				Kind:    approvalPromptKindTool,
-				Cursor:  0,
+				Command:  "go test ./tui",
+				Reason:   "run focused tests",
+				Reply:    reply,
+				Kind:     approvalPromptKindTool,
+				Cursor:   0,
 			},
 			phase: "approval",
 		}

--- a/tui/ports.go
+++ b/tui/ports.go
@@ -39,11 +39,43 @@ type Event struct {
 }
 
 type ApprovalRequest struct {
-	Command string
-	Reason  string
+	ToolName string
+	Command  string
+	Reason   string
 }
 
-type ApprovalHandler func(ApprovalRequest) (bool, error)
+type ApprovalDisposition string
+
+const (
+	ApprovalApproveOnce            ApprovalDisposition = "approve_once"
+	ApprovalApproveSameToolSession ApprovalDisposition = "approve_same_tool_session"
+	ApprovalApproveAllSession      ApprovalDisposition = "approve_all_session"
+	ApprovalDeny                   ApprovalDisposition = "deny"
+)
+
+type ApprovalDecision struct {
+	Disposition ApprovalDisposition
+}
+
+func (d ApprovalDecision) Approved() bool {
+	switch d.Disposition {
+	case ApprovalApproveOnce, ApprovalApproveSameToolSession, ApprovalApproveAllSession:
+		return true
+	default:
+		return false
+	}
+}
+
+func NormalizeApprovalDecision(d ApprovalDecision) ApprovalDecision {
+	switch d.Disposition {
+	case ApprovalApproveOnce, ApprovalApproveSameToolSession, ApprovalApproveAllSession, ApprovalDeny:
+		return d
+	default:
+		return ApprovalDecision{Disposition: ApprovalDeny}
+	}
+}
+
+type ApprovalHandler func(ApprovalRequest) (ApprovalDecision, error)
 
 type Observer func(Event)
 

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -462,6 +462,16 @@ var (
 				Background(lipgloss.Color("#111824")).
 				Padding(0, 1)
 
+	approvalOptionStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextBase)
+
+	approvalOptionSelectedStyle = lipgloss.NewStyle().
+					Foreground(semanticColors.Accent).
+					Bold(true)
+
+	approvalOptionDescriptionStyle = lipgloss.NewStyle().
+					Foreground(semanticColors.TextMuted)
+
 	activeSkillBannerStyle = lipgloss.NewStyle().
 				BorderStyle(lipgloss.NormalBorder()).
 				BorderForeground(semanticColors.Accent).

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -701,3 +701,30 @@ func statusBadgeStyle(badgeType string) lipgloss.Style {
 func renderPillBadge(text, badgeType string) string {
 	return statusBadgeStyle(badgeType).Render(text)
 }
+
+//
+// paste expand styles (compress/expand paste markers in chat)
+//
+
+var (
+	pasteExpandIconStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#55CCFF")).
+				Bold(true)
+
+	pasteMarkerStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.AccentSoft).
+				Bold(true)
+
+	pastePreviewStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextMuted).
+				Italic(true)
+
+	pasteExpandedFrameStyle = lipgloss.NewStyle().
+				BorderLeft(true).
+				BorderStyle(lipgloss.ThickBorder()).
+				BorderForeground(semanticColors.CodeBorder).
+				PaddingLeft(2)
+
+	pasteExpandAllHintStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextMuted)
+)


### PR DESCRIPTION
本 PR 基于最新 main 重新整理了原 #329 的改动，主要包含两部分：

审批交互优化
为 TUI 中的工具审批增加会话级选择能力
支持仅批准当前操作、批准当前工具后续请求、关闭本次会话内后续审批
保留 full access 的单独确认流程，避免误开全局高权限
输入与聊天体验改进
保留输入区中的粘贴标记，减少长文本粘贴后的上下文丢失
增加聊天内容展开模式，提升长消息和长结果的查看体验
附带调整：

对最新主线上的相关测试做了兼容性修正
已通过 go test ./tui -v