### PR TITLE
feat(tui): keep paste markers in input and add chat expand modes

### DIFF
--- a/tui/component_conversation.go
+++ b/tui/component_conversation.go
@@ -20,7 +20,11 @@ func (m model) renderConversation() string {
 	for i := 0; i < len(m.chatItems); {
 		item := m.chatItems[i]
 		if item.Kind == "user" {
-			blocks = append(blocks, renderChatRow(item, width))
+			resolvedItem := item
+			if strings.Contains(item.Body, "[Paste #") || strings.Contains(item.Body, "[Pasted #") {
+				resolvedItem.Body = m.resolveUserBodyPastes(item.Body)
+			}
+			blocks = append(blocks, renderChatRow(resolvedItem, width))
 			i++
 			continue
 		}

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -167,6 +167,49 @@ func TestRenderConversationKeepsProgressBlueAndFinalNeutral(t *testing.T) {
 	}
 }
 
+func TestRenderConversationRendersExpandableUserPasteBlocks(t *testing.T) {
+	m := model{
+		pastedContents: map[string]pastedContent{
+			"1": {
+				ID:      "1",
+				Content: "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12",
+				Lines:   12,
+			},
+		},
+		pastedOrder:      []string{"1"},
+		pasteExpandLevel: map[string]int{},
+	}
+	m.viewport.Width = 100
+	m.chatItems = []chatEntry{{Kind: "user", Title: "You", Body: "inspect [Paste #1 ~12 lines]"}}
+
+	collapsed := stripANSI(m.renderConversation())
+	if !strings.Contains(collapsed, "[Paste #1 ~12 lines]") {
+		t.Fatalf("expected collapsed paste marker in conversation, got %q", collapsed)
+	}
+	if !strings.Contains(collapsed, "[click]") {
+		t.Fatalf("expected collapsed paste marker hint, got %q", collapsed)
+	}
+
+	m.pasteExpandLevel["1"] = 1
+	preview := stripANSI(m.renderConversation())
+	for _, want := range []string{"[Paste #1 ~12 lines] [preview]", "line1", "line10", "... (2 more lines, click again for full, Ctrl+E expand all)"} {
+		if !strings.Contains(preview, want) {
+			t.Fatalf("expected preview conversation to contain %q, got %q", want, preview)
+		}
+	}
+	if strings.Contains(preview, "line11") || strings.Contains(preview, "line12") {
+		t.Fatalf("expected preview not to show remaining lines, got %q", preview)
+	}
+
+	m.pasteExpandLevel["1"] = 2
+	full := stripANSI(m.renderConversation())
+	for _, want := range []string{"[Paste #1 ~12 lines] [full]", "line12", "click again to collapse"} {
+		if !strings.Contains(full, want) {
+			t.Fatalf("expected full conversation to contain %q, got %q", want, full)
+		}
+	}
+}
+
 func TestRenderBytemindRunCardCollapsesConsecutiveReadTools(t *testing.T) {
 	view := stripANSI(renderBytemindRunCard([]chatEntry{
 		{Kind: "assistant", Title: thinkingLabel, Body: "Inspecting files", Status: "thinking"},
@@ -351,7 +394,7 @@ func TestRenderRunSectionDividerUsesAsciiHyphen(t *testing.T) {
 	if !strings.Contains(got, "-----") {
 		t.Fatalf("expected divider to use ascii hyphens, got %q", got)
 	}
-	if strings.Contains(got, "鈹€") {
+	if strings.Contains(got, "─") {
 		t.Fatalf("expected divider not to use box-drawing glyphs, got %q", got)
 	}
 }

--- a/tui/component_text_render.go
+++ b/tui/component_text_render.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 
@@ -19,6 +20,9 @@ func formatChatCopyBody(item chatEntry, width int) string {
 func formatChatBodyMode(item chatEntry, width int, copyMode bool) string {
 	text := strings.ReplaceAll(item.Body, "\r\n", "\n")
 	if item.Kind == "user" {
+		if strings.Contains(text, "[Paste #") || strings.Contains(text, "[Pasted #") {
+			return strings.TrimRight(renderUserPasteAwareBody(text, width, copyMode), "\n")
+		}
 		return strings.TrimRight(wrapPlainText(text, width), "\n")
 	}
 	if item.Kind == "tool" {
@@ -43,6 +47,86 @@ func formatChatBodyMode(item chatEntry, width int, copyMode bool) string {
 		return strings.TrimRight(renderAssistantCopyBody(text, width), "\n")
 	}
 	return strings.TrimRight(renderAssistantBody(text, width), "\n")
+}
+
+func renderUserPasteAwareBody(text string, width int, copyMode bool) string {
+	if !strings.Contains(text, "[Paste #") && !strings.Contains(text, "[Pasted #") {
+		return wrapPlainText(text, width)
+	}
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	rendered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		rendered = append(rendered, renderUserPasteAwareLine(line, width, copyMode)...)
+	}
+	return strings.Join(rendered, "\n")
+}
+
+func renderUserPasteAwareLine(line string, width int, copyMode bool) []string {
+	if strings.TrimSpace(line) == "" {
+		return []string{""}
+	}
+	matches := pastedRefPattern.FindAllStringSubmatchIndex(line, -1)
+	if len(matches) == 0 {
+		return strings.Split(wrapPlainText(line, width), "\n")
+	}
+
+	out := make([]string, 0, len(matches)+1)
+	last := 0
+	for i, idx := range matches {
+		start, end := idx[0], idx[1]
+		prefix := line[last:start]
+		if strings.TrimSpace(prefix) != "" {
+			out = append(out, strings.Split(wrapPlainText(prefix, width), "\n")...)
+		}
+		nextStart := len(line)
+		if i+1 < len(matches) {
+			nextStart = matches[i+1][0]
+		}
+		markerSuffix := line[end:nextStart]
+		if strings.HasPrefix(strings.TrimSpace(markerSuffix), "[preview]") || strings.HasPrefix(strings.TrimSpace(markerSuffix), "[full]") {
+			out = append(out, renderWrappedPasteMarker(line[start:end]+markerSuffix, width, copyMode, false)...)
+			last = nextStart
+			continue
+		}
+		out = append(out, renderWrappedPasteMarker(line[start:end], width, copyMode, true)...)
+		last = end
+	}
+	suffix := line[last:]
+	if strings.TrimSpace(suffix) != "" {
+		out = append(out, strings.Split(wrapPlainText(suffix, width), "\n")...)
+	}
+	if len(out) == 0 {
+		return []string{""}
+	}
+	return out
+}
+
+func renderWrappedPasteMarker(marker string, width int, copyMode bool, showClickHint bool) []string {
+	if strings.TrimSpace(marker) == "" {
+		return nil
+	}
+	if copyMode {
+		return strings.Split(wrapPlainText(marker, width), "\n")
+	}
+	if width <= 0 {
+		width = 72
+	}
+	renderedMarker := pasteMarkerStyle.Render(marker)
+	if !showClickHint {
+		return []string{renderedMarker}
+	}
+	hintText := "[click]"
+	renderedHint := pasteExpandIconStyle.Render(hintText)
+	plainWidth := runewidth.StringWidth(marker) + 1 + runewidth.StringWidth(hintText)
+	if plainWidth <= width {
+		return []string{renderedMarker + " " + renderedHint}
+	}
+	wrapped := strings.Split(wrapPlainText(marker, width), "\n")
+	if len(wrapped) == 0 {
+		return []string{renderedMarker}
+	}
+	wrapped[len(wrapped)-1] = wrapped[len(wrapped)-1] + " " + renderedHint
+	return wrapped
 }
 
 func isHelpMarkdownText(text string) bool {
@@ -484,6 +568,7 @@ func renderSemanticAssistantLine(line string, width int) string {
 	if core == "" {
 		core = trimmed
 	}
+	intent := semanticIntent(core)
 
 	if isDocumentTitleLine(core) {
 		wrapped := strings.Split(wrapPlainText(core, width), "\n")
@@ -512,7 +597,7 @@ func renderSemanticAssistantLine(line string, width int) string {
 	}
 
 	label, rest, ok := splitSemanticLabel(core)
-	if !ok {
+	if !ok || intent == "" {
 		wrapped := strings.Split(wrapPlainText(core, max(8, width-runewidth.StringWidth(listPrefix))), "\n")
 		wrapped = applyIntentStyleToLines(core, wrapped)
 		return joinWithListPrefix(listPrefix, wrapped, isList)
@@ -957,4 +1042,123 @@ func renderMarkdownQuote(line string, width int) string {
 
 func looksLikeMarkdownTable(line string) bool {
 	return strings.Count(line, "|") >= 2
+}
+
+//
+// paste expansion rendering (in-conversation expand/collapse of compressed pastes)
+//
+
+const pastePreviewLineCount = 10
+
+func (m model) resolveUserBodyPastes(body string) string {
+	if !strings.Contains(body, "[Paste #") && !strings.Contains(body, "[Pasted #") {
+		return body
+	}
+	matches := pastedRefPattern.FindAllStringSubmatchIndex(body, -1)
+	if len(matches) == 0 {
+		return body
+	}
+
+	var out strings.Builder
+	last := 0
+	for _, idx := range matches {
+		start, end := idx[0], idx[1]
+		if start > last {
+			out.WriteString(body[last:start])
+		}
+
+		full := body[start:end]
+		pasteID := submatchString(body, idx, pasteRefGroupID)
+		if pasteID == "" {
+			out.WriteString(full)
+			last = end
+			continue
+		}
+
+		content, ok := m.pastedContents[pasteID]
+		if !ok {
+			out.WriteString(full)
+			last = end
+			continue
+		}
+
+		out.WriteString(renderResolvedPasteBlockPlain(content, m.pasteExpandLevel[pasteID]))
+		last = end
+	}
+	if last < len(body) {
+		out.WriteString(body[last:])
+	}
+	return out.String()
+}
+
+func resolvePasteBlockPlain(content pastedContent, level int) string {
+	switch level {
+	case 1:
+		return resolvePastePreviewPlain(content)
+	case 2:
+		return content.Content
+	default:
+		return fmt.Sprintf("▶ [Paste #%s ~%d lines]", content.ID, content.Lines)
+	}
+}
+
+func resolvePastePreviewPlain(content pastedContent) string {
+	lines := strings.Split(content.Content, "\n")
+	n := pastePreviewLineCount
+	if len(lines) < n {
+		n = len(lines)
+	}
+	var out strings.Builder
+	for i := 0; i < n; i++ {
+		out.WriteString(lines[i])
+		if i < n-1 {
+			out.WriteString("\n")
+		}
+	}
+	if len(lines) > pastePreviewLineCount {
+		out.WriteString(fmt.Sprintf("\n... (%d more lines, click or Ctrl+E to expand all)", len(lines)-pastePreviewLineCount))
+	}
+	return out.String()
+}
+
+func renderResolvedPasteBlockPlain(content pastedContent, level int) string {
+	header := fmt.Sprintf("[Paste #%s ~%d lines]", content.ID, content.Lines)
+	switch level {
+	case 1:
+		return renderResolvedPastePreviewPlain(content, header)
+	case 2:
+		return renderResolvedPasteExpandedPlain(content, header)
+	default:
+		return header
+	}
+}
+
+func renderResolvedPastePreviewPlain(content pastedContent, header string) string {
+	lines := strings.Split(content.Content, "\n")
+	n := pastePreviewLineCount
+	if len(lines) < n {
+		n = len(lines)
+	}
+	framed := make([]string, 0, n+2)
+	framed = append(framed, header+" [preview]")
+	for i := 0; i < n; i++ {
+		framed = append(framed, pasteExpandedFrameStyle.Render(lines[i]))
+	}
+	if len(lines) > pastePreviewLineCount {
+		framed = append(framed, pastePreviewStyle.Render(fmt.Sprintf("... (%d more lines, click again for full, Ctrl+E expand all)", len(lines)-pastePreviewLineCount)))
+	} else {
+		framed = append(framed, pastePreviewStyle.Render("click again to show full content"))
+	}
+	return strings.Join(framed, "\n")
+}
+
+func renderResolvedPasteExpandedPlain(content pastedContent, header string) string {
+	lines := strings.Split(content.Content, "\n")
+	framed := make([]string, 0, len(lines)+2)
+	framed = append(framed, header+" [full]")
+	for _, line := range lines {
+		framed = append(framed, pasteExpandedFrameStyle.Render(line))
+	}
+	framed = append(framed, pasteExpandAllHintStyle.Render("click again to collapse"))
+	return strings.Join(framed, "\n")
 }

--- a/tui/component_text_render_paste_test.go
+++ b/tui/component_text_render_paste_test.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatChatBodyModeHandlesPasteMarkersForRenderAndCopy(t *testing.T) {
+	item := chatEntry{
+		Kind: "user",
+		Body: "Please inspect [Paste #1 ~12 lines]",
+	}
+
+	rendered := stripANSI(formatChatBodyMode(item, 80, false))
+	if !strings.Contains(rendered, "[Paste #1 ~12 lines] [click]") {
+		t.Fatalf("expected rendered paste marker with click hint, got %q", rendered)
+	}
+
+	copied := stripANSI(formatChatBodyMode(item, 80, true))
+	if !strings.Contains(copied, "[Paste #1 ~12 lines]") {
+		t.Fatalf("expected copied paste marker text to be preserved, got %q", copied)
+	}
+	if strings.Contains(copied, "[click]") {
+		t.Fatalf("expected copy-mode output to omit click hint, got %q", copied)
+	}
+}
+
+func TestResolveUserBodyPastesRendersCollapsedPreviewAndFullModes(t *testing.T) {
+	m := model{
+		pastedContents: map[string]pastedContent{
+			"1": {
+				ID:      "1",
+				Content: "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12",
+				Lines:   12,
+			},
+		},
+		pasteExpandLevel: map[string]int{},
+	}
+
+	collapsed := stripANSI(m.resolveUserBodyPastes("Before [Paste #1 ~12 lines] after"))
+	if !strings.Contains(collapsed, "Before [Paste #1 ~12 lines] after") {
+		t.Fatalf("expected collapsed paste body to preserve marker inline, got %q", collapsed)
+	}
+
+	m.pasteExpandLevel["1"] = 1
+	preview := stripANSI(m.resolveUserBodyPastes("[Paste #1 ~12 lines]"))
+	for _, want := range []string{"[Paste #1 ~12 lines] [preview]", "line1", "line10", "Ctrl+E expand all"} {
+		if !strings.Contains(preview, want) {
+			t.Fatalf("expected preview paste body to contain %q, got %q", want, preview)
+		}
+	}
+	if strings.Contains(preview, "line12") {
+		t.Fatalf("expected preview paste body to hide final lines, got %q", preview)
+	}
+
+	m.pasteExpandLevel["1"] = 2
+	full := stripANSI(m.resolveUserBodyPastes("[Paste #1 ~12 lines]"))
+	for _, want := range []string{"[Paste #1 ~12 lines] [full]", "line12", "click again to collapse"} {
+		if !strings.Contains(full, want) {
+			t.Fatalf("expected full paste body to contain %q, got %q", want, full)
+		}
+	}
+}

--- a/tui/component_text_render_paste_test.go
+++ b/tui/component_text_render_paste_test.go
@@ -61,3 +61,83 @@ func TestResolveUserBodyPastesRendersCollapsedPreviewAndFullModes(t *testing.T) 
 		}
 	}
 }
+
+func TestRenderUserPasteAwareLineHandlesPreviewSuffixAndWrappedHint(t *testing.T) {
+	line := "Before [Paste #7 ~3 lines] [preview] after"
+	got := stripANSI(strings.Join(renderUserPasteAwareLine(line, 18, false), "\n"))
+	for _, want := range []string{"Before", "[Paste #7 ~3", "lines] [preview]", "after"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected preview-suffixed paste line to contain %q, got %q", want, got)
+		}
+	}
+
+	wrapped := stripANSI(strings.Join(renderWrappedPasteMarker("[Paste #9 ~20 lines]", 10, false, true), "\n"))
+	if !strings.Contains(wrapped, "[click]") {
+		t.Fatalf("expected wrapped paste marker to retain click hint, got %q", wrapped)
+	}
+}
+
+func TestResolvePasteHelpersCoverShortAndFallbackBranches(t *testing.T) {
+	content := pastedContent{
+		ID:      "3",
+		Content: "alpha\nbeta",
+		Lines:   2,
+	}
+
+	if got := stripANSI(resolvePasteBlockPlain(content, 0)); !strings.Contains(got, "[Paste #3 ~2 lines]") {
+		t.Fatalf("expected collapsed plain paste block marker, got %q", got)
+	}
+	if got := stripANSI(resolvePasteBlockPlain(content, 2)); got != "alpha\nbeta" {
+		t.Fatalf("expected full plain paste block content, got %q", got)
+	}
+
+	preview := stripANSI(resolvePastePreviewPlain(content))
+	if strings.Contains(preview, "Ctrl+E") {
+		t.Fatalf("expected short plain preview not to render expansion hint, got %q", preview)
+	}
+
+	framedPreview := stripANSI(renderResolvedPastePreviewPlain(content, "[Paste #3 ~2 lines]"))
+	if !strings.Contains(framedPreview, "click again to show full content") {
+		t.Fatalf("expected short framed preview to render short-content hint, got %q", framedPreview)
+	}
+
+	framedCollapsed := stripANSI(renderResolvedPasteBlockPlain(content, 0))
+	if framedCollapsed != "[Paste #3 ~2 lines]" {
+		t.Fatalf("expected collapsed framed paste block to return header only, got %q", framedCollapsed)
+	}
+}
+
+func TestRenderWrappedPasteMarkerBranchCoverage(t *testing.T) {
+	if got := renderWrappedPasteMarker("", 20, false, true); got != nil {
+		t.Fatalf("expected empty marker to produce nil output, got %#v", got)
+	}
+
+	copyMode := stripANSI(strings.Join(renderWrappedPasteMarker("[Paste #2 ~9 lines]", 12, true, true), "\n"))
+	if !strings.Contains(copyMode, "[Paste #2 ~9 lines]") || strings.Contains(copyMode, "[click]") {
+		t.Fatalf("expected copy mode to keep marker text without click hint, got %q", copyMode)
+	}
+
+	noHint := stripANSI(strings.Join(renderWrappedPasteMarker("[Paste #2 ~9 lines]", 12, false, false), "\n"))
+	if strings.Contains(noHint, "[click]") {
+		t.Fatalf("expected no-hint mode to omit click hint, got %q", noHint)
+	}
+}
+
+func TestResolveUserBodyPastesFallbackBranches(t *testing.T) {
+	m := model{
+		pastedContents: map[string]pastedContent{
+			"1": {ID: "1", Content: "ok", Lines: 1},
+		},
+		pasteExpandLevel: map[string]int{"1": 2},
+	}
+
+	noID := stripANSI(m.resolveUserBodyPastes("[Paste ~12 lines]"))
+	if noID != "[Paste ~12 lines]" {
+		t.Fatalf("expected marker without id to remain unchanged, got %q", noID)
+	}
+
+	missing := stripANSI(m.resolveUserBodyPastes("x [Paste #99 ~3 lines] y"))
+	if missing != "x [Paste #99 ~3 lines] y" {
+		t.Fatalf("expected missing stored paste to keep marker text, got %q", missing)
+	}
+}

--- a/tui/component_text_render_paste_test.go
+++ b/tui/component_text_render_paste_test.go
@@ -113,7 +113,7 @@ func TestRenderWrappedPasteMarkerBranchCoverage(t *testing.T) {
 	}
 
 	copyMode := stripANSI(strings.Join(renderWrappedPasteMarker("[Paste #2 ~9 lines]", 12, true, true), "\n"))
-	if !strings.Contains(copyMode, "[Paste #2 ~9 lines]") || strings.Contains(copyMode, "[click]") {
+	if !strings.Contains(copyMode, "[Paste #2") || !strings.Contains(copyMode, "~9 lines]") || strings.Contains(copyMode, "[click]") {
 		t.Fatalf("expected copy mode to keep marker text without click hint, got %q", copyMode)
 	}
 

--- a/tui/component_text_render_semantic_test.go
+++ b/tui/component_text_render_semantic_test.go
@@ -62,3 +62,28 @@ func TestApplyLineIntentStyleColorsInfoWarningAndError(t *testing.T) {
 		t.Fatalf("expected error styling to preserve text, got %q", errText)
 	}
 }
+
+func TestRenderSemanticAssistantLineDoesNotAccentGenericColonLabels(t *testing.T) {
+	got := renderSemanticAssistantLine("- 工具调用: 读写文件、搜索、打补丁", 80)
+	plain := stripANSI(got)
+	if !strings.Contains(plain, "- 工具调用: 读写文件、搜索、打补丁") {
+		t.Fatalf("expected generic label text to be preserved, got %q", plain)
+	}
+	if got != plain {
+		t.Fatalf("expected generic colon label not to receive standalone semantic highlighting, got %q", got)
+	}
+}
+
+func TestRenderSemanticAssistantLineKeepsIntentLabelsStyled(t *testing.T) {
+	got := stripANSI(renderSemanticAssistantLine("Tip: remember this detail", 12))
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected intent label rendering to wrap with semantic indentation, got %q", got)
+	}
+	if !strings.HasPrefix(lines[0], "Tip: ") {
+		t.Fatalf("expected first line to keep intent label prefix, got %q", got)
+	}
+	if !strings.HasPrefix(lines[1], strings.Repeat(" ", len("Tip: "))) {
+		t.Fatalf("expected wrapped intent label body to align after label prefix, got %q", got)
+	}
+}

--- a/tui/model.go
+++ b/tui/model.go
@@ -2757,6 +2757,10 @@ func (m model) autoFollowLabel() string {
 
 func (m model) currentModelLabel() string {
 	if model := strings.TrimSpace(m.cfg.Provider.Model); model != "" {
+		lower := strings.ToLower(model)
+		if strings.HasSuffix(lower, " (bytemind)") {
+			return strings.TrimSpace(strings.TrimSuffix(lower, " (bytemind)"))
+		}
 		return model
 	}
 	return "-"

--- a/tui/model.go
+++ b/tui/model.go
@@ -270,6 +270,12 @@ type hiddenPasteProbeFlushMsg struct {
 	ID int
 }
 
+type togglePasteExpandMsg struct {
+	PasteID string
+}
+
+type togglePasteExpandAllMsg struct{}
+
 type mcpCommandResultMsg struct {
 	Input    string
 	Response string
@@ -433,6 +439,7 @@ type model struct {
 	pastedOrder                []string
 	nextPasteID                int
 	pastedStateLoaded          bool
+	pasteExpandLevel           map[string]int // 0=collapsed, 1=preview (first 10 lines), 2=full
 	lastCompressedPasteAt      time.Time
 	virtualPasteParts          []virtualPastePart
 	nextVirtualPastePart       int
@@ -538,6 +545,7 @@ func newModel(opts Options) model {
 		nextImageID:          nextSessionImageID(opts.Session),
 		pastedContents:       make(map[string]pastedContent, maxStoredPastedContents),
 		pastedOrder:          make([]string, 0, maxStoredPastedContents),
+		pasteExpandLevel:     make(map[string]int),
 		nextPasteID:          1,
 		virtualPasteParts:    make([]virtualPastePart, 0, maxStoredPastedContents),
 		nextVirtualPastePart: 1,
@@ -835,6 +843,33 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.flushHiddenPasteProbeToInput()
 		m.syncInputOverlays()
+		return m, nil
+	case togglePasteExpandMsg:
+		if m.pasteExpandLevel == nil {
+			m.pasteExpandLevel = make(map[string]int)
+		}
+		m.pasteExpandLevel[msg.PasteID] = (m.pasteExpandLevel[msg.PasteID] + 1) % 3
+		m.refreshViewport()
+		return m, nil
+	case togglePasteExpandAllMsg:
+		if m.pasteExpandLevel == nil {
+			m.pasteExpandLevel = make(map[string]int)
+		}
+		allFull := true
+		for _, id := range m.pastedOrder {
+			if m.pasteExpandLevel[id] != 2 {
+				allFull = false
+				break
+			}
+		}
+		newLevel := 2
+		if allFull {
+			newLevel = 0
+		}
+		for _, id := range m.pastedOrder {
+			m.pasteExpandLevel[id] = newLevel
+		}
+		m.refreshViewport()
 		return m, nil
 	case mouseSelectionScrollTickMsg:
 		return m.handleMouseSelectionScrollTick(msg)
@@ -1350,6 +1385,17 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.toggleApprovalMode()
 		return m, nil
+	case "ctrl+e":
+		if m.screen != screenChat {
+			return m, nil
+		}
+		if m.approval != nil || m.helpOpen || m.sessionsOpen || m.skillsOpen || m.commandOpen || m.mentionOpen || m.planActionOpen {
+			return m, nil
+		}
+		if len(m.pastedOrder) == 0 {
+			return m, nil
+		}
+		return m, func() tea.Msg { return togglePasteExpandAllMsg{} }
 	}
 
 	if m.approval != nil {

--- a/tui/model_mouse_selection.go
+++ b/tui/model_mouse_selection.go
@@ -99,10 +99,23 @@ func (m model) handleViewportMouseEvent(msg tea.MouseMsg) (tea.Model, tea.Cmd, b
 		}
 		return m, nil, true
 	case tea.MouseActionRelease:
-		if point, ok := m.viewportPointFromMouseWithAutoScroll(msg.X, msg.Y); ok && selectionHasRange(m.mouseSelectionStart, point) {
-			m.mouseSelectionEnd = point
-			m.mouseSelectionActive = true
-			m.statusNote = "Selection ready. Press Ctrl+C to copy."
+		if point, ok := m.viewportPointFromMouseWithAutoScroll(msg.X, msg.Y); ok {
+			if !selectionHasRange(m.mouseSelectionStart, point) {
+				if pasteID := m.pasteIDAtViewportPoint(point); pasteID != "" {
+					m.clearMouseSelection()
+					m.mouseSelecting = false
+					m.stopMouseSelectionScrollTicker()
+					m.draggingScrollbar = false
+					return m, func() tea.Msg { return togglePasteExpandMsg{PasteID: pasteID} }, true
+				}
+			}
+			if selectionHasRange(m.mouseSelectionStart, point) {
+				m.mouseSelectionEnd = point
+				m.mouseSelectionActive = true
+				m.statusNote = "Selection ready. Press Ctrl+C to copy."
+			} else {
+				m.clearMouseSelection()
+			}
 		} else {
 			m.clearMouseSelection()
 		}
@@ -879,4 +892,26 @@ func highlightVisibleLineByCells(line string, startCol, endCol int) string {
 
 func selectionHasRange(start, end viewportSelectionPoint) bool {
 	return start.Row != end.Row || start.Col != end.Col
+}
+
+func (m model) pasteIDAtViewportPoint(point viewportSelectionPoint) string {
+	lines := m.selectionSourceLines()
+	if point.Row < 0 || point.Row >= len(lines) {
+		return ""
+	}
+	for row := point.Row; row >= 0; row-- {
+		line := lines[row]
+		match := compressedPasteMarkerAnyPattern.FindString(line)
+		if match != "" {
+			details := compressedPasteMarkerDetailsPattern.FindStringSubmatch(match)
+			if len(details) >= 2 {
+				return details[1]
+			}
+			return ""
+		}
+		if row != point.Row && strings.TrimSpace(stripANSI(line)) == "" {
+			break
+		}
+	}
+	return ""
 }

--- a/tui/model_mouse_selection_test.go
+++ b/tui/model_mouse_selection_test.go
@@ -76,6 +76,25 @@ func TestHandleMouseDragSelectionAutoScrollsBeyondViewport(t *testing.T) {
 	}
 }
 
+func TestPasteIDAtViewportPointFindsExpandedPasteBodyRows(t *testing.T) {
+	m := model{
+		viewportContentCache: strings.Join([]string{
+			"You",
+			"[Paste #1 ~12 lines] [preview]",
+			"│ line1",
+			"│ line2",
+			"... (10 more lines, click again for full, Ctrl+E expand all)",
+		}, "\n"),
+	}
+
+	for _, row := range []int{1, 2, 3, 4} {
+		got := m.pasteIDAtViewportPoint(viewportSelectionPoint{Row: row, Col: 2})
+		if got != "1" {
+			t.Fatalf("expected row %d to resolve to paste 1, got %q", row, got)
+		}
+	}
+}
+
 func TestMouseSelectionScrollTickAutoScrollsWhileHoldingAtBottomEdge(t *testing.T) {
 	input := textarea.New()
 	input.Focus()

--- a/tui/model_mouse_selection_test.go
+++ b/tui/model_mouse_selection_test.go
@@ -95,6 +95,24 @@ func TestPasteIDAtViewportPointFindsExpandedPasteBodyRows(t *testing.T) {
 	}
 }
 
+func TestPasteIDAtViewportPointHandlesOutOfRangeAndBlankBreak(t *testing.T) {
+	m := model{
+		viewportContentCache: strings.Join([]string{
+			"[Paste #1 ~12 lines] [preview]",
+			"│ line1",
+			"",
+			"plain trailing text",
+		}, "\n"),
+	}
+
+	if got := m.pasteIDAtViewportPoint(viewportSelectionPoint{Row: -1, Col: 0}); got != "" {
+		t.Fatalf("expected out-of-range row to return empty paste id, got %q", got)
+	}
+	if got := m.pasteIDAtViewportPoint(viewportSelectionPoint{Row: 3, Col: 0}); got != "" {
+		t.Fatalf("expected blank-line boundary to stop upward paste lookup, got %q", got)
+	}
+}
+
 func TestMouseSelectionScrollTickAutoScrollsWhileHoldingAtBottomEdge(t *testing.T) {
 	input := textarea.New()
 	input.Focus()

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -5503,6 +5503,44 @@ func TestRenderStatusBarUsesCompactBytemindModelLabel(t *testing.T) {
 	}
 }
 
+func TestTogglePasteExpandMessagesAndCtrlE(t *testing.T) {
+	input := textarea.New()
+	m := model{
+		screen:           screenChat,
+		input:            input,
+		pastedOrder:      []string{"1", "2"},
+		pasteExpandLevel: map[string]int{"1": 0, "2": 2},
+	}
+
+	got, _ := m.Update(togglePasteExpandMsg{PasteID: "1"})
+	updated := got.(model)
+	if updated.pasteExpandLevel["1"] != 1 {
+		t.Fatalf("expected single paste toggle to advance to preview, got %d", updated.pasteExpandLevel["1"])
+	}
+
+	got, _ = updated.Update(togglePasteExpandAllMsg{})
+	updated = got.(model)
+	if updated.pasteExpandLevel["1"] != 2 || updated.pasteExpandLevel["2"] != 2 {
+		t.Fatalf("expected expand-all to set every paste to full, got %#v", updated.pasteExpandLevel)
+	}
+
+	got, _ = updated.Update(togglePasteExpandAllMsg{})
+	updated = got.(model)
+	if updated.pasteExpandLevel["1"] != 0 || updated.pasteExpandLevel["2"] != 0 {
+		t.Fatalf("expected second expand-all toggle to collapse every paste, got %#v", updated.pasteExpandLevel)
+	}
+
+	got, cmd := updated.handleKey(tea.KeyMsg{Type: tea.KeyCtrlE})
+	updated = got.(model)
+	if cmd == nil {
+		t.Fatal("expected Ctrl+E to emit a paste expand-all message")
+	}
+	msg := cmd()
+	if _, ok := msg.(togglePasteExpandAllMsg); !ok {
+		t.Fatalf("expected Ctrl+E command to emit togglePasteExpandAllMsg, got %T", msg)
+	}
+}
+
 func TestUpdateRunFinishedMsgResetsBusyState(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := model{

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -5473,6 +5473,36 @@ func TestFullAccessConfirmationRejectKeepsInteractiveMode(t *testing.T) {
 	}
 }
 
+func TestCurrentModelLabelCompactsBytemindPSeriesName(t *testing.T) {
+	m := model{
+		cfg: config.Config{
+			Provider: config.ProviderConfig{Model: "P1 (bytemind)"},
+		},
+	}
+
+	if got := m.currentModelLabel(); got != "p1" {
+		t.Fatalf("expected compact bytemind model label, got %q", got)
+	}
+}
+
+func TestRenderStatusBarUsesCompactBytemindModelLabel(t *testing.T) {
+	m := model{
+		width: 120,
+		mode:  modeBuild,
+		cfg: config.Config{
+			Provider: config.ProviderConfig{Model: "P1 (bytemind)"},
+		},
+	}
+
+	bar := m.renderStatusBar()
+	if !strings.Contains(bar, "Model: p1") {
+		t.Fatalf("expected status bar to show compact model label, got %q", bar)
+	}
+	if strings.Contains(bar, "bytemind") {
+		t.Fatalf("expected status bar to omit verbose provider suffix, got %q", bar)
+	}
+}
+
 func TestUpdateRunFinishedMsgResetsBusyState(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := model{

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -691,3 +691,30 @@ func statusBadgeStyle(badgeType string) lipgloss.Style {
 func renderPillBadge(text, badgeType string) string {
 	return statusBadgeStyle(badgeType).Render(text)
 }
+
+//
+// paste expand styles (compress/expand paste markers in chat)
+//
+
+var (
+	pasteExpandIconStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#55CCFF")).
+				Bold(true)
+
+	pasteMarkerStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.AccentSoft).
+				Bold(true)
+
+	pastePreviewStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextMuted).
+				Italic(true)
+
+	pasteExpandedFrameStyle = lipgloss.NewStyle().
+				BorderLeft(true).
+				BorderStyle(lipgloss.ThickBorder()).
+				BorderForeground(semanticColors.CodeBorder).
+				PaddingLeft(2)
+
+	pasteExpandAllHintStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextMuted)
+)


### PR DESCRIPTION
这个 PR 聚焦于优化“长文本粘贴”的可用性与可读性：当用户粘贴超长内容时，输入框仍保持压缩标记（如 `[Paste #N ~X lines]`），避免输入区被大段文本占满；同时在聊天区提供可视化展开能力，支持“折叠 → 部分展开 → 全量展开 → 折叠”的循环切换，并保留 `Ctrl+E` 的一键全部展开/收起操作。整体目标是在不牺牲输入体验的前提下，让用户能快速查看粘贴内容。

实现上，本次改动将粘贴展开逻辑接入聊天渲染链路，补充了展开态的样式与提示文案，并增强了鼠标点击命中能力（包括点击展开后的内容区域也能正确定位并切换对应 paste 块）。同时保持既有语义不变：`[Paste #N]`、`[Paste #N lineX]`、`[Paste #N lineX~lineY]` 的解析与发送逻辑不受展示状态影响。相关 TUI 测试已同步补充，覆盖输入框压缩保持、聊天区三态展开、点击切换和引用解析稳定性。