### PR TITLE
fix(tui): tighten run section spacing

### DIFF
--- a/tui/component_conversation.go
+++ b/tui/component_conversation.go
@@ -286,10 +286,7 @@ func renderBytemindRunCard(items []chatEntry, width int) string {
 	contentWidth := max(8, width-outer.GetHorizontalFrameSize())
 	sectionGroups := collapseRunSectionGroups(items)
 	sections := make([]string, 0, len(sectionGroups))
-	for i, group := range sectionGroups {
-		if i > 0 {
-			sections = append(sections, renderRunSectionDivider(contentWidth))
-		}
+	for _, group := range sectionGroups {
 		sections = append(sections, renderRunSectionGroup(group, contentWidth))
 	}
 	return outer.Width(contentWidth).Render(strings.Join(sections, "\n"))

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -199,6 +199,20 @@ func TestRenderBytemindRunCardDoesNotCollapseSeparatedReadTools(t *testing.T) {
 	}
 }
 
+func TestRenderBytemindRunCardOmitsDividerBetweenSections(t *testing.T) {
+	view := stripANSI(renderBytemindRunCard([]chatEntry{
+		{Kind: "tool", Title: toolEntryTitle("list_files"), Body: "Read 29 files, listed 31 directories", Status: "done"},
+		{Kind: "tool", Title: "READ x 2 | read_file", Body: "Read 2 files: invalid_args: unknown argument \"limit\", README.md", Status: "error"},
+	}, 100))
+
+	if strings.Contains(view, "-----") {
+		t.Fatalf("expected run card sections to omit divider line, got %q", view)
+	}
+	if !strings.Contains(view, "LIST") || !strings.Contains(view, "READ x 2") {
+		t.Fatalf("expected both sections to render, got %q", view)
+	}
+}
+
 func TestCollapseRunSectionGroupsKeepsNonReadAndSplitsReadRuns(t *testing.T) {
 	items := []chatEntry{
 		{Kind: "assistant", Title: assistantLabel, Body: "Thinking", Status: "final"},


### PR DESCRIPTION
## 背景

在 TUI 的 run 结果区域里，多个工具区块之间原本会插入一条长分隔线，视觉上显得比较松散。

例如 `LIST` 后面紧跟 `READ x 2` 这类结果时，中间会被横线和额外间距拉开，不够紧凑。

## 本次修改

- 移除了同一轮 run 内各个 tool section 之间的长分隔线
- 保留正常换行，让相邻工具结果直接衔接显示
- 补充渲染测试，确保后续不会回退成带横线的布局

## 效果

调整后会从类似下面的展示：

```text
LIST  ✓
Read 29 files, listed 31 directories
-------------------------------------------------------------------------------------------------------------------
READ x 2  error
Read 2 files: invalid_args: unknown argument "limit", README.md
