### PR TITLE
fix: 图片占位符在换行场景保持原子显示

### DIFF
--- a/tui/component_landing_cursor_test.go
+++ b/tui/component_landing_cursor_test.go
@@ -100,3 +100,25 @@ func TestLandingInputCaretBlinkKeepsDisplayWidthForWideRune(t *testing.T) {
 		t.Fatalf("expected stable display width during blink, visible=%d hidden=%d, visible=%q hidden=%q", visibleWidth, hiddenWidth, visible, hidden)
 	}
 }
+
+func TestLandingInputWrapDoesNotSplitImagePlaceholder(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("[Image#1] " + strings.Repeat("0123456789", 16))
+
+	m := model{
+		screen: screenLanding,
+		width:  84,
+		height: 32,
+		input:  input,
+	}
+	m.syncInputStyle()
+
+	rendered := xansi.Strip(m.renderLandingInputBox(false))
+	if strings.Contains(rendered, "[Image\n#1]") {
+		t.Fatalf("expected placeholder to remain atomic while wrapping, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "[Image#1]") {
+		t.Fatalf("expected placeholder to remain visible, got %q", rendered)
+	}
+}

--- a/tui/input_images.go
+++ b/tui/input_images.go
@@ -21,7 +21,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/session"
 )
 
-var imagePlaceholderPattern = regexp.MustCompile(`\[Image #(\d+)\]`)
+var imagePlaceholderPattern = regexp.MustCompile(`\[Image ?#(\d+)\]`)
 var imageMentionPattern = regexp.MustCompile(`(?i)@([^\s@]+?\.(?:png|jpe?g|webp|gif))`)
 var inlineWindowsImagePathPattern = regexp.MustCompile(`(?i)[a-z]:\\[^\r\n\t"'<>|]*?\.(?:png|jpe?g|webp|gif)`)
 var inlineUnixImagePathPattern = regexp.MustCompile(`(?i)/(?:[^\r\n\t"'<>|/]+/)*[^\r\n\t"'<>|/]+\.(?:png|jpe?g|webp|gif)`)
@@ -967,7 +967,7 @@ func extractImagePlaceholderIDs(text string) []int {
 }
 
 func placeholderForImageID(id int) string {
-	return fmt.Sprintf("[Image #%d]", id)
+	return fmt.Sprintf("[Image#%d]", id)
 }
 
 func imageIDFromPlaceholder(value string) (int, bool) {
@@ -1189,7 +1189,7 @@ func (m *model) protectImagePlaceholderDeletion(before, after, source string) (s
 	if len(before)-len(after) != 1 {
 		return after, false
 	}
-	if !strings.Contains(before, "[Image #") {
+	if !strings.Contains(before, "[Image#") && !strings.Contains(before, "[Image #") {
 		return after, false
 	}
 

--- a/tui/input_images_test.go
+++ b/tui/input_images_test.go
@@ -680,6 +680,20 @@ func TestProtectImagePlaceholderDeletionSkipsMalformedPlaceholder(t *testing.T) 
 	}
 }
 
+func TestProtectImagePlaceholderDeletionSkipsNonPlaceholderText(t *testing.T) {
+	m := newImagePipelineModel(t)
+	before := "plain text"
+	after := "plain tex"
+
+	updated, changed := m.protectImagePlaceholderDeletion(before, after, "backspace")
+	if changed {
+		t.Fatalf("expected non-placeholder deletion not to be intercepted, got %q", updated)
+	}
+	if updated != after {
+		t.Fatalf("expected non-placeholder deletion to pass through, got %q", updated)
+	}
+}
+
 func TestRemoveImagePlaceholderSpansHandlesOverlapAndEmptyInput(t *testing.T) {
 	value := "x[Image #1]y"
 	start := strings.Index(value, "[Image #1]")

--- a/tui/input_images_test.go
+++ b/tui/input_images_test.go
@@ -712,3 +712,29 @@ func TestImagePlaceholderPatternAcceptsLegacyAndAtomicFormats(t *testing.T) {
 		t.Fatalf("expected atomic placeholder to parse, got id=%d ok=%v", atomic, atomicOK)
 	}
 }
+
+func TestExtractImagePlaceholderIDsAcceptsLegacyAndAtomicMixed(t *testing.T) {
+	ids := extractImagePlaceholderIDs("a [Image#1] b [Image #2] c [Image#1]")
+	if len(ids) != 2 {
+		t.Fatalf("expected two unique ids, got %#v", ids)
+	}
+	if ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected id order/content: %#v", ids)
+	}
+}
+
+func TestProtectImagePlaceholderDeletionRemovesOnlyTouchedAtomicPlaceholder(t *testing.T) {
+	m := newImagePipelineModel(t)
+	before := "[Image#1] and [Image#2]"
+	first := "[Image#1]"
+	cut := strings.Index(before, first) + len(first) - 1 // simulate deleting trailing ']'
+	after := before[:cut] + before[cut+1:]
+
+	updated, changed := m.protectImagePlaceholderDeletion(before, after, "backspace")
+	if !changed {
+		t.Fatal("expected atomic placeholder deletion to be applied")
+	}
+	if updated != " and [Image#2]" {
+		t.Fatalf("expected only touched placeholder removed, got %q", updated)
+	}
+}

--- a/tui/input_images_test.go
+++ b/tui/input_images_test.go
@@ -31,8 +31,8 @@ func (f fakeClipboardImageReader) ReadImage(context.Context) (string, []byte, st
 }
 
 type fakeClipboardTextReader struct {
-	text string
-	err  error
+	text  string
+	err   error
 	calls *int
 }
 
@@ -100,7 +100,7 @@ func TestApplyInputImagePipelineConvertsPastedPathToPlaceholder(t *testing.T) {
 	}
 
 	updated, note := m.applyInputImagePipeline("", imagePath, "ctrl+v")
-	if updated != "[Image #1]" {
+	if updated != "[Image#1]" {
 		t.Fatalf("expected image placeholder, got %q", updated)
 	}
 	if !strings.Contains(note, "Attached 1 image") {
@@ -205,7 +205,7 @@ func TestBuildPromptInputExpandsReferencedPlaceholdersOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build prompt input: %v", err)
 	}
-	if display != "inspect [Image #1] only" {
+	if display != "inspect [Image#1] only" {
 		t.Fatalf("unexpected display text: %q", display)
 	}
 	if len(input.Assets) != 1 {
@@ -292,7 +292,7 @@ func TestApplyInputImagePipelineReplacesInlinePathAndKeepsTrailingText(t *testin
 	}
 
 	updated, note := m.applyInputImagePipeline("", imagePath+"图片在描述什么？", "ctrl+v")
-	if updated != "[Image #1]图片在描述什么？" {
+	if updated != "[Image#1]图片在描述什么？" {
 		t.Fatalf("expected inline path replaced and text preserved, got %q", updated)
 	}
 	if !strings.Contains(note, "Attached 1 image") {
@@ -314,7 +314,7 @@ func TestBuildPromptInputGracefullyDegradesMissingImageAsset(t *testing.T) {
 	if len(input.Assets) != 0 {
 		t.Fatalf("expected no binary asset payload when cache is missing, got %d", len(input.Assets))
 	}
-	if strings.Contains(input.UserMessage.Text(), "[Image #1]") {
+	if strings.Contains(input.UserMessage.Text(), "[Image#1]") {
 		t.Fatalf("expected unavailable marker text, got %q", input.UserMessage.Text())
 	}
 	if !strings.Contains(input.UserMessage.Text(), "Image #1 unavailable") {
@@ -381,7 +381,7 @@ func TestHandleEmptyClipboardPasteReadsAndAttachesImage(t *testing.T) {
 	if !strings.Contains(note, "Attached image from clipboard") {
 		t.Fatalf("expected clipboard attach note, got %q", note)
 	}
-	if m.input.Value() != "[Image #1]" {
+	if m.input.Value() != "[Image#1]" {
 		t.Fatalf("expected placeholder inserted into input, got %q", m.input.Value())
 	}
 }
@@ -478,7 +478,7 @@ func TestApplyWholeInputImagePathFallbackRequiresPasteSignalOrRecentPaste(t *tes
 
 	m.lastPasteAt = time.Now()
 	updated, note := m.applyWholeInputImagePathFallback(imagePath, "rune")
-	if updated != "[Image #1]" {
+	if updated != "[Image#1]" {
 		t.Fatalf("expected fallback conversion with recent paste window, got %q", updated)
 	}
 	if !strings.Contains(note, "Attached 1 image") {
@@ -698,5 +698,17 @@ func TestRemoveImagePlaceholderSpansHandlesOverlapAndEmptyInput(t *testing.T) {
 	})
 	if updated != "xy" {
 		t.Fatalf("expected overlap-safe placeholder removal, got %q", updated)
+	}
+}
+
+func TestImagePlaceholderPatternAcceptsLegacyAndAtomicFormats(t *testing.T) {
+	legacy, legacyOK := imageIDFromPlaceholder("[Image #7]")
+	if !legacyOK || legacy != 7 {
+		t.Fatalf("expected legacy placeholder to parse, got id=%d ok=%v", legacy, legacyOK)
+	}
+
+	atomic, atomicOK := imageIDFromPlaceholder("[Image#8]")
+	if !atomicOK || atomic != 8 {
+		t.Fatalf("expected atomic placeholder to parse, got id=%d ok=%v", atomic, atomicOK)
 	}
 }

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -2589,7 +2589,7 @@ func TestAltVPastesClipboardImage(t *testing.T) {
 
 	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}, Alt: true})
 	updated := got.(model)
-	if updated.input.Value() != "[Image #1]" {
+	if updated.input.Value() != "[Image#1]" {
 		t.Fatalf("expected alt+v to paste clipboard image placeholder, got %q", updated.input.Value())
 	}
 	if !strings.Contains(updated.statusNote, "Attached image from clipboard") {
@@ -2608,7 +2608,7 @@ func TestCtrlVPastesClipboardImage(t *testing.T) {
 
 	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlV})
 	updated := got.(model)
-	if updated.input.Value() != "[Image #1]" {
+	if updated.input.Value() != "[Image#1]" {
 		t.Fatalf("expected ctrl+v to paste clipboard image placeholder, got %q", updated.input.Value())
 	}
 }
@@ -2624,7 +2624,7 @@ func TestCtrlVControlMarkerRunePastesClipboardImage(t *testing.T) {
 
 	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'\x16'}})
 	updated := got.(model)
-	if updated.input.Value() != "[Image #1]" {
+	if updated.input.Value() != "[Image#1]" {
 		t.Fatalf("expected ctrl+v control marker to paste clipboard image placeholder, got %q", updated.input.Value())
 	}
 }
@@ -2888,7 +2888,7 @@ func TestTerminalPasteEventWithEmptyPayloadPastesClipboardImage(t *testing.T) {
 
 	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Paste: true})
 	updated := got.(model)
-	if updated.input.Value() != "[Image #1]" {
+	if updated.input.Value() != "[Image#1]" {
 		t.Fatalf("expected empty paste event to attach clipboard image, got %q", updated.input.Value())
 	}
 }
@@ -2905,7 +2905,7 @@ func TestTerminalPasteEventWithTextDoesNotForceClipboardImage(t *testing.T) {
 	if updated.input.Value() != "hello" {
 		t.Fatalf("expected text paste to remain text, got %q", updated.input.Value())
 	}
-	if strings.Contains(updated.input.Value(), "[Image #") {
+	if strings.Contains(updated.input.Value(), "[Image#") || strings.Contains(updated.input.Value(), "[Image #") {
 		t.Fatalf("expected no image placeholder for text paste")
 	}
 }
@@ -2924,7 +2924,7 @@ func TestRapidRuneInputForImagePathTriggersFallbackPlaceholder(t *testing.T) {
 		next := got.(model)
 		m = &next
 	}
-	if m.input.Value() != "[Image #1]" {
+	if m.input.Value() != "[Image#1]" {
 		t.Fatalf("expected rapid path input to convert to placeholder, got %q", m.input.Value())
 	}
 }

--- a/tui/services/prompt_builder.go
+++ b/tui/services/prompt_builder.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	builderImagePlaceholderPattern = regexp.MustCompile(`\[Image #(\d+)\]`)
+	builderImagePlaceholderPattern = regexp.MustCompile(`\[Image ?#(\d+)\]`)
 	builderImageMentionPattern     = regexp.MustCompile(`(?i)@([^\s@]+?\.(?:png|jpe?g|webp|gif))`)
 )
 

--- a/tui/services/prompt_builder_test.go
+++ b/tui/services/prompt_builder_test.go
@@ -1,0 +1,109 @@
+package services
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/bytemind/internal/assets"
+	"github.com/1024XEngineer/bytemind/internal/llm"
+	"github.com/1024XEngineer/bytemind/internal/session"
+	tuiapi "github.com/1024XEngineer/bytemind/tui/api"
+	tuiruntime "github.com/1024XEngineer/bytemind/tui/runtime"
+)
+
+type fakePromptBuilderAPI struct {
+	*tuiruntime.Service
+	refs  map[int]tuiruntime.StoredImageRef
+	blobs map[string]assets.ImageBlob
+}
+
+func newFakePromptBuilderAPI() *fakePromptBuilderAPI {
+	return &fakePromptBuilderAPI{
+		Service: tuiruntime.NewService(tuiruntime.Dependencies{}),
+		refs:    make(map[int]tuiruntime.StoredImageRef),
+		blobs:   make(map[string]assets.ImageBlob),
+	}
+}
+
+func (f *fakePromptBuilderAPI) FindSessionAssetByImageID(_ *session.Session, imageID int) (tuiruntime.StoredImageRef, bool) {
+	ref, ok := f.refs[imageID]
+	return ref, ok
+}
+
+func (f *fakePromptBuilderAPI) LoadSessionImageAsset(_ *session.Session, assetID string) (assets.ImageBlob, error) {
+	blob, ok := f.blobs[assetID]
+	if !ok {
+		return assets.ImageBlob{}, errors.New("asset not found")
+	}
+	return blob, nil
+}
+
+func countImageParts(msg llm.Message) int {
+	total := 0
+	for _, part := range msg.Parts {
+		if part.Type == llm.PartImageRef && part.Image != nil {
+			total++
+		}
+	}
+	return total
+}
+
+func TestPromptBuilderBuildParsesAtomicAndLegacyImagePlaceholders(t *testing.T) {
+	api := newFakePromptBuilderAPI()
+	assetID := llm.AssetID("sess:1")
+	api.refs[1] = tuiruntime.StoredImageRef{AssetID: assetID}
+	api.blobs[string(assetID)] = assets.ImageBlob{
+		MediaType: "image/png",
+		Data:      []byte("png-bytes"),
+	}
+
+	builder := NewPromptBuilder(api, session.New(t.TempDir()))
+	cases := []string{"[Image#1]", "[Image #1]"}
+	for _, placeholder := range cases {
+		result := builder.Build(tuiapi.PromptBuildRequest{
+			RawInput: "inspect " + placeholder + " only",
+		}, tuiruntime.PastedState{})
+
+		if !result.Success {
+			t.Fatalf("expected success for %q, got error: %s", placeholder, result.Error)
+		}
+		if got := countImageParts(result.Data.Prompt.UserMessage); got != 1 {
+			t.Fatalf("expected one image part for %q, got %d (message=%#v)", placeholder, got, result.Data.Prompt.UserMessage.Parts)
+		}
+		if len(result.Data.Prompt.Assets) != 1 {
+			t.Fatalf("expected one asset payload for %q, got %d", placeholder, len(result.Data.Prompt.Assets))
+		}
+		if _, ok := result.Data.Prompt.Assets[assetID]; !ok {
+			t.Fatalf("expected asset %q for %q", assetID, placeholder)
+		}
+		if strings.Contains(result.Data.Prompt.UserMessage.Text(), "unavailable") {
+			t.Fatalf("did not expect unavailable fallback for %q, got %q", placeholder, result.Data.Prompt.UserMessage.Text())
+		}
+	}
+}
+
+func TestPromptBuilderBuildFallbackForAtomicAndLegacyUnknownPlaceholders(t *testing.T) {
+	api := tuiruntime.NewService(tuiruntime.Dependencies{})
+	builder := NewPromptBuilder(api, session.New(t.TempDir()))
+
+	cases := []string{"[Image#1]", "[Image #1]"}
+	for _, placeholder := range cases {
+		result := builder.Build(tuiapi.PromptBuildRequest{
+			RawInput: "inspect " + placeholder + " only",
+		}, tuiruntime.PastedState{})
+
+		if !result.Success {
+			t.Fatalf("expected success for %q, got error: %s", placeholder, result.Error)
+		}
+		if got := countImageParts(result.Data.Prompt.UserMessage); got != 0 {
+			t.Fatalf("expected no image part for missing asset %q, got %d", placeholder, got)
+		}
+		if len(result.Data.Prompt.Assets) != 0 {
+			t.Fatalf("expected no assets for missing placeholder %q, got %d", placeholder, len(result.Data.Prompt.Assets))
+		}
+		if !strings.Contains(result.Data.Prompt.UserMessage.Text(), "Image #1 unavailable") {
+			t.Fatalf("expected unavailable fallback for %q, got %q", placeholder, result.Data.Prompt.UserMessage.Text())
+		}
+	}
+}


### PR DESCRIPTION
﻿## 变更内容
- 将图片占位符格式统一为原子 token：`[Image#n]`，避免在输入框自动换行时被空格拆开。
- 占位符解析正则兼容两种格式：`[Image#n]` 与历史格式 `[Image #n]`，确保老输入不回归。
- 同步更新 TUI prompt builder 的占位符匹配逻辑，保证渲染与提交链路一致。
- 新增/更新测试：
  - landing 输入框长文本换行时不拆分图片占位符
  - 新旧占位符解析兼容
  - 相关图片粘贴与输入路径回归断言

## 问题根因
原占位符为 `[Image #n]`，中间包含空格；在窄宽度输入框中，文本换行会把该片段按空格分词换行，导致占位符视觉上被拆开。

## 影响
- 用户输入长文本时，图片占位符在 UI 中保持整体显示，不再被拆分。
- 现有会话中的历史占位符格式仍可正常解析，不影响功能兼容性。

## 验证
- `go test ./tui -count=1`
