### PR TITLE
fix(model): 针对部分模型(deepseek)无法正常调用工具

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type UpdateCheckConfig struct {
 
 type ProviderConfig struct {
 	Type             string            `json:"type"`
+	Family           string            `json:"family"`
 	AutoDetectType   bool              `json:"auto_detect_type"`
 	BaseURL          string            `json:"base_url"`
 	APIPath          string            `json:"api_path"`
@@ -469,6 +470,9 @@ func applyEnv(cfg *Config) {
 	if value := strings.TrimSpace(os.Getenv("BYTEMIND_PROVIDER_TYPE")); value != "" {
 		cfg.Provider.Type = value
 	}
+	if value := strings.TrimSpace(os.Getenv("BYTEMIND_PROVIDER_FAMILY")); value != "" {
+		cfg.Provider.Family = value
+	}
 	if value := strings.TrimSpace(os.Getenv("BYTEMIND_PROVIDER_AUTO_DETECT_TYPE")); value != "" {
 		if parsed, err := strconv.ParseBool(value); err == nil {
 			cfg.Provider.AutoDetectType = parsed
@@ -525,6 +529,7 @@ func applyEnv(cfg *Config) {
 
 func normalize(cfg *Config) error {
 	cfg.Provider.Type = normalizeProviderType(cfg.Provider.Type)
+	cfg.Provider.Family = normalizeProviderFamily(cfg.Provider.Family)
 	if cfg.Provider.Type == "" {
 		if cfg.Provider.AutoDetectType {
 			cfg.Provider.Type = detectProviderType(cfg.Provider)
@@ -586,6 +591,7 @@ func normalize(cfg *Config) error {
 			return fmt.Errorf("provider_runtime.providers has duplicate provider id after normalization: %q (from %q and %q)", normalizedID, existingSource, id)
 		}
 		providerCfg.Type = normalizeProviderType(providerCfg.Type)
+		providerCfg.Family = normalizeProviderFamily(providerCfg.Family)
 		if providerCfg.Type == "" {
 			if providerCfg.AutoDetectType {
 				providerCfg.Type = detectProviderType(providerCfg)
@@ -895,6 +901,19 @@ func normalizeProviderType(value string) string {
 		return "gemini"
 	default:
 		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func normalizeProviderFamily(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "_", "-")
+	switch value {
+	case "moonshot-ai":
+		return "moonshot"
+	case "z-ai", "z.ai", "zhipu-ai":
+		return "zai"
+	default:
+		return value
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,7 @@ func TestLoadUsesEnvOverrides(t *testing.T) {
 	t.Setenv("BYTEMIND_API_KEY", "secret")
 	t.Setenv("BYTEMIND_TOKEN_QUOTA", "88000")
 	t.Setenv("BYTEMIND_PROVIDER_TYPE", "anthropic")
+	t.Setenv("BYTEMIND_PROVIDER_FAMILY", "DeepSeek")
 	t.Setenv("BYTEMIND_PROVIDER_AUTO_DETECT_TYPE", "true")
 	t.Setenv("BYTEMIND_STREAM", "false")
 	t.Setenv("BYTEMIND_APPROVAL_MODE", "away")
@@ -30,6 +31,9 @@ func TestLoadUsesEnvOverrides(t *testing.T) {
 	}
 	if cfg.Provider.Type != "anthropic" {
 		t.Fatalf("expected anthropic provider, got %q", cfg.Provider.Type)
+	}
+	if cfg.Provider.Family != "deepseek" {
+		t.Fatalf("expected provider family from env override, got %q", cfg.Provider.Family)
 	}
 	if !cfg.Provider.AutoDetectType {
 		t.Fatalf("expected auto detect provider type from env")
@@ -378,6 +382,46 @@ func TestLoadDefaultsModelFromProviderEndpointWhenMissing(t *testing.T) {
 	}
 }
 
+func TestLoadNormalizesProviderFamily(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", t.TempDir())
+	if err := writeConfig(projectConfigPath(workspace), map[string]any{
+		"provider": map[string]any{
+			"type":     "openai-compatible",
+			"family":   " Z.AI ",
+			"base_url": "https://open.bigmodel.cn/api/paas/v4",
+			"model":    "glm-4.6",
+			"api_key":  "test-key",
+		},
+		"provider_runtime": map[string]any{
+			"default_provider": "moonshot",
+			"default_model":    "kimi-k2",
+			"providers": map[string]any{
+				"moonshot": map[string]any{
+					"type":     "openai-compatible",
+					"family":   "Moonshot-AI",
+					"base_url": "https://api.moonshot.cn/v1",
+					"model":    "kimi-k2",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(workspace, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider.Family != "zai" {
+		t.Fatalf("expected top-level provider family zai, got %q", cfg.Provider.Family)
+	}
+	runtimeProvider := cfg.ProviderRuntime.Providers["moonshot"]
+	if runtimeProvider.Family != "moonshot" {
+		t.Fatalf("expected runtime provider family moonshot, got %q", runtimeProvider.Family)
+	}
+}
+
 func TestLoadSupportsGeminiProviderDefaults(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("BYTEMIND_HOME", t.TempDir())
@@ -661,7 +705,7 @@ func TestUpsertProviderAPIKeyCreatesConfigWhenMissing(t *testing.T) {
 	}
 }
 
-func TestUpsertProviderFieldUpdatesModelAndBaseURL(t *testing.T) {
+func TestUpsertProviderFieldUpdatesModelBaseURLAndFamily(t *testing.T) {
 	workspace := t.TempDir()
 	configPath := filepath.Join(workspace, "config.json")
 	if err := os.WriteFile(configPath, []byte(`{
@@ -681,6 +725,9 @@ func TestUpsertProviderFieldUpdatesModelAndBaseURL(t *testing.T) {
 	if _, err := UpsertProviderField(configPath, "base_url", "https://api.deepseek.com"); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := UpsertProviderField(configPath, "family", "Moonshot_AI"); err != nil {
+		t.Fatal(err)
+	}
 
 	cfg, err := Load(workspace, configPath)
 	if err != nil {
@@ -691,6 +738,9 @@ func TestUpsertProviderFieldUpdatesModelAndBaseURL(t *testing.T) {
 	}
 	if cfg.Provider.BaseURL != "https://api.deepseek.com" {
 		t.Fatalf("expected updated base url, got %q", cfg.Provider.BaseURL)
+	}
+	if cfg.Provider.Family != "moonshot" {
+		t.Fatalf("expected normalized provider family, got %q", cfg.Provider.Family)
 	}
 }
 

--- a/internal/config/update.go
+++ b/internal/config/update.go
@@ -29,7 +29,7 @@ func UpsertProviderField(configPath, field, value string) (string, error) {
 		return "", errors.New("provider field value is empty")
 	}
 	switch field {
-	case "type", "base_url", "model", "api_key", "api_key_env":
+	case "type", "family", "base_url", "model", "api_key", "api_key_env":
 	default:
 		return "", fmt.Errorf("unsupported provider field: %s", field)
 	}

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -17,8 +17,14 @@ func NewClientFromRuntime(cfg config.ProviderRuntimeConfig, health HealthChecker
 }
 
 func newBaseClient(cfg config.ProviderConfig) (llm.Client, error) {
+	return newBaseClientWithProviderID("", cfg)
+}
+
+func newBaseClientWithProviderID(providerID ProviderID, cfg config.ProviderConfig) (llm.Client, error) {
 	typ := strings.ToLower(strings.TrimSpace(cfg.Type))
 	clientCfg := Config{
+		ProviderID:       providerID,
+		ProviderFamily:   cfg.Family,
 		Type:             typ,
 		BaseURL:          cfg.BaseURL,
 		APIPath:          cfg.APIPath,
@@ -60,13 +66,13 @@ func NewDomainClient(cfg config.ProviderConfig) (Client, error) {
 }
 
 func NewDomainClientWithID(providerID ProviderID, cfg config.ProviderConfig) (Client, error) {
-	baseClient, err := newBaseClient(cfg)
-	if err != nil {
-		return nil, err
-	}
 	id := ProviderID(strings.ToLower(strings.TrimSpace(string(providerID))))
 	if id == "" {
 		id = ProviderID("unknown")
+	}
+	baseClient, err := newBaseClientWithProviderID(id, cfg)
+	if err != nil {
+		return nil, err
 	}
 	return WrapClient(id, ModelID(strings.TrimSpace(cfg.Model)), baseClient), nil
 }

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -168,6 +168,33 @@ func TestNewDomainClientWithIDUsesExplicitProviderInstanceID(t *testing.T) {
 	}
 }
 
+func TestNewDomainClientWithIDPassesProviderIDToOpenAICompatible(t *testing.T) {
+	client, err := NewDomainClientWithID("deepseek", config.ProviderConfig{
+		Type:    "openai-compatible",
+		Family:  "deepseek",
+		BaseURL: "https://api.deepseek.com/v1",
+		APIKey:  "test-key",
+		Model:   "generic-model",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	adapter, ok := client.(*clientAdapter)
+	if !ok {
+		t.Fatalf("expected *clientAdapter, got %T", client)
+	}
+	openaiClient, ok := adapter.client.(*OpenAICompatible)
+	if !ok {
+		t.Fatalf("expected *OpenAICompatible, got %T", adapter.client)
+	}
+	if openaiClient.providerID != "deepseek" {
+		t.Fatalf("expected provider id to be passed to openai client, got %q", openaiClient.providerID)
+	}
+	if openaiClient.family != "deepseek" {
+		t.Fatalf("expected provider family to be passed to openai client, got %q", openaiClient.family)
+	}
+}
+
 func TestNewDomainClientPreservesAnthropicProviderID(t *testing.T) {
 	client, err := NewDomainClient(config.ProviderConfig{
 		Type:             "anthropic",

--- a/internal/provider/model_policy.go
+++ b/internal/provider/model_policy.go
@@ -1,0 +1,143 @@
+package provider
+
+import "strings"
+
+type AssistantToolCallContentMode string
+
+const (
+	AssistantToolCallContentPreserve    AssistantToolCallContentMode = "preserve"
+	AssistantToolCallContentEmptyString AssistantToolCallContentMode = "empty_string"
+	AssistantToolCallContentNull        AssistantToolCallContentMode = "null"
+	AssistantToolCallContentOmit        AssistantToolCallContentMode = "omit"
+)
+
+type ReasoningReplayMode string
+
+const (
+	ReasoningReplayNone        ReasoningReplayMode = "none"
+	ReasoningReplayHiddenField ReasoningReplayMode = "hidden_field"
+)
+
+const (
+	ModelPolicySourceDefault        = "default"
+	ModelPolicySourceFamilyOverride = "family"
+	ModelPolicySourceProviderID     = "provider_id"
+	ModelPolicySourceBaseURL        = "base_url"
+)
+
+type ResolvedModelPolicy struct {
+	ProviderID                   ProviderID
+	ProviderType                 string
+	ModelID                      ModelID
+	Family                       string
+	AssistantToolCallContentMode AssistantToolCallContentMode
+	ReasoningField               string
+	ReasoningReplayMode          ReasoningReplayMode
+	Source                       string
+}
+
+func (p ResolvedModelPolicy) ReplayReasoning() bool {
+	return p.ReasoningReplayMode == ReasoningReplayHiddenField && strings.TrimSpace(p.ReasoningField) != ""
+}
+
+func ResolveModelPolicy(providerID ProviderID, providerType string, modelID ModelID, family string, baseURL string) ResolvedModelPolicy {
+	policy := ResolvedModelPolicy{
+		ProviderID:                   normalizePolicyProviderID(providerID),
+		ProviderType:                 normalizePolicyProviderType(providerType),
+		ModelID:                      ModelID(strings.TrimSpace(string(modelID))),
+		Family:                       normalizePolicyFamily(family),
+		AssistantToolCallContentMode: AssistantToolCallContentOmit,
+		ReasoningReplayMode:          ReasoningReplayNone,
+		Source:                       ModelPolicySourceDefault,
+	}
+
+	if policy.Family != "" {
+		policy.Source = ModelPolicySourceFamilyOverride
+		if providerFamilyUsesOpenAIReasoningContent(policy.Family) {
+			policy.enableOpenAIReasoningContent()
+		}
+		return policy
+	}
+
+	if detected, ok := detectOpenAIReasoningFamily(string(policy.ProviderID)); ok {
+		policy.Family = detected
+		policy.Source = ModelPolicySourceProviderID
+		policy.enableOpenAIReasoningContent()
+		return policy
+	}
+
+	if detected, ok := detectOpenAIReasoningFamily(baseURL); ok {
+		policy.Family = detected
+		policy.Source = ModelPolicySourceBaseURL
+		policy.enableOpenAIReasoningContent()
+	}
+
+	return policy
+}
+
+func (p *ResolvedModelPolicy) enableOpenAIReasoningContent() {
+	p.AssistantToolCallContentMode = AssistantToolCallContentEmptyString
+	p.ReasoningField = openAIReasoningContentKey
+	p.ReasoningReplayMode = ReasoningReplayHiddenField
+}
+
+func normalizePolicyProviderID(providerID ProviderID) ProviderID {
+	id := ProviderID(strings.ToLower(strings.TrimSpace(string(providerID))))
+	if id == "" {
+		return ProviderID("unknown")
+	}
+	return id
+}
+
+func normalizePolicyProviderType(providerType string) string {
+	switch strings.ToLower(strings.TrimSpace(providerType)) {
+	case "", "openai_compatible":
+		return "openai-compatible"
+	default:
+		return strings.ToLower(strings.TrimSpace(providerType))
+	}
+}
+
+func normalizePolicyFamily(family string) string {
+	family = strings.ToLower(strings.TrimSpace(family))
+	family = strings.ReplaceAll(family, "_", "-")
+	switch family {
+	case "moonshot-ai":
+		return "moonshot"
+	case "z-ai", "z.ai", "zhipu-ai":
+		return "zai"
+	default:
+		return family
+	}
+}
+
+func providerFamilyUsesOpenAIReasoningContent(value string) bool {
+	_, ok := detectOpenAIReasoningFamily(value)
+	return ok
+}
+
+func detectOpenAIReasoningFamily(value string) (string, bool) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "", false
+	}
+	for _, marker := range []struct {
+		match  string
+		family string
+	}{
+		{match: "deepseek", family: "deepseek"},
+		{match: "kimi", family: "kimi"},
+		{match: "moonshot", family: "moonshot"},
+		{match: "glm", family: "glm"},
+		{match: "zhipu", family: "zai"},
+		{match: "zai", family: "zai"},
+		{match: "z-ai", family: "zai"},
+		{match: "z.ai", family: "zai"},
+		{match: "bigmodel", family: "zai"},
+	} {
+		if strings.Contains(value, marker.match) {
+			return marker.family, true
+		}
+	}
+	return "", false
+}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -36,6 +36,7 @@ type Config struct {
 
 type OpenAICompatible struct {
 	providerID   ProviderID
+	providerType string
 	family       string
 	baseURL      string
 	apiPath      string
@@ -69,6 +70,7 @@ func NewOpenAICompatible(cfg Config) *OpenAICompatible {
 	}
 	return &OpenAICompatible{
 		providerID:   ProviderID(strings.ToLower(strings.TrimSpace(string(cfg.ProviderID)))),
+		providerType: normalizePolicyProviderType(cfg.Type),
 		family:       strings.ToLower(strings.TrimSpace(cfg.ProviderFamily)),
 		baseURL:      strings.TrimRight(cfg.BaseURL, "/"),
 		apiPath:      apiPath,

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -186,6 +186,9 @@ func (c *OpenAICompatible) StreamMessage(ctx context.Context, req llm.ChatReques
 			if delta.Role != "" {
 				assembled.Role = delta.Role
 			}
+			if delta.Reasoning != "" {
+				appendOpenAIReasoningContent(&assembled, delta.Reasoning)
+			}
 			if delta.Content != "" {
 				assembled.Content += delta.Content
 				if onDelta != nil {

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -21,6 +21,8 @@ const (
 )
 
 type Config struct {
+	ProviderID       ProviderID
+	ProviderFamily   string
 	Type             string
 	BaseURL          string
 	APIPath          string
@@ -33,6 +35,8 @@ type Config struct {
 }
 
 type OpenAICompatible struct {
+	providerID   ProviderID
+	family       string
 	baseURL      string
 	apiPath      string
 	apiKey       string
@@ -64,6 +68,8 @@ func NewOpenAICompatible(cfg Config) *OpenAICompatible {
 		extraHeaders[key] = value
 	}
 	return &OpenAICompatible{
+		providerID:   ProviderID(strings.ToLower(strings.TrimSpace(string(cfg.ProviderID)))),
+		family:       strings.ToLower(strings.TrimSpace(cfg.ProviderFamily)),
 		baseURL:      strings.TrimRight(cfg.BaseURL, "/"),
 		apiPath:      apiPath,
 		apiKey:       cfg.APIKey,

--- a/internal/provider/openai_helpers.go
+++ b/internal/provider/openai_helpers.go
@@ -56,12 +56,14 @@ func (c *OpenAICompatible) postJSON(ctx context.Context, url string, payload map
 }
 
 func (c *OpenAICompatible) chatPayload(req llm.ChatRequest, stream bool) (map[string]any, error) {
+	model := choose(req.Model, c.model)
+	req.Model = model
 	messages, err := openAIMessages(req)
 	if err != nil {
 		return nil, err
 	}
 	payload := map[string]any{
-		"model":    choose(req.Model, c.model),
+		"model":    model,
 		"messages": messages,
 		"stream":   stream,
 	}
@@ -77,18 +79,24 @@ func (c *OpenAICompatible) chatPayload(req llm.ChatRequest, stream bool) (map[st
 
 func openAIMessages(req llm.ChatRequest) ([]map[string]any, error) {
 	converted := make([]map[string]any, 0, len(req.Messages))
+	roundTripReasoning := shouldRoundTripOpenAIReasoningContent(req.Model)
 	for _, message := range req.Messages {
 		message.Normalize()
 		switch message.Role {
 		case llm.RoleSystem, llm.RoleUser, llm.RoleAssistant:
 			entry := map[string]any{"role": string(message.Role)}
 			content := make([]map[string]any, 0)
+			reasoningParts := make([]string, 0)
 			for _, part := range message.Parts {
 				switch part.Type {
 				case llm.PartText:
 					content = append(content, map[string]any{"type": "text", "text": part.Text.Value})
 				case llm.PartThinking:
-					content = append(content, map[string]any{"type": "text", "text": part.Thinking.Value})
+					if roundTripReasoning && message.Role == llm.RoleAssistant {
+						reasoningParts = append(reasoningParts, part.Thinking.Value)
+					} else {
+						content = append(content, map[string]any{"type": "text", "text": part.Thinking.Value})
+					}
 				case llm.PartImageRef:
 					assetID := llm.AssetID("")
 					if part.Image != nil {
@@ -110,11 +118,23 @@ func openAIMessages(req llm.ChatRequest) ([]map[string]any, error) {
 					converted = append(converted, map[string]any{"role": "tool", "tool_call_id": part.ToolResult.ToolUseID, "content": part.ToolResult.Content})
 				}
 			}
+			if roundTripReasoning && message.Role == llm.RoleAssistant {
+				reasoning := openAIReasoningContent(message)
+				if reasoning == "" && len(reasoningParts) > 0 {
+					reasoning = strings.Join(reasoningParts, "")
+				}
+				if reasoning != "" {
+					entry[openAIReasoningContentKey] = reasoning
+				}
+			}
 			hasToolCalls := len(asToolCalls(entry["tool_calls"])) > 0
 			if len(content) == 1 && content[0]["type"] == "text" {
 				entry["content"] = content[0]["text"]
 			} else if len(content) > 0 {
 				entry["content"] = content
+			}
+			if _, hasContent := entry["content"]; !hasContent && hasToolCalls {
+				entry["content"] = ""
 			}
 			if _, hasContent := entry["content"]; hasContent || hasToolCalls {
 				converted = append(converted, entry)

--- a/internal/provider/openai_helpers.go
+++ b/internal/provider/openai_helpers.go
@@ -58,7 +58,8 @@ func (c *OpenAICompatible) postJSON(ctx context.Context, url string, payload map
 func (c *OpenAICompatible) chatPayload(req llm.ChatRequest, stream bool) (map[string]any, error) {
 	model := choose(req.Model, c.model)
 	req.Model = model
-	messages, err := openAIMessages(req, openAIReasoningRoundTripSpecForProvider(c.family, c.providerID, c.baseURL))
+	policy := ResolveModelPolicy(c.providerID, c.providerType, ModelID(model), c.family, c.baseURL)
+	messages, err := openAIMessages(req, policy)
 	if err != nil {
 		return nil, err
 	}
@@ -77,9 +78,9 @@ func (c *OpenAICompatible) chatPayload(req llm.ChatRequest, stream bool) (map[st
 	return payload, nil
 }
 
-func openAIMessages(req llm.ChatRequest, reasoningSpec openAIReasoningRoundTripSpec) ([]map[string]any, error) {
+func openAIMessages(req llm.ChatRequest, policy ResolvedModelPolicy) ([]map[string]any, error) {
 	converted := make([]map[string]any, 0, len(req.Messages))
-	roundTripReasoning := reasoningSpec.Enabled()
+	roundTripReasoning := policy.ReplayReasoning()
 	for _, message := range req.Messages {
 		message.Normalize()
 		switch message.Role {
@@ -94,7 +95,7 @@ func openAIMessages(req llm.ChatRequest, reasoningSpec openAIReasoningRoundTripS
 				case llm.PartThinking:
 					if roundTripReasoning && message.Role == llm.RoleAssistant {
 						reasoningParts = append(reasoningParts, part.Thinking.Value)
-					} else {
+					} else if message.Role != llm.RoleAssistant {
 						content = append(content, map[string]any{"type": "text", "text": part.Thinking.Value})
 					}
 				case llm.PartImageRef:
@@ -119,12 +120,12 @@ func openAIMessages(req llm.ChatRequest, reasoningSpec openAIReasoningRoundTripS
 				}
 			}
 			if roundTripReasoning && message.Role == llm.RoleAssistant {
-				reasoning := openAIReasoningContentForField(message, reasoningSpec.ContentField)
+				reasoning := openAIReasoningContentForField(message, policy.ReasoningField)
 				if reasoning == "" && len(reasoningParts) > 0 {
 					reasoning = strings.Join(reasoningParts, "")
 				}
 				if reasoning != "" {
-					entry[reasoningSpec.ContentField] = reasoning
+					entry[policy.ReasoningField] = reasoning
 				}
 			}
 			hasToolCalls := len(asToolCalls(entry["tool_calls"])) > 0
@@ -133,8 +134,8 @@ func openAIMessages(req llm.ChatRequest, reasoningSpec openAIReasoningRoundTripS
 			} else if len(content) > 0 {
 				entry["content"] = content
 			}
-			if _, hasContent := entry["content"]; !hasContent && hasToolCalls {
-				entry["content"] = ""
+			if hasToolCalls && message.Role == llm.RoleAssistant {
+				applyAssistantToolCallContentPolicy(entry, policy.AssistantToolCallContentMode)
 			}
 			if _, hasContent := entry["content"]; hasContent || hasToolCalls {
 				converted = append(converted, entry)
@@ -144,6 +145,21 @@ func openAIMessages(req llm.ChatRequest, reasoningSpec openAIReasoningRoundTripS
 		}
 	}
 	return converted, nil
+}
+
+func applyAssistantToolCallContentPolicy(entry map[string]any, mode AssistantToolCallContentMode) {
+	switch mode {
+	case AssistantToolCallContentPreserve:
+		return
+	case AssistantToolCallContentEmptyString:
+		entry["content"] = ""
+	case AssistantToolCallContentNull:
+		entry["content"] = nil
+	case AssistantToolCallContentOmit, "":
+		delete(entry, "content")
+	default:
+		delete(entry, "content")
+	}
 }
 
 func asToolCalls(value any) []map[string]any {

--- a/internal/provider/openai_helpers.go
+++ b/internal/provider/openai_helpers.go
@@ -58,7 +58,7 @@ func (c *OpenAICompatible) postJSON(ctx context.Context, url string, payload map
 func (c *OpenAICompatible) chatPayload(req llm.ChatRequest, stream bool) (map[string]any, error) {
 	model := choose(req.Model, c.model)
 	req.Model = model
-	messages, err := openAIMessages(req)
+	messages, err := openAIMessages(req, openAIReasoningRoundTripSpecForProvider(c.family, c.providerID, c.baseURL))
 	if err != nil {
 		return nil, err
 	}
@@ -77,9 +77,9 @@ func (c *OpenAICompatible) chatPayload(req llm.ChatRequest, stream bool) (map[st
 	return payload, nil
 }
 
-func openAIMessages(req llm.ChatRequest) ([]map[string]any, error) {
+func openAIMessages(req llm.ChatRequest, reasoningSpec openAIReasoningRoundTripSpec) ([]map[string]any, error) {
 	converted := make([]map[string]any, 0, len(req.Messages))
-	roundTripReasoning := shouldRoundTripOpenAIReasoningContent(req.Model)
+	roundTripReasoning := reasoningSpec.Enabled()
 	for _, message := range req.Messages {
 		message.Normalize()
 		switch message.Role {
@@ -119,12 +119,12 @@ func openAIMessages(req llm.ChatRequest) ([]map[string]any, error) {
 				}
 			}
 			if roundTripReasoning && message.Role == llm.RoleAssistant {
-				reasoning := openAIReasoningContent(message)
+				reasoning := openAIReasoningContentForField(message, reasoningSpec.ContentField)
 				if reasoning == "" && len(reasoningParts) > 0 {
 					reasoning = strings.Join(reasoningParts, "")
 				}
 				if reasoning != "" {
-					entry[openAIReasoningContentKey] = reasoning
+					entry[reasoningSpec.ContentField] = reasoning
 				}
 			}
 			hasToolCalls := len(asToolCalls(entry["tool_calls"])) > 0

--- a/internal/provider/openai_parse_helpers.go
+++ b/internal/provider/openai_parse_helpers.go
@@ -217,52 +217,6 @@ func argumentString(raw json.RawMessage) string {
 
 const openAIReasoningContentKey = "reasoning_content"
 
-type openAIReasoningRoundTripSpec struct {
-	ContentField string
-}
-
-func (s openAIReasoningRoundTripSpec) Enabled() bool {
-	return strings.TrimSpace(s.ContentField) != ""
-}
-
-func openAIReasoningRoundTripSpecForProvider(family string, providerID ProviderID, baseURL string) openAIReasoningRoundTripSpec {
-	if providerUsesOpenAIReasoningContent(family, providerID, baseURL) {
-		return openAIReasoningRoundTripSpec{ContentField: openAIReasoningContentKey}
-	}
-	return openAIReasoningRoundTripSpec{}
-}
-
-func providerUsesOpenAIReasoningContent(family string, providerID ProviderID, baseURL string) bool {
-	if family = strings.ToLower(strings.TrimSpace(family)); family != "" {
-		return providerFamilyUsesOpenAIReasoningContent(family)
-	}
-	provider := strings.ToLower(strings.TrimSpace(string(providerID)))
-	base := strings.ToLower(strings.TrimSpace(baseURL))
-	if providerFamilyUsesOpenAIReasoningContent(provider) {
-		return true
-	}
-	return providerFamilyUsesOpenAIReasoningContent(base)
-}
-
-func providerFamilyUsesOpenAIReasoningContent(value string) bool {
-	value = strings.ToLower(strings.TrimSpace(value))
-	for _, marker := range []string{
-		"deepseek",
-		"kimi",
-		"moonshot",
-		"glm",
-		"zhipu",
-		"zai",
-		"z.ai",
-		"bigmodel",
-	} {
-		if strings.Contains(value, marker) {
-			return true
-		}
-	}
-	return false
-}
-
 func appendOpenAIReasoningContent(msg *llm.Message, delta string) {
 	if msg == nil || delta == "" {
 		return

--- a/internal/provider/openai_parse_helpers.go
+++ b/internal/provider/openai_parse_helpers.go
@@ -217,6 +217,52 @@ func argumentString(raw json.RawMessage) string {
 
 const openAIReasoningContentKey = "reasoning_content"
 
+type openAIReasoningRoundTripSpec struct {
+	ContentField string
+}
+
+func (s openAIReasoningRoundTripSpec) Enabled() bool {
+	return strings.TrimSpace(s.ContentField) != ""
+}
+
+func openAIReasoningRoundTripSpecForProvider(family string, providerID ProviderID, baseURL string) openAIReasoningRoundTripSpec {
+	if providerUsesOpenAIReasoningContent(family, providerID, baseURL) {
+		return openAIReasoningRoundTripSpec{ContentField: openAIReasoningContentKey}
+	}
+	return openAIReasoningRoundTripSpec{}
+}
+
+func providerUsesOpenAIReasoningContent(family string, providerID ProviderID, baseURL string) bool {
+	if family = strings.ToLower(strings.TrimSpace(family)); family != "" {
+		return providerFamilyUsesOpenAIReasoningContent(family)
+	}
+	provider := strings.ToLower(strings.TrimSpace(string(providerID)))
+	base := strings.ToLower(strings.TrimSpace(baseURL))
+	if providerFamilyUsesOpenAIReasoningContent(provider) {
+		return true
+	}
+	return providerFamilyUsesOpenAIReasoningContent(base)
+}
+
+func providerFamilyUsesOpenAIReasoningContent(value string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	for _, marker := range []string{
+		"deepseek",
+		"kimi",
+		"moonshot",
+		"glm",
+		"zhipu",
+		"zai",
+		"z.ai",
+		"bigmodel",
+	} {
+		if strings.Contains(value, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 func appendOpenAIReasoningContent(msg *llm.Message, delta string) {
 	if msg == nil || delta == "" {
 		return
@@ -236,19 +282,22 @@ func setOpenAIReasoningContent(msg *llm.Message, reasoning string) {
 }
 
 func openAIReasoningContent(msg llm.Message) string {
+	return openAIReasoningContentForField(msg, openAIReasoningContentKey)
+}
+
+func openAIReasoningContentForField(msg llm.Message, field string) string {
 	if len(msg.Meta) == 0 {
 		return ""
 	}
-	value, _ := msg.Meta[openAIReasoningContentKey].(string)
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return ""
+	}
+	value, _ := msg.Meta[field].(string)
 	if strings.TrimSpace(value) == "" {
 		return ""
 	}
 	return value
-}
-
-func shouldRoundTripOpenAIReasoningContent(model string) bool {
-	model = strings.ToLower(strings.TrimSpace(model))
-	return strings.Contains(model, "deepseek")
 }
 
 func extractTextFromRaw(raw json.RawMessage, includeReasoning bool) string {

--- a/internal/provider/openai_parse_helpers.go
+++ b/internal/provider/openai_parse_helpers.go
@@ -118,6 +118,9 @@ func parseOpenAIMessage(raw json.RawMessage) llm.Message {
 			msg.Content = extractTextFromRaw(outputRaw, false)
 		}
 	}
+	if reasoningRaw, ok := obj[openAIReasoningContentKey]; ok {
+		setOpenAIReasoningContent(&msg, extractTextFromRaw(reasoningRaw, false))
+	}
 	if toolCallsRaw, ok := obj["tool_calls"]; ok {
 		msg.ToolCalls = parseToolCalls(toolCallsRaw)
 	}
@@ -210,6 +213,42 @@ func argumentString(raw json.RawMessage) string {
 		}
 	}
 	return trimmed
+}
+
+const openAIReasoningContentKey = "reasoning_content"
+
+func appendOpenAIReasoningContent(msg *llm.Message, delta string) {
+	if msg == nil || delta == "" {
+		return
+	}
+	existing := openAIReasoningContent(*msg)
+	setOpenAIReasoningContent(msg, existing+delta)
+}
+
+func setOpenAIReasoningContent(msg *llm.Message, reasoning string) {
+	if msg == nil || strings.TrimSpace(reasoning) == "" {
+		return
+	}
+	if msg.Meta == nil {
+		msg.Meta = llm.MessageMeta{}
+	}
+	msg.Meta[openAIReasoningContentKey] = reasoning
+}
+
+func openAIReasoningContent(msg llm.Message) string {
+	if len(msg.Meta) == 0 {
+		return ""
+	}
+	value, _ := msg.Meta[openAIReasoningContentKey].(string)
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	return value
+}
+
+func shouldRoundTripOpenAIReasoningContent(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	return strings.Contains(model, "deepseek")
 }
 
 func extractTextFromRaw(raw json.RawMessage, includeReasoning bool) string {

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -422,6 +422,88 @@ func TestOpenAICompatibleChatPayloadUsesFallbackModelAndTools(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatibleChatPayloadUsesExplicitProviderFamilyReasoningSpec(t *testing.T) {
+	client := NewOpenAICompatible(Config{ProviderID: ProviderOpenAI, ProviderFamily: "deepseek", BaseURL: "https://api.example.com/v1", APIKey: "test-key", Model: "generic-model"})
+	payload, err := client.chatPayload(llm.ChatRequest{
+		Messages: []llm.Message{{
+			Role: llm.RoleAssistant,
+			Meta: llm.MessageMeta{
+				openAIReasoningContentKey: "provider reasoning",
+			},
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "list_files",
+					Arguments: `{"path":"."}`,
+				},
+			}},
+		}},
+	}, false)
+	if err != nil {
+		t.Fatalf("chat payload: %v", err)
+	}
+	messages, _ := payload["messages"].([]map[string]any)
+	if len(messages) != 1 {
+		t.Fatalf("expected one message, got %#v", payload["messages"])
+	}
+	if messages[0][openAIReasoningContentKey] != "provider reasoning" {
+		t.Fatalf("expected provider reasoning_content to be sent, got %#v", messages[0])
+	}
+}
+
+func TestOpenAICompatibleChatPayloadDoesNotUseModelNameForReasoningSpec(t *testing.T) {
+	client := NewOpenAICompatible(Config{ProviderID: ProviderOpenAI, BaseURL: "https://api.openai.com/v1", APIKey: "test-key", Model: "deepseek-v4-pro"})
+	payload, err := client.chatPayload(llm.ChatRequest{
+		Messages: []llm.Message{{
+			Role: llm.RoleAssistant,
+			Meta: llm.MessageMeta{
+				openAIReasoningContentKey: "provider reasoning",
+			},
+			Content: "done",
+		}},
+	}, false)
+	if err != nil {
+		t.Fatalf("chat payload: %v", err)
+	}
+	messages, _ := payload["messages"].([]map[string]any)
+	if len(messages) != 1 {
+		t.Fatalf("expected one message, got %#v", payload["messages"])
+	}
+	if _, ok := messages[0][openAIReasoningContentKey]; ok {
+		t.Fatalf("did not expect reasoning_content based on model name alone, got %#v", messages[0])
+	}
+}
+
+func TestOpenAIReasoningRoundTripSpecFollowsProviderFamily(t *testing.T) {
+	cases := []struct {
+		name     string
+		family   string
+		provider ProviderID
+		baseURL  string
+		want     bool
+	}{
+		{name: "deepseek explicit family", family: "deepseek", provider: ProviderOpenAI, baseURL: "https://api.example.com/v1", want: true},
+		{name: "kimi explicit family", family: "kimi", provider: ProviderOpenAI, want: true},
+		{name: "moonshot explicit family", family: "moonshot", provider: ProviderOpenAI, want: true},
+		{name: "glm explicit family", family: "glm", provider: ProviderOpenAI, want: true},
+		{name: "zhipu explicit family", family: "zhipu", provider: ProviderOpenAI, want: true},
+		{name: "zai explicit family", family: "zai", provider: ProviderOpenAI, want: true},
+		{name: "explicit openai family overrides fallback signals", family: "openai", provider: "deepseek", baseURL: "https://api.deepseek.com/v1", want: false},
+		{name: "deepseek provider id fallback", provider: "deepseek", want: true},
+		{name: "bigmodel base url fallback", provider: ProviderOpenAI, baseURL: "https://open.bigmodel.cn/api/paas/v4", want: true},
+		{name: "openai provider", provider: ProviderOpenAI, baseURL: "https://api.openai.com/v1", want: false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := openAIReasoningRoundTripSpecForProvider(tt.family, tt.provider, tt.baseURL).Enabled()
+			if got != tt.want {
+				t.Fatalf("unexpected reasoning spec enabled=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOpenAIMessagesMapsThinkingAndToolResultParts(t *testing.T) {
 	messages, err := openAIMessages(llm.ChatRequest{
 		Messages: []llm.Message{
@@ -434,7 +516,7 @@ func TestOpenAIMessagesMapsThinkingAndToolResultParts(t *testing.T) {
 			},
 			llm.NewToolResultMessage("call-1", `{"ok":true}`),
 		},
-	})
+	}, openAIReasoningRoundTripSpec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,9 +537,8 @@ func TestOpenAIMessagesMapsThinkingAndToolResultParts(t *testing.T) {
 	}
 }
 
-func TestOpenAIMessagesRoundTripsDeepSeekReasoningWithToolCalls(t *testing.T) {
+func TestOpenAIMessagesRoundTripsProviderReasoningWithToolCalls(t *testing.T) {
 	messages, err := openAIMessages(llm.ChatRequest{
-		Model: "deepseek-v4-pro",
 		Messages: []llm.Message{
 			{
 				Role: llm.RoleAssistant,
@@ -475,7 +556,7 @@ func TestOpenAIMessagesRoundTripsDeepSeekReasoningWithToolCalls(t *testing.T) {
 			},
 			llm.NewToolResultMessage("call-1", `{"ok":true}`),
 		},
-	})
+	}, openAIReasoningRoundTripSpecForProvider("deepseek", ProviderOpenAI, ""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -496,9 +577,9 @@ func TestOpenAIMessagesRoundTripsDeepSeekReasoningWithToolCalls(t *testing.T) {
 	}
 }
 
-func TestOpenAIMessagesDoesNotSendReasoningToNonDeepSeekModel(t *testing.T) {
+func TestOpenAIMessagesDoesNotSendReasoningToProviderWithoutReasoningContent(t *testing.T) {
 	messages, err := openAIMessages(llm.ChatRequest{
-		Model: "gpt-5.4-mini",
+		Model: "deepseek-v4-pro",
 		Messages: []llm.Message{{
 			Role: llm.RoleAssistant,
 			Meta: llm.MessageMeta{
@@ -506,7 +587,7 @@ func TestOpenAIMessagesDoesNotSendReasoningToNonDeepSeekModel(t *testing.T) {
 			},
 			Content: "done",
 		}},
-	})
+	}, openAIReasoningRoundTripSpecForProvider("openai", ProviderOpenAI, ""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +595,7 @@ func TestOpenAIMessagesDoesNotSendReasoningToNonDeepSeekModel(t *testing.T) {
 		t.Fatalf("expected one assistant message, got %#v", messages)
 	}
 	if _, ok := messages[0][openAIReasoningContentKey]; ok {
-		t.Fatalf("did not expect reasoning_content for non-DeepSeek model, got %#v", messages[0])
+		t.Fatalf("did not expect reasoning_content for provider without reasoning_content support, got %#v", messages[0])
 	}
 	if messages[0]["content"] != "done" {
 		t.Fatalf("expected normal assistant content, got %#v", messages[0])
@@ -530,7 +611,7 @@ func TestOpenAIMessagesDegradesMissingImageAsset(t *testing.T) {
 				Image: &llm.ImagePartRef{AssetID: "asset-1"},
 			}},
 		}},
-	})
+	}, openAIReasoningRoundTripSpec{})
 	if err != nil {
 		t.Fatalf("openAIMessages: %v", err)
 	}

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -270,6 +270,9 @@ func TestOpenAICompatibleCreateMessageDoesNotExposeReasoningOnlyResponse(t *test
 	if msg.Content != "" {
 		t.Fatalf("expected reasoning-only response to stay empty, got %#v", msg)
 	}
+	if got := openAIReasoningContent(msg); got != "final from reasoning" {
+		t.Fatalf("expected reasoning metadata to be preserved, got %#v", msg.Meta)
+	}
 }
 
 func TestOpenAICompatibleCreateMessageParsesLegacyFunctionCall(t *testing.T) {
@@ -321,6 +324,9 @@ func TestOpenAICompatibleStreamMessageDoesNotExposeReasoningOnlyResponse(t *test
 	}
 	if msg.Content != "" {
 		t.Fatalf("expected reasoning-only stream to stay empty, got %#v", msg)
+	}
+	if got := openAIReasoningContent(msg); got != "hello world" {
+		t.Fatalf("expected streamed reasoning metadata to be preserved, got %#v", msg.Meta)
 	}
 }
 
@@ -446,6 +452,72 @@ func TestOpenAIMessagesMapsThinkingAndToolResultParts(t *testing.T) {
 	}
 	if messages[1]["role"] != "tool" || messages[1]["tool_call_id"] != "call-1" {
 		t.Fatalf("expected tool_result mapping, got %#v", messages[1])
+	}
+}
+
+func TestOpenAIMessagesRoundTripsDeepSeekReasoningWithToolCalls(t *testing.T) {
+	messages, err := openAIMessages(llm.ChatRequest{
+		Model: "deepseek-v4-pro",
+		Messages: []llm.Message{
+			{
+				Role: llm.RoleAssistant,
+				Meta: llm.MessageMeta{
+					openAIReasoningContentKey: "need a file listing",
+				},
+				ToolCalls: []llm.ToolCall{{
+					ID:   "call-1",
+					Type: "function",
+					Function: llm.ToolFunctionCall{
+						Name:      "list_files",
+						Arguments: `{"path":"."}`,
+					},
+				}},
+			},
+			llm.NewToolResultMessage("call-1", `{"ok":true}`),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected assistant and tool_result messages, got %#v", messages)
+	}
+
+	assistant := messages[0]
+	if assistant["content"] != "" {
+		t.Fatalf("expected empty assistant content to be sent for tool call, got %#v", assistant)
+	}
+	if assistant[openAIReasoningContentKey] != "need a file listing" {
+		t.Fatalf("expected reasoning_content to round-trip, got %#v", assistant)
+	}
+	toolCalls, _ := assistant["tool_calls"].([]map[string]any)
+	if len(toolCalls) != 1 || toolCalls[0]["id"] != "call-1" {
+		t.Fatalf("expected tool call mapping, got %#v", assistant)
+	}
+}
+
+func TestOpenAIMessagesDoesNotSendReasoningToNonDeepSeekModel(t *testing.T) {
+	messages, err := openAIMessages(llm.ChatRequest{
+		Model: "gpt-5.4-mini",
+		Messages: []llm.Message{{
+			Role: llm.RoleAssistant,
+			Meta: llm.MessageMeta{
+				openAIReasoningContentKey: "provider-specific reasoning",
+			},
+			Content: "done",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected one assistant message, got %#v", messages)
+	}
+	if _, ok := messages[0][openAIReasoningContentKey]; ok {
+		t.Fatalf("did not expect reasoning_content for non-DeepSeek model, got %#v", messages[0])
+	}
+	if messages[0]["content"] != "done" {
+		t.Fatalf("expected normal assistant content, got %#v", messages[0])
 	}
 }
 

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -422,8 +422,8 @@ func TestOpenAICompatibleChatPayloadUsesFallbackModelAndTools(t *testing.T) {
 	}
 }
 
-func TestOpenAICompatibleChatPayloadUsesExplicitProviderFamilyReasoningSpec(t *testing.T) {
-	client := NewOpenAICompatible(Config{ProviderID: ProviderOpenAI, ProviderFamily: "deepseek", BaseURL: "https://api.example.com/v1", APIKey: "test-key", Model: "generic-model"})
+func TestOpenAICompatibleChatPayloadUsesExplicitProviderFamilyPolicy(t *testing.T) {
+	client := NewOpenAICompatible(Config{ProviderID: ProviderOpenAI, Type: "openai-compatible", ProviderFamily: "deepseek", BaseURL: "https://api.example.com/v1", APIKey: "test-key", Model: "generic-model"})
 	payload, err := client.chatPayload(llm.ChatRequest{
 		Messages: []llm.Message{{
 			Role: llm.RoleAssistant,
@@ -450,10 +450,13 @@ func TestOpenAICompatibleChatPayloadUsesExplicitProviderFamilyReasoningSpec(t *t
 	if messages[0][openAIReasoningContentKey] != "provider reasoning" {
 		t.Fatalf("expected provider reasoning_content to be sent, got %#v", messages[0])
 	}
+	if messages[0]["content"] != "" {
+		t.Fatalf("expected deepseek policy to send empty assistant content for tool calls, got %#v", messages[0])
+	}
 }
 
-func TestOpenAICompatibleChatPayloadDoesNotUseModelNameForReasoningSpec(t *testing.T) {
-	client := NewOpenAICompatible(Config{ProviderID: ProviderOpenAI, BaseURL: "https://api.openai.com/v1", APIKey: "test-key", Model: "deepseek-v4-pro"})
+func TestOpenAICompatibleChatPayloadDoesNotUseModelNameForReasoningPolicy(t *testing.T) {
+	client := NewOpenAICompatible(Config{ProviderID: ProviderOpenAI, Type: "openai-compatible", BaseURL: "https://api.openai.com/v1", APIKey: "test-key", Model: "deepseek-v4-pro"})
 	payload, err := client.chatPayload(llm.ChatRequest{
 		Messages: []llm.Message{{
 			Role: llm.RoleAssistant,
@@ -475,30 +478,41 @@ func TestOpenAICompatibleChatPayloadDoesNotUseModelNameForReasoningSpec(t *testi
 	}
 }
 
-func TestOpenAIReasoningRoundTripSpecFollowsProviderFamily(t *testing.T) {
+func TestResolveModelPolicyFollowsProviderFamily(t *testing.T) {
 	cases := []struct {
-		name     string
-		family   string
-		provider ProviderID
-		baseURL  string
-		want     bool
+		name       string
+		family     string
+		provider   ProviderID
+		baseURL    string
+		wantReplay bool
+		wantFamily string
+		wantSource string
 	}{
-		{name: "deepseek explicit family", family: "deepseek", provider: ProviderOpenAI, baseURL: "https://api.example.com/v1", want: true},
-		{name: "kimi explicit family", family: "kimi", provider: ProviderOpenAI, want: true},
-		{name: "moonshot explicit family", family: "moonshot", provider: ProviderOpenAI, want: true},
-		{name: "glm explicit family", family: "glm", provider: ProviderOpenAI, want: true},
-		{name: "zhipu explicit family", family: "zhipu", provider: ProviderOpenAI, want: true},
-		{name: "zai explicit family", family: "zai", provider: ProviderOpenAI, want: true},
-		{name: "explicit openai family overrides fallback signals", family: "openai", provider: "deepseek", baseURL: "https://api.deepseek.com/v1", want: false},
-		{name: "deepseek provider id fallback", provider: "deepseek", want: true},
-		{name: "bigmodel base url fallback", provider: ProviderOpenAI, baseURL: "https://open.bigmodel.cn/api/paas/v4", want: true},
-		{name: "openai provider", provider: ProviderOpenAI, baseURL: "https://api.openai.com/v1", want: false},
+		{name: "deepseek explicit family", family: "deepseek", provider: ProviderOpenAI, baseURL: "https://api.example.com/v1", wantReplay: true, wantFamily: "deepseek", wantSource: ModelPolicySourceFamilyOverride},
+		{name: "kimi explicit family", family: "kimi", provider: ProviderOpenAI, wantReplay: true, wantFamily: "kimi", wantSource: ModelPolicySourceFamilyOverride},
+		{name: "moonshot explicit family", family: "moonshot", provider: ProviderOpenAI, wantReplay: true, wantFamily: "moonshot", wantSource: ModelPolicySourceFamilyOverride},
+		{name: "glm explicit family", family: "glm", provider: ProviderOpenAI, wantReplay: true, wantFamily: "glm", wantSource: ModelPolicySourceFamilyOverride},
+		{name: "zhipu explicit family", family: "zhipu", provider: ProviderOpenAI, wantReplay: true, wantFamily: "zhipu", wantSource: ModelPolicySourceFamilyOverride},
+		{name: "zai explicit family", family: "zai", provider: ProviderOpenAI, wantReplay: true, wantFamily: "zai", wantSource: ModelPolicySourceFamilyOverride},
+		{name: "explicit openai family overrides fallback signals", family: "openai", provider: "deepseek", baseURL: "https://api.deepseek.com/v1", wantReplay: false, wantFamily: "openai", wantSource: ModelPolicySourceFamilyOverride},
+		{name: "deepseek provider id fallback", provider: "deepseek", wantReplay: true, wantFamily: "deepseek", wantSource: ModelPolicySourceProviderID},
+		{name: "bigmodel base url fallback", provider: ProviderOpenAI, baseURL: "https://open.bigmodel.cn/api/paas/v4", wantReplay: true, wantFamily: "zai", wantSource: ModelPolicySourceBaseURL},
+		{name: "openai provider", provider: ProviderOpenAI, baseURL: "https://api.openai.com/v1", wantReplay: false, wantSource: ModelPolicySourceDefault},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := openAIReasoningRoundTripSpecForProvider(tt.family, tt.provider, tt.baseURL).Enabled()
-			if got != tt.want {
-				t.Fatalf("unexpected reasoning spec enabled=%v want=%v", got, tt.want)
+			got := ResolveModelPolicy(tt.provider, "openai-compatible", "test-model", tt.family, tt.baseURL)
+			if got.ReplayReasoning() != tt.wantReplay {
+				t.Fatalf("unexpected reasoning replay=%v want=%v policy=%#v", got.ReplayReasoning(), tt.wantReplay, got)
+			}
+			if got.Family != tt.wantFamily {
+				t.Fatalf("unexpected family %q want %q policy=%#v", got.Family, tt.wantFamily, got)
+			}
+			if got.Source != tt.wantSource {
+				t.Fatalf("unexpected source %q want %q policy=%#v", got.Source, tt.wantSource, got)
+			}
+			if tt.wantReplay && (got.ReasoningField != openAIReasoningContentKey || got.AssistantToolCallContentMode != AssistantToolCallContentEmptyString) {
+				t.Fatalf("expected reasoning policy fields to be set, got %#v", got)
 			}
 		})
 	}
@@ -516,7 +530,7 @@ func TestOpenAIMessagesMapsThinkingAndToolResultParts(t *testing.T) {
 			},
 			llm.NewToolResultMessage("call-1", `{"ok":true}`),
 		},
-	}, openAIReasoningRoundTripSpec{})
+	}, ResolvedModelPolicy{AssistantToolCallContentMode: AssistantToolCallContentOmit})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,8 +539,8 @@ func TestOpenAIMessagesMapsThinkingAndToolResultParts(t *testing.T) {
 	}
 
 	assistant := messages[0]
-	if assistant["content"] != "reasoning" {
-		t.Fatalf("expected thinking mapped as string content, got %#v", assistant)
+	if _, ok := assistant["content"]; ok {
+		t.Fatalf("did not expect assistant thinking to be exposed as content under generic policy, got %#v", assistant)
 	}
 	toolCalls, _ := assistant["tool_calls"].([]map[string]any)
 	if len(toolCalls) != 1 || toolCalls[0]["id"] != "call-1" {
@@ -556,7 +570,7 @@ func TestOpenAIMessagesRoundTripsProviderReasoningWithToolCalls(t *testing.T) {
 			},
 			llm.NewToolResultMessage("call-1", `{"ok":true}`),
 		},
-	}, openAIReasoningRoundTripSpecForProvider("deepseek", ProviderOpenAI, ""))
+	}, ResolveModelPolicy(ProviderOpenAI, "openai-compatible", "", "deepseek", ""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -587,7 +601,7 @@ func TestOpenAIMessagesDoesNotSendReasoningToProviderWithoutReasoningContent(t *
 			},
 			Content: "done",
 		}},
-	}, openAIReasoningRoundTripSpecForProvider("openai", ProviderOpenAI, ""))
+	}, ResolveModelPolicy(ProviderOpenAI, "openai-compatible", "deepseek-v4-pro", "openai", ""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -611,7 +625,7 @@ func TestOpenAIMessagesDegradesMissingImageAsset(t *testing.T) {
 				Image: &llm.ImagePartRef{AssetID: "asset-1"},
 			}},
 		}},
-	}, openAIReasoningRoundTripSpec{})
+	}, ResolvedModelPolicy{AssistantToolCallContentMode: AssistantToolCallContentOmit})
 	if err != nil {
 		t.Fatalf("openAIMessages: %v", err)
 	}


### PR DESCRIPTION
#347 现象是：

一开始发“你好”正常，因为 session 历史里还没有 tool_call。
一旦模型触发 web_fetch / list_files，工具本身执行成功。
下一次请求带着历史里的 assistant tool_calls，但没有原始 reasoning_content，DeepSeek 拒绝请求。
同一个 session 后续再发“你好”，仍然会带着那段坏历史，所以继续 provider rejected request。

不同的模型或者模型商对工具调用的返回具体字段有要求，因为之前是没法按需求返回，所以有问题。经过调查发现，同一类的provider迭代返回具体字段要求是基本一致的，因此在模型配置的时候需要加一个family来识别当前模型配置属于哪种provider(openai/anthropic/gemini/claude)，然后bytemind识别对应的provider来输出对应的字段格式。

我已经做了修复：

- provider.type：决定大类协议（openai-compatible / anthropic / gemini）。
- provider.family：在同一协议内再细分厂商规范（主要是 openai-compatible 里的 deepseek/kimi/glm/moonshot 等差异）。