### PR TITLE
fix: #340 #342 #343 CI/codecov补测试

### DIFF
--- a/internal/app/bootstrap_task_store_test.go
+++ b/internal/app/bootstrap_task_store_test.go
@@ -181,7 +181,7 @@ func TestBootstrapPersistsRuntimeTasksOnlyToUnifiedTaskLog(t *testing.T) {
 		t.Fatalf("Bootstrap failed: %v", err)
 	}
 
-	taskID, err := rt.TaskManager.Submit(context.Background(), runtimepkg.TaskSpec{Name: "persist"})
+	taskID, err := rt.TaskManager.Submit(context.Background(), blockingRuntimeTaskSpec(t, rt.TaskManager, "persist"))
 	if err != nil {
 		t.Fatalf("Submit failed: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestBootstrapFallsBackToLegacyRuntimeTaskStoreWhenUnifiedInitFails(t *testi
 		t.Fatalf("Bootstrap failed: %v", err)
 	}
 
-	taskID, err := rt.TaskManager.Submit(context.Background(), runtimepkg.TaskSpec{Name: "legacy-fallback"})
+	taskID, err := rt.TaskManager.Submit(context.Background(), blockingRuntimeTaskSpec(t, rt.TaskManager, "legacy-fallback"))
 	if err != nil {
 		t.Fatalf("Submit failed: %v", err)
 	}
@@ -286,5 +286,27 @@ func TestBootstrapFallsBackToLegacyRuntimeTaskStoreWhenUnifiedInitFails(t *testi
 	}
 	if len(legacyLogFiles) == 0 {
 		t.Fatal("expected legacy runtime log files when unified init fails")
+	}
+}
+
+func blockingRuntimeTaskSpec(t *testing.T, taskManager runtimepkg.TaskManager, name string) runtimepkg.TaskSpec {
+	t.Helper()
+
+	manager, ok := taskManager.(*runtimepkg.InMemoryTaskManager)
+	if !ok {
+		t.Fatalf("expected *runtime.InMemoryTaskManager, got %T", taskManager)
+	}
+
+	token := "test-" + name
+	manager.RegisterExecution(token, func(ctx context.Context, _ runtimepkg.Task) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	return runtimepkg.TaskSpec{
+		Name: name,
+		Metadata: map[string]string{
+			runtimepkg.TaskExecutionTokenMetadataKey: token,
+		},
 	}
 }

--- a/internal/app/session_utils.go
+++ b/internal/app/session_utils.go
@@ -50,15 +50,19 @@ func ParseSessionListLimit(raw string) (int, error) {
 }
 
 func SameWorkspace(a, b string) bool {
-	left, err := filepath.Abs(a)
+	return strings.EqualFold(normalizeWorkspacePath(a), normalizeWorkspacePath(b))
+}
+
+func normalizeWorkspacePath(path string) string {
+	normalized, err := filepath.Abs(path)
 	if err != nil {
-		left = a
+		normalized = path
 	}
-	right, err := filepath.Abs(b)
-	if err != nil {
-		right = b
+	normalized = filepath.Clean(normalized)
+	if resolved, err := filepath.EvalSymlinks(normalized); err == nil {
+		normalized = filepath.Clean(resolved)
 	}
-	return strings.EqualFold(filepath.Clean(left), filepath.Clean(right))
+	return normalized
 }
 
 func CreateSession(store *session.Store, workspace string) (*session.Session, error) {

--- a/internal/app/session_utils_test.go
+++ b/internal/app/session_utils_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -86,6 +87,21 @@ func TestSameWorkspaceNormalizesPaths(t *testing.T) {
 	workspace := t.TempDir()
 	if !SameWorkspace(workspace, filepath.Join(workspace, ".")) {
 		t.Fatal("expected normalized paths to match")
+	}
+}
+
+func TestSameWorkspaceNormalizesSymlinkedPaths(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	if err := os.Mkdir(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "workspace-link")
+	if err := os.Symlink(workspace, link); err != nil {
+		t.Skipf("symlinks are not available: %v", err)
+	}
+	if !SameWorkspace(workspace, link) {
+		t.Fatalf("expected symlinked workspace %q to match %q", link, workspace)
 	}
 }
 

--- a/internal/app/workspace_test.go
+++ b/internal/app/workspace_test.go
@@ -106,6 +106,7 @@ func TestResolveWorkspaceRejectsHighRiskHomeWithoutOverride(t *testing.T) {
 	})
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", "")
+	t.Setenv("BYTEMIND_ALLOW_BROAD_WORKSPACE", "")
 	if err := os.Chdir(home); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestInMemoryTaskManagerSubmitAndCancel(t *testing.T) {
-	mgr := NewInMemoryTaskManager()
+	mgr := newBlockingTaskManager()
 	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
 	if err != nil {
 		t.Fatalf("Submit failed: %v", err)
@@ -36,10 +36,7 @@ func TestInMemoryTaskManagerSubmitAndCancel(t *testing.T) {
 }
 
 func TestInMemoryTaskManagerWaitReturnsTerminalResult(t *testing.T) {
-	mgr := NewInMemoryTaskManager(WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
-		<-ctx.Done()
-		return nil, ctx.Err()
-	}))
+	mgr := newBlockingTaskManager()
 	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
 	if err != nil {
 		t.Fatalf("Submit failed: %v", err)
@@ -195,11 +192,16 @@ func TestInMemoryTaskManagerRetryFromFailedResetsTaskForRetry(t *testing.T) {
 }
 
 func TestInMemoryTaskManagerRetryRejectsNonFailedTask(t *testing.T) {
-	mgr := NewInMemoryTaskManager()
+	mgr := newBlockingTaskManager()
 	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
 	if err != nil {
 		t.Fatalf("Submit failed: %v", err)
 	}
+	defer func() {
+		if err := mgr.Cancel(context.Background(), id, "cleanup"); err != nil && !hasErrorCode(err, ErrorCodeInvalidTransition) {
+			t.Fatalf("cleanup cancel failed: %v", err)
+		}
+	}()
 
 	_, err = mgr.Retry(context.Background(), id)
 	if err == nil {
@@ -249,7 +251,7 @@ func TestInMemoryTaskManagerRetryUnknownTaskReturnsTaskNotFound(t *testing.T) {
 }
 
 func TestInMemoryTaskManagerCancelIsIdempotent(t *testing.T) {
-	mgr := NewInMemoryTaskManager()
+	mgr := newBlockingTaskManager()
 	id, err := mgr.Submit(context.Background(), TaskSpec{Name: "demo"})
 	if err != nil {
 		t.Fatalf("Submit failed: %v", err)
@@ -261,6 +263,13 @@ func TestInMemoryTaskManagerCancelIsIdempotent(t *testing.T) {
 	if err := mgr.Cancel(context.Background(), id, "second cancel"); err != nil {
 		t.Fatalf("second cancel should be idempotent, got: %v", err)
 	}
+}
+
+func newBlockingTaskManager() *InMemoryTaskManager {
+	return NewInMemoryTaskManager(WithTaskExecutor(func(ctx context.Context, _ Task) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}))
 }
 
 func TestInMemoryTaskManagerCancelRejectsCompletedTask(t *testing.T) {


### PR DESCRIPTION
#340
失败项不是 coverage 阈值没过，而是 Test with coverage 这一步里的 go test 挂了。

失败点：

--- FAIL: TestBootstrapPersistsRuntimeTasksOnlyToUnifiedTaskLog
bootstrap_task_store_test.go:189: Cancel failed: invalid task transition: failed -> killed
FAIL github.com/1024XEngineer/bytemind/internal/app
诊断：这个测试提交 runtime task 后立刻 Cancel，但当时 task 可能已经先进入 failed，所以取消时变成非法状态转换 failed -> killed。这是一个测试时序/测试 fixture 不稳定问题，不是 --version / --yolo 功能本身明显坏了。

处理建议：不用 revert #340。把后来那个 test(runtime): stabilize task cancellation tests 的修复正式合回 main，核心思路是给测试注册一个阻塞 executor，让任务稳定处于可取消状态后再 cancel。

#342
失败项是 Sandbox Acceptance (macos-latest) 里的 Run sandbox acceptance (Unix)，真正失败的是 ./internal/app 测试。

失败点：

--- FAIL: TestResolveWorkspaceRejectsHighRiskHomeWithoutOverride
workspace_test.go:115: expected high-risk home workspace to be rejected
FAIL github.com/1024XEngineer/bytemind/internal/app
诊断：这个是 #342 自己新增/改动的 workspace 风险目录逻辑相关测试。测试期望：当前目录是 HOME 时，默认应该拒绝作为 workspace。但在 macOS acceptance 环境里 ResolveWorkspace("") 没报错，说明高风险 HOME 判断被绕过了。

我本地验证了一点：如果环境里有 BYTEMIND_ALLOW_BROAD_WORKSPACE=true，会复现同样失败。因此最高概率是这个测试没有显式清掉 opt-in 环境变量，或者 macOS runner 上 HOME/路径归一化导致判断没命中。这个要修，不建议忽略。

处理建议：不用 revert 整个 #342，因为它修的是“大目录遍历卡死”这类有价值问题；应该开修复 PR，专门修 workspace.go/workspace_test.go 的 macOS 行为和测试隔离。

#343
失败项和 #342 完全同源：

--- FAIL: TestResolveWorkspaceRejectsHighRiskHomeWithoutOverride
workspace_test.go:115: expected high-risk home workspace to be rejected
诊断：#343 是 UI 改动，基本没有碰 workspace 风险判断。它失败是因为 #343 的 base 已经包含 #342，macOS acceptance 继续跑到同一个 #342 引入/暴露的问题。#343 本身不是这条 macOS 红灯的根因。

处理建议：不用 revert #343。先修 #342 的 workspace 测试/逻辑，#343 的这条红灯会一起消失。