### PR TITLE
feat(notify): 新增桌面通知（审批与任务完成/失败）

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ go run ./cmd/bytemind run -prompt "refactor this module" -max-iterations 64
     "api_key": "your-api-key-here"
   },
   "approval_policy": "on-request",
+  "notifications": {
+    "desktop": {
+      "enabled": true,
+      "on_approval_required": true,
+      "on_run_completed": true,
+      "on_run_failed": true,
+      "on_run_canceled": false,
+      "cooldown_seconds": 3
+    }
+  },
   "max_iterations": 32,
   "stream": true
 }
@@ -186,6 +196,12 @@ See [docs/environment-variables.md](docs/environment-variables.md) for runtime T
 - `BYTEMIND_ENABLE_MOUSE`
 - `BYTEMIND_WINDOWS_INPUT_TTY`
 - `BYTEMIND_MOUSE_Y_OFFSET`
+- `BYTEMIND_DESKTOP_NOTIFY`
+- `BYTEMIND_NOTIFY_APPROVAL`
+- `BYTEMIND_NOTIFY_RUN_COMPLETED`
+- `BYTEMIND_NOTIFY_RUN_FAILED`
+- `BYTEMIND_NOTIFY_RUN_CANCELED`
+- `BYTEMIND_NOTIFY_COOLDOWN_SECONDS`
 
 ## 📄 License
 

--- a/config.example.json
+++ b/config.example.json
@@ -7,6 +7,16 @@
     "api_key": ""
   },
   "approval_policy": "on-request",
+  "notifications": {
+    "desktop": {
+      "enabled": true,
+      "on_approval_required": true,
+      "on_run_completed": true,
+      "on_run_failed": true,
+      "on_run_canceled": false,
+      "cooldown_seconds": 3
+    }
+  },
   "max_iterations": 32,
   "stream": true,
   "update_check": {

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -10,6 +10,12 @@ ByteMind TUI supports the following runtime environment variables:
 | `BYTEMIND_APPROVAL_MODE` | `interactive` | Runtime approval mode override. Supported values: `interactive`, `full_access`. Legacy `away` is blocked by default to prevent silent privilege escalation. |
 | `BYTEMIND_ALLOW_AWAY_FULL_ACCESS` | `false` | Temporary migration gate. Set to `true` to allow legacy `approval_mode=away` to map to `full_access`. |
 | `BYTEMIND_AWAY_POLICY` | `auto_deny_continue` | Deprecated compatibility field. Still validated (`auto_deny_continue`, `fail_fast`) but no longer changes runtime approval behavior. |
+| `BYTEMIND_DESKTOP_NOTIFY` | `true` | Enable/disable desktop notifications globally. |
+| `BYTEMIND_NOTIFY_APPROVAL` | `true` | Enable/disable desktop notifications for approval requests. |
+| `BYTEMIND_NOTIFY_RUN_COMPLETED` | `true` | Enable/disable desktop notifications for successful run completion. |
+| `BYTEMIND_NOTIFY_RUN_FAILED` | `true` | Enable/disable desktop notifications for failed runs. |
+| `BYTEMIND_NOTIFY_RUN_CANCELED` | `false` | Enable/disable desktop notifications for canceled runs. |
+| `BYTEMIND_NOTIFY_COOLDOWN_SECONDS` | `3` | Cooldown window in seconds for identical notification keys. `0` disables cooldown dedupe. |
 | `BYTEMIND_SANDBOX_ENABLED` | `false` | Enables lease-based sandbox policy checks and worker-path enforcement for shell/file tools. |
 | `BYTEMIND_SYSTEM_SANDBOX_MODE` | `off` | System sandbox execution mode for shell tools. Supported values: `off`, `best_effort`, `required`. `required` fail-closes when backend is unavailable; `best_effort` falls back without system sandbox and logs a startup warning. |
 | `BYTEMIND_WRITABLE_ROOTS` | empty | Additional writable roots. Use the OS path-list separator (`;` on Windows, `:` on Linux/macOS). |

--- a/internal/app/tui_run_test.go
+++ b/internal/app/tui_run_test.go
@@ -35,6 +35,9 @@ func TestRunTUIBuildsOptionsAndInvokesProgram(t *testing.T) {
 		if opts.ImageStore == nil {
 			t.Fatalf("expected image store to be initialized")
 		}
+		if opts.Notifier == nil {
+			t.Fatalf("expected notifier to be initialized")
+		}
 		if opts.Workspace != workspace {
 			t.Fatalf("expected workspace %q, got %q", workspace, opts.Workspace)
 		}

--- a/internal/app/tui_runtime.go
+++ b/internal/app/tui_runtime.go
@@ -1,14 +1,17 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"io"
 	"os"
+	"time"
 
 	"bytemind/internal/assets"
 	"bytemind/internal/config"
 	"bytemind/internal/mcpctl"
+	notifypkg "bytemind/internal/notify"
 	"bytemind/tui"
 )
 
@@ -23,6 +26,8 @@ type TUIRuntime struct {
 	Options tui.Options
 	close   func() error
 }
+
+const tuiRuntimeNotifierCloseTimeout = 2 * time.Second
 
 func (r TUIRuntime) Close() error {
 	if r.close == nil {
@@ -99,6 +104,10 @@ func BuildTUIRuntime(req TUIRequest) (TUIRuntime, error) {
 	if err != nil {
 		return TUIRuntime{}, err
 	}
+	notifier := notifypkg.NewDesktopNotifier(notifypkg.DesktopConfig{
+		Enabled:         cfg.Notifications.Desktop.Enabled,
+		CooldownSeconds: cfg.Notifications.Desktop.CooldownSeconds,
+	})
 
 	return TUIRuntime{
 		Options: tui.Options{
@@ -107,11 +116,24 @@ func BuildTUIRuntime(req TUIRequest) (TUIRuntime, error) {
 			MCPService:   mcpctl.NewService(workspace, *configPath, runtimeBundle.Extensions),
 			Session:      runtimeBundle.Session,
 			ImageStore:   imageStore,
+			Notifier:     notifier,
 			Config:       cfg,
 			Workspace:    runtimeBundle.Session.Workspace,
 			StartupGuide: guide,
 		},
-		close: runner.Close,
+		close: func() error {
+			runnerErr := runner.Close()
+			closeCtx, cancel := context.WithTimeout(context.Background(), tuiRuntimeNotifierCloseTimeout)
+			defer cancel()
+			notifierErr := notifier.Close(closeCtx)
+			if runnerErr != nil {
+				return runnerErr
+			}
+			if notifierErr != nil {
+				return notifierErr
+			}
+			return nil
+		},
 	}, nil
 }
 

--- a/internal/app/tui_runtime.go
+++ b/internal/app/tui_runtime.go
@@ -121,20 +121,30 @@ func BuildTUIRuntime(req TUIRequest) (TUIRuntime, error) {
 			Workspace:    runtimeBundle.Session.Workspace,
 			StartupGuide: guide,
 		},
-		close: func() error {
-			runnerErr := runner.Close()
+		close: chainTUIRuntimeClose(runner.Close, notifier),
+	}, nil
+}
+
+func chainTUIRuntimeClose(runnerClose func() error, notifier notifypkg.Notifier) func() error {
+	return func() error {
+		runnerErr := error(nil)
+		if runnerClose != nil {
+			runnerErr = runnerClose()
+		}
+		notifierErr := error(nil)
+		if notifier != nil {
 			closeCtx, cancel := context.WithTimeout(context.Background(), tuiRuntimeNotifierCloseTimeout)
 			defer cancel()
-			notifierErr := notifier.Close(closeCtx)
-			if runnerErr != nil {
-				return runnerErr
-			}
-			if notifierErr != nil {
-				return notifierErr
-			}
-			return nil
-		},
-	}, nil
+			notifierErr = notifier.Close(closeCtx)
+		}
+		if runnerErr != nil {
+			return runnerErr
+		}
+		if notifierErr != nil {
+			return notifierErr
+		}
+		return nil
+	}
 }
 
 func resolveTUIStartupPolicy(interactive bool) (tui.StartupGuide, bool) {

--- a/internal/app/tui_runtime_test.go
+++ b/internal/app/tui_runtime_test.go
@@ -1,6 +1,12 @@
 package app
 
-import "testing"
+import (
+	notifypkg "bytemind/internal/notify"
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
 
 func TestResolveTUIStartupPolicyInteractiveDisablesGuideAndAPIKeyRequirement(t *testing.T) {
 	guide, requireAPIKey := resolveTUIStartupPolicy(true)
@@ -19,5 +25,74 @@ func TestResolveTUIStartupPolicyNonInteractiveRequiresAPIKey(t *testing.T) {
 	}
 	if !requireAPIKey {
 		t.Fatal("expected non-interactive tui to require API key")
+	}
+}
+
+type stubRuntimeNotifier struct {
+	closeFn func(context.Context) error
+}
+
+func (stubRuntimeNotifier) Notify(notifypkg.Message) {}
+
+func (s stubRuntimeNotifier) Close(ctx context.Context) error {
+	if s.closeFn == nil {
+		return nil
+	}
+	return s.closeFn(ctx)
+}
+
+func TestChainTUIRuntimeCloseReturnsRunnerErrorFirst(t *testing.T) {
+	runnerErr := errors.New("runner close failed")
+	notifierErr := errors.New("notifier close failed")
+	closeFn := chainTUIRuntimeClose(
+		func() error { return runnerErr },
+		stubRuntimeNotifier{
+			closeFn: func(context.Context) error { return notifierErr },
+		},
+	)
+
+	err := closeFn()
+	if !errors.Is(err, runnerErr) {
+		t.Fatalf("expected runner error to have priority, got %v", err)
+	}
+}
+
+func TestChainTUIRuntimeCloseReturnsNotifierError(t *testing.T) {
+	notifierErr := errors.New("notifier close failed")
+	closeFn := chainTUIRuntimeClose(
+		nil,
+		stubRuntimeNotifier{
+			closeFn: func(context.Context) error { return notifierErr },
+		},
+	)
+
+	err := closeFn()
+	if !errors.Is(err, notifierErr) {
+		t.Fatalf("expected notifier close error, got %v", err)
+	}
+}
+
+func TestChainTUIRuntimeCloseUsesFixedNotifierTimeout(t *testing.T) {
+	closeFn := chainTUIRuntimeClose(
+		nil,
+		stubRuntimeNotifier{
+			closeFn: func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		},
+	)
+
+	start := time.Now()
+	err := closeFn()
+	if err == nil {
+		t.Fatalf("expected timeout error from notifier close")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < tuiRuntimeNotifierCloseTimeout/2 || elapsed > tuiRuntimeNotifierCloseTimeout*3 {
+		t.Fatalf("expected timeout close to be near %s, got %s", tuiRuntimeNotifierCloseTimeout, elapsed)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	WritableRoots     []string              `json:"writable_roots"`
 	ExecAllowlist     []ExecAllowRule       `json:"exec_allowlist"`
 	NetworkAllowlist  []NetworkAllowRule    `json:"network_allowlist"`
+	Notifications     NotificationsConfig   `json:"notifications"`
 	MaxIterations     int                   `json:"max_iterations"`
 	Stream            bool                  `json:"stream"`
 	UpdateCheck       UpdateCheckConfig     `json:"update_check"`
@@ -99,6 +100,19 @@ type NetworkAllowRule struct {
 	Host   string `json:"host"`
 	Port   int    `json:"port"`
 	Scheme string `json:"scheme"`
+}
+
+type NotificationsConfig struct {
+	Desktop DesktopNotificationConfig `json:"desktop"`
+}
+
+type DesktopNotificationConfig struct {
+	Enabled            bool `json:"enabled"`
+	OnApprovalRequired bool `json:"on_approval_required"`
+	OnRunCompleted     bool `json:"on_run_completed"`
+	OnRunFailed        bool `json:"on_run_failed"`
+	OnRunCanceled      bool `json:"on_run_canceled"`
+	CooldownSeconds    int  `json:"cooldown_seconds"`
 }
 
 type MCPConfig struct {
@@ -170,8 +184,18 @@ func Default(workspace string) Config {
 		WritableRoots:     []string{},
 		ExecAllowlist:     []ExecAllowRule{},
 		NetworkAllowlist:  []NetworkAllowRule{},
-		MaxIterations:     32,
-		Stream:            true,
+		Notifications: NotificationsConfig{
+			Desktop: DesktopNotificationConfig{
+				Enabled:            true,
+				OnApprovalRequired: true,
+				OnRunCompleted:     true,
+				OnRunFailed:        true,
+				OnRunCanceled:      false,
+				CooldownSeconds:    3,
+			},
+		},
+		MaxIterations: 32,
+		Stream:        true,
 		UpdateCheck: UpdateCheckConfig{
 			Enabled: true,
 		},
@@ -338,8 +362,18 @@ func ensureDefaultConfigFile(home string) error {
 		WritableRoots:     []string{},
 		ExecAllowlist:     []ExecAllowRule{},
 		NetworkAllowlist:  []NetworkAllowRule{},
-		MaxIterations:     32,
-		Stream:            true,
+		Notifications: NotificationsConfig{
+			Desktop: DesktopNotificationConfig{
+				Enabled:            true,
+				OnApprovalRequired: true,
+				OnRunCompleted:     true,
+				OnRunFailed:        true,
+				OnRunCanceled:      false,
+				CooldownSeconds:    3,
+			},
+		},
+		MaxIterations: 32,
+		Stream:        true,
 		UpdateCheck: UpdateCheckConfig{
 			Enabled: true,
 		},
@@ -522,6 +556,36 @@ func applyEnv(cfg *Config) {
 	if value := strings.TrimSpace(os.Getenv("BYTEMIND_TOKEN_QUOTA")); value != "" {
 		if parsed, err := strconv.Atoi(value); err == nil {
 			cfg.TokenQuota = parsed
+		}
+	}
+	if value := strings.TrimSpace(os.Getenv("BYTEMIND_DESKTOP_NOTIFY")); value != "" {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			cfg.Notifications.Desktop.Enabled = parsed
+		}
+	}
+	if value := strings.TrimSpace(os.Getenv("BYTEMIND_NOTIFY_APPROVAL")); value != "" {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			cfg.Notifications.Desktop.OnApprovalRequired = parsed
+		}
+	}
+	if value := strings.TrimSpace(os.Getenv("BYTEMIND_NOTIFY_RUN_COMPLETED")); value != "" {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			cfg.Notifications.Desktop.OnRunCompleted = parsed
+		}
+	}
+	if value := strings.TrimSpace(os.Getenv("BYTEMIND_NOTIFY_RUN_FAILED")); value != "" {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			cfg.Notifications.Desktop.OnRunFailed = parsed
+		}
+	}
+	if value := strings.TrimSpace(os.Getenv("BYTEMIND_NOTIFY_RUN_CANCELED")); value != "" {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			cfg.Notifications.Desktop.OnRunCanceled = parsed
+		}
+	}
+	if value := strings.TrimSpace(os.Getenv("BYTEMIND_NOTIFY_COOLDOWN_SECONDS")); value != "" {
+		if parsed, err := strconv.Atoi(value); err == nil {
+			cfg.Notifications.Desktop.CooldownSeconds = parsed
 		}
 	}
 }
@@ -711,6 +775,9 @@ func normalize(cfg *Config) error {
 	}
 	if cfg.TokenQuota < 1 {
 		cfg.TokenQuota = DefaultTokenQuota
+	}
+	if cfg.Notifications.Desktop.CooldownSeconds < 0 {
+		return errors.New("notifications.desktop.cooldown_seconds must be >= 0")
 	}
 	if strings.TrimSpace(cfg.TokenUsage.StorageType) == "" {
 		cfg.TokenUsage.StorageType = "file"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,12 @@ func TestLoadUsesEnvOverrides(t *testing.T) {
 	t.Setenv("BYTEMIND_STREAM", "false")
 	t.Setenv("BYTEMIND_APPROVAL_MODE", "full_access")
 	t.Setenv("BYTEMIND_AWAY_POLICY", "fail_fast")
+	t.Setenv("BYTEMIND_DESKTOP_NOTIFY", "true")
+	t.Setenv("BYTEMIND_NOTIFY_APPROVAL", "false")
+	t.Setenv("BYTEMIND_NOTIFY_RUN_COMPLETED", "false")
+	t.Setenv("BYTEMIND_NOTIFY_RUN_FAILED", "false")
+	t.Setenv("BYTEMIND_NOTIFY_RUN_CANCELED", "true")
+	t.Setenv("BYTEMIND_NOTIFY_COOLDOWN_SECONDS", "9")
 
 	cfg, err := Load(workspace, "")
 	if err != nil {
@@ -52,6 +58,24 @@ func TestLoadUsesEnvOverrides(t *testing.T) {
 	if cfg.AwayPolicy != "fail_fast" {
 		t.Fatalf("expected away policy from env override, got %q", cfg.AwayPolicy)
 	}
+	if !cfg.Notifications.Desktop.Enabled {
+		t.Fatalf("expected desktop notify enabled from env override")
+	}
+	if cfg.Notifications.Desktop.OnApprovalRequired {
+		t.Fatalf("expected notify approval disabled from env override")
+	}
+	if cfg.Notifications.Desktop.OnRunCompleted {
+		t.Fatalf("expected run completed notify disabled from env override")
+	}
+	if cfg.Notifications.Desktop.OnRunFailed {
+		t.Fatalf("expected run failed notify disabled from env override")
+	}
+	if !cfg.Notifications.Desktop.OnRunCanceled {
+		t.Fatalf("expected run canceled notify enabled from env override")
+	}
+	if cfg.Notifications.Desktop.CooldownSeconds != 9 {
+		t.Fatalf("expected notify cooldown from env override, got %d", cfg.Notifications.Desktop.CooldownSeconds)
+	}
 }
 
 func TestLoadIgnoresInvalidTokenQuotaEnv(t *testing.T) {
@@ -70,6 +94,22 @@ func TestLoadIgnoresInvalidTokenQuotaEnv(t *testing.T) {
 	}
 }
 
+func TestLoadIgnoresInvalidNotifyCooldownEnv(t *testing.T) {
+	workspace := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", home)
+	t.Setenv("BYTEMIND_API_KEY", "secret")
+	t.Setenv("BYTEMIND_NOTIFY_COOLDOWN_SECONDS", "invalid")
+
+	cfg, err := Load(workspace, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Notifications.Desktop.CooldownSeconds != 3 {
+		t.Fatalf("expected invalid notify cooldown env to keep default 3, got %d", cfg.Notifications.Desktop.CooldownSeconds)
+	}
+}
+
 func TestLoadDefaultsUpdateCheckEnabled(t *testing.T) {
 	workspace := t.TempDir()
 	home := t.TempDir()
@@ -82,6 +122,65 @@ func TestLoadDefaultsUpdateCheckEnabled(t *testing.T) {
 	}
 	if !cfg.UpdateCheck.Enabled {
 		t.Fatalf("expected update_check.enabled default true")
+	}
+}
+
+func TestLoadDefaultsDesktopNotifications(t *testing.T) {
+	workspace := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", home)
+	t.Setenv("BYTEMIND_API_KEY", "secret")
+
+	cfg, err := Load(workspace, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Notifications.Desktop.Enabled {
+		t.Fatalf("expected desktop notifications enabled by default")
+	}
+	if !cfg.Notifications.Desktop.OnApprovalRequired {
+		t.Fatalf("expected approval notifications enabled by default")
+	}
+	if !cfg.Notifications.Desktop.OnRunCompleted {
+		t.Fatalf("expected run completed notifications enabled by default")
+	}
+	if !cfg.Notifications.Desktop.OnRunFailed {
+		t.Fatalf("expected run failed notifications enabled by default")
+	}
+	if cfg.Notifications.Desktop.OnRunCanceled {
+		t.Fatalf("expected run canceled notifications disabled by default")
+	}
+	if cfg.Notifications.Desktop.CooldownSeconds != 3 {
+		t.Fatalf("expected default cooldown 3, got %d", cfg.Notifications.Desktop.CooldownSeconds)
+	}
+}
+
+func TestLoadAllowsDisabledDesktopNotifyWithEnabledSubSwitches(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", t.TempDir())
+	if err := writeConfig(projectConfigPath(workspace), map[string]any{
+		"provider": minimalProviderConfigDoc("gpt-5.4-mini", "test-key"),
+		"notifications": map[string]any{
+			"desktop": map[string]any{
+				"enabled":              false,
+				"on_approval_required": true,
+				"on_run_completed":     true,
+				"on_run_failed":        true,
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(workspace, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Notifications.Desktop.Enabled {
+		t.Fatalf("expected desktop notify to stay disabled")
+	}
+	if !cfg.Notifications.Desktop.OnApprovalRequired || !cfg.Notifications.Desktop.OnRunCompleted || !cfg.Notifications.Desktop.OnRunFailed {
+		t.Fatalf("expected sub-switches to remain configured when desktop notify is disabled: %#v", cfg.Notifications.Desktop)
 	}
 }
 
@@ -205,6 +304,29 @@ func TestLoadRejectsNegativeMaxReactiveRetry(t *testing.T) {
 		t.Fatal("expected negative max_reactive_retry to fail")
 	}
 	if !strings.Contains(err.Error(), "context_budget.max_reactive_retry") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadRejectsNegativeNotificationCooldown(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", t.TempDir())
+	if err := writeConfig(projectConfigPath(workspace), map[string]any{
+		"provider": minimalProviderConfigDoc("gpt-5.4-mini", "test-key"),
+		"notifications": map[string]any{
+			"desktop": map[string]any{
+				"cooldown_seconds": -1,
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(workspace, "")
+	if err == nil {
+		t.Fatal("expected negative notifications.desktop.cooldown_seconds to fail")
+	}
+	if !strings.Contains(err.Error(), "notifications.desktop.cooldown_seconds") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -643,6 +765,24 @@ func TestEnsureHomeLayoutCreatesStandardDirectories(t *testing.T) {
 	}
 	if !cfg.UpdateCheck.Enabled {
 		t.Fatalf("expected default update_check.enabled=true in generated config")
+	}
+	if !cfg.Notifications.Desktop.Enabled {
+		t.Fatalf("expected default notifications.desktop.enabled=true in generated config")
+	}
+	if !cfg.Notifications.Desktop.OnApprovalRequired {
+		t.Fatalf("expected default notifications.desktop.on_approval_required=true in generated config")
+	}
+	if !cfg.Notifications.Desktop.OnRunCompleted {
+		t.Fatalf("expected default notifications.desktop.on_run_completed=true in generated config")
+	}
+	if !cfg.Notifications.Desktop.OnRunFailed {
+		t.Fatalf("expected default notifications.desktop.on_run_failed=true in generated config")
+	}
+	if cfg.Notifications.Desktop.OnRunCanceled {
+		t.Fatalf("expected default notifications.desktop.on_run_canceled=false in generated config")
+	}
+	if cfg.Notifications.Desktop.CooldownSeconds != 3 {
+		t.Fatalf("expected default notifications.desktop.cooldown_seconds=3 in generated config, got %d", cfg.Notifications.Desktop.CooldownSeconds)
 	}
 }
 

--- a/internal/notify/builder.go
+++ b/internal/notify/builder.go
@@ -13,15 +13,17 @@ const (
 )
 
 func BuildApprovalRequiredMessage(command, reason string) Message {
-	reason = truncate(sanitizeNotificationText(reason), 100)
-	command = truncate(sanitizeNotificationText(command), 120)
+	sanitizedReason := sanitizeNotificationText(reason)
+	sanitizedCommand := sanitizeNotificationText(command)
+	displayReason := truncate(sanitizedReason, 100)
+	displayCommand := truncate(sanitizedCommand, 120)
 
 	parts := make([]string, 0, 2)
-	if reason != "" {
-		parts = append(parts, "原因: "+reason)
+	if displayReason != "" {
+		parts = append(parts, "原因: "+displayReason)
 	}
-	if command != "" {
-		parts = append(parts, "命令: "+command)
+	if displayCommand != "" {
+		parts = append(parts, "命令: "+displayCommand)
 	}
 
 	body := "有新的权限审批请求，请回到终端处理。"
@@ -36,8 +38,8 @@ func BuildApprovalRequiredMessage(command, reason string) Message {
 		Body:  body,
 		Key: fmt.Sprintf(
 			"approval_required|cmd=%s|reason=%s",
-			normalizeForKey(command),
-			normalizeForKey(reason),
+			normalizeForKey(sanitizedCommand),
+			normalizeForKey(sanitizedReason),
 		),
 	}
 }

--- a/internal/notify/builder.go
+++ b/internal/notify/builder.go
@@ -1,0 +1,89 @@
+package notify
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	titleApprovalRequired = "ByteMind 需要权限审批"
+	titleRunCompleted     = "ByteMind 任务已完成"
+	titleRunFailed        = "ByteMind 任务失败"
+	titleRunCanceled      = "ByteMind 任务已取消"
+)
+
+func BuildApprovalRequiredMessage(command, reason string) Message {
+	reason = truncate(sanitizeNotificationText(reason), 100)
+	command = truncate(sanitizeNotificationText(command), 120)
+
+	parts := make([]string, 0, 2)
+	if reason != "" {
+		parts = append(parts, "原因: "+reason)
+	}
+	if command != "" {
+		parts = append(parts, "命令: "+command)
+	}
+
+	body := "有新的权限审批请求，请回到终端处理。"
+	if len(parts) > 0 {
+		body = strings.Join(parts, " | ")
+	}
+	body = truncate(body, 180)
+
+	return Message{
+		Event: EventApprovalRequired,
+		Title: titleApprovalRequired,
+		Body:  body,
+		Key: fmt.Sprintf(
+			"approval_required|cmd=%s|reason=%s",
+			normalizeForKey(command),
+			normalizeForKey(reason),
+		),
+	}
+}
+
+func BuildRunCompletedMessage(runID int) Message {
+	return Message{
+		Event: EventRunCompleted,
+		Title: titleRunCompleted,
+		Body:  "任务已完成，可回到终端查看结果。",
+		Key:   fmt.Sprintf("run_completed|id=%d", runID),
+	}
+}
+
+func BuildRunFailedMessage(runID int, detail string) Message {
+	detail = truncate(sanitizeNotificationText(detail), 140)
+	body := "任务执行失败，请回到终端查看详情。"
+	if detail != "" {
+		body = "任务执行失败: " + detail
+	}
+	return Message{
+		Event: EventRunFailed,
+		Title: titleRunFailed,
+		Body:  truncate(body, 180),
+		Key:   fmt.Sprintf("run_failed|id=%d", runID),
+	}
+}
+
+func BuildRunCanceledMessage(runID int) Message {
+	return Message{
+		Event: EventRunCanceled,
+		Title: titleRunCanceled,
+		Body:  "任务已取消。",
+		Key:   fmt.Sprintf("run_canceled|id=%d", runID),
+	}
+}
+
+func normalizeMessage(msg Message) Message {
+	msg.Title = truncate(sanitizeNotificationText(msg.Title), 80)
+	msg.Body = truncate(sanitizeNotificationText(msg.Body), 180)
+	if msg.Key == "" {
+		msg.Key = fmt.Sprintf(
+			"%s|%s|%s",
+			normalizeForKey(string(msg.Event)),
+			normalizeForKey(msg.Title),
+			normalizeForKey(msg.Body),
+		)
+	}
+	return msg
+}

--- a/internal/notify/builder_test.go
+++ b/internal/notify/builder_test.go
@@ -34,6 +34,15 @@ func TestBuildApprovalRequiredMessageKeyUsesFullSanitizedText(t *testing.T) {
 	}
 }
 
+func TestBuildApprovalRequiredMessageKeyNormalizesWhitespaceAndCase(t *testing.T) {
+	msgOne := BuildApprovalRequiredMessage("  GO   TEST   ./TUI  ", "  Run Focused Tests ")
+	msgTwo := BuildApprovalRequiredMessage("go test ./tui", "run focused tests")
+
+	if msgOne.Key != msgTwo.Key {
+		t.Fatalf("expected normalized keys to match, got %q vs %q", msgOne.Key, msgTwo.Key)
+	}
+}
+
 func TestBuildRunFailedMessageRedactsDetail(t *testing.T) {
 	msg := BuildRunFailedMessage(7, "authorization: bearer secret-token")
 	if msg.Event != EventRunFailed {

--- a/internal/notify/builder_test.go
+++ b/internal/notify/builder_test.go
@@ -21,6 +21,19 @@ func TestBuildApprovalRequiredMessageIncludesReasonAndCommand(t *testing.T) {
 	}
 }
 
+func TestBuildApprovalRequiredMessageKeyUsesFullSanitizedText(t *testing.T) {
+	longPrefix := strings.Repeat("segment-", 30)
+	commandOne := "run " + longPrefix + "one"
+	commandTwo := "run " + longPrefix + "two"
+
+	msgOne := BuildApprovalRequiredMessage(commandOne, "same reason")
+	msgTwo := BuildApprovalRequiredMessage(commandTwo, "same reason")
+
+	if msgOne.Key == msgTwo.Key {
+		t.Fatalf("expected different keys for different long commands, got same key %q", msgOne.Key)
+	}
+}
+
 func TestBuildRunFailedMessageRedactsDetail(t *testing.T) {
 	msg := BuildRunFailedMessage(7, "authorization: bearer secret-token")
 	if msg.Event != EventRunFailed {

--- a/internal/notify/builder_test.go
+++ b/internal/notify/builder_test.go
@@ -1,0 +1,35 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildApprovalRequiredMessageIncludesReasonAndCommand(t *testing.T) {
+	msg := BuildApprovalRequiredMessage("go test ./...", "run focused tests")
+	if msg.Event != EventApprovalRequired {
+		t.Fatalf("expected approval_required event, got %q", msg.Event)
+	}
+	if msg.Title != titleApprovalRequired {
+		t.Fatalf("unexpected title: %q", msg.Title)
+	}
+	if !strings.Contains(msg.Body, "原因:") || !strings.Contains(msg.Body, "命令:") {
+		t.Fatalf("expected reason and command in body, got %q", msg.Body)
+	}
+	if !strings.Contains(msg.Key, "approval_required|") {
+		t.Fatalf("expected stable dedupe key, got %q", msg.Key)
+	}
+}
+
+func TestBuildRunFailedMessageRedactsDetail(t *testing.T) {
+	msg := BuildRunFailedMessage(7, "authorization: bearer secret-token")
+	if msg.Event != EventRunFailed {
+		t.Fatalf("expected run_failed event, got %q", msg.Event)
+	}
+	if strings.Contains(strings.ToLower(msg.Body), "secret-token") {
+		t.Fatalf("expected body to be sanitized, got %q", msg.Body)
+	}
+	if msg.Key != "run_failed|id=7" {
+		t.Fatalf("expected run_failed key, got %q", msg.Key)
+	}
+}

--- a/internal/notify/desktop.go
+++ b/internal/notify/desktop.go
@@ -1,0 +1,154 @@
+package notify
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultQueueSize   = 32
+	defaultSendTimeout = 2 * time.Second
+)
+
+type platformSender interface {
+	Send(ctx context.Context, title, body string) error
+}
+
+type desktopNotifier struct {
+	sender      platformSender
+	queue       chan Message
+	done        chan struct{}
+	sendTimeout time.Duration
+	cooldown    time.Duration
+	now         func() time.Time
+
+	mu     sync.Mutex
+	closed bool
+	recent map[string]time.Time
+	drop   int64
+
+	closeOnce sync.Once
+}
+
+func NewDesktopNotifier(cfg DesktopConfig) Notifier {
+	if !cfg.Enabled {
+		return NewNoopNotifier()
+	}
+	sender, ok := newPlatformSender()
+	if !ok || sender == nil {
+		return NewNoopNotifier()
+	}
+	return newDesktopNotifierWithSender(cfg, sender, time.Now)
+}
+
+func newDesktopNotifierWithSender(cfg DesktopConfig, sender platformSender, now func() time.Time) *desktopNotifier {
+	queueSize := cfg.QueueSize
+	if queueSize <= 0 {
+		queueSize = defaultQueueSize
+	}
+	sendTimeout := time.Duration(cfg.SendTimeoutMs) * time.Millisecond
+	if sendTimeout <= 0 {
+		sendTimeout = defaultSendTimeout
+	}
+	cooldownSeconds := cfg.CooldownSeconds
+	if cooldownSeconds < 0 {
+		cooldownSeconds = 0
+	}
+	notifier := &desktopNotifier{
+		sender:      sender,
+		queue:       make(chan Message, queueSize),
+		done:        make(chan struct{}),
+		sendTimeout: sendTimeout,
+		cooldown:    time.Duration(cooldownSeconds) * time.Second,
+		now:         now,
+		recent:      make(map[string]time.Time, queueSize),
+	}
+	go notifier.run()
+	return notifier
+}
+
+func (n *desktopNotifier) Notify(msg Message) {
+	if n == nil {
+		return
+	}
+	msg = normalizeMessage(msg)
+	now := n.now()
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.closed {
+		return
+	}
+	if n.cooldown > 0 && msg.Key != "" {
+		if last, ok := n.recent[msg.Key]; ok && now.Sub(last) < n.cooldown {
+			return
+		}
+	}
+	n.enqueueLocked(msg)
+	if msg.Key != "" {
+		n.recent[msg.Key] = now
+	}
+}
+
+func (n *desktopNotifier) Close(ctx context.Context) error {
+	if n == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	n.closeOnce.Do(func() {
+		n.mu.Lock()
+		if !n.closed {
+			n.closed = true
+			close(n.queue)
+		}
+		n.mu.Unlock()
+	})
+	select {
+	case <-n.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (n *desktopNotifier) droppedCount() int64 {
+	if n == nil {
+		return 0
+	}
+	return atomic.LoadInt64(&n.drop)
+}
+
+func (n *desktopNotifier) enqueueLocked(msg Message) {
+	select {
+	case n.queue <- msg:
+		return
+	default:
+	}
+	select {
+	case <-n.queue:
+		atomic.AddInt64(&n.drop, 1)
+	default:
+	}
+	select {
+	case n.queue <- msg:
+	default:
+		atomic.AddInt64(&n.drop, 1)
+	}
+}
+
+func (n *desktopNotifier) run() {
+	defer close(n.done)
+	for msg := range n.queue {
+		if n.sender == nil {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), n.sendTimeout)
+		_ = n.sender.Send(ctx, msg.Title, msg.Body)
+		cancel()
+	}
+}

--- a/internal/notify/desktop.go
+++ b/internal/notify/desktop.go
@@ -82,13 +82,16 @@ func (n *desktopNotifier) Notify(msg Message) {
 	if n.closed {
 		return
 	}
-	if n.cooldown > 0 && msg.Key != "" {
-		if last, ok := n.recent[msg.Key]; ok && now.Sub(last) < n.cooldown {
-			return
+	if n.cooldown > 0 {
+		n.pruneRecentLocked(now)
+		if msg.Key != "" {
+			if last, ok := n.recent[msg.Key]; ok && now.Sub(last) < n.cooldown {
+				return
+			}
 		}
 	}
 	n.enqueueLocked(msg)
-	if msg.Key != "" {
+	if n.cooldown > 0 && msg.Key != "" {
 		n.recent[msg.Key] = now
 	}
 }
@@ -138,6 +141,18 @@ func (n *desktopNotifier) enqueueLocked(msg Message) {
 	case n.queue <- msg:
 	default:
 		atomic.AddInt64(&n.drop, 1)
+	}
+}
+
+func (n *desktopNotifier) pruneRecentLocked(now time.Time) {
+	if n.cooldown <= 0 || len(n.recent) == 0 {
+		return
+	}
+	cutoff := now.Add(-n.cooldown)
+	for key, last := range n.recent {
+		if !last.After(cutoff) {
+			delete(n.recent, key)
+		}
 	}
 }
 

--- a/internal/notify/desktop_darwin.go
+++ b/internal/notify/desktop_darwin.go
@@ -1,0 +1,27 @@
+package notify
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+type darwinSender struct{}
+
+func newPlatformSender() (platformSender, bool) {
+	if _, err := exec.LookPath("osascript"); err != nil {
+		return nil, false
+	}
+	return darwinSender{}, true
+}
+
+func (darwinSender) Send(ctx context.Context, title, body string) error {
+	command := "display notification \"" + escapeAppleScriptString(body) + "\" with title \"" + escapeAppleScriptString(title) + "\""
+	cmd := exec.CommandContext(ctx, "osascript", "-e", command)
+	return cmd.Run()
+}
+
+func escapeAppleScriptString(input string) string {
+	input = strings.ReplaceAll(input, "\\", "\\\\")
+	return strings.ReplaceAll(input, "\"", "\\\"")
+}

--- a/internal/notify/desktop_linux.go
+++ b/internal/notify/desktop_linux.go
@@ -1,0 +1,24 @@
+package notify
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+type linuxSender struct {
+	executable string
+}
+
+func newPlatformSender() (platformSender, bool) {
+	executable, err := exec.LookPath("notify-send")
+	if err != nil || strings.TrimSpace(executable) == "" {
+		return nil, false
+	}
+	return linuxSender{executable: executable}, true
+}
+
+func (s linuxSender) Send(ctx context.Context, title, body string) error {
+	cmd := exec.CommandContext(ctx, s.executable, title, body)
+	return cmd.Run()
+}

--- a/internal/notify/desktop_test.go
+++ b/internal/notify/desktop_test.go
@@ -1,0 +1,191 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+type senderCall struct {
+	Title string
+	Body  string
+}
+
+type stubSender struct {
+	mu      sync.Mutex
+	calls   []senderCall
+	err     error
+	started chan struct{}
+	block   chan struct{}
+}
+
+func (s *stubSender) Send(ctx context.Context, title, body string) error {
+	if s.started != nil {
+		select {
+		case s.started <- struct{}{}:
+		default:
+		}
+	}
+	if s.block != nil {
+		select {
+		case <-s.block:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	s.mu.Lock()
+	s.calls = append(s.calls, senderCall{Title: title, Body: body})
+	s.mu.Unlock()
+	return s.err
+}
+
+func (s *stubSender) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+func (s *stubSender) callTitles() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.calls))
+	for _, call := range s.calls {
+		out = append(out, call.Title)
+	}
+	return out
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("condition not met before timeout %s", timeout)
+}
+
+func TestDesktopNotifierCooldownByKey(t *testing.T) {
+	now := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	sender := &stubSender{}
+	notifier := newDesktopNotifierWithSender(
+		DesktopConfig{Enabled: true, CooldownSeconds: 3, QueueSize: 8, SendTimeoutMs: 1000},
+		sender,
+		func() time.Time { return now },
+	)
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := notifier.Close(closeCtx); err != nil {
+			t.Fatalf("close notifier: %v", err)
+		}
+	}()
+
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "Approval", Body: "need approval", Key: "approval|go test"})
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "Approval", Body: "need approval", Key: "approval|go test"})
+	waitForCondition(t, time.Second, func() bool { return sender.callCount() == 1 })
+
+	now = now.Add(4 * time.Second)
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "Approval", Body: "need approval", Key: "approval|go test"})
+	waitForCondition(t, time.Second, func() bool { return sender.callCount() == 2 })
+}
+
+func TestDesktopNotifierQueueFullDropsOldest(t *testing.T) {
+	block := make(chan struct{})
+	started := make(chan struct{}, 4)
+	sender := &stubSender{block: block, started: started}
+	notifier := newDesktopNotifierWithSender(
+		DesktopConfig{Enabled: true, CooldownSeconds: 0, QueueSize: 1, SendTimeoutMs: 2000},
+		sender,
+		time.Now,
+	)
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := notifier.Close(closeCtx); err != nil {
+			t.Fatalf("close notifier: %v", err)
+		}
+	}()
+
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "first", Body: "first body", Key: "k1"})
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatalf("expected first send to start")
+	}
+
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "second", Body: "second body", Key: "k2"})
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "third", Body: "third body", Key: "k3"})
+
+	if notifier.droppedCount() < 1 {
+		t.Fatalf("expected dropped count >= 1, got %d", notifier.droppedCount())
+	}
+
+	close(block)
+	waitForCondition(t, 2*time.Second, func() bool { return sender.callCount() >= 2 })
+	titles := sender.callTitles()
+	if len(titles) < 2 {
+		t.Fatalf("expected at least two sends, got %v", titles)
+	}
+	if titles[0] != "first" {
+		t.Fatalf("expected first message to be delivered first, got %v", titles)
+	}
+	foundThird := false
+	for _, title := range titles {
+		if title == "third" {
+			foundThird = true
+			break
+		}
+	}
+	if !foundThird {
+		t.Fatalf("expected newest message to survive queue overflow, got %v", titles)
+	}
+}
+
+func TestDesktopNotifierSenderFailureDoesNotStopQueue(t *testing.T) {
+	sender := &stubSender{err: errors.New("send failed")}
+	notifier := newDesktopNotifierWithSender(
+		DesktopConfig{Enabled: true, CooldownSeconds: 0, QueueSize: 4, SendTimeoutMs: 100},
+		sender,
+		time.Now,
+	)
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := notifier.Close(closeCtx); err != nil {
+			t.Fatalf("close notifier: %v", err)
+		}
+	}()
+
+	notifier.Notify(Message{Event: EventRunFailed, Title: "failed-1", Body: "first", Key: "run_failed|1"})
+	notifier.Notify(Message{Event: EventRunFailed, Title: "failed-2", Body: "second", Key: "run_failed|2"})
+	waitForCondition(t, time.Second, func() bool { return sender.callCount() == 2 })
+}
+
+func TestDesktopNotifierCloseHonorsContextTimeout(t *testing.T) {
+	block := make(chan struct{})
+	sender := &stubSender{block: block}
+	notifier := newDesktopNotifierWithSender(
+		DesktopConfig{Enabled: true, CooldownSeconds: 0, QueueSize: 2, SendTimeoutMs: 2000},
+		sender,
+		time.Now,
+	)
+	notifier.Notify(Message{Event: EventRunCompleted, Title: "done", Body: "done", Key: "run_completed|1"})
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := notifier.Close(closeCtx); err == nil {
+		t.Fatalf("expected close timeout while sender is blocked")
+	}
+
+	close(block)
+	finalCtx, finalCancel := context.WithTimeout(context.Background(), time.Second)
+	defer finalCancel()
+	if err := notifier.Close(finalCtx); err != nil {
+		t.Fatalf("expected notifier to close after unblock, got %v", err)
+	}
+}

--- a/internal/notify/desktop_test.go
+++ b/internal/notify/desktop_test.go
@@ -189,3 +189,76 @@ func TestDesktopNotifierCloseHonorsContextTimeout(t *testing.T) {
 		t.Fatalf("expected notifier to close after unblock, got %v", err)
 	}
 }
+
+func TestDesktopNotifierPrunesExpiredRecentKeys(t *testing.T) {
+	now := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	sender := &stubSender{}
+	notifier := newDesktopNotifierWithSender(
+		DesktopConfig{Enabled: true, CooldownSeconds: 3, QueueSize: 8, SendTimeoutMs: 1000},
+		sender,
+		func() time.Time { return now },
+	)
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := notifier.Close(closeCtx); err != nil {
+			t.Fatalf("close notifier: %v", err)
+		}
+	}()
+
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "first", Body: "body", Key: "k1"})
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "second", Body: "body", Key: "k2"})
+
+	notifier.mu.Lock()
+	initialRecentCount := len(notifier.recent)
+	notifier.mu.Unlock()
+	if initialRecentCount != 2 {
+		t.Fatalf("expected 2 recent keys, got %d", initialRecentCount)
+	}
+
+	now = now.Add(4 * time.Second)
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "third", Body: "body", Key: "k3"})
+
+	notifier.mu.Lock()
+	prunedRecentCount := len(notifier.recent)
+	_, k1Exists := notifier.recent["k1"]
+	_, k2Exists := notifier.recent["k2"]
+	_, k3Exists := notifier.recent["k3"]
+	notifier.mu.Unlock()
+
+	if prunedRecentCount != 1 {
+		t.Fatalf("expected 1 recent key after pruning, got %d", prunedRecentCount)
+	}
+	if k1Exists || k2Exists {
+		t.Fatalf("expected expired keys to be pruned")
+	}
+	if !k3Exists {
+		t.Fatalf("expected newest key to remain in recent set")
+	}
+}
+
+func TestDesktopNotifierDoesNotTrackRecentWhenCooldownDisabled(t *testing.T) {
+	sender := &stubSender{}
+	notifier := newDesktopNotifierWithSender(
+		DesktopConfig{Enabled: true, CooldownSeconds: 0, QueueSize: 8, SendTimeoutMs: 1000},
+		sender,
+		time.Now,
+	)
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := notifier.Close(closeCtx); err != nil {
+			t.Fatalf("close notifier: %v", err)
+		}
+	}()
+
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "first", Body: "body", Key: "k1"})
+	notifier.Notify(Message{Event: EventApprovalRequired, Title: "second", Body: "body", Key: "k2"})
+
+	notifier.mu.Lock()
+	recentCount := len(notifier.recent)
+	notifier.mu.Unlock()
+	if recentCount != 0 {
+		t.Fatalf("expected no recent key tracking when cooldown is disabled, got %d", recentCount)
+	}
+}

--- a/internal/notify/desktop_unsupported.go
+++ b/internal/notify/desktop_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !windows && !darwin && !linux
+
+package notify
+
+func newPlatformSender() (platformSender, bool) {
+	return nil, false
+}

--- a/internal/notify/desktop_windows.go
+++ b/internal/notify/desktop_windows.go
@@ -1,0 +1,67 @@
+package notify
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+type windowsSender struct {
+	executable string
+}
+
+func newPlatformSender() (platformSender, bool) {
+	executable := resolveWindowsPowerShellExecutable()
+	if strings.TrimSpace(executable) == "" {
+		return nil, false
+	}
+	return windowsSender{executable: executable}, true
+}
+
+func (s windowsSender) Send(ctx context.Context, title, body string) error {
+	script := buildWindowsToastScript(title, body)
+	cmd := exec.CommandContext(
+		ctx,
+		s.executable,
+		"-NoProfile",
+		"-NonInteractive",
+		"-ExecutionPolicy",
+		"Bypass",
+		"-Command",
+		script,
+	)
+	return cmd.Run()
+}
+
+func resolveWindowsPowerShellExecutable() string {
+	candidates := []string{
+		"powershell.exe",
+		"powershell",
+		"pwsh.exe",
+		"pwsh",
+	}
+	for _, candidate := range candidates {
+		if path, err := exec.LookPath(candidate); err == nil && strings.TrimSpace(path) != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+func buildWindowsToastScript(title, body string) string {
+	titleEscaped := escapePowerShellSingleQuoted(title)
+	bodyEscaped := escapePowerShellSingleQuoted(body)
+	return "$t=[System.Security.SecurityElement]::Escape('" + titleEscaped + "');" +
+		"$b=[System.Security.SecurityElement]::Escape('" + bodyEscaped + "');" +
+		"[Windows.UI.Notifications.ToastNotificationManager,Windows.UI.Notifications,ContentType=WindowsRuntime]>$null;" +
+		"[Windows.Data.Xml.Dom.XmlDocument,Windows.Data.Xml.Dom.XmlDocument,ContentType=WindowsRuntime]>$null;" +
+		"$xml=New-Object Windows.Data.Xml.Dom.XmlDocument;" +
+		"$xml.LoadXml(\"<toast><visual><binding template='ToastGeneric'><text>$t</text><text>$b</text></binding></visual></toast>\");" +
+		"$toast=[Windows.UI.Notifications.ToastNotification]::new($xml);" +
+		"$notifier=[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('ByteMind');" +
+		"$notifier.Show($toast);"
+}
+
+func escapePowerShellSingleQuoted(input string) string {
+	return strings.ReplaceAll(input, "'", "''")
+}

--- a/internal/notify/desktop_windows.go
+++ b/internal/notify/desktop_windows.go
@@ -19,7 +19,7 @@ func newPlatformSender() (platformSender, bool) {
 }
 
 func (s windowsSender) Send(ctx context.Context, title, body string) error {
-	script := buildWindowsToastScript(title, body)
+	script := buildWindowsNotificationScript(title, body)
 	cmd := exec.CommandContext(
 		ctx,
 		s.executable,
@@ -48,18 +48,56 @@ func resolveWindowsPowerShellExecutable() string {
 	return ""
 }
 
-func buildWindowsToastScript(title, body string) string {
+func buildWindowsNotificationScript(title, body string) string {
 	titleEscaped := escapePowerShellSingleQuoted(title)
 	bodyEscaped := escapePowerShellSingleQuoted(body)
-	return "$t=[System.Security.SecurityElement]::Escape('" + titleEscaped + "');" +
-		"$b=[System.Security.SecurityElement]::Escape('" + bodyEscaped + "');" +
-		"[Windows.UI.Notifications.ToastNotificationManager,Windows.UI.Notifications,ContentType=WindowsRuntime]>$null;" +
-		"[Windows.Data.Xml.Dom.XmlDocument,Windows.Data.Xml.Dom.XmlDocument,ContentType=WindowsRuntime]>$null;" +
-		"$xml=New-Object Windows.Data.Xml.Dom.XmlDocument;" +
-		"$xml.LoadXml(\"<toast><visual><binding template='ToastGeneric'><text>$t</text><text>$b</text></binding></visual></toast>\");" +
-		"$toast=[Windows.UI.Notifications.ToastNotification]::new($xml);" +
-		"$notifier=[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('ByteMind');" +
-		"$notifier.Show($toast);"
+	parts := []string{
+		"$ErrorActionPreference='Stop';",
+		"$t=[System.Security.SecurityElement]::Escape('" + titleEscaped + "');",
+		"$b=[System.Security.SecurityElement]::Escape('" + bodyEscaped + "');",
+		"function Show-ByteMindBalloon(){",
+		"try{",
+		"Add-Type -AssemblyName System.Windows.Forms >$null;",
+		"Add-Type -AssemblyName System.Drawing >$null;",
+		"$notifyIcon=New-Object System.Windows.Forms.NotifyIcon;",
+		"$notifyIcon.Icon=[System.Drawing.SystemIcons]::Information;",
+		"$notifyIcon.Visible=$true;",
+		"$notifyIcon.BalloonTipTitle=$t;",
+		"$notifyIcon.BalloonTipText=$b;",
+		"$notifyIcon.ShowBalloonTip(5000);",
+		"Start-Sleep -Milliseconds 1500;",
+		"$notifyIcon.Dispose();",
+		"return $true;",
+		"}catch{",
+		"return $false;",
+		"}",
+		"}",
+		"function Show-ByteMindToast([string]$appId){",
+		"try{",
+		"[Windows.UI.Notifications.ToastNotificationManager,Windows.UI.Notifications,ContentType=WindowsRuntime]>$null;",
+		"[Windows.Data.Xml.Dom.XmlDocument,Windows.Data.Xml.Dom.XmlDocument,ContentType=WindowsRuntime]>$null;",
+		"$xml=New-Object Windows.Data.Xml.Dom.XmlDocument;",
+		"$xml.LoadXml(\"<toast><visual><binding template='ToastGeneric'><text>$t</text><text>$b</text></binding></visual></toast>\");",
+		"$toast=[Windows.UI.Notifications.ToastNotification]::new($xml);",
+		"$notifier=[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($appId);",
+		"$notifier.Show($toast);",
+		"return $true;",
+		"}catch{",
+		"return $false;",
+		"}",
+		"}",
+		"$balloonSent=Show-ByteMindBalloon;",
+		"if(-not $balloonSent){",
+		"$toastSent=$false;",
+		"foreach($appId in @('Windows PowerShell','PowerShell','Microsoft.WindowsTerminal_8wekyb3d8bbwe!App')){",
+		"if(Show-ByteMindToast $appId){$toastSent=$true;break;}",
+		"}",
+		"if(-not $toastSent){",
+		"exit 0;",
+		"}",
+		"}",
+	}
+	return strings.Join(parts, "")
 }
 
 func escapePowerShellSingleQuoted(input string) string {

--- a/internal/notify/desktop_windows_test.go
+++ b/internal/notify/desktop_windows_test.go
@@ -1,0 +1,36 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildWindowsNotificationScriptPrefersBalloonAndHasToastFallback(t *testing.T) {
+	script := buildWindowsNotificationScript("title", "body")
+
+	required := []string{
+		"function Show-ByteMindBalloon(){",
+		"$balloonSent=Show-ByteMindBalloon;",
+		"if(-not $balloonSent){",
+		"function Show-ByteMindToast([string]$appId){",
+		"CreateToastNotifier($appId)",
+		"'Windows PowerShell'",
+		"'PowerShell'",
+		"'Microsoft.WindowsTerminal_8wekyb3d8bbwe!App'",
+	}
+	for _, token := range required {
+		if !strings.Contains(script, token) {
+			t.Fatalf("script missing token %q", token)
+		}
+	}
+}
+
+func TestBuildWindowsNotificationScriptEscapesSingleQuote(t *testing.T) {
+	script := buildWindowsNotificationScript("o'hara", "don't leak")
+	if strings.Count(script, "o''hara") == 0 {
+		t.Fatalf("expected escaped title in script")
+	}
+	if strings.Count(script, "don''t leak") == 0 {
+		t.Fatalf("expected escaped body in script")
+	}
+}

--- a/internal/notify/noop.go
+++ b/internal/notify/noop.go
@@ -1,0 +1,15 @@
+package notify
+
+import "context"
+
+type noopNotifier struct{}
+
+func NewNoopNotifier() Notifier {
+	return noopNotifier{}
+}
+
+func (noopNotifier) Notify(Message) {}
+
+func (noopNotifier) Close(context.Context) error {
+	return nil
+}

--- a/internal/notify/sanitize.go
+++ b/internal/notify/sanitize.go
@@ -1,0 +1,55 @@
+package notify
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	reHeaderAuthorization = regexp.MustCompile(`(?i)\bauthorization\b\s*:\s*[^\r\n]+`)
+	reBearerToken         = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._+\-=/]+`)
+	reKeyValueSecret      = regexp.MustCompile(`(?i)\b(api[_-]?key|token|secret|password)\b\s*[:=]\s*(\"[^\"]*\"|'[^']*'|[^\s,;|]+)`)
+	reQuerySecret         = regexp.MustCompile(`(?i)([?&](?:api[_-]?key|token|secret|password)=)([^&#\s]+)`)
+	reFlagSecret          = regexp.MustCompile(`(?i)(--?(?:api[_-]?key|token|secret|password)\s+)([^\s]+)`)
+	reLongHex             = regexp.MustCompile(`\b[0-9A-Fa-f]{24,}\b`)
+	reBase64Like          = regexp.MustCompile(`\b[A-Za-z0-9+/=]{40,}\b`)
+)
+
+func sanitizeNotificationText(input string) string {
+	text := strings.TrimSpace(input)
+	if text == "" {
+		return ""
+	}
+
+	text = reHeaderAuthorization.ReplaceAllString(text, "authorization: [REDACTED]")
+	text = reBearerToken.ReplaceAllString(text, "bearer [REDACTED]")
+	text = reKeyValueSecret.ReplaceAllString(text, "$1=[REDACTED]")
+	text = reQuerySecret.ReplaceAllString(text, "$1[REDACTED]")
+	text = reFlagSecret.ReplaceAllString(text, "$1[REDACTED]")
+	text = reLongHex.ReplaceAllString(text, "[REDACTED]")
+	text = reBase64Like.ReplaceAllString(text, "[REDACTED]")
+	return text
+}
+
+func truncate(input string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(input) <= limit {
+		return input
+	}
+	if limit <= 3 {
+		return strings.Repeat(".", limit)
+	}
+	runes := []rune(input)
+	return string(runes[:limit-3]) + "..."
+}
+
+func normalizeForKey(input string) string {
+	fields := strings.Fields(strings.ToLower(strings.TrimSpace(input)))
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.Join(fields, " ")
+}

--- a/internal/notify/sanitize_test.go
+++ b/internal/notify/sanitize_test.go
@@ -1,0 +1,32 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeNotificationTextRedactsSecrets(t *testing.T) {
+	input := "Authorization: Bearer abcdefghijklmnopqrstuvwxyz TOKEN=abc123 password=hunter2 https://x.test?a=1&token=xyz --secret my-secret"
+	got := sanitizeNotificationText(input)
+	lower := strings.ToLower(got)
+	for _, forbidden := range []string{"abcdefghijklmnopqrstuvwxyz", "abc123", "hunter2", "token=xyz", "my-secret"} {
+		if strings.Contains(lower, strings.ToLower(forbidden)) {
+			t.Fatalf("expected %q to be redacted in %q", forbidden, got)
+		}
+	}
+	if !strings.Contains(lower, "[redacted]") {
+		t.Fatalf("expected redacted marker in %q", got)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("abc", 0); got != "" {
+		t.Fatalf("expected empty string for zero limit, got %q", got)
+	}
+	if got := truncate("abc", 3); got != "abc" {
+		t.Fatalf("expected unchanged string within limit, got %q", got)
+	}
+	if got := truncate("abcdef", 5); got != "ab..." {
+		t.Fatalf("expected truncated string, got %q", got)
+	}
+}

--- a/internal/notify/types.go
+++ b/internal/notify/types.go
@@ -1,0 +1,31 @@
+package notify
+
+import "context"
+
+type EventType string
+
+const (
+	EventApprovalRequired EventType = "approval_required"
+	EventRunCompleted     EventType = "run_completed"
+	EventRunFailed        EventType = "run_failed"
+	EventRunCanceled      EventType = "run_canceled"
+)
+
+type Message struct {
+	Event EventType
+	Title string
+	Body  string
+	Key   string
+}
+
+type Notifier interface {
+	Notify(msg Message)
+	Close(ctx context.Context) error
+}
+
+type DesktopConfig struct {
+	Enabled         bool
+	CooldownSeconds int
+	QueueSize       int
+	SendTimeoutMs   int
+}

--- a/tui/app.go
+++ b/tui/app.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"bytemind/internal/assets"
 	"bytemind/internal/config"
+	notifypkg "bytemind/internal/notify"
 	"bytemind/internal/session"
 	"os"
 	"runtime"
@@ -18,6 +19,7 @@ type Options struct {
 	MCPService   MCPService
 	Session      *session.Session
 	ImageStore   assets.ImageStore
+	Notifier     notifypkg.Notifier
 	Config       config.Config
 	Workspace    string
 	StartupGuide StartupGuide

--- a/tui/model.go
+++ b/tui/model.go
@@ -18,6 +18,7 @@ import (
 	"bytemind/internal/history"
 	"bytemind/internal/llm"
 	"bytemind/internal/mention"
+	notifypkg "bytemind/internal/notify"
 	planpkg "bytemind/internal/plan"
 	"bytemind/internal/session"
 
@@ -336,6 +337,7 @@ type model struct {
 	imageStore assets.ImageStore
 	cfg        config.Config
 	workspace  string
+	notifier   notifypkg.Notifier
 
 	width  int
 	height int
@@ -460,6 +462,10 @@ type model struct {
 func newModel(opts Options) model {
 	ensureZoneManager()
 	async := make(chan tea.Msg, 128)
+	notifier := opts.Notifier
+	if notifier == nil {
+		notifier = notifypkg.NewNoopNotifier()
+	}
 
 	input := textarea.New()
 	input.Placeholder = "Ask Bytemind to inspect, change, or verify this workspace..."
@@ -507,6 +513,7 @@ func newModel(opts Options) model {
 		imageStore:           opts.ImageStore,
 		cfg:                  opts.Config,
 		workspace:            opts.Workspace,
+		notifier:             notifier,
 		async:                async,
 		viewport:             vp,
 		copyView:             copyVP,
@@ -711,6 +718,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.closePlanActionPicker()
 				m.statusNote = "Ready."
 			}
+			m.notifyRunCompleted(msg.RunID)
 		case runFinishReasonCanceled:
 			m.lastRunDuration = elapsed
 			m.runIndicatorState = runIndicatorCanceled
@@ -719,6 +727,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusNote = "Run canceled."
 			m.phase = "idle"
 			m.llmConnected = true
+			m.notifyRunCanceled(msg.RunID)
 		case runFinishReasonFailed:
 			m.lastRunDuration = elapsed
 			m.runIndicatorState = runIndicatorFailed
@@ -728,6 +737,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.phase = "error"
 			m.llmConnected = false
 			m.failLatestAssistant(msg.Err.Error())
+			m.notifyRunFailed(msg.RunID, msg.Err)
 		default:
 			m.lastRunDuration = 0
 			m.runIndicatorState = runIndicatorReady
@@ -748,6 +758,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.statusNote = "Approval required."
 		m.phase = "approval"
+		m.notifyApprovalRequired(msg.Request)
 		return m, waitForAsync(m.async)
 	case sessionsLoadedMsg:
 		if msg.Err == nil {
@@ -2798,6 +2809,45 @@ func (m *model) resolveApprovalDecision(approved bool) {
 		}
 	}
 	m.approval = nil
+}
+
+func (m *model) desktopNotificationEnabled() bool {
+	if m == nil || m.notifier == nil {
+		return false
+	}
+	return m.cfg.Notifications.Desktop.Enabled
+}
+
+func (m *model) notifyApprovalRequired(req ApprovalRequest) {
+	if !m.desktopNotificationEnabled() || !m.cfg.Notifications.Desktop.OnApprovalRequired {
+		return
+	}
+	m.notifier.Notify(notifypkg.BuildApprovalRequiredMessage(req.Command, req.Reason))
+}
+
+func (m *model) notifyRunCompleted(runID int) {
+	if !m.desktopNotificationEnabled() || !m.cfg.Notifications.Desktop.OnRunCompleted {
+		return
+	}
+	m.notifier.Notify(notifypkg.BuildRunCompletedMessage(runID))
+}
+
+func (m *model) notifyRunFailed(runID int, err error) {
+	if !m.desktopNotificationEnabled() || !m.cfg.Notifications.Desktop.OnRunFailed {
+		return
+	}
+	detail := ""
+	if err != nil {
+		detail = err.Error()
+	}
+	m.notifier.Notify(notifypkg.BuildRunFailedMessage(runID, detail))
+}
+
+func (m *model) notifyRunCanceled(runID int) {
+	if !m.desktopNotificationEnabled() || !m.cfg.Notifications.Desktop.OnRunCanceled {
+		return
+	}
+	m.notifier.Notify(notifypkg.BuildRunCanceledMessage(runID))
 }
 
 func (m *model) setApprovalMode(mode string) {

--- a/tui/model.go
+++ b/tui/model.go
@@ -660,7 +660,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refreshViewport()
 		return m, waitForAsync(m.async)
 	case runFinishedMsg:
-		if msg.RunID > 0 && msg.RunID != m.activeRunID {
+		if m.activeRunID > 0 && msg.RunID != m.activeRunID {
 			return m, waitForAsync(m.async)
 		}
 		elapsed := time.Duration(0)

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -5753,6 +5753,32 @@ func TestRunFinishedDesktopNotificationsSkipBTWRestartAndStaleRun(t *testing.T) 
 	})
 }
 
+func TestRunFinishedDesktopNotificationsDisabledSkipsSend(t *testing.T) {
+	notifier := &fakeNotifier{}
+	m := model{
+		async:       make(chan tea.Msg, 1),
+		notifier:    notifier,
+		busy:        true,
+		activeRunID: 21,
+		cfg: config.Config{
+			Notifications: config.NotificationsConfig{
+				Desktop: config.DesktopNotificationConfig{
+					Enabled:        false,
+					OnRunCompleted: true,
+					OnRunFailed:    true,
+					OnRunCanceled:  true,
+				},
+			},
+		},
+	}
+
+	got, _ := m.Update(runFinishedMsg{RunID: 21})
+	_ = got.(model)
+	if len(notifier.messages) != 0 {
+		t.Fatalf("expected no notification when desktop notifications are disabled, got %d", len(notifier.messages))
+	}
+}
+
 func TestRunFinishedKeepsStreamingSlotForLateAssistantMessage(t *testing.T) {
 	m := model{
 		async: make(chan tea.Msg, 1),

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -18,6 +18,7 @@ import (
 	"bytemind/internal/history"
 	"bytemind/internal/llm"
 	"bytemind/internal/mention"
+	notifypkg "bytemind/internal/notify"
 	planpkg "bytemind/internal/plan"
 	"bytemind/internal/session"
 	"bytemind/internal/tools"
@@ -32,6 +33,18 @@ type fakeClipboardTextWriter struct {
 	last       string
 	err        error
 	waitForCtx bool
+}
+
+type fakeNotifier struct {
+	messages []notifypkg.Message
+}
+
+func (f *fakeNotifier) Notify(msg notifypkg.Message) {
+	f.messages = append(f.messages, msg)
+}
+
+func (*fakeNotifier) Close(context.Context) error {
+	return nil
 }
 
 func (f *fakeClipboardTextWriter) WriteText(ctx context.Context, text string) error {
@@ -5236,6 +5249,69 @@ func TestUpdateApprovalRequestMsgSetsApprovalPhase(t *testing.T) {
 	}
 }
 
+func TestUpdateApprovalRequestMsgSendsDesktopNotification(t *testing.T) {
+	reply := make(chan approvalDecision, 1)
+	notifier := &fakeNotifier{}
+	m := model{
+		async:    make(chan tea.Msg, 1),
+		notifier: notifier,
+		cfg: config.Config{
+			Notifications: config.NotificationsConfig{
+				Desktop: config.DesktopNotificationConfig{
+					Enabled:            true,
+					OnApprovalRequired: true,
+				},
+			},
+		},
+	}
+
+	got, _ := m.Update(approvalRequestMsg{
+		Request: ApprovalRequest{
+			Command: "go test ./tui",
+			Reason:  "run focused tests",
+		},
+		Reply: reply,
+	})
+	_ = got.(model)
+
+	if len(notifier.messages) != 1 {
+		t.Fatalf("expected one desktop notification, got %d", len(notifier.messages))
+	}
+	if notifier.messages[0].Event != notifypkg.EventApprovalRequired {
+		t.Fatalf("expected approval_required event, got %q", notifier.messages[0].Event)
+	}
+}
+
+func TestUpdateApprovalRequestMsgSkipsDesktopNotificationWhenDisabled(t *testing.T) {
+	reply := make(chan approvalDecision, 1)
+	notifier := &fakeNotifier{}
+	m := model{
+		async:    make(chan tea.Msg, 1),
+		notifier: notifier,
+		cfg: config.Config{
+			Notifications: config.NotificationsConfig{
+				Desktop: config.DesktopNotificationConfig{
+					Enabled:            false,
+					OnApprovalRequired: true,
+				},
+			},
+		},
+	}
+
+	got, _ := m.Update(approvalRequestMsg{
+		Request: ApprovalRequest{
+			Command: "go test ./tui",
+			Reason:  "run focused tests",
+		},
+		Reply: reply,
+	})
+	_ = got.(model)
+
+	if len(notifier.messages) != 0 {
+		t.Fatalf("expected no desktop notification when disabled, got %d", len(notifier.messages))
+	}
+}
+
 func TestApprovalKeysTransitionStateAndSendDecision(t *testing.T) {
 	t.Run("approve", func(t *testing.T) {
 		reply := make(chan approvalDecision, 1)
@@ -5530,6 +5606,149 @@ func TestUpdateRunFinishedMsgResetsBusyState(t *testing.T) {
 		last := updated.chatItems[len(updated.chatItems)-1]
 		if last.Status != "error" || !strings.Contains(last.Body, "provider unavailable") {
 			t.Fatalf("expected latest assistant card to show failure, got %+v", last)
+		}
+	})
+}
+
+func TestRunFinishedDesktopNotifications(t *testing.T) {
+	t.Run("completed", func(t *testing.T) {
+		notifier := &fakeNotifier{}
+		m := model{
+			async:       make(chan tea.Msg, 1),
+			notifier:    notifier,
+			busy:        true,
+			activeRunID: 3,
+			cfg: config.Config{
+				Notifications: config.NotificationsConfig{
+					Desktop: config.DesktopNotificationConfig{
+						Enabled:        true,
+						OnRunCompleted: true,
+					},
+				},
+			},
+		}
+
+		got, _ := m.Update(runFinishedMsg{RunID: 3})
+		_ = got.(model)
+
+		if len(notifier.messages) != 1 {
+			t.Fatalf("expected one notification, got %d", len(notifier.messages))
+		}
+		if notifier.messages[0].Event != notifypkg.EventRunCompleted {
+			t.Fatalf("expected run_completed event, got %q", notifier.messages[0].Event)
+		}
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		notifier := &fakeNotifier{}
+		m := model{
+			async:       make(chan tea.Msg, 1),
+			notifier:    notifier,
+			busy:        true,
+			activeRunID: 8,
+			cfg: config.Config{
+				Notifications: config.NotificationsConfig{
+					Desktop: config.DesktopNotificationConfig{
+						Enabled:       true,
+						OnRunFailed:   true,
+						OnRunCanceled: false,
+					},
+				},
+			},
+		}
+
+		got, _ := m.Update(runFinishedMsg{RunID: 8, Err: errors.New("provider unavailable")})
+		_ = got.(model)
+
+		if len(notifier.messages) != 1 {
+			t.Fatalf("expected one notification, got %d", len(notifier.messages))
+		}
+		if notifier.messages[0].Event != notifypkg.EventRunFailed {
+			t.Fatalf("expected run_failed event, got %q", notifier.messages[0].Event)
+		}
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		notifier := &fakeNotifier{}
+		m := model{
+			async:       make(chan tea.Msg, 1),
+			notifier:    notifier,
+			busy:        true,
+			activeRunID: 9,
+			cfg: config.Config{
+				Notifications: config.NotificationsConfig{
+					Desktop: config.DesktopNotificationConfig{
+						Enabled:       true,
+						OnRunCanceled: true,
+					},
+				},
+			},
+		}
+
+		got, _ := m.Update(runFinishedMsg{RunID: 9, Err: context.Canceled})
+		_ = got.(model)
+
+		if len(notifier.messages) != 1 {
+			t.Fatalf("expected one notification, got %d", len(notifier.messages))
+		}
+		if notifier.messages[0].Event != notifypkg.EventRunCanceled {
+			t.Fatalf("expected run_canceled event, got %q", notifier.messages[0].Event)
+		}
+	})
+}
+
+func TestRunFinishedDesktopNotificationsSkipBTWRestartAndStaleRun(t *testing.T) {
+	t.Run("btw restart", func(t *testing.T) {
+		notifier := &fakeNotifier{}
+		m := model{
+			async:        make(chan tea.Msg, 1),
+			notifier:     notifier,
+			busy:         true,
+			activeRunID:  10,
+			interrupting: true,
+			pendingBTW:   []string{"new direction"},
+			cfg: config.Config{
+				Notifications: config.NotificationsConfig{
+					Desktop: config.DesktopNotificationConfig{
+						Enabled:        true,
+						OnRunCompleted: true,
+						OnRunFailed:    true,
+						OnRunCanceled:  true,
+					},
+				},
+			},
+		}
+
+		got, _ := m.Update(runFinishedMsg{RunID: 10})
+		_ = got.(model)
+		if len(notifier.messages) != 0 {
+			t.Fatalf("expected no notification for btw restart, got %d", len(notifier.messages))
+		}
+	})
+
+	t.Run("stale run", func(t *testing.T) {
+		notifier := &fakeNotifier{}
+		m := model{
+			async:       make(chan tea.Msg, 1),
+			notifier:    notifier,
+			busy:        true,
+			activeRunID: 11,
+			cfg: config.Config{
+				Notifications: config.NotificationsConfig{
+					Desktop: config.DesktopNotificationConfig{
+						Enabled:        true,
+						OnRunCompleted: true,
+						OnRunFailed:    true,
+						OnRunCanceled:  true,
+					},
+				},
+			},
+		}
+
+		got, _ := m.Update(runFinishedMsg{RunID: 12})
+		_ = got.(model)
+		if len(notifier.messages) != 0 {
+			t.Fatalf("expected no notification for stale run, got %d", len(notifier.messages))
 		}
 	})
 }

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -6398,6 +6398,28 @@ func TestUpdateIgnoresStaleRunFinishedMsg(t *testing.T) {
 	}
 }
 
+func TestUpdateTreatsZeroRunIDAsStaleWhenActiveRunExists(t *testing.T) {
+	m := model{
+		async:       make(chan tea.Msg, 1),
+		busy:        true,
+		activeRunID: 7,
+		statusNote:  "Running...",
+		phase:       "responding",
+	}
+
+	got, cmd := m.Update(runFinishedMsg{})
+	updated := got.(model)
+	if cmd == nil {
+		t.Fatalf("expected stale run finished to keep waiting for async events")
+	}
+	if !updated.busy {
+		t.Fatalf("expected zero RunID to be treated as stale while active run exists")
+	}
+	if updated.activeRunID != 7 {
+		t.Fatalf("expected activeRunID to remain unchanged, got %d", updated.activeRunID)
+	}
+}
+
 func TestBTWCommandInIdleSubmitsPrompt(t *testing.T) {
 	input := textarea.New()
 	input.Focus()

--- a/www/reference/config-reference.md
+++ b/www/reference/config-reference.md
@@ -42,6 +42,19 @@ Deprecated compatibility field. Legacy `approval_mode: away` is blocked by defau
 | `auto_deny_continue` (default) | Accepted for compatibility; no runtime behavior change |
 | `fail_fast`                    | Accepted for compatibility; no runtime behavior change |
 
+## `notifications.desktop`
+
+Desktop notification preferences.
+
+| Field                  | Type | Default | Description |
+| ---------------------- | ---- | ------- | ----------- |
+| `enabled`              | bool | `true`  | Master switch for desktop notifications. |
+| `on_approval_required` | bool | `true`  | Notify when an approval prompt is raised. |
+| `on_run_completed`     | bool | `true`  | Notify when a run completes successfully. |
+| `on_run_failed`        | bool | `true`  | Notify when a run fails. |
+| `on_run_canceled`      | bool | `false` | Notify when a run is canceled. |
+| `cooldown_seconds`     | int  | `3`     | Cooldown window for duplicate notification keys. `0` disables cooldown dedupe. |
+
 ## `max_iterations`
 
 | Type    | Default |
@@ -123,6 +136,16 @@ Controls context window management.
   },
   "approval_policy": "on-request",
   "approval_mode": "interactive",
+  "notifications": {
+    "desktop": {
+      "enabled": true,
+      "on_approval_required": true,
+      "on_run_completed": true,
+      "on_run_failed": true,
+      "on_run_canceled": false,
+      "cooldown_seconds": 3
+    }
+  },
   "max_iterations": 32,
   "stream": true,
   "sandbox_enabled": false,

--- a/www/zh/reference/config-reference.md
+++ b/www/zh/reference/config-reference.md
@@ -1,84 +1,97 @@
-# 配置参考
+﻿# 閰嶇疆鍙傝€?
 
-`.bytemind/config.json` 所有字段的完整说明。
+`.bytemind/config.json` 鎵€鏈夊瓧娈电殑瀹屾暣璇存槑銆?
 
-可用示例参考 [`config.example.json`](https://github.com/1024XEngineer/bytemind/blob/main/config.example.json)。
+鍙敤绀轰緥鍙傝€?[`config.example.json`](https://github.com/1024XEngineer/bytemind/blob/main/config.example.json)銆?
 
 ## `provider`
 
-模型 Provider 配置。
+妯″瀷 Provider 閰嶇疆銆?
 
-| 字段                | 类型   | 说明                                     | 默认值                      |
+| 瀛楁                | 绫诲瀷   | 璇存槑                                     | 榛樿鍊?                     |
 | ------------------- | ------ | ---------------------------------------- | --------------------------- |
-| `type`              | string | `openai-compatible`、`anthropic` 或 `gemini` | `openai-compatible`      |
-| `base_url`          | string | API 端点 URL                             | `https://api.openai.com/v1` |
-| `model`             | string | 使用的模型 ID                            | `gpt-5.4-mini`              |
-| `api_key`           | string | API 密钥（明文，建议改用 `api_key_env`） | —                           |
-| `api_key_env`       | string | 从该环境变量读取 API 密钥                | `BYTEMIND_API_KEY`          |
-| `anthropic_version` | string | Anthropic API 版本头                     | `2023-06-01`                |
-| `auth_header`       | string | 自定义鉴权头名称                         | `Authorization`             |
-| `auth_scheme`       | string | 鉴权前缀（如 `Bearer`）                  | `Bearer`                    |
-| `auto_detect_type`  | bool   | 根据 `base_url` 自动推断 Provider 类型   | `false`                     |
+| `type`              | string | `openai-compatible`銆乣anthropic` 鎴?`gemini` | `openai-compatible`      |
+| `base_url`          | string | API 绔偣 URL                             | `https://api.openai.com/v1` |
+| `model`             | string | 浣跨敤鐨勬ā鍨?ID                            | `gpt-5.4-mini`              |
+| `api_key`           | string | API 瀵嗛挜锛堟槑鏂囷紝寤鸿鏀圭敤 `api_key_env`锛?| 鈥?                          |
+| `api_key_env`       | string | 浠庤鐜鍙橀噺璇诲彇 API 瀵嗛挜                | `BYTEMIND_API_KEY`          |
+| `anthropic_version` | string | Anthropic API 鐗堟湰澶?                    | `2023-06-01`                |
+| `auth_header`       | string | 鑷畾涔夐壌鏉冨ご鍚嶇О                         | `Authorization`             |
+| `auth_scheme`       | string | 閴存潈鍓嶇紑锛堝 `Bearer`锛?                 | `Bearer`                    |
+| `auto_detect_type`  | bool   | 鏍规嵁 `base_url` 鑷姩鎺ㄦ柇 Provider 绫诲瀷   | `false`                     |
 
 ## `approval_policy`
 
-| 值                   | 行为                         |
+| 鍊?                  | 琛屼负                         |
 | -------------------- | ---------------------------- |
-| `on-request`（默认） | 每次高风险工具调用前等待确认 |
+| `on-request`锛堥粯璁わ級 | 姣忔楂橀闄╁伐鍏疯皟鐢ㄥ墠绛夊緟纭 |
 
 ## `approval_mode`
 
-| 值                    | 行为                                  |
+| 鍊?                   | 琛屼负                                  |
 | --------------------- | ------------------------------------- |
-| `interactive`（默认） | 交互式审批，每次操作弹出确认          |
-| `full_access`         | 全部权限模式，审批请求自动通过且不中断任务 |
+| `interactive`锛堥粯璁わ級 | 浜や簰寮忓鎵癸紝姣忔鎿嶄綔寮瑰嚭纭          |
+| `full_access`         | 鍏ㄩ儴鏉冮檺妯″紡锛屽鎵硅姹傝嚜鍔ㄩ€氳繃涓斾笉涓柇浠诲姟 |
 
-兼容说明：为避免静默提权，`approval_mode: away` 默认被阻止。仅在迁移旧配置时，显式设置 `BYTEMIND_ALLOW_AWAY_FULL_ACCESS=true` 才会临时映射到 `full_access`。
+鍏煎璇存槑锛氫负閬垮厤闈欓粯鎻愭潈锛宍approval_mode: away` 榛樿琚樆姝€備粎鍦ㄨ縼绉绘棫閰嶇疆鏃讹紝鏄惧紡璁剧疆 `BYTEMIND_ALLOW_AWAY_FULL_ACCESS=true` 鎵嶄細涓存椂鏄犲皠鍒?`full_access`銆?
 
 ## `away_policy`
 
-已弃用兼容字段。保留用于兼容旧配置形状，不再影响运行时行为。
+宸插純鐢ㄥ吋瀹瑰瓧娈点€備繚鐣欑敤浜庡吋瀹规棫閰嶇疆褰㈢姸锛屼笉鍐嶅奖鍝嶈繍琛屾椂琛屼负銆?
 
-| 值                           | 行为                         |
+| 鍊?                          | 琛屼负                         |
 | ---------------------------- | ---------------------------- |
-| `auto_deny_continue`（默认） | 仅用于兼容旧配置，不再影响运行时行为 |
-| `fail_fast`                  | 仅用于兼容旧配置，不再影响运行时行为 |
+| `auto_deny_continue`锛堥粯璁わ級 | 浠呯敤浜庡吋瀹规棫閰嶇疆锛屼笉鍐嶅奖鍝嶈繍琛屾椂琛屼负 |
+| `fail_fast`                  | 浠呯敤浜庡吋瀹规棫閰嶇疆锛屼笉鍐嶅奖鍝嶈繍琛屾椂琛屼负 |
 
+
+## `notifications.desktop`
+
+妗岄潰閫氱煡閰嶇疆銆?
+
+| 瀛楁                    | 绫诲瀷 | 榛樿鍊?| 璇存槑 |
+| ----------------------- | ---- | ------ | ---- |
+| `enabled`               | bool | `true` | 妗岄潰閫氱煡鎬诲紑鍏炽€? |
+| `on_approval_required`  | bool | `true` | 鍑虹幇瀹℃壒璇锋眰鏃跺彂閫侀€氱煡銆? |
+| `on_run_completed`      | bool | `true` | 浠诲姟鎴愬姛瀹屾垚鏃跺彂閫侀€氱煡銆? |
+| `on_run_failed`         | bool | `true` | 浠诲姟澶辫触鏃跺彂閫侀€氱煡銆? |
+| `on_run_canceled`       | bool | `false` | 浠诲姟鍙栨秷鏃跺彂閫侀€氱煡銆? |
+| `cooldown_seconds`      | int  | `3` | 鍚屼竴閫氱煡 key 鍐呯殑鍘婚噸鏃堕棿绐楀彛锛?`0` 琛ㄧず鍏抽棴 cooldown 鍘婚噸銆? |
 ## `max_iterations`
 
-| 类型    | 默认值 |
+| 绫诲瀷    | 榛樿鍊?|
 | ------- | ------ |
 | integer | `32`   |
 
-单任务最大工具调用轮次。到达上限后 Agent 输出阶段性总结并停止。
+鍗曚换鍔℃渶澶у伐鍏疯皟鐢ㄨ疆娆°€傚埌杈句笂闄愬悗 Agent 杈撳嚭闃舵鎬ф€荤粨骞跺仠姝€?
 
 ## `stream`
 
-| 类型 | 默认值 |
+| 绫诲瀷 | 榛樿鍊?|
 | ---- | ------ |
 | bool | `true` |
 
-开启流式输出。非 TTY 环境（如 CI 管道）建议设为 `false`。
+寮€鍚祦寮忚緭鍑恒€傞潪 TTY 鐜锛堝 CI 绠￠亾锛夊缓璁涓?`false`銆?
 
 ## `sandbox_enabled`
 
-| 类型 | 默认值  |
+| 绫诲瀷 | 榛樿鍊? |
 | ---- | ------- |
 | bool | `false` |
 
-设为 `true` 后，文件和 Shell 工具的写入操作将被限制在 `writable_roots` 范围内。
+璁句负 `true` 鍚庯紝鏂囦欢鍜?Shell 宸ュ叿鐨勫啓鍏ユ搷浣滃皢琚檺鍒跺湪 `writable_roots` 鑼冨洿鍐呫€?
 
 ## `writable_roots`
 
-| 类型     | 默认值 |
+| 绫诲瀷     | 榛樿鍊?|
 | -------- | ------ |
 | string[] | `[]`   |
 
-开启沙箱时允许写入的目录列表。
+寮€鍚矙绠辨椂鍏佽鍐欏叆鐨勭洰褰曞垪琛ㄣ€?
 
 ## `exec_allowlist`
 
-跳过审批提示的 Shell 命令白名单。
+璺宠繃瀹℃壒鎻愮ず鐨?Shell 鍛戒护鐧藉悕鍗曘€?
 
 ```json
 {
@@ -91,29 +104,29 @@
 
 ## `token_quota`
 
-| 类型    | 默认值   |
+| 绫诲瀷    | 榛樿鍊?  |
 | ------- | -------- |
 | integer | `300000` |
 
-单会话 token 消耗预警阈值。
+鍗曚細璇?token 娑堣€楅璀﹂槇鍊笺€?
 
 ## `update_check`
 
-| 字段      | 类型 | 默认值 | 说明               |
+| 瀛楁      | 绫诲瀷 | 榛樿鍊?| 璇存槑               |
 | --------- | ---- | ------ | ------------------ |
-| `enabled` | bool | `true` | 启动时是否检查更新 |
+| `enabled` | bool | `true` | 鍚姩鏃舵槸鍚︽鏌ユ洿鏂?|
 
 ## `context_budget`
 
-上下文窗口用量管理。
+涓婁笅鏂囩獥鍙ｇ敤閲忕鐞嗐€?
 
-| 字段                 | 类型  | 默认值 | 说明                           |
+| 瀛楁                 | 绫诲瀷  | 榛樿鍊?| 璇存槑                           |
 | -------------------- | ----- | ------ | ------------------------------ |
-| `warning_ratio`      | float | `0.85` | 用量达到此比例时输出警告       |
-| `critical_ratio`     | float | `0.95` | 用量达到此比例时触发压缩或停止 |
-| `max_reactive_retry` | int   | `1`    | 上下文压缩后最大重试次数       |
+| `warning_ratio`      | float | `0.85` | 鐢ㄩ噺杈惧埌姝ゆ瘮渚嬫椂杈撳嚭璀﹀憡       |
+| `critical_ratio`     | float | `0.95` | 鐢ㄩ噺杈惧埌姝ゆ瘮渚嬫椂瑙﹀彂鍘嬬缉鎴栧仠姝?|
+| `max_reactive_retry` | int   | `1`    | 涓婁笅鏂囧帇缂╁悗鏈€澶ч噸璇曟鏁?      |
 
-## 完整示例
+## 瀹屾暣绀轰緥
 
 ```json
 {
@@ -125,6 +138,16 @@
   },
   "approval_policy": "on-request",
   "approval_mode": "interactive",
+  "notifications": {
+    "desktop": {
+      "enabled": true,
+      "on_approval_required": true,
+      "on_run_completed": true,
+      "on_run_failed": true,
+      "on_run_canceled": false,
+      "cooldown_seconds": 3
+    }
+  },
   "max_iterations": 32,
   "stream": true,
   "sandbox_enabled": false,

--- a/www/zh/reference/config-reference.md
+++ b/www/zh/reference/config-reference.md
@@ -1,97 +1,97 @@
-﻿# 閰嶇疆鍙傝€?
+# 配置参考
 
-`.bytemind/config.json` 鎵€鏈夊瓧娈电殑瀹屾暣璇存槑銆?
+`.bytemind/config.json` 所有字段的完整说明。
 
-鍙敤绀轰緥鍙傝€?[`config.example.json`](https://github.com/1024XEngineer/bytemind/blob/main/config.example.json)銆?
+可用示例参考 [`config.example.json`](https://github.com/1024XEngineer/bytemind/blob/main/config.example.json)。
 
 ## `provider`
 
-妯″瀷 Provider 閰嶇疆銆?
+模型 Provider 配置。
 
-| 瀛楁                | 绫诲瀷   | 璇存槑                                     | 榛樿鍊?                     |
+| 字段                | 类型   | 说明                                     | 默认值                      |
 | ------------------- | ------ | ---------------------------------------- | --------------------------- |
-| `type`              | string | `openai-compatible`銆乣anthropic` 鎴?`gemini` | `openai-compatible`      |
-| `base_url`          | string | API 绔偣 URL                             | `https://api.openai.com/v1` |
-| `model`             | string | 浣跨敤鐨勬ā鍨?ID                            | `gpt-5.4-mini`              |
-| `api_key`           | string | API 瀵嗛挜锛堟槑鏂囷紝寤鸿鏀圭敤 `api_key_env`锛?| 鈥?                          |
-| `api_key_env`       | string | 浠庤鐜鍙橀噺璇诲彇 API 瀵嗛挜                | `BYTEMIND_API_KEY`          |
-| `anthropic_version` | string | Anthropic API 鐗堟湰澶?                    | `2023-06-01`                |
-| `auth_header`       | string | 鑷畾涔夐壌鏉冨ご鍚嶇О                         | `Authorization`             |
-| `auth_scheme`       | string | 閴存潈鍓嶇紑锛堝 `Bearer`锛?                 | `Bearer`                    |
-| `auto_detect_type`  | bool   | 鏍规嵁 `base_url` 鑷姩鎺ㄦ柇 Provider 绫诲瀷   | `false`                     |
+| `type`              | string | `openai-compatible`、`anthropic` 或 `gemini` | `openai-compatible`      |
+| `base_url`          | string | API 端点 URL                             | `https://api.openai.com/v1` |
+| `model`             | string | 使用的模型 ID                            | `gpt-5.4-mini`              |
+| `api_key`           | string | API 密钥（明文，建议改用 `api_key_env`） | —                           |
+| `api_key_env`       | string | 从该环境变量读取 API 密钥                | `BYTEMIND_API_KEY`          |
+| `anthropic_version` | string | Anthropic API 版本头                     | `2023-06-01`                |
+| `auth_header`       | string | 自定义鉴权头名称                         | `Authorization`             |
+| `auth_scheme`       | string | 鉴权前缀（如 `Bearer`）                  | `Bearer`                    |
+| `auto_detect_type`  | bool   | 根据 `base_url` 自动推断 Provider 类型   | `false`                     |
 
 ## `approval_policy`
 
-| 鍊?                  | 琛屼负                         |
+| 值                   | 行为                         |
 | -------------------- | ---------------------------- |
-| `on-request`锛堥粯璁わ級 | 姣忔楂橀闄╁伐鍏疯皟鐢ㄥ墠绛夊緟纭 |
+| `on-request`（默认） | 每次高风险工具调用前等待确认 |
 
 ## `approval_mode`
 
-| 鍊?                   | 琛屼负                                  |
+| 值                    | 行为                                  |
 | --------------------- | ------------------------------------- |
-| `interactive`锛堥粯璁わ級 | 浜や簰寮忓鎵癸紝姣忔鎿嶄綔寮瑰嚭纭          |
-| `full_access`         | 鍏ㄩ儴鏉冮檺妯″紡锛屽鎵硅姹傝嚜鍔ㄩ€氳繃涓斾笉涓柇浠诲姟 |
+| `interactive`（默认） | 交互式审批，每次操作弹出确认          |
+| `full_access`         | 全部权限模式，审批请求自动通过且不中断任务 |
 
-鍏煎璇存槑锛氫负閬垮厤闈欓粯鎻愭潈锛宍approval_mode: away` 榛樿琚樆姝€備粎鍦ㄨ縼绉绘棫閰嶇疆鏃讹紝鏄惧紡璁剧疆 `BYTEMIND_ALLOW_AWAY_FULL_ACCESS=true` 鎵嶄細涓存椂鏄犲皠鍒?`full_access`銆?
+兼容说明：为避免静默提权，`approval_mode: away` 默认被阻止。仅在迁移旧配置时，显式设置 `BYTEMIND_ALLOW_AWAY_FULL_ACCESS=true` 才会临时映射到 `full_access`。
 
 ## `away_policy`
 
-宸插純鐢ㄥ吋瀹瑰瓧娈点€備繚鐣欑敤浜庡吋瀹规棫閰嶇疆褰㈢姸锛屼笉鍐嶅奖鍝嶈繍琛屾椂琛屼负銆?
+已弃用兼容字段。保留用于兼容旧配置形状，不再影响运行时行为。
 
-| 鍊?                          | 琛屼负                         |
+| 值                           | 行为                         |
 | ---------------------------- | ---------------------------- |
-| `auto_deny_continue`锛堥粯璁わ級 | 浠呯敤浜庡吋瀹规棫閰嶇疆锛屼笉鍐嶅奖鍝嶈繍琛屾椂琛屼负 |
-| `fail_fast`                  | 浠呯敤浜庡吋瀹规棫閰嶇疆锛屼笉鍐嶅奖鍝嶈繍琛屾椂琛屼负 |
-
+| `auto_deny_continue`（默认） | 仅用于兼容旧配置，不再影响运行时行为 |
+| `fail_fast`                  | 仅用于兼容旧配置，不再影响运行时行为 |
 
 ## `notifications.desktop`
 
-妗岄潰閫氱煡閰嶇疆銆?
+桌面通知偏好设置。
 
-| 瀛楁                    | 绫诲瀷 | 榛樿鍊?| 璇存槑 |
+| 字段                    | 类型 | 默认值 | 说明 |
 | ----------------------- | ---- | ------ | ---- |
-| `enabled`               | bool | `true` | 妗岄潰閫氱煡鎬诲紑鍏炽€? |
-| `on_approval_required`  | bool | `true` | 鍑虹幇瀹℃壒璇锋眰鏃跺彂閫侀€氱煡銆? |
-| `on_run_completed`      | bool | `true` | 浠诲姟鎴愬姛瀹屾垚鏃跺彂閫侀€氱煡銆? |
-| `on_run_failed`         | bool | `true` | 浠诲姟澶辫触鏃跺彂閫侀€氱煡銆? |
-| `on_run_canceled`       | bool | `false` | 浠诲姟鍙栨秷鏃跺彂閫侀€氱煡銆? |
-| `cooldown_seconds`      | int  | `3` | 鍚屼竴閫氱煡 key 鍐呯殑鍘婚噸鏃堕棿绐楀彛锛?`0` 琛ㄧず鍏抽棴 cooldown 鍘婚噸銆? |
+| `enabled`               | bool | `true` | 桌面通知总开关。 |
+| `on_approval_required`  | bool | `true` | 出现审批请求时发送通知。 |
+| `on_run_completed`      | bool | `true` | 任务成功完成时发送通知。 |
+| `on_run_failed`         | bool | `true` | 任务失败时发送通知。 |
+| `on_run_canceled`       | bool | `false` | 任务取消时发送通知。 |
+| `cooldown_seconds`      | int  | `3` | 同一通知 key 的去重窗口。`0` 表示关闭 cooldown 去重。 |
+
 ## `max_iterations`
 
-| 绫诲瀷    | 榛樿鍊?|
+| 类型    | 默认值 |
 | ------- | ------ |
 | integer | `32`   |
 
-鍗曚换鍔℃渶澶у伐鍏疯皟鐢ㄨ疆娆°€傚埌杈句笂闄愬悗 Agent 杈撳嚭闃舵鎬ф€荤粨骞跺仠姝€?
+单任务最大工具调用轮次。到达上限后 Agent 输出阶段性总结并停止。
 
 ## `stream`
 
-| 绫诲瀷 | 榛樿鍊?|
+| 类型 | 默认值 |
 | ---- | ------ |
 | bool | `true` |
 
-寮€鍚祦寮忚緭鍑恒€傞潪 TTY 鐜锛堝 CI 绠￠亾锛夊缓璁涓?`false`銆?
+开启流式输出。非 TTY 环境（如 CI 管道）建议设为 `false`。
 
 ## `sandbox_enabled`
 
-| 绫诲瀷 | 榛樿鍊? |
+| 类型 | 默认值  |
 | ---- | ------- |
 | bool | `false` |
 
-璁句负 `true` 鍚庯紝鏂囦欢鍜?Shell 宸ュ叿鐨勫啓鍏ユ搷浣滃皢琚檺鍒跺湪 `writable_roots` 鑼冨洿鍐呫€?
+设为 `true` 后，文件和 Shell 工具的写入操作将被限制在 `writable_roots` 范围内。
 
 ## `writable_roots`
 
-| 绫诲瀷     | 榛樿鍊?|
+| 类型     | 默认值 |
 | -------- | ------ |
 | string[] | `[]`   |
 
-寮€鍚矙绠辨椂鍏佽鍐欏叆鐨勭洰褰曞垪琛ㄣ€?
+开启沙箱时允许写入的目录列表。
 
 ## `exec_allowlist`
 
-璺宠繃瀹℃壒鎻愮ず鐨?Shell 鍛戒护鐧藉悕鍗曘€?
+跳过审批提示的 Shell 命令白名单。
 
 ```json
 {
@@ -104,29 +104,29 @@
 
 ## `token_quota`
 
-| 绫诲瀷    | 榛樿鍊?  |
+| 类型    | 默认值   |
 | ------- | -------- |
 | integer | `300000` |
 
-鍗曚細璇?token 娑堣€楅璀﹂槇鍊笺€?
+单会话 token 消耗预警阈值。
 
 ## `update_check`
 
-| 瀛楁      | 绫诲瀷 | 榛樿鍊?| 璇存槑               |
+| 字段      | 类型 | 默认值 | 说明               |
 | --------- | ---- | ------ | ------------------ |
-| `enabled` | bool | `true` | 鍚姩鏃舵槸鍚︽鏌ユ洿鏂?|
+| `enabled` | bool | `true` | 启动时是否检查更新 |
 
 ## `context_budget`
 
-涓婁笅鏂囩獥鍙ｇ敤閲忕鐞嗐€?
+上下文窗口用量管理。
 
-| 瀛楁                 | 绫诲瀷  | 榛樿鍊?| 璇存槑                           |
+| 字段                 | 类型  | 默认值 | 说明                           |
 | -------------------- | ----- | ------ | ------------------------------ |
-| `warning_ratio`      | float | `0.85` | 鐢ㄩ噺杈惧埌姝ゆ瘮渚嬫椂杈撳嚭璀﹀憡       |
-| `critical_ratio`     | float | `0.95` | 鐢ㄩ噺杈惧埌姝ゆ瘮渚嬫椂瑙﹀彂鍘嬬缉鎴栧仠姝?|
-| `max_reactive_retry` | int   | `1`    | 涓婁笅鏂囧帇缂╁悗鏈€澶ч噸璇曟鏁?      |
+| `warning_ratio`      | float | `0.85` | 用量达到此比例时输出警告       |
+| `critical_ratio`     | float | `0.95` | 用量达到此比例时触发压缩或停止 |
+| `max_reactive_retry` | int   | `1`    | 上下文压缩后最大重试次数       |
 
-## 瀹屾暣绀轰緥
+## 完整示例
 
 ```json
 {


### PR DESCRIPTION
## 变更概述
本 PR 为 TUI 增加桌面通知能力，覆盖权限审批与任务结束事件，并补齐配置、去重、防抖、脱敏、生命周期回收及文档说明。

## 主要改动
- 新增 `notifications.desktop` 配置项（默认开启）：
  - `enabled`
  - `on_approval_required`
  - `on_run_completed`
  - `on_run_failed`
  - `on_run_canceled`
  - `cooldown_seconds`
- 新增环境变量覆盖：
  - `BYTEMIND_DESKTOP_NOTIFY`
  - `BYTEMIND_NOTIFY_APPROVAL`
  - `BYTEMIND_NOTIFY_RUN_COMPLETED`
  - `BYTEMIND_NOTIFY_RUN_FAILED`
  - `BYTEMIND_NOTIFY_RUN_CANCELED`
  - `BYTEMIND_NOTIFY_COOLDOWN_SECONDS`
- 新增 `internal/notify` 异步通知模块：
  - 非阻塞队列发送
  - cooldown 去重
  - 队列满时 drop-oldest
  - 通知文案脱敏与截断
  - `Close(ctx)` 生命周期回收
- 接入 TUI 触发点：
  - `approvalRequestMsg` 触发审批通知
  - `runFinishedMsg` 触发 completed/failed/canceled 通知
  - 显式排除 `stale run` 与 `btw_restart`
  - active run 存在时要求严格 run id 匹配
- Runtime 关闭链路：
  - 在 `BuildTUIRuntime()` 构建 notifier
  - 退出时以固定超时回收 notifier worker
- 文档与示例配置同步更新：
  - `config.example.json`
  - `README.md`
  - `docs/environment-variables.md`
  - `www/reference/config-reference.md`
  - `www/zh/reference/config-reference.md`
- Windows 可见性修复：
  - 优先托盘气泡通知（右下角更稳定）
  - 不可用时回退 toast

## 验证
- `go test ./internal/notify -count=1`
- `go test ./internal/app -count=1`
- `go test ./... -count=1`

## 备注
本次按小步提交拆分为多个 commit，便于 review 与回溯。
