### PR TITLE
refactor(tui): 接入会话 Markdown 渲染（参考 Glow/Glamour）

### DIFF
--- a/tui/assistant_render_pipeline.go
+++ b/tui/assistant_render_pipeline.go
@@ -38,6 +38,15 @@ var (
 )
 
 func renderAssistantBody(text string, width int) string {
+	text = stripAssistantStructuralTags(text)
+	if strings.TrimSpace(text) == "" {
+		return ""
+	}
+
+	if rendered, err := renderAssistantBodyWithMarkdownAndTags(text, width); err == nil && strings.TrimSpace(rendered) != "" {
+		return rendered
+	}
+
 	return renderAssistantBodyLegacy(text, width)
 }
 

--- a/tui/assistant_render_pipeline.go
+++ b/tui/assistant_render_pipeline.go
@@ -35,6 +35,8 @@ var (
 	}
 
 	glamourRenderers sync.Map // map[string]*glamour.TermRenderer
+	// renderAssistantMarkdownFn is a test seam so unit tests can force fallback paths.
+	renderAssistantMarkdownFn = renderAssistantBodyWithMarkdownAndTags
 )
 
 func renderAssistantBody(text string, width int) string {
@@ -43,7 +45,7 @@ func renderAssistantBody(text string, width int) string {
 		return ""
 	}
 
-	if rendered, err := renderAssistantBodyWithMarkdownAndTags(text, width); err == nil && strings.TrimSpace(rendered) != "" {
+	if rendered, err := renderAssistantMarkdownFn(text, width); err == nil && strings.TrimSpace(rendered) != "" {
 		return rendered
 	}
 

--- a/tui/assistant_render_pipeline_test.go
+++ b/tui/assistant_render_pipeline_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -99,5 +100,44 @@ func TestBlueGlamourStyleOverridesCoreBlueThemeSlots(t *testing.T) {
 	}
 	if cfg.Table.ColumnSeparator == nil || *cfg.Table.ColumnSeparator != "\u2502" {
 		t.Fatalf("expected table column separator override, got %+v", cfg.Table.ColumnSeparator)
+	}
+}
+
+func TestRenderAssistantBodyReturnsEmptyAfterStructuralTagStripping(t *testing.T) {
+	got := renderAssistantBody("<proposed_plan>\n\n</proposed_plan>", 80)
+	if got != "" {
+		t.Fatalf("expected empty output after stripping structural tags, got %q", got)
+	}
+}
+
+func TestRenderAssistantBodyUsesMarkdownRendererWhenAvailable(t *testing.T) {
+	got := renderAssistantBody("## Goal\n\n- ship it", 80)
+	if strings.TrimSpace(got) == "" {
+		t.Fatal("expected rendered markdown output")
+	}
+	if strings.Contains(got, "## Goal") {
+		t.Fatalf("expected markdown heading marker to be rendered, got %q", got)
+	}
+	if !strings.Contains(got, "Goal") || !strings.Contains(got, "ship it") {
+		t.Fatalf("expected rendered markdown content, got %q", got)
+	}
+}
+
+func TestRenderAssistantBodyFallsBackToLegacyOnMarkdownRenderError(t *testing.T) {
+	original := renderAssistantMarkdownFn
+	renderAssistantMarkdownFn = func(text string, width int) (string, error) {
+		return "", errors.New("forced markdown renderer failure")
+	}
+	t.Cleanup(func() { renderAssistantMarkdownFn = original })
+
+	got := renderAssistantBody("# Fallback heading\nBody", 80)
+	if strings.TrimSpace(got) == "" {
+		t.Fatal("expected fallback legacy renderer output")
+	}
+	if strings.Contains(got, "# Fallback heading") {
+		t.Fatalf("expected fallback renderer to normalize heading markers, got %q", got)
+	}
+	if !strings.Contains(got, "Fallback heading") || !strings.Contains(got, "Body") {
+		t.Fatalf("expected fallback content in output, got %q", got)
 	}
 }

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -6759,7 +6759,7 @@ func TestScrollbarTrackBoundsAndDragScrollbarTo(t *testing.T) {
 		viewport:   viewport.New(60, 10),
 		tokenUsage: newTokenUsageComponent(),
 		chatItems: []chatEntry{
-			{Kind: "assistant", Body: strings.Repeat("line\n", 260), Status: "final"},
+			{Kind: "assistant", Body: strings.Repeat("- line item\n", 260), Status: "final"},
 		},
 	}
 	m.refreshViewport()
@@ -6816,7 +6816,7 @@ func TestHandleMouseScrollbarDragLifecycle(t *testing.T) {
 		tokenUsage:     newTokenUsageComponent(),
 		chatAutoFollow: true,
 		chatItems: []chatEntry{
-			{Kind: "assistant", Body: strings.Repeat("row\n", 280), Status: "final"},
+			{Kind: "assistant", Body: strings.Repeat("- row item\n", 280), Status: "final"},
 		},
 	}
 	m.refreshViewport()

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -6555,8 +6555,8 @@ func TestFormatChatBodySeparatesParagraphAndList(t *testing.T) {
 	if !strings.Contains(got, "Explanation") {
 		t.Fatalf("expected explanation text to remain, got %q", got)
 	}
-	if !strings.Contains(got, "- first") {
-		t.Fatalf("expected markdown list marker to be normalized, got %q", got)
+	if !strings.Contains(got, "first") || !strings.Contains(got, "second") {
+		t.Fatalf("expected markdown list items to be rendered, got %q", got)
 	}
 }
 
@@ -6632,7 +6632,8 @@ func TestFormatChatBodyHighlightsSemanticChineseLines(t *testing.T) {
 	for _, want := range []string{
 		"\u7b2c\u4e00\u9636\u6bb5\uff1a\u57fa\u7840\u51c6\u5907\uff081-2\u4e2a\u6708\uff09",
 		"\u5b66\u4e60\u5185\u5bb9\uff1a",
-		"\\u76ee\\u6807\\uff1a \\u5efa\\u7acb\\u57fa\\u7840\\u80fd\\u529b",
+		"\\u76ee\\u6807\\uff1a",
+		"\\u5efa\\u7acb\\u57fa\\u7840\\u80fd\\u529b",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected semantic lines to remain (%q), got %q", want, got)
@@ -6677,8 +6678,8 @@ func TestFormatChatBodyStripsInlineMarkdownTokens(t *testing.T) {
 		Body: "We are **ByteMind** project, support go test ./... and [docs](https://example.com/docs).",
 	}
 
-	got := formatChatBody(item, 120)
-	for _, unwanted := range []string{"**", "`", "[", "]("} {
+	got := stripANSI(formatChatBody(item, 120))
+	for _, unwanted := range []string{"**", "`", "]("} {
 		if strings.Contains(got, unwanted) {
 			t.Fatalf("expected inline markdown token %q to be removed, got %q", unwanted, got)
 		}
@@ -6689,7 +6690,7 @@ func TestFormatChatBodyStripsInlineMarkdownTokens(t *testing.T) {
 	if !strings.Contains(got, "go test ./...") {
 		t.Fatalf("expected inline code content to remain after normalization, got %q", got)
 	}
-	if !strings.Contains(got, "docs (https://example.com/docs)") {
+	if !strings.Contains(got, "docs") || !strings.Contains(got, "https://example.com/docs") {
 		t.Fatalf("expected markdown link to be normalized to plain text, got %q", got)
 	}
 }


### PR DESCRIPTION
## 背景
当前会话正文对 Markdown 的渲染不完整。此 PR 将助手消息主链路切换为 Glamour 风格渲染，并保留回退逻辑，提升代码块、列表、标题、链接的可读性。

## 变更内容
- 接入助手正文 Markdown 渲染主链路（失败时回退 legacy 渲染）
- 保留并清理结构标签处理（如 `<proposed_plan>`）
- 调整相关测试断言，兼容新的 Markdown 渲染输出

## 提交记录
- `b91a890` tui: render assistant replies with glamour markdown
- `7423274` test: align chat markdown assertions with glamour output

## 验证
已通过：
- `go test ./tui -run "TestFormatChatBody(SeparatesParagraphAndList|RendersMarkdownHeadingWithoutHashes|StripsInlineMarkdownTokens|RendersCodeBlockWithoutFences|HidesProposedPlanTagsAndKeepsDocumentSections)" -count=1 -v`
- `go test ./tui -run "TestRenderStructuredMarkdownPrepared|TestFormatChatCopyBodyUsesPlainMarkdownCopy|TestFormatChatCopyBodyUsesPlainToolMarkdownCopy" -count=1 -v`
- `go test ./tui -run "TestRenderMarkdownHeadingAddsVisualPrefixes" -count=1 -v`
