### PR TITLE
feat(tui): Esc 中断运行能力

### DIFF
--- a/tui/component_footer.go
+++ b/tui/component_footer.go
@@ -174,7 +174,8 @@ func (m model) renderFooterInfoLine() string {
 	if modelName == "-" {
 		modelName = ""
 	}
-	right := renderFooterInfoRight(modelName, 1<<30)
+	hints := m.footerShortcutHints()
+	right := renderFooterInfoRight(modelName, hints, 1<<30)
 
 	leftW := lipgloss.Width(left)
 	rightW := lipgloss.Width(right)
@@ -182,9 +183,9 @@ func (m model) renderFooterInfoLine() string {
 	if gap < 2 {
 		available := max(10, width-leftW-2)
 		if available <= 10 {
-			return lipgloss.NewStyle().Width(width).Render(renderFooterInfoRight(modelName, width))
+			return lipgloss.NewStyle().Width(width).Render(renderFooterInfoRight(modelName, hints, width))
 		}
-		compacted := renderFooterInfoRight(modelName, available)
+		compacted := renderFooterInfoRight(modelName, hints, available)
 		gap = width - leftW - lipgloss.Width(compacted)
 		return lipgloss.NewStyle().Width(width).Render(left + strings.Repeat(" ", max(2, gap)) + compacted)
 	}
@@ -192,11 +193,20 @@ func (m model) renderFooterInfoLine() string {
 	return lipgloss.NewStyle().Width(width).Render(left + strings.Repeat(" ", gap) + right)
 }
 
-func renderFooterInfoRight(modelName string, maxWidth int) string {
+func (m model) footerShortcutHints() []footerShortcutHint {
+	hints := make([]footerShortcutHint, 0, len(footerShortcutHints)+1)
+	hints = append(hints, footerShortcutHints...)
+	if m.busy && m.runCancel != nil {
+		hints = append(hints, footerShortcutHint{Key: "Esc", Label: "interrupt"})
+	}
+	return hints
+}
+
+func renderFooterInfoRight(modelName string, hints []footerShortcutHint, maxWidth int) string {
 	maxWidth = max(1, maxWidth)
 	modelName = strings.TrimSpace(modelName)
 	if modelName == "" {
-		return renderInlineShortcutHintsCompacted(footerShortcutHints, maxWidth)
+		return renderInlineShortcutHintsCompacted(hints, maxWidth)
 	}
 	modelText := compact(modelName, maxWidth)
 	modelWidth := runewidth.StringWidth(modelText)
@@ -209,11 +219,11 @@ func renderFooterInfoRight(modelName string, maxWidth int) string {
 	if remaining <= 0 {
 		return mutedStyle.Render(modelText)
 	}
-	hints := renderInlineShortcutHintsCompacted(footerShortcutHints, remaining)
-	if strings.TrimSpace(hints) == "" {
+	hintsText := renderInlineShortcutHintsCompacted(hints, remaining)
+	if strings.TrimSpace(hintsText) == "" {
 		return mutedStyle.Render(modelText)
 	}
-	return mutedStyle.Render(modelText) + footerHintDividerStyle.Render(dividerPlain) + hints
+	return mutedStyle.Render(modelText) + footerHintDividerStyle.Render(dividerPlain) + hintsText
 }
 
 func renderFooterShortcutHints() string {

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -64,14 +64,45 @@ func TestComponentCommandAndMentionPaletteRenderStates(t *testing.T) {
 }
 
 func TestComponentFooterInfoRightModelAndHintPaths(t *testing.T) {
-	withModel := renderFooterInfoRight("GPT-5.4", 40)
+	hints := []footerShortcutHint{
+		{Key: "tab", Label: "agents"},
+		{Key: "/", Label: "commands"},
+	}
+	withModel := renderFooterInfoRight("GPT-5.4", hints, 40)
 	if !strings.Contains(withModel, "GPT-5.4") {
 		t.Fatalf("expected model text in footer right, got %q", withModel)
 	}
 
-	hintsOnly := renderFooterInfoRight("", 20)
+	hintsOnly := renderFooterInfoRight("", hints, 20)
 	if strings.TrimSpace(hintsOnly) == "" {
 		t.Fatal("expected compacted hints when model is empty")
+	}
+}
+
+func TestComponentFooterHintsShowEscInterruptOnlyWhenCancelable(t *testing.T) {
+	m := model{
+		busy:      true,
+		runCancel: func() {},
+	}
+
+	hints := m.footerShortcutHints()
+	foundEsc := false
+	for _, hint := range hints {
+		if hint.Key == "Esc" && hint.Label == "interrupt" {
+			foundEsc = true
+			break
+		}
+	}
+	if !foundEsc {
+		t.Fatalf("expected Esc interrupt hint while run is cancelable, got %#v", hints)
+	}
+
+	m.runCancel = nil
+	hints = m.footerShortcutHints()
+	for _, hint := range hints {
+		if hint.Key == "Esc" {
+			t.Fatalf("did not expect Esc hint when runCancel is nil, got %#v", hints)
+		}
 	}
 }
 

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -104,6 +104,15 @@ func TestComponentFooterHintsShowEscInterruptOnlyWhenCancelable(t *testing.T) {
 			t.Fatalf("did not expect Esc hint when runCancel is nil, got %#v", hints)
 		}
 	}
+
+	m.busy = false
+	m.runCancel = func() {}
+	hints = m.footerShortcutHints()
+	for _, hint := range hints {
+		if hint.Key == "Esc" {
+			t.Fatalf("did not expect Esc hint when not busy, got %#v", hints)
+		}
+	}
 }
 
 func TestComponentPlanPanelContentAndStepRender(t *testing.T) {

--- a/tui/component_run_flow.go
+++ b/tui/component_run_flow.go
@@ -127,30 +127,61 @@ func (m model) submitBTW(value string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	wasToolPhase := m.phase == "tool"
-	m.interrupting = true
-	m.phase = "interrupting"
-	if m.runCancel != nil {
-		if wasToolPhase {
-			m.interruptSafe = true
-			m.statusNote = "BTW queued. Waiting for current tool step to finish..."
-		} else {
-			m.interruptSafe = false
-			m.statusNote = "BTW received. Stopping current run..."
-			m.runCancel()
-		}
-	} else {
+	if m.runCancel == nil {
 		prompt := composeBTWPrompt(m.pendingBTW)
 		m.pendingBTW = nil
 		m.interrupting = false
 		m.interruptSafe = false
+		m.pendingInterrupt = false
+		m.pendingInterruptReason = ""
 		return m, m.beginRun(prompt, string(m.mode), "BTW accepted. Restarting with your update...")
+	}
+	if m.requestRunInterrupt("btw") {
+		if m.pendingInterrupt {
+			m.statusNote = "BTW queued. Waiting for current tool step to finish..."
+		} else {
+			m.statusNote = "BTW received. Stopping current run..."
+		}
 	}
 	if m.width > 0 && m.height > 0 {
 		m.syncLayoutForCurrentScreen()
 		m.refreshViewport()
 	}
 	return m, nil
+}
+
+func (m *model) requestRunInterrupt(source string) bool {
+	if m.interrupting {
+		if strings.EqualFold(strings.TrimSpace(source), "esc") {
+			m.statusNote = "Interrupt already requested. Waiting for current run to stop..."
+		}
+		return true
+	}
+	if m.runCancel == nil || !m.busy {
+		return false
+	}
+
+	wasToolPhase := strings.EqualFold(strings.TrimSpace(m.phase), "tool")
+	m.interrupting = true
+	m.phase = "interrupting"
+	m.pendingInterruptReason = strings.TrimSpace(source)
+	if wasToolPhase {
+		m.interruptSafe = true
+		m.pendingInterrupt = true
+		if strings.EqualFold(strings.TrimSpace(source), "esc") {
+			m.statusNote = "Interrupt requested. Waiting for current tool step to finish..."
+		}
+		return true
+	}
+
+	m.interruptSafe = false
+	m.pendingInterrupt = false
+	m.pendingInterruptReason = ""
+	if strings.EqualFold(strings.TrimSpace(source), "esc") {
+		m.statusNote = "Interrupt requested. Stopping current run..."
+	}
+	m.runCancel()
+	return true
 }
 
 func (m *model) handleAgentEvent(event Event) {
@@ -193,10 +224,12 @@ func (m *model) handleAgentEvent(event Event) {
 		}
 		m.statusNote = summary
 		m.phase = "thinking"
-		if m.interruptSafe && m.interrupting && len(m.pendingBTW) > 0 && m.runCancel != nil {
+		if m.interruptSafe && m.interrupting && m.pendingInterrupt && m.runCancel != nil {
 			m.interruptSafe = false
+			m.pendingInterrupt = false
+			m.pendingInterruptReason = ""
 			m.phase = "interrupting"
-			m.statusNote = "BTW received. Stopping current run..."
+			m.statusNote = "Interrupt requested. Stopping current run..."
 			m.runCancel()
 		}
 	case EventPlanUpdated:

--- a/tui/component_sessions.go
+++ b/tui/component_sessions.go
@@ -151,6 +151,8 @@ func (m *model) newSession() error {
 	m.pasteTransaction = pasteTransactionState{}
 	m.ensurePastedContentState()
 	m.pendingBTW = nil
+	m.pendingInterrupt = false
+	m.pendingInterruptReason = ""
 	m.interrupting = false
 	m.interruptSafe = false
 	m.runCancel = nil
@@ -209,6 +211,8 @@ func (m *model) resumeSession(prefix string) error {
 	m.ensurePastedContentState()
 	m.syncInputImageRefs("")
 	m.pendingBTW = nil
+	m.pendingInterrupt = false
+	m.pendingInterruptReason = ""
 	m.interrupting = false
 	m.interruptSafe = false
 	m.runCancel = nil

--- a/tui/model.go
+++ b/tui/model.go
@@ -450,6 +450,8 @@ type model struct {
 	clipboardText              clipboardTextWriter
 	runCancel                  context.CancelFunc
 	pendingBTW                 []string
+	pendingInterrupt           bool
+	pendingInterruptReason     string
 	interrupting               bool
 	interruptSafe              bool
 	runSeq                     int
@@ -674,6 +676,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.runCancel = nil
 		m.activeRunID = 0
 		m.interruptSafe = false
+		m.pendingInterrupt = false
+		m.pendingInterruptReason = ""
 		shouldResumeBTW := m.interrupting && len(m.pendingBTW) > 0
 		m.interrupting = false
 		finishReason := classifyRunFinish(msg.Err, shouldResumeBTW)

--- a/tui/model.go
+++ b/tui/model.go
@@ -1278,9 +1278,55 @@ func (m model) mouseOverLandingInput(y int) bool {
 	return y >= inputTop && y <= inputBottom
 }
 
+func (m model) handleEscKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.approval != nil {
+		m.resolveApprovalDecision(false)
+		return m, nil
+	}
+	if m.promptSearchOpen {
+		return m.handlePromptSearchKey(msg)
+	}
+	if m.planActionOpen {
+		return m.handlePlanActionKey(msg)
+	}
+	if m.helpOpen {
+		m.helpOpen = false
+		return m, nil
+	}
+	if m.commandOpen {
+		return m.handleCommandPaletteKey(msg)
+	}
+	if m.skillsOpen {
+		m.skillsOpen = false
+		m.commandCursor = 0
+		return m, nil
+	}
+	if m.mentionOpen {
+		return m.handleMentionPaletteKey(msg)
+	}
+	if m.sessionsOpen {
+		return m.handleSessionsModalKey(msg)
+	}
+	if m.requestRunInterrupt("esc") {
+		if m.width > 0 && m.height > 0 {
+			m.syncLayoutForCurrentScreen()
+			m.refreshViewport()
+		}
+		return m, nil
+	}
+	if m.hasCopyableSelection() {
+		m.clearMouseSelection()
+		m.clearInputSelection()
+		m.statusNote = "Selection cleared."
+		return m, nil
+	}
+	return m, nil
+}
+
 func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	pasteDebugf("handleKey %s %s", summarizePasteMsg(msg), m.pasteDebugState())
-	switch msg.String() {
+	key := msg.String()
+	switch key {
 	case "ctrl+c":
 		if m.hasCopyableSelection() {
 			return m, m.copyCurrentSelection()
@@ -1292,6 +1338,8 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.runCancel()
 		}
 		return m, tea.Quit
+	case "esc":
+		return m.handleEscKey(msg)
 	}
 
 	if m.promptSearchOpen {
@@ -1327,14 +1375,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.ingestPasteFragment(fragment, source)
 	}
 
-	switch msg.String() {
-	case "esc":
-		if m.hasCopyableSelection() {
-			m.clearMouseSelection()
-			m.clearInputSelection()
-			m.statusNote = "Selection cleared."
-			return m, nil
-		}
+	switch key {
 	case "tab":
 		if m.commandOpen || m.mentionOpen || m.sessionsOpen || m.helpOpen || m.approval != nil || m.planActionOpen {
 			break
@@ -1366,7 +1407,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.approval != nil {
-		switch msg.String() {
+		switch key {
 		case "left", "h", "up", "k", "shift+tab", "backtab":
 			m.setApprovalChoice(approvalChoiceApprove)
 		case "right", "l", "down", "j", "tab":
@@ -1382,7 +1423,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.helpOpen {
-		if msg.String() == "esc" || msg.String() == "ctrl+g" {
+		if key == "esc" || key == "ctrl+g" {
 			m.helpOpen = false
 		}
 		return m, nil
@@ -1407,7 +1448,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		switch msg.String() {
+		switch key {
 		case "esc":
 			m.skillsOpen = false
 			m.commandCursor = 0
@@ -1487,7 +1528,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	switch msg.String() {
+	switch key {
 	case "ctrl+l":
 		if !m.busy {
 			if err := m.openSessionsModal(); err != nil {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -4204,6 +4204,29 @@ func TestEscapeClosesPromptSearchBeforeInterruptingRun(t *testing.T) {
 	}
 }
 
+func TestEscapeClosesSessionsModalBeforeInterruptingRun(t *testing.T) {
+	canceled := false
+	m := model{
+		screen:       screenChat,
+		busy:         true,
+		runCancel:    func() { canceled = true },
+		sessionsOpen: true,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if updated.sessionsOpen {
+		t.Fatalf("expected esc to close sessions modal first")
+	}
+	if canceled {
+		t.Fatalf("expected esc not to interrupt run while sessions modal is open")
+	}
+	if updated.interrupting {
+		t.Fatalf("expected interrupting to stay false when esc only closes sessions modal")
+	}
+}
+
 func TestEscapePrioritizesApprovalOverPromptSearch(t *testing.T) {
 	reply := make(chan approvalDecision, 1)
 	m := model{

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -4300,6 +4300,35 @@ func TestEscapeClosesCommandPaletteBeforeInterruptingRun(t *testing.T) {
 	}
 }
 
+func TestEscapeClosesMentionPaletteBeforeInterruptingRun(t *testing.T) {
+	canceled := false
+	input := textarea.New()
+	input.SetValue("@mod")
+	m := model{
+		screen:    screenChat,
+		busy:      true,
+		runCancel: func() { canceled = true },
+		input:     input,
+		mentionIndex: mention.NewStaticWorkspaceFileIndex([]mention.Candidate{
+			{Path: "tui/model.go", BaseName: "model.go"},
+		}, 0, false),
+	}
+	m.syncInputOverlays()
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if updated.mentionOpen {
+		t.Fatalf("expected esc to close mention palette first")
+	}
+	if canceled {
+		t.Fatalf("expected esc not to interrupt run while mention palette is open")
+	}
+	if updated.interrupting {
+		t.Fatalf("expected interrupting to stay false when esc only closes mention palette")
+	}
+}
+
 func TestEscapePrioritizesApprovalOverPromptSearch(t *testing.T) {
 	reply := make(chan approvalDecision, 1)
 	m := model{

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -4274,6 +4274,32 @@ func TestEscapeClosesPlanActionPickerBeforeInterruptingRun(t *testing.T) {
 	}
 }
 
+func TestEscapeClosesCommandPaletteBeforeInterruptingRun(t *testing.T) {
+	canceled := false
+	input := textarea.New()
+	input.SetValue("/h")
+	m := model{
+		screen:      screenChat,
+		busy:        true,
+		runCancel:   func() { canceled = true },
+		commandOpen: true,
+		input:       input,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if updated.commandOpen {
+		t.Fatalf("expected esc to close command palette first")
+	}
+	if canceled {
+		t.Fatalf("expected esc not to interrupt run while command palette is open")
+	}
+	if updated.interrupting {
+		t.Fatalf("expected interrupting to stay false when esc only closes command palette")
+	}
+}
+
 func TestEscapePrioritizesApprovalOverPromptSearch(t *testing.T) {
 	reply := make(chan approvalDecision, 1)
 	m := model{

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -6110,10 +6110,11 @@ func TestSubmitBTWWithoutRunCancelRestartsImmediately(t *testing.T) {
 func TestToolCallCompletedTriggersDeferredBTWCancel(t *testing.T) {
 	canceled := false
 	m := model{
-		interrupting:  true,
-		interruptSafe: true,
-		pendingBTW:    []string{"change plan"},
-		runCancel:     func() { canceled = true },
+		interrupting:     true,
+		interruptSafe:    true,
+		pendingBTW:       []string{"change plan"},
+		pendingInterrupt: true,
+		runCancel:        func() { canceled = true },
 	}
 
 	m.handleAgentEvent(Event{
@@ -6128,8 +6129,41 @@ func TestToolCallCompletedTriggersDeferredBTWCancel(t *testing.T) {
 	if m.interruptSafe {
 		t.Fatalf("expected deferred interrupt flag to clear after cancel")
 	}
+	if m.pendingInterrupt {
+		t.Fatalf("expected pending interrupt flag to clear after deferred cancel")
+	}
 	if m.phase != "interrupting" {
 		t.Fatalf("expected phase to switch to interrupting, got %q", m.phase)
+	}
+}
+
+func TestToolCallCompletedTriggersDeferredInterruptWithoutBTWQueue(t *testing.T) {
+	canceled := false
+	m := model{
+		interrupting:           true,
+		interruptSafe:          true,
+		pendingInterrupt:       true,
+		pendingInterruptReason: "esc",
+		runCancel:              func() { canceled = true },
+	}
+
+	m.handleAgentEvent(Event{
+		Type:       EventToolCallCompleted,
+		ToolName:   "read_file",
+		ToolResult: `{"path":"tui/model.go","start_line":1,"end_line":3}`,
+	})
+
+	if !canceled {
+		t.Fatalf("expected deferred interrupt cancel to trigger after tool completion")
+	}
+	if m.interruptSafe {
+		t.Fatalf("expected deferred interruptSafe to clear after cancel")
+	}
+	if m.pendingInterrupt {
+		t.Fatalf("expected deferred pendingInterrupt to clear after cancel")
+	}
+	if m.pendingInterruptReason != "" {
+		t.Fatalf("expected deferred interrupt reason to clear after cancel, got %q", m.pendingInterruptReason)
 	}
 }
 
@@ -6181,6 +6215,27 @@ func TestRunFinishedWithPendingBTWRestartsRun(t *testing.T) {
 	}
 	if updated.activeRunID == 0 {
 		t.Fatalf("expected resumed run to have a new active run id")
+	}
+}
+
+func TestRunFinishedClearsPendingInterruptState(t *testing.T) {
+	m := model{
+		async:                  make(chan tea.Msg, 1),
+		busy:                   true,
+		activeRunID:            4,
+		interrupting:           true,
+		pendingInterrupt:       true,
+		pendingInterruptReason: "esc",
+	}
+
+	got, _ := m.Update(runFinishedMsg{RunID: 4, Err: context.Canceled})
+	updated := got.(model)
+
+	if updated.pendingInterrupt {
+		t.Fatalf("expected pending interrupt flag to clear after run finish")
+	}
+	if updated.pendingInterruptReason != "" {
+		t.Fatalf("expected pending interrupt reason to clear after run finish, got %q", updated.pendingInterruptReason)
 	}
 }
 
@@ -6288,15 +6343,17 @@ func TestNewSessionClearsInterruptState(t *testing.T) {
 	input := textarea.New()
 	input.SetValue("pending input")
 	m := model{
-		store:         store,
-		sess:          current,
-		workspace:     workspace,
-		input:         input,
-		pendingBTW:    []string{"keep this"},
-		interrupting:  true,
-		interruptSafe: true,
-		runCancel:     func() {},
-		activeRunID:   9,
+		store:                  store,
+		sess:                   current,
+		workspace:              workspace,
+		input:                  input,
+		pendingBTW:             []string{"keep this"},
+		pendingInterrupt:       true,
+		pendingInterruptReason: "esc",
+		interrupting:           true,
+		interruptSafe:          true,
+		runCancel:              func() {},
+		activeRunID:            9,
 	}
 
 	if err := m.newSession(); err != nil {
@@ -6307,6 +6364,9 @@ func TestNewSessionClearsInterruptState(t *testing.T) {
 	}
 	if len(m.pendingBTW) != 0 {
 		t.Fatalf("expected pending btw queue cleared, got %#v", m.pendingBTW)
+	}
+	if m.pendingInterrupt || m.pendingInterruptReason != "" {
+		t.Fatalf("expected pending interrupt state cleared, got pending=%v reason=%q", m.pendingInterrupt, m.pendingInterruptReason)
 	}
 	if m.runCancel != nil {
 		t.Fatalf("expected runCancel cleared on new session")
@@ -6338,15 +6398,17 @@ func TestResumeSessionClearsInterruptState(t *testing.T) {
 	}
 
 	m := model{
-		store:         store,
-		sess:          current,
-		workspace:     workspace,
-		sessions:      []session.Summary{{ID: target.ID}},
-		pendingBTW:    []string{"queued"},
-		interrupting:  true,
-		interruptSafe: true,
-		runCancel:     func() {},
-		activeRunID:   7,
+		store:                  store,
+		sess:                   current,
+		workspace:              workspace,
+		sessions:               []session.Summary{{ID: target.ID}},
+		pendingBTW:             []string{"queued"},
+		pendingInterrupt:       true,
+		pendingInterruptReason: "esc",
+		interrupting:           true,
+		interruptSafe:          true,
+		runCancel:              func() {},
+		activeRunID:            7,
 	}
 
 	if err := m.resumeSession(target.ID); err != nil {
@@ -6360,6 +6422,9 @@ func TestResumeSessionClearsInterruptState(t *testing.T) {
 	}
 	if len(m.pendingBTW) != 0 {
 		t.Fatalf("expected pending btw queue cleared, got %#v", m.pendingBTW)
+	}
+	if m.pendingInterrupt || m.pendingInterruptReason != "" {
+		t.Fatalf("expected pending interrupt state cleared, got pending=%v reason=%q", m.pendingInterrupt, m.pendingInterruptReason)
 	}
 	if m.runCancel != nil {
 		t.Fatalf("expected runCancel cleared on resume")

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -4143,6 +4143,100 @@ func TestEscapeClosesCommandPalette(t *testing.T) {
 	}
 }
 
+func TestEscapeDuringBusyInterruptsBeforeClearingSelection(t *testing.T) {
+	canceled := false
+	m := model{
+		screen:               screenChat,
+		busy:                 true,
+		runCancel:            func() { canceled = true },
+		phase:                "thinking",
+		inputSelectionActive: true,
+		inputSelectionStart:  viewportSelectionPoint{Col: 0, Row: 0},
+		inputSelectionEnd:    viewportSelectionPoint{Col: 2, Row: 0},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if !canceled {
+		t.Fatalf("expected esc to request run interrupt before clearing selection")
+	}
+	if !updated.interrupting {
+		t.Fatalf("expected esc to set interrupting state")
+	}
+	if !updated.inputSelectionActive {
+		t.Fatalf("expected esc interrupt path not to clear existing selection")
+	}
+	if updated.statusNote != "Interrupt requested. Stopping current run..." {
+		t.Fatalf("expected esc interrupt status note, got %q", updated.statusNote)
+	}
+}
+
+func TestEscapeClosesPromptSearchBeforeInterruptingRun(t *testing.T) {
+	canceled := false
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("draft")
+
+	m := model{
+		screen:                screenChat,
+		busy:                  true,
+		runCancel:             func() { canceled = true },
+		input:                 input,
+		promptSearchOpen:      true,
+		promptSearchBaseInput: "draft",
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if updated.promptSearchOpen {
+		t.Fatalf("expected esc to close prompt search first")
+	}
+	if canceled {
+		t.Fatalf("expected esc not to interrupt run while prompt search overlay is open")
+	}
+	if updated.interrupting {
+		t.Fatalf("expected interrupting to stay false when esc only closes prompt search")
+	}
+	if updated.statusNote != "Prompt search canceled." {
+		t.Fatalf("expected prompt search cancel note, got %q", updated.statusNote)
+	}
+}
+
+func TestEscapePrioritizesApprovalOverPromptSearch(t *testing.T) {
+	reply := make(chan approvalDecision, 1)
+	m := model{
+		approval: &approvalPrompt{
+			Command: "write_file",
+			Reason:  "needs approval",
+			Reply:   reply,
+			Kind:    approvalPromptKindTool,
+			Choice:  approvalChoiceApprove,
+		},
+		promptSearchOpen: true,
+		phase:            "approval",
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if updated.approval != nil {
+		t.Fatalf("expected esc to resolve approval first")
+	}
+	if !updated.promptSearchOpen {
+		t.Fatalf("expected prompt search to remain open when esc is consumed by approval")
+	}
+	select {
+	case decision := <-reply:
+		if decision.Approved {
+			t.Fatalf("expected esc approval decision to reject")
+		}
+	default:
+		t.Fatalf("expected approval decision to be sent")
+	}
+}
+
 func TestCommandPaletteEnterOnQuitReturnsQuitCmd(t *testing.T) {
 	input := textarea.New()
 	input.SetValue("/quit")

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -6550,6 +6550,37 @@ func TestRunFinishedClearsPendingInterruptStateOnFailure(t *testing.T) {
 	}
 }
 
+func TestRunFinishedClearsToolPhaseEscInterruptStateWithoutExtraCancel(t *testing.T) {
+	cancelCalls := 0
+	m := model{
+		async:       make(chan tea.Msg, 1),
+		busy:        true,
+		activeRunID: 12,
+		phase:       "tool",
+		runCancel:   func() { cancelCalls++ },
+	}
+
+	if !m.requestRunInterrupt("esc") {
+		t.Fatalf("expected esc interrupt request to be accepted during tool phase")
+	}
+	if !m.pendingInterrupt || !m.interruptSafe || !m.interrupting {
+		t.Fatalf("expected tool-phase esc interrupt to set deferred flags")
+	}
+
+	got, _ := m.Update(runFinishedMsg{RunID: 12, Err: nil})
+	updated := got.(model)
+
+	if cancelCalls != 0 {
+		t.Fatalf("expected no additional cancel call when run already finished, got %d", cancelCalls)
+	}
+	if updated.pendingInterrupt || updated.pendingInterruptReason != "" {
+		t.Fatalf("expected pending interrupt state cleared after normal run finish, got pending=%v reason=%q", updated.pendingInterrupt, updated.pendingInterruptReason)
+	}
+	if updated.interrupting || updated.interruptSafe {
+		t.Fatalf("expected interrupt flags cleared after normal run finish, got interrupting=%v interruptSafe=%v", updated.interrupting, updated.interruptSafe)
+	}
+}
+
 func TestClassifyRunFinish(t *testing.T) {
 	if got := classifyRunFinish(nil, false); got != runFinishReasonCompleted {
 		t.Fatalf("expected completed, got %q", got)

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -4250,6 +4250,30 @@ func TestEscapeClosesHelpOverlayBeforeInterruptingRun(t *testing.T) {
 	}
 }
 
+func TestEscapeClosesPlanActionPickerBeforeInterruptingRun(t *testing.T) {
+	canceled := false
+	m := model{
+		screen:         screenChat,
+		busy:           true,
+		runCancel:      func() { canceled = true },
+		planActionOpen: true,
+		mode:           modePlan,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if updated.planActionOpen {
+		t.Fatalf("expected esc to close plan action picker first")
+	}
+	if canceled {
+		t.Fatalf("expected esc not to interrupt run while plan action picker is open")
+	}
+	if updated.interrupting {
+		t.Fatalf("expected interrupting to stay false when esc only closes plan action picker")
+	}
+}
+
 func TestEscapePrioritizesApprovalOverPromptSearch(t *testing.T) {
 	reply := make(chan approvalDecision, 1)
 	m := model{

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -6377,6 +6377,27 @@ func TestRunFinishedClearsPendingInterruptState(t *testing.T) {
 	}
 }
 
+func TestRunFinishedClearsPendingInterruptStateOnFailure(t *testing.T) {
+	m := model{
+		async:                  make(chan tea.Msg, 1),
+		busy:                   true,
+		activeRunID:            5,
+		interrupting:           true,
+		pendingInterrupt:       true,
+		pendingInterruptReason: "esc",
+	}
+
+	got, _ := m.Update(runFinishedMsg{RunID: 5, Err: errors.New("network unavailable")})
+	updated := got.(model)
+
+	if updated.pendingInterrupt {
+		t.Fatalf("expected pending interrupt flag to clear after failed run finish")
+	}
+	if updated.pendingInterruptReason != "" {
+		t.Fatalf("expected pending interrupt reason cleared after failed run finish, got %q", updated.pendingInterruptReason)
+	}
+}
+
 func TestClassifyRunFinish(t *testing.T) {
 	if got := classifyRunFinish(nil, false); got != runFinishReasonCompleted {
 		t.Fatalf("expected completed, got %q", got)

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -4329,6 +4329,33 @@ func TestEscapeClosesMentionPaletteBeforeInterruptingRun(t *testing.T) {
 	}
 }
 
+func TestEscapeClosesSkillsPickerBeforeInterruptingRun(t *testing.T) {
+	canceled := false
+	m := model{
+		screen:        screenChat,
+		busy:          true,
+		runCancel:     func() { canceled = true },
+		skillsOpen:    true,
+		commandCursor: 3,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if updated.skillsOpen {
+		t.Fatalf("expected esc to close skills picker first")
+	}
+	if updated.commandCursor != 0 {
+		t.Fatalf("expected esc to reset skills cursor, got %d", updated.commandCursor)
+	}
+	if canceled {
+		t.Fatalf("expected esc not to interrupt run while skills picker is open")
+	}
+	if updated.interrupting {
+		t.Fatalf("expected interrupting to stay false when esc only closes skills picker")
+	}
+}
+
 func TestEscapePrioritizesApprovalOverPromptSearch(t *testing.T) {
 	reply := make(chan approvalDecision, 1)
 	m := model{

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -4227,6 +4227,29 @@ func TestEscapeClosesSessionsModalBeforeInterruptingRun(t *testing.T) {
 	}
 }
 
+func TestEscapeClosesHelpOverlayBeforeInterruptingRun(t *testing.T) {
+	canceled := false
+	m := model{
+		screen:    screenChat,
+		busy:      true,
+		runCancel: func() { canceled = true },
+		helpOpen:  true,
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if updated.helpOpen {
+		t.Fatalf("expected esc to close help overlay first")
+	}
+	if canceled {
+		t.Fatalf("expected esc not to interrupt run while help overlay is open")
+	}
+	if updated.interrupting {
+		t.Fatalf("expected interrupting to stay false when esc only closes help overlay")
+	}
+}
+
 func TestEscapePrioritizesApprovalOverPromptSearch(t *testing.T) {
 	reply := make(chan approvalDecision, 1)
 	m := model{

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -6457,6 +6457,33 @@ func TestToolCallCompletedTriggersDeferredInterruptWithoutBTWQueue(t *testing.T)
 	}
 }
 
+func TestToolCallCompletedDeferredInterruptCancelsAtMostOnce(t *testing.T) {
+	cancelCalls := 0
+	m := model{
+		interrupting:     true,
+		interruptSafe:    true,
+		pendingInterrupt: true,
+		runCancel:        func() { cancelCalls++ },
+	}
+
+	first := Event{
+		Type:       EventToolCallCompleted,
+		ToolName:   "read_file",
+		ToolResult: `{"path":"tui/model.go","start_line":1,"end_line":3}`,
+	}
+	second := Event{
+		Type:       EventToolCallCompleted,
+		ToolName:   "read_file",
+		ToolResult: `{"path":"tui/model.go","start_line":4,"end_line":6}`,
+	}
+	m.handleAgentEvent(first)
+	m.handleAgentEvent(second)
+
+	if cancelCalls != 1 {
+		t.Fatalf("expected deferred interrupt cancel to trigger once, got %d", cancelCalls)
+	}
+}
+
 func TestRunFinishedWithPendingBTWRestartsRun(t *testing.T) {
 	m := model{
 		async:        make(chan tea.Msg, 1),

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -4237,6 +4237,50 @@ func TestEscapePrioritizesApprovalOverPromptSearch(t *testing.T) {
 	}
 }
 
+func TestEscapeWhileInterruptingDoesNotInvokeRunCancelAgain(t *testing.T) {
+	cancelCalls := 0
+	m := model{
+		screen:       screenChat,
+		busy:         true,
+		interrupting: true,
+		runCancel:    func() { cancelCalls++ },
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if cancelCalls != 0 {
+		t.Fatalf("expected esc while already interrupting not to call runCancel again, got %d", cancelCalls)
+	}
+	if !updated.interrupting {
+		t.Fatalf("expected interrupting state to stay true")
+	}
+	if updated.statusNote != "Interrupt already requested. Waiting for current run to stop..." {
+		t.Fatalf("expected repeated interrupt hint, got %q", updated.statusNote)
+	}
+}
+
+func TestEscapeFallsBackToSelectionClearWhenRunIsNotCancelable(t *testing.T) {
+	m := model{
+		screen:               screenChat,
+		busy:                 true,
+		runCancel:            nil,
+		inputSelectionActive: true,
+		inputSelectionStart:  viewportSelectionPoint{Col: 0, Row: 0},
+		inputSelectionEnd:    viewportSelectionPoint{Col: 3, Row: 0},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := got.(model)
+
+	if updated.inputSelectionActive {
+		t.Fatalf("expected esc to clear selection when no cancelable run exists")
+	}
+	if updated.statusNote != "Selection cleared." {
+		t.Fatalf("expected selection cleared note, got %q", updated.statusNote)
+	}
+}
+
 func TestCommandPaletteEnterOnQuitReturnsQuitCmd(t *testing.T) {
 	input := textarea.New()
 	input.SetValue("/quit")


### PR DESCRIPTION
## 变更目标
为 TUI 增加可用的运行中断能力：当任务执行中，用户可通过 `Esc` 请求中断当前 run，并保持交互优先级一致、状态清理完整。

## 范围说明
- 仅修改 `tui` 相关代码
- 未改动其他模块功能
- 按 MVP 实现，避免过度设计

## 主要改动
1. 中断状态拆分
- 新增独立中断状态（`pendingInterrupt` / `pendingInterruptReason`）
- 不再复用 `pendingBTW` 队列语义承载 Esc 中断

2. Esc 路由优先级收口
- 统一为：`approval -> overlay/modal -> run interrupt -> selection clear -> no-op`
- 修复原先 Esc 路由分散导致的优先级不一致问题

3. tool 阶段延迟取消
- 在 tool 阶段请求中断时先进入 pending，待 `EventToolCallCompleted` 后触发 cancel
- 覆盖 run finished 收尾清理，避免中断脏状态残留

4. Footer 动态提示
- 仅在 `busy && runCancel != nil` 时显示 `Esc interrupt`
- 非可中断状态不显示该提示，避免误导

## 测试
已执行：
- `go test ./tui -count=1`
- 若干针对性用例（Esc 优先级、中断边界、收尾清理、footer 提示）

## 风险与兼容性
- 无外部接口变更
- 变更集中在 `tui`，兼容现有 BTW 中断流程
