### PR TITLE
Codex/codeblock single frame

### DIFF
--- a/tui/component_text_render.go
+++ b/tui/component_text_render.go
@@ -402,25 +402,22 @@ func renderAssistantBodyLegacy(text string, width int) string {
 	lines := strings.Split(text, "\n")
 	out := make([]string, 0, len(lines))
 	inCodeBlock := false
+	codeLines := make([]string, 0, 8)
 	prevBlank := true
 
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "```") {
+			if inCodeBlock {
+				out = append(out, renderLegacyFencedCodeBlock(codeLines, width))
+				codeLines = codeLines[:0]
+			}
 			inCodeBlock = !inCodeBlock
 			continue
 		}
 
 		if inCodeBlock {
-			codeLine := strings.TrimRight(wrapPlainText(line, width), "\n")
-			if strings.TrimSpace(codeLine) == "" {
-				if !prevBlank {
-					out = append(out, "")
-				}
-				prevBlank = true
-				continue
-			}
-			out = append(out, codeStyle.Render(codeLine))
+			codeLines = append(codeLines, line)
 			prevBlank = false
 			continue
 		}
@@ -445,7 +442,29 @@ func renderAssistantBodyLegacy(text string, width int) string {
 		prevBlank = false
 	}
 
+	if inCodeBlock {
+		out = append(out, renderLegacyFencedCodeBlock(codeLines, width))
+	}
+
 	return strings.Join(out, "\n")
+}
+
+func renderLegacyFencedCodeBlock(codeLines []string, width int) string {
+	if len(codeLines) == 0 {
+		return enhancedCodeStyle.Render("")
+	}
+
+	innerWidth := max(8, width-enhancedCodeStyle.GetHorizontalFrameSize())
+	wrapped := make([]string, 0, len(codeLines))
+	for _, line := range codeLines {
+		if line == "" {
+			wrapped = append(wrapped, "")
+			continue
+		}
+		wrapped = append(wrapped, strings.Split(wrapPlainText(line, innerWidth), "\n")...)
+	}
+
+	return enhancedCodeStyle.Render(strings.Join(wrapped, "\n"))
 }
 
 func stripAssistantStructuralTags(text string) string {

--- a/tui/component_text_render_semantic_test.go
+++ b/tui/component_text_render_semantic_test.go
@@ -62,3 +62,63 @@ func TestApplyLineIntentStyleColorsInfoWarningAndError(t *testing.T) {
 		t.Fatalf("expected error styling to preserve text, got %q", errText)
 	}
 }
+
+func TestRenderLegacyFencedCodeBlockHandlesEmptyBlock(t *testing.T) {
+	got := renderLegacyFencedCodeBlock(nil, 24)
+	plain := stripANSI(got)
+	if !strings.Contains(plain, "╭") || !strings.Contains(plain, "╰") {
+		t.Fatalf("expected framed empty code block, got %q", plain)
+	}
+}
+
+func TestRenderLegacyFencedCodeBlockPreservesBlankLinesAndWrapsLongLines(t *testing.T) {
+	got := renderLegacyFencedCodeBlock([]string{
+		"short",
+		"",
+		"this is a very long code line that should wrap in the legacy fenced renderer",
+	}, 16)
+	plain := stripANSI(got)
+
+	if !strings.Contains(plain, "short") {
+		t.Fatalf("expected first code line, got %q", plain)
+	}
+	if !strings.Contains(plain, "very long") || !strings.Contains(plain, "legacy") || !strings.Contains(plain, "fenced") {
+		t.Fatalf("expected wrapped long line fragments, got %q", plain)
+	}
+}
+
+func TestRenderAssistantBodyLegacyRendersFencedCodeAsSingleFrame(t *testing.T) {
+	input := strings.Join([]string{
+		"before",
+		"```go",
+		"line one",
+		"",
+		"line two is very very long and should wrap",
+		"```",
+		"after",
+	}, "\n")
+	got := stripANSI(renderAssistantBodyLegacy(input, 20))
+
+	if strings.Count(got, "╭") != 1 || strings.Count(got, "╰") != 1 {
+		t.Fatalf("expected a single code frame, got %q", got)
+	}
+	if !strings.Contains(got, "before") || !strings.Contains(got, "after") {
+		t.Fatalf("expected non-code content to be preserved, got %q", got)
+	}
+}
+
+func TestRenderAssistantBodyLegacyUnclosedFenceFlushesAtEOF(t *testing.T) {
+	input := strings.Join([]string{
+		"```",
+		"alpha",
+		"beta",
+	}, "\n")
+	got := stripANSI(renderAssistantBodyLegacy(input, 24))
+
+	if !strings.Contains(got, "alpha") || !strings.Contains(got, "beta") {
+		t.Fatalf("expected unclosed fenced code content rendered, got %q", got)
+	}
+	if strings.Count(got, "╭") != 1 || strings.Count(got, "╰") != 1 {
+		t.Fatalf("expected single framed block for unclosed fence, got %q", got)
+	}
+}


### PR DESCRIPTION
## 变更背景
当前 assistant 文本中的 fenced code block 在 legacy 渲染路径下，会对每一行代码单独应用样式，导致视觉上出现“每行一个小框”的碎片化效果，阅读体验较差。

## 变更内容
- 调整 `tui/component_text_render.go` 中 `renderAssistantBodyLegacy` 的代码块处理逻辑：
- 在进入代码块后先收集全部代码行；
- 在代码块结束时一次性渲染为单个块级容器；
- 新增 `renderLegacyFencedCodeBlock(...)`，统一处理代码块内换行与宽度适配。

## 变更效果
- 代码块显示从“逐行小框”改为“整块包裹”；
- 多行代码、空行与长行换行场景下，均保持在同一个代码块容器内；
- 与当前语义渲染主路径兼容，不影响普通段落/列表/引用展示。

## 影响范围
- 仅影响 assistant legacy 渲染路径中的 fenced code block 显示行为；
- 未改动工具消息与普通文本渲染逻辑。

## 验证
- `go test ./tui -run 'TestRenderAssistantBody|TestRenderMarkdown|TestSimpleMarkdownRenderer' -count=1`
- 结果：通过
