### PR TITLE
tui: align landing plan purple with workspace plan styling

### DIFF
--- a/tui/styles.go
+++ b/tui/styles.go
@@ -4,8 +4,8 @@ import "github.com/charmbracelet/lipgloss"
 
 const (
 	landingBuildAccent = "#4CB7FF"
-	landingPlanAccent  = "#D86BFF"
-	landingPlanBg      = "#2C123D"
+	landingPlanAccent  = "#9D8AC8"
+	landingPlanBg      = "#231421"
 )
 
 type semanticColorTokens struct {


### PR DESCRIPTION
## 变更说明
- 将启动页（Landing）`Plan` 模式的紫色样式与工作页（Workspace）保持一致。
- 本次仅调整 `tui/styles.go` 中两处颜色常量：
  - `landingPlanAccent`: `#D86BFF` -> `#9D8AC8`
  - `landingPlanBg`: `#2C123D` -> `#231421`

## 影响范围
- 启动页 `Plan` 标签的紫色高亮
- 启动页 `Plan` 模式下输入框边框紫色

## 验证
- `go test ./tui -run LandingModeAccentColors -v` 通过
- 手动在启动页与工作页切换 `Plan` 模式，紫色视觉一致
