### PR TITLE
fix(model): 配置加载顺序和path顺序有问题

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -27,7 +27,7 @@ func LoadRuntimeConfig(req ConfigRequest) (config.Config, error) {
 		return cfg, err
 	}
 	if req.ModelOverride != "" {
-		cfg.Provider.Model = req.ModelOverride
+		applyModelOverride(&cfg, req.ModelOverride)
 	}
 	if req.StreamOverride != "" {
 		parsed, err := strconv.ParseBool(req.StreamOverride)
@@ -85,4 +85,33 @@ func LoadRuntimeConfig(req ConfigRequest) (config.Config, error) {
 		return cfg, fmt.Errorf("system_sandbox_mode requires sandbox_enabled=true (set -sandbox-enabled true)")
 	}
 	return cfg, nil
+}
+
+func applyModelOverride(cfg *config.Config, model string) {
+	if cfg == nil {
+		return
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return
+	}
+	cfg.Provider.Model = model
+	cfg.ProviderRuntime.DefaultModel = model
+	if len(cfg.ProviderRuntime.Providers) == 0 {
+		return
+	}
+	defaultProvider := strings.ToLower(strings.TrimSpace(cfg.ProviderRuntime.DefaultProvider))
+	if defaultProvider != "" {
+		if providerCfg, ok := cfg.ProviderRuntime.Providers[defaultProvider]; ok {
+			providerCfg.Model = model
+			cfg.ProviderRuntime.Providers[defaultProvider] = providerCfg
+			return
+		}
+	}
+	if len(cfg.ProviderRuntime.Providers) == 1 {
+		for id, providerCfg := range cfg.ProviderRuntime.Providers {
+			providerCfg.Model = model
+			cfg.ProviderRuntime.Providers[id] = providerCfg
+		}
+	}
 }

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -67,6 +67,66 @@ func TestLoadRuntimeConfigAppliesOverrides(t *testing.T) {
 	}
 }
 
+func TestApplyModelOverrideHandlesEmptyAndSingleProviderRuntime(t *testing.T) {
+	applyModelOverride(nil, "gpt-5.4")
+
+	cfg := config.Config{
+		Provider: config.ProviderConfig{Model: "base-model"},
+		ProviderRuntime: config.ProviderRuntimeConfig{
+			DefaultModel: "base-model",
+			Providers: map[string]config.ProviderConfig{
+				"deepseek": {Model: "deepseek-old"},
+			},
+		},
+	}
+	applyModelOverride(&cfg, " ")
+	if cfg.Provider.Model != "base-model" {
+		t.Fatalf("blank model override should be ignored, got %q", cfg.Provider.Model)
+	}
+	if cfg.ProviderRuntime.Providers["deepseek"].Model != "deepseek-old" {
+		t.Fatalf("blank model override should not change runtime provider, got %#v", cfg.ProviderRuntime.Providers["deepseek"])
+	}
+
+	applyModelOverride(&cfg, "deepseek-chat")
+	if cfg.Provider.Model != "deepseek-chat" {
+		t.Fatalf("expected provider model override, got %q", cfg.Provider.Model)
+	}
+	if cfg.ProviderRuntime.DefaultModel != "deepseek-chat" {
+		t.Fatalf("expected runtime default model override, got %q", cfg.ProviderRuntime.DefaultModel)
+	}
+	if cfg.ProviderRuntime.Providers["deepseek"].Model != "deepseek-chat" {
+		t.Fatalf("expected single runtime provider model override, got %#v", cfg.ProviderRuntime.Providers["deepseek"])
+	}
+}
+
+func TestApplyModelOverrideLeavesMultipleRuntimeProvidersWhenDefaultMissing(t *testing.T) {
+	cfg := config.Config{
+		Provider: config.ProviderConfig{Model: "base-model"},
+		ProviderRuntime: config.ProviderRuntimeConfig{
+			DefaultProvider: "missing",
+			DefaultModel:    "base-model",
+			Providers: map[string]config.ProviderConfig{
+				"openai":   {Model: "gpt-5.4-mini"},
+				"deepseek": {Model: "deepseek-chat"},
+			},
+		},
+	}
+
+	applyModelOverride(&cfg, "gpt-5.4")
+	if cfg.Provider.Model != "gpt-5.4" {
+		t.Fatalf("expected legacy provider model override, got %q", cfg.Provider.Model)
+	}
+	if cfg.ProviderRuntime.DefaultModel != "gpt-5.4" {
+		t.Fatalf("expected runtime default model override, got %q", cfg.ProviderRuntime.DefaultModel)
+	}
+	if cfg.ProviderRuntime.Providers["openai"].Model != "gpt-5.4-mini" {
+		t.Fatalf("expected non-default openai provider model to remain unchanged, got %#v", cfg.ProviderRuntime.Providers["openai"])
+	}
+	if cfg.ProviderRuntime.Providers["deepseek"].Model != "deepseek-chat" {
+		t.Fatalf("expected non-default deepseek provider model to remain unchanged, got %#v", cfg.ProviderRuntime.Providers["deepseek"])
+	}
+}
+
 func TestLoadRuntimeConfigRejectsLegacyAwayApprovalModeOverrideByDefault(t *testing.T) {
 	workspace := t.TempDir()
 	writeCfg := `{

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -41,6 +41,12 @@ func TestLoadRuntimeConfigAppliesOverrides(t *testing.T) {
 	if cfg.Provider.Model != "gpt-5.4" {
 		t.Fatalf("unexpected model: %q", cfg.Provider.Model)
 	}
+	if cfg.ProviderRuntime.DefaultModel != "gpt-5.4" {
+		t.Fatalf("unexpected runtime default model: %q", cfg.ProviderRuntime.DefaultModel)
+	}
+	if providerCfg := cfg.ProviderRuntime.Providers["openai"]; providerCfg.Model != "gpt-5.4" {
+		t.Fatalf("unexpected runtime provider model: %q", providerCfg.Model)
+	}
 	if !cfg.Stream {
 		t.Fatal("expected stream=true")
 	}

--- a/internal/app/startup_guide.go
+++ b/internal/app/startup_guide.go
@@ -37,6 +37,11 @@ func ConfigPathHint(workspace, explicit string) string {
 		return explicit
 	}
 
+	home, err := config.ResolveHomeDir()
+	if err == nil {
+		return filepath.Join(home, "config.json")
+	}
+
 	candidates := []string{
 		filepath.Join(workspace, "config.json"),
 		filepath.Join(workspace, ".bytemind", "config.json"),
@@ -47,11 +52,7 @@ func ConfigPathHint(workspace, explicit string) string {
 			return candidate
 		}
 	}
-	home, err := config.ResolveHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, "config.json")
+	return ""
 }
 
 func CompactLine(raw string, limit int) string {

--- a/internal/app/startup_guide_test.go
+++ b/internal/app/startup_guide_test.go
@@ -38,6 +38,9 @@ func TestStartupIssueHint(t *testing.T) {
 
 func TestConfigPathHint(t *testing.T) {
 	workspace := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", home)
+
 	explicit := filepath.Join(workspace, "custom.json")
 	got := ConfigPathHint(workspace, explicit)
 	if !strings.HasSuffix(got, "custom.json") {
@@ -49,8 +52,9 @@ func TestConfigPathHint(t *testing.T) {
 		t.Fatal(err)
 	}
 	got = ConfigPathHint(workspace, "")
-	if filepath.Clean(got) != filepath.Clean(defaultPath) {
-		t.Fatalf("expected workspace config path %q, got %q", defaultPath, got)
+	userConfig := filepath.Join(home, "config.json")
+	if filepath.Clean(got) != filepath.Clean(userConfig) {
+		t.Fatalf("expected user config path %q, got %q", userConfig, got)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -231,6 +231,7 @@ func Load(workspace, configPath string) (Config, error) {
 
 func LoadWithMCPConfigPath(workspace, configPath, mcpConfigPath string) (Config, error) {
 	cfg := Default(workspace)
+	var userProviderOverride map[string]json.RawMessage
 
 	if strings.TrimSpace(configPath) != "" {
 		path, err := resolveConfigPath(workspace, configPath)
@@ -247,12 +248,20 @@ func LoadWithMCPConfigPath(workspace, configPath, mcpConfigPath string) (Config,
 			if err := mergeConfigFromFile(userConfig, &cfg); err != nil {
 				return cfg, err
 			}
+			userProviderOverride, err = loadUserProviderOverride(userConfig)
+			if err != nil {
+				return cfg, err
+			}
 		}
 
 		if projectConfig := resolveProjectConfigPath(workspace); projectConfig != "" {
 			if err := mergeConfigFromFile(projectConfig, &cfg); err != nil {
 				return cfg, err
 			}
+		}
+
+		if err := mergeProviderOverride(userProviderOverride, &cfg); err != nil {
+			return cfg, err
 		}
 	}
 
@@ -476,6 +485,84 @@ func mergeConfigFromFile(path string, cfg *Config) error {
 		return err
 	}
 	return nil
+}
+
+func loadUserProviderOverride(path string) (map[string]json.RawMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	if !hasProviderCredential(raw) {
+		return nil, nil
+	}
+	return raw, nil
+}
+
+func mergeProviderOverride(raw map[string]json.RawMessage, cfg *Config) error {
+	if raw == nil || cfg == nil {
+		return nil
+	}
+	providerOverridden := false
+	if providerRaw, ok := raw["provider"]; ok {
+		if err := json.Unmarshal(providerRaw, &cfg.Provider); err != nil {
+			return err
+		}
+		providerOverridden = true
+	}
+	if runtimeRaw, ok := raw["provider_runtime"]; ok {
+		if err := json.Unmarshal(runtimeRaw, &cfg.ProviderRuntime); err != nil {
+			return err
+		}
+	} else if providerOverridden {
+		cfg.ProviderRuntime = ProviderRuntimeConfig{}
+	}
+	return nil
+}
+
+func hasProviderCredential(raw map[string]json.RawMessage) bool {
+	if providerRaw, ok := raw["provider"]; ok && providerRawHasCredential(providerRaw) {
+		return true
+	}
+	runtimeRaw, ok := raw["provider_runtime"]
+	if !ok {
+		return false
+	}
+	var runtime struct {
+		Providers map[string]json.RawMessage `json:"providers"`
+	}
+	if err := json.Unmarshal(runtimeRaw, &runtime); err != nil {
+		return false
+	}
+	for _, providerRaw := range runtime.Providers {
+		if providerRawHasCredential(providerRaw) {
+			return true
+		}
+	}
+	return false
+}
+
+func providerRawHasCredential(raw json.RawMessage) bool {
+	var provider map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &provider); err != nil {
+		return false
+	}
+	if valueRaw, ok := provider["api_key"]; ok {
+		var value string
+		if err := json.Unmarshal(valueRaw, &value); err == nil && strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	if valueRaw, ok := provider["api_key_env"]; ok {
+		var value string
+		if err := json.Unmarshal(valueRaw, &value); err == nil && strings.TrimSpace(os.Getenv(strings.TrimSpace(value))) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func mergeMCPConfigFromFile(path string, cfg *MCPConfig) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -597,6 +597,172 @@ func TestLoadUserProviderPrecedenceResetsProjectProviderRuntime(t *testing.T) {
 	}
 }
 
+func TestLoadUserProviderOverrideHandlesMissingMalformedAndRuntimeOnlyConfigs(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BYTEMIND_TEST_MISSING_PROVIDER_KEY", "")
+
+	_, err := loadUserProviderOverride(filepath.Join(dir, "missing.json"))
+	if err == nil {
+		t.Fatal("expected missing user provider override to fail")
+	}
+
+	malformedPath := filepath.Join(dir, "malformed.json")
+	if err := os.WriteFile(malformedPath, []byte(`{"provider":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = loadUserProviderOverride(malformedPath)
+	if err == nil {
+		t.Fatal("expected malformed user provider override to fail")
+	}
+
+	uncredentialedPath := filepath.Join(dir, "uncredentialed.json")
+	if err := writeConfig(uncredentialedPath, map[string]any{
+		"provider": map[string]any{
+			"type":        "openai-compatible",
+			"model":       "gpt-5.4-mini",
+			"api_key":     " ",
+			"api_key_env": "BYTEMIND_TEST_MISSING_PROVIDER_KEY",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := loadUserProviderOverride(uncredentialedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw != nil {
+		t.Fatalf("expected uncredentialed user provider override to be ignored, got %#v", raw)
+	}
+
+	runtimeOnlyPath := filepath.Join(dir, "runtime-only.json")
+	if err := writeConfig(runtimeOnlyPath, map[string]any{
+		"provider_runtime": map[string]any{
+			"default_provider": "deepseek",
+			"default_model":    "deepseek-chat",
+			"providers": map[string]any{
+				"deepseek": map[string]any{
+					"type":     "openai-compatible",
+					"base_url": "https://api.deepseek.com",
+					"model":    "deepseek-chat",
+					"api_key":  "runtime-key",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = loadUserProviderOverride(runtimeOnlyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw == nil {
+		t.Fatal("expected credentialed runtime provider override")
+	}
+	if _, ok := raw["provider_runtime"]; !ok {
+		t.Fatalf("expected provider_runtime in raw override, got %#v", raw)
+	}
+}
+
+func TestMergeProviderOverrideAppliesRuntimeAndReportsMalformedSections(t *testing.T) {
+	if err := mergeProviderOverride(nil, &Config{}); err != nil {
+		t.Fatalf("nil override should not fail: %v", err)
+	}
+	if err := mergeProviderOverride(map[string]json.RawMessage{}, nil); err != nil {
+		t.Fatalf("nil config should not fail: %v", err)
+	}
+	if err := mergeProviderOverride(map[string]json.RawMessage{
+		"provider": json.RawMessage(`{"api_key":`),
+	}, &Config{}); err == nil {
+		t.Fatal("expected malformed provider override to fail")
+	}
+	if err := mergeProviderOverride(map[string]json.RawMessage{
+		"provider_runtime": json.RawMessage(`{"providers":`),
+	}, &Config{}); err == nil {
+		t.Fatal("expected malformed provider_runtime override to fail")
+	}
+
+	cfg := Config{
+		ProviderRuntime: ProviderRuntimeConfig{
+			DefaultProvider: "project",
+			DefaultModel:    "project-model",
+			Providers: map[string]ProviderConfig{
+				"project": {Model: "project-model", APIKey: "project-key"},
+			},
+		},
+	}
+	raw := map[string]json.RawMessage{
+		"provider": json.RawMessage(`{
+			"type": "openai-compatible",
+			"base_url": "https://api.deepseek.com",
+			"model": "deepseek-chat",
+			"api_key": "user-key"
+		}`),
+		"provider_runtime": json.RawMessage(`{
+			"default_provider": "deepseek",
+			"default_model": "deepseek-chat",
+			"providers": {
+				"deepseek": {
+					"type": "openai-compatible",
+					"base_url": "https://api.deepseek.com",
+					"model": "deepseek-chat",
+					"api_key": "runtime-key"
+				}
+			}
+		}`),
+	}
+	if err := mergeProviderOverride(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider.Model != "deepseek-chat" || cfg.Provider.ResolveAPIKey() != "user-key" {
+		t.Fatalf("expected user provider override, got %#v", cfg.Provider)
+	}
+	if cfg.ProviderRuntime.DefaultProvider != "deepseek" {
+		t.Fatalf("expected runtime default provider deepseek, got %q", cfg.ProviderRuntime.DefaultProvider)
+	}
+	if provider := cfg.ProviderRuntime.Providers["deepseek"]; provider.ResolveAPIKey() != "runtime-key" {
+		t.Fatalf("expected runtime provider override key, got %#v", provider)
+	}
+}
+
+func TestProviderCredentialDetection(t *testing.T) {
+	t.Setenv("BYTEMIND_TEST_PROVIDER_KEY", "env-key")
+	t.Setenv("BYTEMIND_TEST_MISSING_PROVIDER_KEY", "")
+
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+		want bool
+	}{
+		{name: "malformed provider", raw: json.RawMessage(`{"api_key":`), want: false},
+		{name: "literal api key", raw: json.RawMessage(`{"api_key":"literal-key"}`), want: true},
+		{name: "blank api key", raw: json.RawMessage(`{"api_key":" "}`), want: false},
+		{name: "env api key", raw: json.RawMessage(`{"api_key_env":"BYTEMIND_TEST_PROVIDER_KEY"}`), want: true},
+		{name: "missing env api key", raw: json.RawMessage(`{"api_key_env":"BYTEMIND_TEST_MISSING_PROVIDER_KEY"}`), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := providerRawHasCredential(tt.raw); got != tt.want {
+				t.Fatalf("providerRawHasCredential() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	if hasProviderCredential(map[string]json.RawMessage{
+		"provider_runtime": json.RawMessage(`{"providers":`),
+	}) {
+		t.Fatal("expected malformed provider_runtime to have no credential")
+	}
+	if !hasProviderCredential(map[string]json.RawMessage{
+		"provider_runtime": json.RawMessage(`{
+			"providers": {
+				"deepseek": {"api_key_env": "BYTEMIND_TEST_PROVIDER_KEY"}
+			}
+		}`),
+	}) {
+		t.Fatal("expected provider_runtime env credential to be detected")
+	}
+}
+
 func TestLoadIgnoresLegacyBytemindConfigJSON(t *testing.T) {
 	workspace := t.TempDir()
 	home := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -349,7 +349,7 @@ func TestResolveConfigPathExplicit(t *testing.T) {
 	}
 }
 
-func TestLoadMergesUserAndProjectConfigWithProjectPrecedence(t *testing.T) {
+func TestLoadMergesUserAndProjectConfigWithUserProviderPrecedence(t *testing.T) {
 	workspace := t.TempDir()
 	home := t.TempDir()
 	t.Setenv("BYTEMIND_HOME", home)
@@ -394,11 +394,11 @@ func TestLoadMergesUserAndProjectConfigWithProjectPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Provider.Model != "project-model" {
-		t.Fatalf("expected project model precedence, got %q", cfg.Provider.Model)
+	if cfg.Provider.Model != "user-model" {
+		t.Fatalf("expected user provider model precedence, got %q", cfg.Provider.Model)
 	}
-	if cfg.Provider.ResolveAPIKey() != "project-key" {
-		t.Fatalf("expected project api key precedence, got %q", cfg.Provider.ResolveAPIKey())
+	if cfg.Provider.ResolveAPIKey() != "user-key" {
+		t.Fatalf("expected user provider api key precedence, got %q", cfg.Provider.ResolveAPIKey())
 	}
 	if cfg.ApprovalPolicy != "never" {
 		t.Fatalf("expected project approval policy precedence, got %q", cfg.ApprovalPolicy)
@@ -414,6 +414,186 @@ func TestLoadMergesUserAndProjectConfigWithProjectPrecedence(t *testing.T) {
 	}
 	if cfg.Stream {
 		t.Fatalf("expected project stream value false")
+	}
+}
+
+func TestLoadKeepsUserProviderWhenProjectProviderIsUnconfigured(t *testing.T) {
+	workspace := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", home)
+	t.Setenv("BYTEMIND_API_KEY", "")
+
+	if err := writeConfig(filepath.Join(home, "config.json"), map[string]any{
+		"provider": map[string]any{
+			"type":     "openai-compatible",
+			"base_url": "https://api.deepseek.com",
+			"model":    "deepseek-reasoner",
+			"api_key":  "user-key",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeConfig(projectConfigPath(workspace), map[string]any{
+		"provider": map[string]any{
+			"type":        "openai-compatible",
+			"base_url":    "https://api.openai.com/v1",
+			"model":       "gpt-5.4-mini",
+			"api_key":     "",
+			"api_key_env": "",
+		},
+		"approval_policy": "never",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(workspace, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider.BaseURL != "https://api.deepseek.com" {
+		t.Fatalf("expected user provider base_url, got %q", cfg.Provider.BaseURL)
+	}
+	if cfg.Provider.Model != "deepseek-reasoner" {
+		t.Fatalf("expected user provider model, got %q", cfg.Provider.Model)
+	}
+	if cfg.Provider.ResolveAPIKey() != "user-key" {
+		t.Fatalf("expected user provider api key, got %q", cfg.Provider.ResolveAPIKey())
+	}
+	if cfg.ApprovalPolicy != "never" {
+		t.Fatalf("expected project policy to still apply, got %q", cfg.ApprovalPolicy)
+	}
+}
+
+func TestLoadAllowsProjectProviderWhenUserConfigHasNoCredential(t *testing.T) {
+	workspace := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", home)
+	t.Setenv("BYTEMIND_API_KEY", "")
+
+	if err := writeConfig(filepath.Join(home, "config.json"), map[string]any{
+		"provider": map[string]any{
+			"type":        "openai-compatible",
+			"base_url":    "https://api.openai.com/v1",
+			"model":       "gpt-5.4-mini",
+			"api_key_env": "BYTEMIND_API_KEY",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeConfig(projectConfigPath(workspace), map[string]any{
+		"provider": map[string]any{
+			"type":     "openai-compatible",
+			"base_url": "https://api.deepseek.com",
+			"model":    "deepseek-chat",
+			"api_key":  "project-key",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(workspace, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider.Model != "deepseek-chat" {
+		t.Fatalf("expected project provider model, got %q", cfg.Provider.Model)
+	}
+	if cfg.Provider.ResolveAPIKey() != "project-key" {
+		t.Fatalf("expected project provider api key, got %q", cfg.Provider.ResolveAPIKey())
+	}
+}
+
+func TestLoadUsesUserProviderWhenConfiguredThroughEnvKey(t *testing.T) {
+	workspace := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", home)
+	t.Setenv("DEEPSEEK_TEST_KEY", "env-user-key")
+
+	if err := writeConfig(filepath.Join(home, "config.json"), map[string]any{
+		"provider": map[string]any{
+			"type":        "openai-compatible",
+			"base_url":    "https://api.deepseek.com",
+			"model":       "deepseek-reasoner",
+			"api_key_env": "DEEPSEEK_TEST_KEY",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeConfig(projectConfigPath(workspace), map[string]any{
+		"provider": map[string]any{
+			"type":     "openai-compatible",
+			"base_url": "https://api.openai.com/v1",
+			"model":    "gpt-5.4-mini",
+			"api_key":  "",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(workspace, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider.Model != "deepseek-reasoner" {
+		t.Fatalf("expected user env-key provider model, got %q", cfg.Provider.Model)
+	}
+	if cfg.Provider.ResolveAPIKey() != "env-user-key" {
+		t.Fatalf("expected api key from user env-key provider")
+	}
+}
+
+func TestLoadUserProviderPrecedenceResetsProjectProviderRuntime(t *testing.T) {
+	workspace := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("BYTEMIND_HOME", home)
+
+	if err := writeConfig(filepath.Join(home, "config.json"), map[string]any{
+		"provider": map[string]any{
+			"type":     "openai-compatible",
+			"base_url": "https://api.deepseek.com",
+			"model":    "deepseek-reasoner",
+			"api_key":  "user-key",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeConfig(projectConfigPath(workspace), map[string]any{
+		"provider_runtime": map[string]any{
+			"default_provider": "project",
+			"default_model":    "project-model",
+			"providers": map[string]any{
+				"project": map[string]any{
+					"type":     "openai-compatible",
+					"base_url": "https://api.openai.com/v1",
+					"model":    "project-model",
+					"api_key":  "",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(workspace, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ProviderRuntime.DefaultModel != "deepseek-reasoner" {
+		t.Fatalf("expected runtime to be rebuilt from user provider, got default model %q", cfg.ProviderRuntime.DefaultModel)
+	}
+	runtimeProvider, ok := cfg.ProviderRuntime.Providers["openai"]
+	if !ok {
+		t.Fatalf("expected rebuilt legacy openai runtime provider, got %#v", cfg.ProviderRuntime.Providers)
+	}
+	if runtimeProvider.BaseURL != "https://api.deepseek.com" {
+		t.Fatalf("expected user provider base_url in runtime provider, got %q", runtimeProvider.BaseURL)
+	}
+	if runtimeProvider.ResolveAPIKey() != "user-key" {
+		t.Fatalf("expected user api key in runtime provider")
 	}
 }
 

--- a/internal/config/provider_runtime_test.go
+++ b/internal/config/provider_runtime_test.go
@@ -10,6 +10,7 @@ import (
 
 func writeProviderRuntimeConfigFile(t *testing.T, workspace string, cfg map[string]any) {
 	t.Helper()
+	t.Setenv("BYTEMIND_HOME", t.TempDir())
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## 1. 配置加载顺序有问题
当前逻辑是：默认配置 -> 用户目录 C:\Users\<username>\.bytemind\config.json -> 项目 .bytemind\config.json -> 环境变量。
也就是说，它虽然“先读本地用户配置”，但后读的项目配置会覆盖用户配置。所以只要项目 .bytemind/config.json 里出现了：

```
"provider": {
  "api_key": "",
  "api_key_env": "",
  "base_url": "https://api.openai.com/v1",
  "model": "..."
}
```
哪怕 key 是空字符串，也会把用户目录里可用的 API 配置顶掉。项目配置完全不存在或真的是 {} 理论上不该坏；会坏通常说明项目配置里有 provider 字段、空 key、默认 endpoint，或者运行时显式传了 -config。

## 2. PATH 顺序有问题
查到 where bytemind 的第一项是：
`D:\...\bytemind\bytemind.exe`
它排在安装目录前面：

```
C:\Users\<username>\.bytemind\bin\bytemind.exe
C:\Users\<username>\bin\bytemind.exe
```
所以在项目目录里运行 bytemind 时，很可能跑的是项目根目录的旧二进制，而不是“发包/安装版”。这个会让测试结果很迷惑。

结论：不是单纯“没读本地 .bytemind”，而是项目 .bytemind 后读并覆盖了本地 provider/API 配置，再叠加当前目录 bytemind.exe 遮住安装版。