### PR TITLE
chore: 补充 MIT LICENSE 并对齐 README 许可说明

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 1024XEngineer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -189,4 +189,4 @@ See [docs/environment-variables.md](docs/environment-variables.md) for runtime T
 
 ## 📄 License
 
-MIT License
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## 变更说明
- 新增仓库根目录 LICENSE，补充标准 MIT 协议文本。
- 更新 README.md 的 License 段落，明确链接到仓库内的 LICENSE 文件。

## 背景
README 已声明 MIT，但仓库缺少实际协议文件，导致链接指向缺失页面。

## 影响范围
- 仅文档与协议补充，不涉及业务代码逻辑改动。

## 验证
- 本地确认 LICENSE 文件已存在。
- 本地确认 README License 段落链接为相对路径 LICENSE。