### PR TITLE
323 336 provider相关收尾

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -83,28 +83,28 @@ type SubAgentPromptInput struct {
 }
 
 type Runner struct {
-	workspace       string
-	config          config.Config
-	client          llm.Client
-	store           SessionStore
-	registry        ToolRegistry
-	executor        ToolExecutor
-	policyGateway   PolicyGateway
-	engine          Engine
-	taskManager     runtimepkg.TaskManager
-	runtime         RuntimeGateway
-	extensions      extensionspkg.Manager
-	skillManager    *skills.Manager
-	subAgentManager *subagentspkg.Manager
+	workspace        string
+	config           config.Config
+	client           llm.Client
+	store            SessionStore
+	registry         ToolRegistry
+	executor         ToolExecutor
+	policyGateway    PolicyGateway
+	engine           Engine
+	taskManager      runtimepkg.TaskManager
+	runtime          RuntimeGateway
+	extensions       extensionspkg.Manager
+	skillManager     *skills.Manager
+	subAgentManager  *subagentspkg.Manager
 	subAgentExecutor SubAgentExecutor
 	subAgentNotifier SubAgentNotifier
-	tokenManager    *tokenusage.TokenUsageManager
-	auditStore      storagepkg.AuditStore
-	promptStore     storagepkg.PromptHistoryWriter
-	observer        Observer
-	approval        tools.ApprovalHandler
-	stdin           io.Reader
-	stdout          io.Writer
+	tokenManager     *tokenusage.TokenUsageManager
+	auditStore       storagepkg.AuditStore
+	promptStore      storagepkg.PromptHistoryWriter
+	observer         Observer
+	approval         tools.ApprovalHandler
+	stdin            io.Reader
+	stdout           io.Writer
 
 	bridgeMu            sync.Mutex
 	bridgeSessions      map[string]bridgeSessionState
@@ -246,10 +246,6 @@ func (r *Runner) ListModels(ctx context.Context) ([]provider.ModelInfo, []provid
 	if len(runtimeCfg.Providers) == 0 {
 		runtimeCfg = config.LegacyProviderRuntimeConfig(r.config.Provider)
 	}
-	baseClient := r.GetClient()
-	if _, ok := baseClient.(provider.Client); !ok {
-		return nil, nil, fmt.Errorf("provider runtime is unavailable")
-	}
 	registry, err := provider.NewRegistry(runtimeCfg)
 	if err != nil {
 		return nil, nil, err
@@ -286,7 +282,6 @@ func (r *Runner) storeModelsCache(models []provider.ModelInfo, warnings []provid
 	r.modelsCache = append([]provider.ModelInfo(nil), models...)
 	r.modelsCacheWarnings = append([]provider.Warning(nil), warnings...)
 }
-
 
 func (r *Runner) modelID() string {
 	if r == nil {

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -230,6 +230,31 @@ func (r *Runner) GetConfig() config.Config {
 	return r.config
 }
 
+func (r *Runner) ListModels(ctx context.Context) ([]provider.ModelInfo, []provider.Warning, error) {
+	if r == nil || r.client == nil {
+		return nil, nil, fmt.Errorf("client is unavailable")
+	}
+	runtimeCfg := r.config.ProviderRuntime
+	if len(runtimeCfg.Providers) == 0 {
+		runtimeCfg = config.LegacyProviderRuntimeConfig(r.config.Provider)
+	}
+	baseClient := r.GetClient()
+	if _, ok := baseClient.(provider.Client); !ok {
+		return nil, nil, fmt.Errorf("provider runtime is unavailable")
+	}
+	registry, err := provider.NewRegistry(runtimeCfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	models, warnings, err := provider.ListModels(ctx, registry)
+	if err != nil {
+		return nil, nil, err
+	}
+	registryView := provider.NewModelRegistry(runtimeCfg, models)
+	return registryView.Models(), warnings, nil
+}
+
+
 func (r *Runner) modelID() string {
 	if r == nil {
 		return ""

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -117,6 +117,11 @@ type Runner struct {
 	extensionSyncDirty bool
 	extensionSyncGen   uint64
 	extensionToolKeys  map[string]map[string]struct{}
+
+	modelsCacheMu       sync.RWMutex
+	modelsCacheAt       time.Time
+	modelsCache         []provider.ModelInfo
+	modelsCacheWarnings []provider.Warning
 }
 
 func NewRunner(opts Options) *Runner {
@@ -234,6 +239,9 @@ func (r *Runner) ListModels(ctx context.Context) ([]provider.ModelInfo, []provid
 	if r == nil || r.client == nil {
 		return nil, nil, fmt.Errorf("client is unavailable")
 	}
+	if cachedModels, cachedWarnings, ok := r.listModelsFromCache(); ok {
+		return cachedModels, cachedWarnings, nil
+	}
 	runtimeCfg := r.config.ProviderRuntime
 	if len(runtimeCfg.Providers) == 0 {
 		runtimeCfg = config.LegacyProviderRuntimeConfig(r.config.Provider)
@@ -251,7 +259,32 @@ func (r *Runner) ListModels(ctx context.Context) ([]provider.ModelInfo, []provid
 		return nil, nil, err
 	}
 	registryView := provider.NewModelRegistry(runtimeCfg, models)
-	return registryView.Models(), warnings, nil
+	resolved := registryView.Models()
+	r.storeModelsCache(resolved, warnings)
+	return resolved, warnings, nil
+}
+
+func (r *Runner) listModelsFromCache() ([]provider.ModelInfo, []provider.Warning, bool) {
+	if r == nil {
+		return nil, nil, false
+	}
+	r.modelsCacheMu.RLock()
+	defer r.modelsCacheMu.RUnlock()
+	if r.modelsCacheAt.IsZero() || time.Since(r.modelsCacheAt) > 30*time.Second {
+		return nil, nil, false
+	}
+	return append([]provider.ModelInfo(nil), r.modelsCache...), append([]provider.Warning(nil), r.modelsCacheWarnings...), true
+}
+
+func (r *Runner) storeModelsCache(models []provider.ModelInfo, warnings []provider.Warning) {
+	if r == nil {
+		return
+	}
+	r.modelsCacheMu.Lock()
+	defer r.modelsCacheMu.Unlock()
+	r.modelsCacheAt = time.Now()
+	r.modelsCache = append([]provider.ModelInfo(nil), models...)
+	r.modelsCacheWarnings = append([]provider.Warning(nil), warnings...)
 }
 
 

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -283,6 +283,17 @@ func (r *Runner) storeModelsCache(models []provider.ModelInfo, warnings []provid
 	r.modelsCacheWarnings = append([]provider.Warning(nil), warnings...)
 }
 
+func (r *Runner) clearModelsCache() {
+	if r == nil {
+		return
+	}
+	r.modelsCacheMu.Lock()
+	defer r.modelsCacheMu.Unlock()
+	r.modelsCacheAt = time.Time{}
+	r.modelsCache = nil
+	r.modelsCacheWarnings = nil
+}
+
 func (r *Runner) modelID() string {
 	if r == nil {
 		return ""

--- a/internal/agent/runner_control.go
+++ b/internal/agent/runner_control.go
@@ -15,10 +15,19 @@ func (r *Runner) SetApprovalHandler(handler tools.ApprovalHandler) {
 }
 
 func (r *Runner) UpdateProvider(providerCfg config.ProviderConfig, client llm.Client) {
-	r.config.Provider = providerCfg
-	if client != nil {
-		r.client = client
+	if r == nil {
+		return
 	}
+	r.config.Provider = providerCfg
+	r.config.ProviderRuntime = config.SyncProviderRuntimeWithProvider(r.config.ProviderRuntime, providerCfg)
+	if client != nil {
+		if _, ok := client.(routeAwareClient); ok {
+			r.client = client
+		} else {
+			r.client = routeAwareClient{base: client}
+		}
+	}
+	r.clearModelsCache()
 }
 
 func (r *Runner) UpdateApprovalMode(mode string) {

--- a/internal/agent/runner_models_test.go
+++ b/internal/agent/runner_models_test.go
@@ -1,0 +1,132 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/bytemind/internal/config"
+	"github.com/1024XEngineer/bytemind/internal/provider"
+)
+
+func TestRunnerListModelsUsesConfiguredRuntime(t *testing.T) {
+	runner := NewRunner(Options{
+		Config: config.Config{
+			ProviderRuntime: config.ProviderRuntimeConfig{
+				DefaultProvider: "primary",
+				DefaultModel:    "gpt-5.4",
+				Providers: map[string]config.ProviderConfig{
+					"primary": {
+						Type:  "openai-compatible",
+						Model: "gpt-5.4",
+					},
+				},
+			},
+		},
+		Client: &fakeClient{},
+	})
+
+	models, warnings, err := runner.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("expected models to list, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings %#v", warnings)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected one model, got %#v", models)
+	}
+	if models[0].ProviderID != "primary" || models[0].ModelID != "gpt-5.4" {
+		t.Fatalf("unexpected model %#v", models[0])
+	}
+}
+
+func TestRunnerListModelsFallsBackToLegacyProviderConfig(t *testing.T) {
+	runner := NewRunner(Options{
+		Config: config.Config{
+			Provider: config.ProviderConfig{
+				Type:  "openai-compatible",
+				Model: "legacy-model",
+			},
+		},
+		Client: &fakeClient{},
+	})
+
+	models, warnings, err := runner.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("expected legacy models to list, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings %#v", warnings)
+	}
+	if len(models) != 1 || models[0].ProviderID != provider.ProviderOpenAI || models[0].ModelID != "legacy-model" {
+		t.Fatalf("unexpected legacy models %#v", models)
+	}
+}
+
+func TestRunnerListModelsUsesCacheAndCopiesResults(t *testing.T) {
+	runner := NewRunner(Options{
+		Config: config.Config{
+			ProviderRuntime: config.ProviderRuntimeConfig{
+				DefaultProvider: "primary",
+				DefaultModel:    "cached-model",
+				Providers: map[string]config.ProviderConfig{
+					"primary": {Type: "openai-compatible", Model: "fresh-model"},
+				},
+			},
+		},
+		Client: &fakeClient{},
+	})
+	runner.storeModelsCache(
+		[]provider.ModelInfo{{ProviderID: "primary", ModelID: "cached-model"}},
+		[]provider.Warning{{ProviderID: "primary", Reason: "cached-warning"}},
+	)
+
+	models, warnings, err := runner.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("expected cached models, got %v", err)
+	}
+	if len(models) != 1 || models[0].ModelID != "cached-model" {
+		t.Fatalf("expected cached model, got %#v", models)
+	}
+	if len(warnings) != 1 || warnings[0].Reason != "cached-warning" {
+		t.Fatalf("expected cached warning, got %#v", warnings)
+	}
+
+	models[0].ModelID = "mutated"
+	warnings[0].Reason = "mutated"
+	models, warnings, ok := runner.listModelsFromCache()
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if models[0].ModelID != "cached-model" || warnings[0].Reason != "cached-warning" {
+		t.Fatalf("expected cache copies to protect stored state, got models=%#v warnings=%#v", models, warnings)
+	}
+
+	runner.modelsCacheAt = time.Now().Add(-31 * time.Second)
+	if _, _, ok := runner.listModelsFromCache(); ok {
+		t.Fatal("expected expired cache miss")
+	}
+}
+
+func TestRunnerListModelsRejectsInvalidState(t *testing.T) {
+	if _, _, err := (*Runner)(nil).ListModels(context.Background()); err == nil || !strings.Contains(err.Error(), "client is unavailable") {
+		t.Fatalf("expected nil runner error, got %v", err)
+	}
+
+	runner := NewRunner(Options{
+		Config: config.Config{
+			ProviderRuntime: config.ProviderRuntimeConfig{
+				DefaultProvider: "missing",
+				Providers: map[string]config.ProviderConfig{
+					"primary": {Type: "openai-compatible", Model: "model"},
+				},
+			},
+		},
+		Client: &fakeClient{},
+	})
+	if _, _, err := runner.ListModels(context.Background()); err == nil {
+		t.Fatal("expected invalid provider runtime to fail")
+	}
+}

--- a/internal/agent/runner_models_test.go
+++ b/internal/agent/runner_models_test.go
@@ -130,3 +130,47 @@ func TestRunnerListModelsRejectsInvalidState(t *testing.T) {
 		t.Fatal("expected invalid provider runtime to fail")
 	}
 }
+
+func TestRunnerUpdateProviderSyncsRuntimeAndClearsModelCache(t *testing.T) {
+	runner := NewRunner(Options{
+		Config: config.Config{
+			ProviderRuntime: config.ProviderRuntimeConfig{
+				DefaultProvider: "old",
+				DefaultModel:    "old-model",
+				Providers: map[string]config.ProviderConfig{
+					"old": {Type: "openai-compatible", Model: "old-model"},
+				},
+			},
+		},
+		Client: &fakeClient{},
+	})
+	runner.storeModelsCache(
+		[]provider.ModelInfo{{ProviderID: "old", ModelID: "old-model"}},
+		[]provider.Warning{{ProviderID: "old", Reason: "old-warning"}},
+	)
+
+	nextClient := &fakeClient{}
+	runner.UpdateProvider(config.ProviderConfig{
+		Type:  "anthropic",
+		Model: "claude-sonnet-4",
+	}, nextClient)
+
+	if _, _, ok := runner.listModelsFromCache(); ok {
+		t.Fatal("expected provider update to clear model cache")
+	}
+	if runner.config.ProviderRuntime.DefaultProvider != "anthropic" {
+		t.Fatalf("expected runtime default provider to sync, got %q", runner.config.ProviderRuntime.DefaultProvider)
+	}
+	if runner.config.ProviderRuntime.DefaultModel != "claude-sonnet-4" {
+		t.Fatalf("expected runtime default model to sync, got %q", runner.config.ProviderRuntime.DefaultModel)
+	}
+	if _, ok := runner.config.ProviderRuntime.Providers["old"]; !ok {
+		t.Fatalf("expected existing providers to be preserved, got %#v", runner.config.ProviderRuntime.Providers)
+	}
+	if runner.config.ProviderRuntime.Providers["anthropic"].Model != "claude-sonnet-4" {
+		t.Fatalf("expected anthropic provider entry to be updated, got %#v", runner.config.ProviderRuntime.Providers["anthropic"])
+	}
+	if got := runner.GetClient(); got != nextClient {
+		t.Fatalf("expected GetClient to unwrap updated route-aware client")
+	}
+}

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/1024XEngineer/bytemind/internal/agent"
 	"github.com/1024XEngineer/bytemind/internal/config"
@@ -16,6 +17,7 @@ import (
 	runtimepkg "github.com/1024XEngineer/bytemind/internal/runtime"
 	"github.com/1024XEngineer/bytemind/internal/session"
 	storagepkg "github.com/1024XEngineer/bytemind/internal/storage"
+	"github.com/1024XEngineer/bytemind/internal/tokenusage"
 	"github.com/1024XEngineer/bytemind/internal/tools"
 )
 
@@ -127,6 +129,10 @@ func Bootstrap(req BootstrapRequest) (Runtime, error) {
 	if err != nil {
 		promptStore = storagepkg.NopPromptHistoryStore{}
 	}
+	tokenManager, err := newTokenUsageManagerFromConfig(cfg.TokenUsage)
+	if err != nil {
+		return Runtime{}, err
+	}
 
 	taskEventStore := runtimepkg.TaskEventStore(runtimepkg.NopTaskEventStore{})
 	taskStore, taskStoreErr := storagepkg.NewDefaultTaskStoreWithOptions(nil, storagepkg.TaskStoreOptions{
@@ -152,17 +158,18 @@ func Bootstrap(req BootstrapRequest) (Runtime, error) {
 	baseExtensions := extensionspkg.NewManager(workspace)
 	extensions := extensionsruntime.NewManager(workspace, req.ConfigPath, baseExtensions, cfg)
 	runner := agent.NewRunner(agent.Options{
-		Workspace:   workspace,
-		Config:      cfg,
-		Client:      client,
-		Store:       store,
-		Registry:    tools.DefaultRegistry(),
-		TaskManager: taskManager,
-		Extensions:  extensions,
-		AuditStore:  auditStore,
-		PromptStore: promptStore,
-		Stdin:       req.Stdin,
-		Stdout:      req.Stdout,
+		Workspace:    workspace,
+		Config:       cfg,
+		Client:       client,
+		Store:        store,
+		Registry:     tools.DefaultRegistry(),
+		TaskManager:  taskManager,
+		Extensions:   extensions,
+		AuditStore:   auditStore,
+		PromptStore:  promptStore,
+		TokenManager: tokenManager,
+		Stdin:        req.Stdin,
+		Stdout:       req.Stdout,
 	})
 
 	return Runtime{
@@ -173,4 +180,30 @@ func Bootstrap(req BootstrapRequest) (Runtime, error) {
 		TaskManager: taskManager,
 		Extensions:  extensions,
 	}, nil
+}
+
+func newTokenUsageManagerFromConfig(cfg config.TokenUsageConfig) (*tokenusage.TokenUsageManager, error) {
+	backupInterval, err := time.ParseDuration(strings.TrimSpace(cfg.BackupInterval))
+	if err != nil || backupInterval <= 0 {
+		backupInterval = time.Minute
+	}
+	monitorInterval, err := time.ParseDuration(strings.TrimSpace(cfg.MonitorInterval))
+	if err != nil || monitorInterval <= 0 {
+		monitorInterval = 30 * time.Second
+	}
+	storagePath := strings.TrimSpace(cfg.StoragePath)
+	if storagePath != "" && !filepath.IsAbs(storagePath) {
+		storagePath = filepath.Clean(storagePath)
+	}
+	return tokenusage.NewTokenUsageManager(&tokenusage.Config{
+		StorageType:     strings.TrimSpace(cfg.StorageType),
+		StoragePath:     storagePath,
+		BackupInterval:  backupInterval,
+		MaxSessions:     cfg.MaxSessions,
+		AlertThreshold:  cfg.AlertThreshold,
+		EnableRealtime:  cfg.EnableRealtime,
+		RetentionDays:   cfg.RetentionDays,
+		MonitorInterval: monitorInterval,
+		DatabaseDriver:  strings.TrimSpace(cfg.DatabaseDriver),
+	})
 }

--- a/internal/app/tui_adapter.go
+++ b/internal/app/tui_adapter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/agent"
 	"github.com/1024XEngineer/bytemind/internal/config"
 	"github.com/1024XEngineer/bytemind/internal/llm"
+	"github.com/1024XEngineer/bytemind/internal/provider"
 	"github.com/1024XEngineer/bytemind/internal/session"
 	"github.com/1024XEngineer/bytemind/internal/skills"
 	subagentspkg "github.com/1024XEngineer/bytemind/internal/subagents"
@@ -124,6 +125,13 @@ func (a *tuiRunnerAdapter) CompactSession(ctx context.Context, sess *session.Ses
 		return "", false, errors.New("runner is unavailable")
 	}
 	return a.runner.CompactSession(ctx, sess)
+}
+
+func (a *tuiRunnerAdapter) ListModels(ctx context.Context) ([]provider.ModelInfo, []provider.Warning, error) {
+	if a == nil || a.runner == nil {
+		return nil, nil, errors.New("runner is unavailable")
+	}
+	return a.runner.ListModels(ctx)
 }
 
 func (a *tuiRunnerAdapter) ListSubAgents() ([]subagentspkg.Agent, []subagentspkg.Diagnostic) {

--- a/internal/app/tui_runtime.go
+++ b/internal/app/tui_runtime.go
@@ -12,6 +12,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/config"
 	"github.com/1024XEngineer/bytemind/internal/mcpctl"
 	notifypkg "github.com/1024XEngineer/bytemind/internal/notify"
+	"github.com/1024XEngineer/bytemind/internal/provider"
 	"github.com/1024XEngineer/bytemind/tui"
 )
 
@@ -73,6 +74,10 @@ func BuildTUIRuntime(req TUIRequest) (TUIRuntime, error) {
 
 	interactive := isInteractiveStdin(req.Stdin)
 	guide, requireAPIKey := resolveTUIStartupPolicy(interactive)
+	providerCheck := checkTUIProviderAvailability(cfg)
+	if interactive && !providerCheck.Ready {
+		guide = BuildStartupGuide(cfg, providerCheck, workspace, *configPath)
+	}
 	runtimeBundle, err := BootstrapEntrypoint(EntrypointRequest{
 		WorkspaceOverride:     *workspaceOverride,
 		ConfigPath:            *configPath,
@@ -149,9 +154,15 @@ func chainTUIRuntimeClose(runnerClose func() error, notifier notifypkg.Notifier)
 }
 
 func resolveTUIStartupPolicy(interactive bool) (tui.StartupGuide, bool) {
-	// Startup guide at UI entry is disabled by default.
-	// Keep interactive TUI accessible even when API key is not configured yet.
 	return tui.StartupGuide{}, !interactive
+}
+
+func checkTUIProviderAvailability(cfg config.Config) provider.Availability {
+	providerCfg := cfg.Provider
+	if model := providerCfg.Model; model == "" {
+		providerCfg.Model = cfg.ProviderRuntime.DefaultModel
+	}
+	return provider.CheckAvailability(context.Background(), providerCfg)
 }
 
 func isInteractiveStdin(stdin io.Reader) bool {

--- a/internal/app/tui_runtime_test.go
+++ b/internal/app/tui_runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	notifypkg "github.com/1024XEngineer/bytemind/internal/notify"
+	"github.com/1024XEngineer/bytemind/internal/config"
 	"testing"
 	"time"
 )
@@ -15,6 +16,19 @@ func TestResolveTUIStartupPolicyInteractiveDisablesGuideAndAPIKeyRequirement(t *
 	}
 	if requireAPIKey {
 		t.Fatal("expected interactive tui to allow startup without API key")
+	}
+}
+
+func TestCheckTUIProviderAvailabilityReportsMissingKey(t *testing.T) {
+	check := checkTUIProviderAvailability(config.Config{
+		Provider: config.ProviderConfig{
+			Type:    "openai-compatible",
+			BaseURL: "https://api.openai.com/v1",
+			Model:   "gpt-5.4-mini",
+		},
+	})
+	if check.Ready {
+		t.Fatal("expected provider availability to fail when api key is missing")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1187,6 +1187,17 @@ func TestUpsertProviderAPIKeyUpdatesExistingConfig(t *testing.T) {
     "api_key": "old-key",
     "api_key_env": "BYTEMIND_API_KEY"
   },
+  "provider_runtime": {
+    "default_provider": "old",
+    "default_model": "old-model",
+    "allow_fallback": true,
+    "providers": {
+      "old": {
+        "type": "openai-compatible",
+        "model": "old-model"
+      }
+    }
+  },
   "custom": "keep-me"
 }`), 0o644); err != nil {
 		t.Fatal(err)
@@ -1217,6 +1228,22 @@ func TestUpsertProviderAPIKeyUpdatesExistingConfig(t *testing.T) {
 	}
 	if doc["custom"] != "keep-me" {
 		t.Fatalf("expected custom field to be preserved, got %#v", doc["custom"])
+	}
+	cfg, err := Load(workspace, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ProviderRuntime.DefaultProvider != "openai" || cfg.ProviderRuntime.DefaultModel != "GPT-5.4" {
+		t.Fatalf("expected provider runtime defaults to sync, got %#v", cfg.ProviderRuntime)
+	}
+	if !cfg.ProviderRuntime.AllowFallback {
+		t.Fatal("expected provider runtime allow_fallback to be preserved")
+	}
+	if _, ok := cfg.ProviderRuntime.Providers["old"]; !ok {
+		t.Fatalf("expected existing runtime provider to be preserved, got %#v", cfg.ProviderRuntime.Providers)
+	}
+	if providerCfg := cfg.ProviderRuntime.Providers["openai"]; providerCfg.ResolveAPIKey() != "new-key" {
+		t.Fatalf("expected synced runtime provider to include updated API key, got %#v", providerCfg)
 	}
 }
 
@@ -1284,6 +1311,49 @@ func TestUpsertProviderFieldUpdatesModelBaseURLAndFamily(t *testing.T) {
 	}
 	if cfg.Provider.Family != "moonshot" {
 		t.Fatalf("expected normalized provider family, got %q", cfg.Provider.Family)
+	}
+}
+
+func TestUpsertProviderFieldSyncsProviderRuntime(t *testing.T) {
+	workspace := t.TempDir()
+	configPath := filepath.Join(workspace, "config.json")
+	if err := os.WriteFile(configPath, []byte(`{
+  "provider": {
+    "type": "openai-compatible",
+    "base_url": "https://api.openai.com/v1",
+    "model": "old-model",
+    "api_key": "test-key"
+  },
+  "provider_runtime": {
+    "default_provider": "old",
+    "default_model": "old-model",
+    "providers": {
+      "old": {
+        "type": "openai-compatible",
+        "model": "old-model"
+      }
+    }
+  }
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := UpsertProviderField(configPath, "model", "gpt-5.4"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(workspace, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ProviderRuntime.DefaultProvider != "openai" || cfg.ProviderRuntime.DefaultModel != "gpt-5.4" {
+		t.Fatalf("expected provider runtime defaults to sync, got %#v", cfg.ProviderRuntime)
+	}
+	if _, ok := cfg.ProviderRuntime.Providers["old"]; !ok {
+		t.Fatalf("expected existing runtime provider to be preserved, got %#v", cfg.ProviderRuntime.Providers)
+	}
+	if providerCfg := cfg.ProviderRuntime.Providers["openai"]; providerCfg.Model != "gpt-5.4" || providerCfg.ResolveAPIKey() != "test-key" {
+		t.Fatalf("expected synced runtime provider entry, got %#v", providerCfg)
 	}
 }
 

--- a/internal/config/provider_runtime.go
+++ b/internal/config/provider_runtime.go
@@ -37,3 +37,27 @@ func LegacyProviderRuntimeConfig(cfg ProviderConfig) ProviderRuntimeConfig {
 		},
 	}
 }
+
+func SyncProviderRuntimeWithProvider(runtimeCfg ProviderRuntimeConfig, providerCfg ProviderConfig) ProviderRuntimeConfig {
+	legacy := LegacyProviderRuntimeConfig(providerCfg)
+	providerID := strings.ToLower(strings.TrimSpace(legacy.DefaultProvider))
+	if providerID == "" {
+		return runtimeCfg
+	}
+	providerEntry := legacy.Providers[providerID]
+
+	providers := make(map[string]ProviderConfig, len(runtimeCfg.Providers)+1)
+	for id, cfg := range runtimeCfg.Providers {
+		normalizedID := strings.ToLower(strings.TrimSpace(id))
+		if normalizedID == "" {
+			continue
+		}
+		providers[normalizedID] = cfg
+	}
+	providers[providerID] = providerEntry
+
+	runtimeCfg.DefaultProvider = providerID
+	runtimeCfg.DefaultModel = strings.TrimSpace(providerEntry.Model)
+	runtimeCfg.Providers = providers
+	return runtimeCfg
+}

--- a/internal/config/provider_runtime_test.go
+++ b/internal/config/provider_runtime_test.go
@@ -92,6 +92,53 @@ func TestLegacyProviderRuntimeConfigNormalizesProviderIDs(t *testing.T) {
 	}
 }
 
+func TestSyncProviderRuntimeWithProviderUpdatesDefaultAndPreservesOthers(t *testing.T) {
+	runtime := SyncProviderRuntimeWithProvider(ProviderRuntimeConfig{
+		DefaultProvider: "old",
+		DefaultModel:    "old-model",
+		AllowFallback:   true,
+		Providers: map[string]ProviderConfig{
+			"old": {Type: "openai-compatible", Model: "old-model"},
+		},
+	}, ProviderConfig{
+		Type:      "anthropic",
+		BaseURL:   "https://api.anthropic.com",
+		Model:     "claude-sonnet-4",
+		APIKeyEnv: "ANTHROPIC_API_KEY",
+	})
+
+	if runtime.DefaultProvider != "anthropic" {
+		t.Fatalf("expected default provider to sync to anthropic, got %q", runtime.DefaultProvider)
+	}
+	if runtime.DefaultModel != "claude-sonnet-4" {
+		t.Fatalf("expected default model to sync, got %q", runtime.DefaultModel)
+	}
+	if !runtime.AllowFallback {
+		t.Fatal("expected existing allow_fallback setting to be preserved")
+	}
+	if _, ok := runtime.Providers["old"]; !ok {
+		t.Fatalf("expected existing provider entry to be preserved, got %#v", runtime.Providers)
+	}
+	anthropic := runtime.Providers["anthropic"]
+	if anthropic.Model != "claude-sonnet-4" || anthropic.APIKeyEnv != "ANTHROPIC_API_KEY" {
+		t.Fatalf("expected synced anthropic provider entry, got %#v", anthropic)
+	}
+}
+
+func TestSyncProviderRuntimeWithProviderBuildsMissingProvidersMap(t *testing.T) {
+	runtime := SyncProviderRuntimeWithProvider(ProviderRuntimeConfig{}, ProviderConfig{
+		Type:  "openai-compatible",
+		Model: "gpt-5.4",
+	})
+
+	if runtime.DefaultProvider != "openai" || runtime.DefaultModel != "gpt-5.4" {
+		t.Fatalf("unexpected runtime defaults %#v", runtime)
+	}
+	if providerCfg, ok := runtime.Providers["openai"]; !ok || providerCfg.Type != "openai" || providerCfg.Model != "gpt-5.4" {
+		t.Fatalf("unexpected provider entry %#v", runtime.Providers)
+	}
+}
+
 func TestConfigLoadRejectsDuplicateNormalizedProviderRuntimeIDs(t *testing.T) {
 	workspace := t.TempDir()
 	writeProviderRuntimeConfigFile(t, workspace, map[string]any{

--- a/internal/config/update.go
+++ b/internal/config/update.go
@@ -77,6 +77,7 @@ func upsertProviderValues(configPath string, values map[string]string) (string, 
 		providerSection["model"] = defaultModel(providerType, asString(providerSection["base_url"]))
 	}
 	raw["provider"] = providerSection
+	syncProviderRuntimeDocument(raw, providerSection)
 
 	if _, ok := raw["approval_policy"]; !ok {
 		raw["approval_policy"] = "on-request"
@@ -99,6 +100,30 @@ func upsertProviderValues(configPath string, values map[string]string) (string, 
 	}
 
 	return path, nil
+}
+
+func syncProviderRuntimeDocument(raw map[string]any, providerSection map[string]any) {
+	if raw == nil || providerSection == nil {
+		return
+	}
+	providerCfg := providerConfigFromDocument(providerSection)
+	runtimeCfg := ProviderRuntimeConfig{}
+	if runtimeRaw, ok := raw["provider_runtime"]; ok {
+		if data, err := json.Marshal(runtimeRaw); err == nil {
+			_ = json.Unmarshal(data, &runtimeCfg)
+		}
+	}
+	raw["provider_runtime"] = SyncProviderRuntimeWithProvider(runtimeCfg, providerCfg)
+}
+
+func providerConfigFromDocument(providerSection map[string]any) ProviderConfig {
+	providerCfg := ProviderConfig{}
+	data, err := json.Marshal(providerSection)
+	if err != nil {
+		return providerCfg
+	}
+	_ = json.Unmarshal(data, &providerCfg)
+	return providerCfg
 }
 
 func MutateMCPConfig(workspace, explicitPath string, mutator func(*MCPConfig) error) (Config, string, error) {

--- a/internal/provider/model_registry.go
+++ b/internal/provider/model_registry.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/1024XEngineer/bytemind/internal/config"
+)
+
+type ModelRegistry struct {
+	models []ModelInfo
+	index  map[string]ModelInfo
+}
+
+func NewModelRegistry(runtimeCfg config.ProviderRuntimeConfig, discovered []ModelInfo) ModelRegistry {
+	merged := make([]ModelInfo, 0, len(discovered)+len(runtimeCfg.Providers))
+	seen := make(map[string]struct{})
+	for _, model := range discovered {
+		normalized := normalizeModelInfo(model)
+		key := modelRegistryKey(normalized.ProviderID, normalized.ModelID)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, normalized)
+	}
+	for providerID, providerCfg := range runtimeCfg.Providers {
+		modelID := strings.TrimSpace(providerCfg.Model)
+		if modelID == "" {
+			continue
+		}
+		info := ModelInfo{
+			ProviderID: ProviderID(strings.ToLower(strings.TrimSpace(providerID))),
+			ModelID:    ModelID(modelID),
+			Metadata: map[string]string{
+				"family":          strings.TrimSpace(providerCfg.Family),
+				"context_window":  "",
+				"max_output_tokens": "",
+				"supports_tools":  "true",
+				"source":          "config",
+			},
+		}
+		info = normalizeModelInfo(info)
+		key := modelRegistryKey(info.ProviderID, info.ModelID)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, info)
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		if merged[i].ProviderID == merged[j].ProviderID {
+			return merged[i].ModelID < merged[j].ModelID
+		}
+		return merged[i].ProviderID < merged[j].ProviderID
+	})
+	index := make(map[string]ModelInfo, len(merged))
+	for _, model := range merged {
+		index[modelRegistryKey(model.ProviderID, model.ModelID)] = model
+	}
+	return ModelRegistry{models: merged, index: index}
+}
+
+func (r ModelRegistry) Models() []ModelInfo {
+	return append([]ModelInfo(nil), r.models...)
+}
+
+func (r ModelRegistry) Lookup(providerID ProviderID, modelID ModelID) (ModelInfo, bool) {
+	info, ok := r.index[modelRegistryKey(providerID, modelID)]
+	return info, ok
+}
+
+func normalizeModelInfo(model ModelInfo) ModelInfo {
+	model.ProviderID = ProviderID(strings.ToLower(strings.TrimSpace(string(model.ProviderID))))
+	model.ModelID = ModelID(strings.TrimSpace(string(model.ModelID)))
+	model.DisplayAlias = strings.TrimSpace(model.DisplayAlias)
+	if model.Metadata == nil {
+		model.Metadata = map[string]string{}
+	}
+	if strings.TrimSpace(model.Metadata["source"]) == "" {
+		model.Metadata["source"] = "provider"
+	}
+	if strings.TrimSpace(model.Metadata["supports_tools"]) == "" {
+		model.Metadata["supports_tools"] = "true"
+	}
+	return model
+}
+
+func modelRegistryKey(providerID ProviderID, modelID ModelID) string {
+	provider := strings.ToLower(strings.TrimSpace(string(providerID)))
+	model := strings.TrimSpace(string(modelID))
+	if provider == "" || model == "" {
+		return ""
+	}
+	return provider + "/" + model
+}

--- a/internal/provider/model_registry.go
+++ b/internal/provider/model_registry.go
@@ -76,6 +76,14 @@ func (r ModelRegistry) Lookup(providerID ProviderID, modelID ModelID) (ModelInfo
 	return info, ok
 }
 
+func (r ModelRegistry) ContextWindow(providerID ProviderID, modelID ModelID) int {
+	info, ok := r.Lookup(providerID, modelID)
+	if !ok {
+		return 0
+	}
+	return info.ModelMetadata().ContextWindow
+}
+
 func normalizeModelInfo(model ModelInfo) ModelInfo {
 	model.ProviderID = ProviderID(strings.ToLower(strings.TrimSpace(string(model.ProviderID))))
 	model.ModelID = ModelID(strings.TrimSpace(string(model.ModelID)))

--- a/internal/provider/model_registry_test.go
+++ b/internal/provider/model_registry_test.go
@@ -1,0 +1,30 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/1024XEngineer/bytemind/internal/config"
+)
+
+func TestModelRegistryContextWindow(t *testing.T) {
+	registry := NewModelRegistry(config.ProviderRuntimeConfig{
+		DefaultProvider: "openai",
+		DefaultModel:    "gpt-5.4-mini",
+		Providers: map[string]config.ProviderConfig{
+			"openai": {
+				Model:  "gpt-5.4-mini",
+				Family: "openai",
+			},
+		},
+	}, []ModelInfo{{
+		ProviderID: "openai",
+		ModelID:    "gpt-5.4-mini",
+		Metadata: map[string]string{
+			"context_window": "128000",
+		},
+	}})
+
+	if got := registry.ContextWindow("openai", "gpt-5.4-mini"); got != 128000 {
+		t.Fatalf("expected context window 128000, got %d", got)
+	}
+}

--- a/internal/provider/model_registry_test.go
+++ b/internal/provider/model_registry_test.go
@@ -28,3 +28,80 @@ func TestModelRegistryContextWindow(t *testing.T) {
 		t.Fatalf("expected context window 128000, got %d", got)
 	}
 }
+
+func TestModelRegistryMergesNormalizesAndCopiesModels(t *testing.T) {
+	registry := NewModelRegistry(config.ProviderRuntimeConfig{
+		Providers: map[string]config.ProviderConfig{
+			" OpenAI ": {
+				Model:  " gpt-5.4-mini ",
+				Family: " openai ",
+			},
+			"empty": {
+				Model: " ",
+			},
+		},
+	}, []ModelInfo{
+		{
+			ProviderID:   " OpenAI ",
+			ModelID:      " gpt-5.4 ",
+			DisplayAlias: " GPT ",
+			Metadata:     map[string]string{"source": "", "supports_tools": ""},
+		},
+		{
+			ProviderID: "openai",
+			ModelID:    "gpt-5.4",
+		},
+		{
+			ProviderID: "",
+			ModelID:    "ignored",
+		},
+	})
+
+	models := registry.Models()
+	if len(models) != 2 {
+		t.Fatalf("expected discovered and config fallback models, got %#v", models)
+	}
+	if models[0].ProviderID != "openai" || models[0].ModelID != "gpt-5.4" {
+		t.Fatalf("expected normalized discovered model first, got %#v", models[0])
+	}
+	if models[0].DisplayAlias != "GPT" {
+		t.Fatalf("expected display alias to be trimmed, got %q", models[0].DisplayAlias)
+	}
+	if models[0].Metadata["source"] != "provider" || models[0].Metadata["supports_tools"] != "true" {
+		t.Fatalf("expected discovered metadata defaults, got %#v", models[0].Metadata)
+	}
+	if models[1].ModelID != "gpt-5.4-mini" {
+		t.Fatalf("expected config fallback model, got %#v", models[1])
+	}
+	if models[1].Metadata["source"] != "config" || models[1].Metadata["family"] != "openai" {
+		t.Fatalf("expected config metadata, got %#v", models[1].Metadata)
+	}
+
+	models[0].ModelID = "mutated"
+	copiedAgain := registry.Models()
+	if copiedAgain[0].ModelID != "gpt-5.4" {
+		t.Fatalf("expected Models to return a copy, got %#v", copiedAgain)
+	}
+
+	if _, ok := registry.Lookup(" OPENAI ", " gpt-5.4 "); !ok {
+		t.Fatal("expected lookup to normalize provider and model ids")
+	}
+	if _, ok := registry.Lookup("openai", "missing"); ok {
+		t.Fatal("expected missing lookup to return false")
+	}
+	if got := registry.ContextWindow("openai", "missing"); got != 0 {
+		t.Fatalf("expected missing context window to be zero, got %d", got)
+	}
+}
+
+func TestModelRegistryKeyRejectsEmptyParts(t *testing.T) {
+	if got := modelRegistryKey("", "model"); got != "" {
+		t.Fatalf("expected empty provider key to be rejected, got %q", got)
+	}
+	if got := modelRegistryKey("provider", " "); got != "" {
+		t.Fatalf("expected empty model key to be rejected, got %q", got)
+	}
+	if got := modelRegistryKey(" Provider ", " model "); got != "provider/model" {
+		t.Fatalf("expected normalized key, got %q", got)
+	}
+}

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 
 	"github.com/1024XEngineer/bytemind/internal/llm"
@@ -50,11 +51,36 @@ var (
 	ErrDuplicateProvider = errors.New(string(ErrCodeDuplicateProvider))
 )
 
+type ModelMetadata struct {
+	ProviderID      ProviderID
+	ModelID         ModelID
+	Family          string
+	ContextWindow   int
+	MaxOutputTokens int
+	SupportsTools   bool
+	UsageSource     string
+	Metadata        map[string]string
+}
+
 type ModelInfo struct {
 	ProviderID   ProviderID
 	ModelID      ModelID
 	DisplayAlias string
 	Metadata     map[string]string
+}
+
+func (m ModelInfo) ModelMetadata() ModelMetadata {
+	metadata := cloneMetadataMap(m.Metadata)
+	return ModelMetadata{
+		ProviderID:      m.ProviderID,
+		ModelID:         m.ModelID,
+		Family:          firstNonEmptyMetadata(metadata["family"], metadata["provider_family"]),
+		ContextWindow:   parseMetadataInt(metadata, "context_window"),
+		MaxOutputTokens: parseMetadataInt(metadata, "max_output_tokens"),
+		SupportsTools:   parseMetadataBool(metadata, "supports_tools"),
+		UsageSource:     firstNonEmptyMetadata(metadata["usage_source"], metadata["source"]),
+		Metadata:        metadata,
+	}
 }
 
 type Warning struct {
@@ -111,4 +137,51 @@ type Event struct {
 	Usage      *Usage
 	Result     *llm.Message
 	Error      *Error
+}
+
+func cloneMetadataMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func firstNonEmptyMetadata(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func parseMetadataInt(metadata map[string]string, key string) int {
+	raw := strings.TrimSpace(metadata[key])
+	if raw == "" {
+		return 0
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0
+	}
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func parseMetadataBool(metadata map[string]string, key string) bool {
+	raw := strings.TrimSpace(metadata[key])
+	if raw == "" {
+		return false
+	}
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false
+	}
+	return value
 }

--- a/internal/provider/types_test.go
+++ b/internal/provider/types_test.go
@@ -33,3 +33,67 @@ func TestProviderErrorStringAndUnwrap(t *testing.T) {
 		t.Fatalf("unexpected code-only message: %q", withCodeOnly.Error())
 	}
 }
+
+func TestModelInfoMetadataParsing(t *testing.T) {
+	info := ModelInfo{
+		ProviderID: "openai",
+		ModelID:    "gpt-5.4",
+		Metadata: map[string]string{
+			"provider_family":   "openai-compatible",
+			"context_window":    "128000",
+			"max_output_tokens": "4096",
+			"supports_tools":    "true",
+			"usage_source":      "discovered",
+		},
+	}
+	metadata := info.ModelMetadata()
+	if metadata.Family != "openai-compatible" {
+		t.Fatalf("unexpected family %q", metadata.Family)
+	}
+	if metadata.ContextWindow != 128000 || metadata.MaxOutputTokens != 4096 {
+		t.Fatalf("unexpected token metadata %+v", metadata)
+	}
+	if !metadata.SupportsTools {
+		t.Fatal("expected supports_tools to parse true")
+	}
+	if metadata.UsageSource != "discovered" {
+		t.Fatalf("unexpected usage source %q", metadata.UsageSource)
+	}
+
+	metadata.Metadata["context_window"] = "mutated"
+	if info.Metadata["context_window"] != "128000" {
+		t.Fatalf("expected metadata clone to protect original, got %#v", info.Metadata)
+	}
+}
+
+func TestModelInfoMetadataParsingFallbacks(t *testing.T) {
+	info := ModelInfo{
+		ProviderID: "local",
+		ModelID:    "model",
+		Metadata: map[string]string{
+			"family":            "custom",
+			"context_window":    "-1",
+			"max_output_tokens": "not-a-number",
+			"supports_tools":    "not-bool",
+			"source":            "config",
+		},
+	}
+	metadata := info.ModelMetadata()
+	if metadata.Family != "custom" {
+		t.Fatalf("expected family fallback, got %q", metadata.Family)
+	}
+	if metadata.ContextWindow != 0 || metadata.MaxOutputTokens != 0 {
+		t.Fatalf("expected invalid ints to parse as zero, got %+v", metadata)
+	}
+	if metadata.SupportsTools {
+		t.Fatal("expected invalid bool to parse false")
+	}
+	if metadata.UsageSource != "config" {
+		t.Fatalf("expected source fallback, got %q", metadata.UsageSource)
+	}
+
+	empty := (ModelInfo{}).ModelMetadata()
+	if len(empty.Metadata) != 0 {
+		t.Fatalf("expected empty metadata map, got %#v", empty.Metadata)
+	}
+}

--- a/tui/approval_bridge_test.go
+++ b/tui/approval_bridge_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/1024XEngineer/bytemind/internal/config"
 	"github.com/1024XEngineer/bytemind/internal/llm"
+	"github.com/1024XEngineer/bytemind/internal/provider"
 	"github.com/1024XEngineer/bytemind/internal/session"
 	"github.com/1024XEngineer/bytemind/internal/skills"
 
@@ -48,6 +49,10 @@ func (r *approvalBridgeRunnerStub) ClearActiveSkill(_ *session.Session) error {
 
 func (r *approvalBridgeRunnerStub) ClearSkill(_ string) (skills.ClearResult, error) {
 	return skills.ClearResult{}, nil
+}
+
+func (r *approvalBridgeRunnerStub) ListModels(_ context.Context) ([]provider.ModelInfo, []provider.Warning, error) {
+	return nil, nil, nil
 }
 
 func TestInstallApprovalBridgeRoutesRunnerApprovalsToAsyncChannel(t *testing.T) {

--- a/tui/component_models_command.go
+++ b/tui/component_models_command.go
@@ -1,0 +1,119 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/1024XEngineer/bytemind/internal/config"
+	"github.com/1024XEngineer/bytemind/internal/provider"
+)
+
+func (m *model) runModelsCommand(input string, fields []string) error {
+	if m == nil || m.runner == nil {
+		return fmt.Errorf("runner is unavailable")
+	}
+	if len(fields) > 1 {
+		sub := strings.ToLower(strings.TrimSpace(fields[1]))
+		if sub != "list" && sub != "status" {
+			return fmt.Errorf("usage: /models [list|status]")
+		}
+	}
+	models, warnings, err := m.runner.ListModels(context.Background())
+	if err != nil {
+		return err
+	}
+	response := formatModelsStatus(m.cfg, models, warnings)
+	m.appendCommandExchange(input, response)
+	m.statusNote = fmt.Sprintf("Listed %d model(s).", len(models))
+	return nil
+}
+
+func formatModelsStatus(cfg config.Config, models []provider.ModelInfo, warnings []provider.Warning) string {
+	lines := []string{
+		fmt.Sprintf("active: %s", activeModelLabel(cfg)),
+		fmt.Sprintf("default provider: %s", defaultProviderLabel(cfg)),
+	}
+	if len(models) == 0 {
+		lines = append(lines, "", "No models discovered.")
+	} else {
+		lines = append(lines, "", "providers:")
+		providerGroups := make(map[string][]provider.ModelInfo)
+		providerOrder := make([]string, 0)
+		for _, model := range models {
+			key := strings.TrimSpace(string(model.ProviderID))
+			if _, ok := providerGroups[key]; !ok {
+				providerOrder = append(providerOrder, key)
+			}
+			providerGroups[key] = append(providerGroups[key], model)
+		}
+		sort.Strings(providerOrder)
+		activeProvider, activeModel := activeProviderAndModel(cfg)
+		for _, providerID := range providerOrder {
+			entries := providerGroups[providerID]
+			providerLine := fmt.Sprintf("- %s", providerID)
+			if providerID == activeProvider {
+				providerLine = "* " + providerID
+			}
+			lines = append(lines, providerLine)
+			sort.Slice(entries, func(i, j int) bool { return entries[i].ModelID < entries[j].ModelID })
+			for _, entry := range entries {
+				metadata := entry.ModelMetadata()
+				labels := make([]string, 0, 3)
+				if providerID == activeProvider && string(entry.ModelID) == activeModel {
+					labels = append(labels, "active")
+				}
+				if providerID == strings.TrimSpace(cfg.ProviderRuntime.DefaultProvider) && string(entry.ModelID) == strings.TrimSpace(cfg.ProviderRuntime.DefaultModel) {
+					labels = append(labels, "default")
+				}
+				if metadata.Family != "" {
+					labels = append(labels, "family="+metadata.Family)
+				}
+				meta := ""
+				if len(labels) > 0 {
+					meta = "  [" + strings.Join(labels, ", ") + "]"
+				}
+				lines = append(lines, fmt.Sprintf("  - %s%s", entry.ModelID, meta))
+			}
+		}
+	}
+	if len(warnings) > 0 {
+		lines = append(lines, "", "warnings:")
+		for _, warning := range warnings {
+			lines = append(lines, fmt.Sprintf("- %s: %s", warning.ProviderID, warning.Reason))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func activeModelLabel(cfg config.Config) string {
+	providerID, modelID := activeProviderAndModel(cfg)
+	if providerID == "" && modelID == "" {
+		return "unknown"
+	}
+	if providerID == "" {
+		return modelID
+	}
+	if modelID == "" {
+		return providerID
+	}
+	return providerID + "/" + modelID
+}
+
+func activeProviderAndModel(cfg config.Config) (string, string) {
+	providerID := strings.TrimSpace(cfg.ProviderRuntime.DefaultProvider)
+	modelID := strings.TrimSpace(cfg.ProviderRuntime.DefaultModel)
+	if modelID == "" {
+		modelID = strings.TrimSpace(cfg.Provider.Model)
+	}
+	return providerID, modelID
+}
+
+func defaultProviderLabel(cfg config.Config) string {
+	providerID := strings.TrimSpace(cfg.ProviderRuntime.DefaultProvider)
+	if providerID == "" {
+		return "unknown"
+	}
+	return providerID
+}

--- a/tui/component_models_command.go
+++ b/tui/component_models_command.go
@@ -24,6 +24,7 @@ func (m *model) runModelsCommand(input string, fields []string) error {
 	if err != nil {
 		return err
 	}
+	m.setDiscoveredModels(models)
 	response := formatModelsStatus(m.cfg, models, warnings)
 	m.appendCommandExchange(input, response)
 	m.statusNote = fmt.Sprintf("Listed %d model(s).", len(models))

--- a/tui/component_models_command_test.go
+++ b/tui/component_models_command_test.go
@@ -1,0 +1,115 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/bytemind/internal/config"
+	"github.com/1024XEngineer/bytemind/internal/provider"
+)
+
+func TestFormatModelsStatusGroupsSortsLabelsAndWarnings(t *testing.T) {
+	cfg := config.Config{
+		ProviderRuntime: config.ProviderRuntimeConfig{
+			DefaultProvider: "openai",
+			DefaultModel:    "gpt-5.4",
+		},
+	}
+	status := formatModelsStatus(cfg, []provider.ModelInfo{
+		{ProviderID: "deepseek", ModelID: "deepseek-chat", Metadata: map[string]string{"family": "deepseek"}},
+		{ProviderID: "openai", ModelID: "gpt-5.4-mini", Metadata: map[string]string{"family": "openai"}},
+		{ProviderID: "openai", ModelID: "gpt-5.4", Metadata: map[string]string{"family": "openai"}},
+	}, []provider.Warning{{ProviderID: "deepseek", Reason: "provider_list_models_failed"}})
+
+	for _, want := range []string{
+		"active: openai/gpt-5.4",
+		"default provider: openai",
+		"* openai",
+		"  - gpt-5.4  [active, default, family=openai]",
+		"  - gpt-5.4-mini  [family=openai]",
+		"- deepseek",
+		"  - deepseek-chat  [family=deepseek]",
+		"warnings:",
+		"- deepseek: provider_list_models_failed",
+	} {
+		if !strings.Contains(status, want) {
+			t.Fatalf("expected status to contain %q, got:\n%s", want, status)
+		}
+	}
+	if strings.Index(status, "- deepseek") > strings.Index(status, "* openai") {
+		t.Fatalf("expected providers to be sorted, got:\n%s", status)
+	}
+}
+
+func TestFormatModelsStatusFallbackLabelsWhenEmpty(t *testing.T) {
+	status := formatModelsStatus(config.Config{}, nil, nil)
+	for _, want := range []string{
+		"active: unknown",
+		"default provider: unknown",
+		"No models discovered.",
+	} {
+		if !strings.Contains(status, want) {
+			t.Fatalf("expected status to contain %q, got:\n%s", want, status)
+		}
+	}
+
+	legacyStatus := formatModelsStatus(config.Config{
+		Provider: config.ProviderConfig{Model: "legacy-model"},
+	}, nil, nil)
+	if !strings.Contains(legacyStatus, "active: legacy-model") {
+		t.Fatalf("expected legacy model fallback, got:\n%s", legacyStatus)
+	}
+}
+
+func TestRunModelsCommandAppendsResponse(t *testing.T) {
+	runner := &subAgentCommandRunnerStub{
+		models: []provider.ModelInfo{{
+			ProviderID: "openai",
+			ModelID:    "gpt-5.4",
+			Metadata:   map[string]string{"family": "openai"},
+		}},
+	}
+	m := &model{
+		runner: runner,
+		cfg: config.Config{
+			ProviderRuntime: config.ProviderRuntimeConfig{
+				DefaultProvider: "openai",
+				DefaultModel:    "gpt-5.4",
+			},
+		},
+	}
+
+	if err := m.runModelsCommand("/models", []string{"/models"}); err != nil {
+		t.Fatalf("expected /models to run, got %v", err)
+	}
+	if m.statusNote != "Listed 1 model(s)." {
+		t.Fatalf("unexpected status note %q", m.statusNote)
+	}
+	if len(m.chatItems) != 2 {
+		t.Fatalf("expected command exchange to append two chat items, got %d", len(m.chatItems))
+	}
+	if m.chatItems[0].Body != "/models" {
+		t.Fatalf("expected user command body, got %q", m.chatItems[0].Body)
+	}
+	if !strings.Contains(m.chatItems[1].Body, "active: openai/gpt-5.4") {
+		t.Fatalf("expected assistant response to include model status, got:\n%s", m.chatItems[1].Body)
+	}
+}
+
+func TestRunModelsCommandRejectsInvalidState(t *testing.T) {
+	if err := (&model{}).runModelsCommand("/models", []string{"/models"}); err == nil || !strings.Contains(err.Error(), "runner is unavailable") {
+		t.Fatalf("expected missing runner error, got %v", err)
+	}
+
+	m := &model{runner: &subAgentCommandRunnerStub{}}
+	if err := m.runModelsCommand("/models delete", []string{"/models", "delete"}); err == nil || !strings.Contains(err.Error(), "usage: /models") {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+
+	runnerErr := errors.New("models offline")
+	m = &model{runner: &subAgentCommandRunnerStub{modelsErr: runnerErr}}
+	if err := m.runModelsCommand("/models status", []string{"/models", "status"}); !errors.Is(err, runnerErr) {
+		t.Fatalf("expected runner error, got %v", err)
+	}
+}

--- a/tui/component_models_command_test.go
+++ b/tui/component_models_command_test.go
@@ -67,12 +67,14 @@ func TestRunModelsCommandAppendsResponse(t *testing.T) {
 		models: []provider.ModelInfo{{
 			ProviderID: "openai",
 			ModelID:    "gpt-5.4",
-			Metadata:   map[string]string{"family": "openai"},
+			Metadata:   map[string]string{"family": "openai", "context_window": "128000"},
 		}},
 	}
 	m := &model{
-		runner: runner,
+		runner:     runner,
+		tokenUsage: newTokenUsageComponent(),
 		cfg: config.Config{
+			TokenQuota: 1000,
 			ProviderRuntime: config.ProviderRuntimeConfig{
 				DefaultProvider: "openai",
 				DefaultModel:    "gpt-5.4",
@@ -94,6 +96,9 @@ func TestRunModelsCommandAppendsResponse(t *testing.T) {
 	}
 	if !strings.Contains(m.chatItems[1].Body, "active: openai/gpt-5.4") {
 		t.Fatalf("expected assistant response to include model status, got:\n%s", m.chatItems[1].Body)
+	}
+	if m.tokenBudget != 128000 || m.tokenUsage.total != 128000 {
+		t.Fatalf("expected discovered model metadata to refresh token budget, got budget=%d total=%d", m.tokenBudget, m.tokenUsage.total)
 	}
 }
 

--- a/tui/component_run_flow.go
+++ b/tui/component_run_flow.go
@@ -54,6 +54,10 @@ func (m model) submitPrompt(value string) (tea.Model, tea.Cmd) {
 		m.statusNote = err.Error()
 		return m, nil
 	}
+	if err := validatePromptImageSupport(promptInput.UserMessage, m.currentModelLabel()); err != nil {
+		m.statusNote = err.Error()
+		return m, nil
+	}
 	return m.submitPreparedPrompt(promptInput, displayText)
 }
 

--- a/tui/component_sessions.go
+++ b/tui/component_sessions.go
@@ -134,9 +134,7 @@ func (m *model) newSession() error {
 	m.statusNote = "Started a new session."
 	m.chatAutoFollow = true
 	m.restoreTokenUsageFromSession(next)
-	_ = m.tokenUsage.SetUsage(m.tokenUsedTotal, 0)
-	m.tokenUsage.SetUnavailable(!m.tokenHasOfficialUsage)
-	m.tokenUsage.SetBreakdown(m.tokenInput, m.tokenOutput, m.tokenContext)
+	m.syncTokenUsageComponent()
 	m.inputImageRefs = make(map[int]llm.AssetID, 8)
 	m.inputImageMentions = make(map[string]llm.AssetID, 8)
 	m.orphanedImages = make(map[llm.AssetID]time.Time, 8)
@@ -194,9 +192,7 @@ func (m *model) resumeSession(prefix string) error {
 	m.statusNote = "Resumed session " + shortID(next.ID)
 	m.chatAutoFollow = true
 	m.restoreTokenUsageFromSession(next)
-	_ = m.tokenUsage.SetUsage(m.tokenUsedTotal, 0)
-	m.tokenUsage.SetUnavailable(!m.tokenHasOfficialUsage)
-	m.tokenUsage.SetBreakdown(m.tokenInput, m.tokenOutput, m.tokenContext)
+	m.syncTokenUsageComponent()
 	m.inputImageRefs = make(map[int]llm.AssetID, 8)
 	m.inputImageMentions = make(map[string]llm.AssetID, 8)
 	m.orphanedImages = make(map[llm.AssetID]time.Time, 8)

--- a/tui/component_slash_entry.go
+++ b/tui/component_slash_entry.go
@@ -46,6 +46,8 @@ func (m *model) handleSlashCommand(input string) error {
 		return m.runBuiltinSubAgentCommand(input, fields[0])
 	case "/mcp":
 		return m.runMCPCommandDispatch(input, fields)
+	case "/models":
+		return m.runModelsCommand(input, fields)
 	case "/new":
 		return m.newSession()
 	case "/compact":

--- a/tui/component_startup_guide.go
+++ b/tui/component_startup_guide.go
@@ -93,6 +93,10 @@ func (m *model) verifyAndFinalizeStartupAPIKey(rawInput string) error {
 		m.runner.UpdateProvider(checkCfg, client)
 	}
 	m.cfg.Provider = checkCfg
+	m.cfg.ProviderRuntime = config.SyncProviderRuntimeWithProvider(m.cfg.ProviderRuntime, checkCfg)
+	m.discoveredModels = nil
+	m.refreshTokenBudget()
+	m.syncTokenUsageComponent()
 	m.startupGuide.Active = false
 	m.statusNote = "Provider configured and verified. You can start chatting."
 	m.llmConnected = true
@@ -132,6 +136,8 @@ func (m *model) applyStartupConfigField(field, value string) error {
 	default:
 		return fmt.Errorf("unsupported setup field: %s", field)
 	}
+	m.cfg.ProviderRuntime = config.SyncProviderRuntimeWithProvider(m.cfg.ProviderRuntime, m.cfg.Provider)
+	m.discoveredModels = nil
 
 	writtenPath, err := config.UpsertProviderField(m.startupGuide.ConfigPath, field, persistValue)
 	if err != nil {

--- a/tui/component_startup_guide.go
+++ b/tui/component_startup_guide.go
@@ -50,6 +50,9 @@ func (m *model) handleStartupGuideSubmission(rawInput string) error {
 func (m *model) verifyAndFinalizeStartupAPIKey(rawInput string) error {
 	apiKey := sanitizeAPIKeyInput(rawInput)
 	if apiKey == "" {
+		apiKey = strings.TrimSpace(m.cfg.Provider.ResolveAPIKey())
+	}
+	if apiKey == "" {
 		return fmt.Errorf("please paste a non-empty API key")
 	}
 
@@ -59,7 +62,14 @@ func (m *model) verifyAndFinalizeStartupAPIKey(rawInput string) error {
 	if !check.Ready {
 		m.llmConnected = false
 		m.phase = "error"
-		m.setStartupGuideStep(startupFieldAPIKey, startupGuideIssueHint(check))
+		recoveryField := startupGuideRecoveryField(check)
+		if recoveryField != startupFieldAPIKey {
+			m.cfg.Provider.APIKey = apiKey
+			m.input.Reset()
+			m.clearPasteTransaction()
+			m.releasePasteSubmitSuppression()
+		}
+		m.setStartupGuideStep(recoveryField, startupGuideIssueHint(check))
 		return nil
 	}
 
@@ -332,12 +342,16 @@ func startupGuideStepLines(field string, cfg config.Config, configPath, issue st
 		lines = append(lines, "Enter provider: openai-compatible or anthropic.")
 	case startupFieldBaseURL:
 		lines = append(lines, "Enter provider base_url.")
-		lines = append(lines, "Example: https://api.deepseek.com")
+		lines = append(lines, "Example: https://api.deepseek.com/v1")
 	case startupFieldModel:
 		lines = append(lines, "Enter model name.")
 		lines = append(lines, "Example: deepseek-chat or GPT-5.4")
 	case startupFieldAPIKey:
-		lines = append(lines, "Paste API key and press Enter.")
+		if strings.TrimSpace(cfg.Provider.ResolveAPIKey()) != "" {
+			lines = append(lines, "Press Enter to retry the current API key, or paste a new one.")
+		} else {
+			lines = append(lines, "Paste API key and press Enter.")
+		}
 		lines = append(lines, "Bytemind will verify it automatically.")
 	}
 
@@ -365,6 +379,23 @@ func startupGuideStepLines(field string, cfg config.Config, configPath, issue st
 		lines = append(lines, "Config file: "+configPath)
 	}
 	return lines
+}
+
+func startupGuideRecoveryField(check provider.Availability) string {
+	reason := strings.ToLower(strings.TrimSpace(check.Reason))
+	detail := strings.ToLower(strings.TrimSpace(check.Detail))
+	switch {
+	case strings.Contains(reason, "missing api key"), strings.Contains(reason, "unauthorized"):
+		return startupFieldAPIKey
+	case strings.Contains(reason, "incomplete"),
+		strings.Contains(reason, "failed to build"),
+		strings.Contains(reason, "failed to reach"),
+		strings.Contains(reason, "not found"),
+		strings.Contains(detail, "base_url"):
+		return startupFieldBaseURL
+	default:
+		return startupFieldAPIKey
+	}
 }
 
 func startupGuideIssueHint(check provider.Availability) string {

--- a/tui/component_status_scroll.go
+++ b/tui/component_status_scroll.go
@@ -22,6 +22,9 @@ func (m model) renderTopRightCluster(width int) string {
 }
 
 func (m model) renderTokenBadge(width int) string {
+	if width < 80 {
+		return m.tokenUsage.CompactView()
+	}
 	return m.tokenUsage.View()
 }
 

--- a/tui/component_subagent_commands_test.go
+++ b/tui/component_subagent_commands_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/agent"
 	"github.com/1024XEngineer/bytemind/internal/config"
 	"github.com/1024XEngineer/bytemind/internal/llm"
+	"github.com/1024XEngineer/bytemind/internal/provider"
 	"github.com/1024XEngineer/bytemind/internal/session"
 	"github.com/1024XEngineer/bytemind/internal/skills"
 	subagentspkg "github.com/1024XEngineer/bytemind/internal/subagents"
@@ -56,6 +57,10 @@ func (s *subAgentCommandRunnerStub) ClearActiveSkill(*session.Session) error {
 
 func (s *subAgentCommandRunnerStub) ClearSkill(string) (skills.ClearResult, error) {
 	return skills.ClearResult{}, nil
+}
+
+func (s *subAgentCommandRunnerStub) ListModels(context.Context) ([]provider.ModelInfo, []provider.Warning, error) {
+	return nil, nil, nil
 }
 
 func (s *subAgentCommandRunnerStub) ListSubAgents() ([]subagentspkg.Agent, []subagentspkg.Diagnostic) {

--- a/tui/component_subagent_commands_test.go
+++ b/tui/component_subagent_commands_test.go
@@ -27,6 +27,9 @@ type subAgentCommandRunnerStub struct {
 	builtinAgent subagentspkg.Agent
 	builtinOK    bool
 	lastRequest  tools.DelegateSubAgentRequest
+	models       []provider.ModelInfo
+	warnings     []provider.Warning
+	modelsErr    error
 }
 
 func (s *subAgentCommandRunnerStub) RunPromptWithInput(context.Context, *session.Session, RunPromptInput, string, io.Writer) (string, error) {
@@ -60,7 +63,7 @@ func (s *subAgentCommandRunnerStub) ClearSkill(string) (skills.ClearResult, erro
 }
 
 func (s *subAgentCommandRunnerStub) ListModels(context.Context) ([]provider.ModelInfo, []provider.Warning, error) {
-	return nil, nil, nil
+	return s.models, s.warnings, s.modelsErr
 }
 
 func (s *subAgentCommandRunnerStub) ListSubAgents() ([]subagentspkg.Agent, []subagentspkg.Diagnostic) {

--- a/tui/component_token_usage_runtime.go
+++ b/tui/component_token_usage_runtime.go
@@ -6,7 +6,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/1024XEngineer/bytemind/internal/config"
 	"github.com/1024XEngineer/bytemind/internal/llm"
+	"github.com/1024XEngineer/bytemind/internal/provider"
 	"github.com/1024XEngineer/bytemind/internal/session"
 )
 
@@ -139,11 +141,20 @@ func (m *model) refreshTokenBudget() {
 		return
 	}
 	budget := max(1, m.cfg.TokenQuota)
-	if m.cfg.ProviderRuntime.DefaultModel == "" {
-		m.tokenBudget = budget
-		return
+	runtimeCfg := m.cfg.ProviderRuntime
+	if len(runtimeCfg.Providers) == 0 {
+		runtimeCfg = config.LegacyProviderRuntimeConfig(m.cfg.Provider)
 	}
-	if strings.TrimSpace(m.cfg.ProviderRuntime.DefaultModel) != "" {
-		m.tokenBudget = budget
+	providerID := strings.TrimSpace(runtimeCfg.DefaultProvider)
+	modelID := strings.TrimSpace(runtimeCfg.DefaultModel)
+	if modelID == "" {
+		modelID = strings.TrimSpace(m.cfg.Provider.Model)
 	}
+	if providerID != "" && modelID != "" {
+		registry := provider.NewModelRegistry(runtimeCfg, nil)
+		if contextWindow := registry.ContextWindow(provider.ProviderID(providerID), provider.ModelID(modelID)); contextWindow > 0 {
+			budget = contextWindow
+		}
+	}
+	m.tokenBudget = budget
 }

--- a/tui/component_token_usage_runtime.go
+++ b/tui/component_token_usage_runtime.go
@@ -53,6 +53,24 @@ func (m *model) SetUsage(used, total int) tea.Cmd {
 	return m.tokenUsage.SetUsage(used, m.tokenBudget)
 }
 
+func (m *model) syncTokenUsageComponent() {
+	if m == nil {
+		return
+	}
+	_ = m.tokenUsage.SetUsage(m.tokenUsedTotal, m.tokenBudget)
+	m.tokenUsage.SetUnavailable(!m.tokenHasOfficialUsage)
+	m.tokenUsage.SetBreakdown(m.tokenInput, m.tokenOutput, m.tokenContext)
+}
+
+func (m *model) setDiscoveredModels(models []provider.ModelInfo) {
+	if m == nil {
+		return
+	}
+	m.discoveredModels = append([]provider.ModelInfo(nil), models...)
+	m.refreshTokenBudget()
+	m.syncTokenUsageComponent()
+}
+
 func (m model) renderStartupGuidePanel() string {
 	width := max(24, m.commandPaletteWidth())
 	title := strings.TrimSpace(m.startupGuide.Title)
@@ -142,16 +160,23 @@ func (m *model) refreshTokenBudget() {
 	}
 	budget := max(1, m.cfg.TokenQuota)
 	runtimeCfg := m.cfg.ProviderRuntime
-	if len(runtimeCfg.Providers) == 0 {
-		runtimeCfg = config.LegacyProviderRuntimeConfig(m.cfg.Provider)
-	}
 	providerID := strings.TrimSpace(runtimeCfg.DefaultProvider)
 	modelID := strings.TrimSpace(runtimeCfg.DefaultModel)
 	if modelID == "" {
 		modelID = strings.TrimSpace(m.cfg.Provider.Model)
 	}
+	if providerID == "" {
+		legacy := config.LegacyProviderRuntimeConfig(m.cfg.Provider)
+		providerID = strings.TrimSpace(legacy.DefaultProvider)
+		if modelID == "" {
+			modelID = strings.TrimSpace(legacy.DefaultModel)
+		}
+		if len(runtimeCfg.Providers) == 0 {
+			runtimeCfg = legacy
+		}
+	}
 	if providerID != "" && modelID != "" {
-		registry := provider.NewModelRegistry(runtimeCfg, nil)
+		registry := provider.NewModelRegistry(runtimeCfg, m.discoveredModels)
 		if contextWindow := registry.ContextWindow(provider.ProviderID(providerID), provider.ModelID(modelID)); contextWindow > 0 {
 			budget = contextWindow
 		}

--- a/tui/component_token_usage_runtime.go
+++ b/tui/component_token_usage_runtime.go
@@ -23,6 +23,7 @@ func (m *model) applyUsage(usage llm.Usage) {
 	if used == 0 && input == 0 && output == 0 && context == 0 {
 		return
 	}
+	m.refreshTokenBudget()
 
 	// Replace provisional stream estimate with provider-confirmed usage.
 	if m.tempEstimatedOutput > 0 {
@@ -35,7 +36,7 @@ func (m *model) applyUsage(usage llm.Usage) {
 	m.tokenInput += input
 	m.tokenOutput += output
 	m.tokenContext += context
-	_ = m.tokenUsage.SetUsage(m.tokenUsedTotal, 0)
+	_ = m.tokenUsage.SetUsage(m.tokenUsedTotal, m.tokenBudget)
 	m.tokenUsage.SetUnavailable(false)
 	m.tokenUsage.SetBreakdown(m.tokenInput, m.tokenOutput, m.tokenContext)
 }
@@ -43,7 +44,11 @@ func (m *model) applyUsage(usage llm.Usage) {
 func (m *model) SetUsage(used, total int) tea.Cmd {
 	m.tokenHasOfficialUsage = true
 	m.tokenUsage.SetUnavailable(false)
-	return m.tokenUsage.SetUsage(used, 0)
+	m.refreshTokenBudget()
+	if total > 0 {
+		m.tokenBudget = total
+	}
+	return m.tokenUsage.SetUsage(used, m.tokenBudget)
 }
 
 func (m model) renderStartupGuidePanel() string {
@@ -109,6 +114,7 @@ func (m *model) restoreTokenUsageFromSession(sess *session.Session) {
 	if sess != nil {
 		m.accumulateTokenUsage(sess.Messages)
 	}
+	m.refreshTokenBudget()
 }
 
 func (m *model) accumulateTokenUsage(messages []llm.Message) {
@@ -125,5 +131,19 @@ func (m *model) accumulateTokenUsage(messages []llm.Message) {
 		m.tokenInput += max(0, msg.Usage.InputTokens)
 		m.tokenOutput += max(0, msg.Usage.OutputTokens)
 		m.tokenContext += max(0, msg.Usage.ContextTokens)
+	}
+}
+
+func (m *model) refreshTokenBudget() {
+	if m == nil {
+		return
+	}
+	budget := max(1, m.cfg.TokenQuota)
+	if m.cfg.ProviderRuntime.DefaultModel == "" {
+		m.tokenBudget = budget
+		return
+	}
+	if strings.TrimSpace(m.cfg.ProviderRuntime.DefaultModel) != "" {
+		m.tokenBudget = budget
 	}
 }

--- a/tui/component_token_usage_runtime_test.go
+++ b/tui/component_token_usage_runtime_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/1024XEngineer/bytemind/internal/config"
 	"github.com/1024XEngineer/bytemind/internal/llm"
+	"github.com/1024XEngineer/bytemind/internal/provider"
+	"github.com/1024XEngineer/bytemind/internal/session"
 )
 
 func TestApplyUsageEarlyReturnWhenPayloadHasNoTokens(t *testing.T) {
@@ -122,5 +125,58 @@ func TestRestoreTokenUsageFromSessionNilResetsCounters(t *testing.T) {
 	}
 	if m.tempEstimatedOutput != 0 {
 		t.Fatalf("expected nil-session restore to clear temporary estimate, got %d", m.tempEstimatedOutput)
+	}
+}
+
+func TestNewModelRestoresTokenBudgetOnFirstRender(t *testing.T) {
+	sess := session.New(t.TempDir())
+	sess.Messages = append(sess.Messages, llm.Message{
+		Role:  llm.RoleAssistant,
+		Usage: &llm.Usage{TotalTokens: 42},
+	})
+
+	m := newModel(Options{
+		Session: sess,
+		Config: config.Config{
+			TokenQuota: 12345,
+			Provider:   config.ProviderConfig{Model: "gpt-5.4"},
+		},
+		Workspace: t.TempDir(),
+	})
+
+	if m.tokenBudget != 12345 {
+		t.Fatalf("expected restored token budget 12345, got %d", m.tokenBudget)
+	}
+	if m.tokenUsage.total != 12345 {
+		t.Fatalf("expected token monitor total to preserve budget, got %d", m.tokenUsage.total)
+	}
+	if m.tokenUsage.used != 42 {
+		t.Fatalf("expected token monitor to show restored usage, got %d", m.tokenUsage.used)
+	}
+	if m.tokenUsage.unavailable {
+		t.Fatal("expected restored session usage to mark token monitor available")
+	}
+}
+
+func TestRefreshTokenBudgetUsesDiscoveredModelMetadata(t *testing.T) {
+	m := model{
+		cfg: config.Config{
+			TokenQuota: 1000,
+			ProviderRuntime: config.ProviderRuntimeConfig{
+				DefaultProvider: "openai",
+				DefaultModel:    "gpt-5.4",
+			},
+		},
+		discoveredModels: []provider.ModelInfo{{
+			ProviderID: "openai",
+			ModelID:    "gpt-5.4",
+			Metadata:   map[string]string{"context_window": "128000"},
+		}},
+	}
+
+	m.refreshTokenBudget()
+
+	if m.tokenBudget != 128000 {
+		t.Fatalf("expected model context window budget, got %d", m.tokenBudget)
 	}
 }

--- a/tui/input_images.go
+++ b/tui/input_images.go
@@ -21,6 +21,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/session"
 )
 
+
 var imagePlaceholderPattern = regexp.MustCompile(`\[Image ?#(\d+)\]`)
 var imageMentionPattern = regexp.MustCompile(`(?i)@([^\s@]+?\.(?:png|jpe?g|webp|gif))`)
 var inlineWindowsImagePathPattern = regexp.MustCompile(`(?i)[a-z]:\\[^\r\n\t"'<>|]*?\.(?:png|jpe?g|webp|gif)`)
@@ -779,6 +780,39 @@ func collectImageAssetIDsFromMessages(messages []llm.Message) []llm.AssetID {
 		return nil
 	}
 	return assetIDs
+}
+
+func validatePromptImageSupport(message llm.Message, modelLabel string) error {
+	message.Normalize()
+	hasImage := false
+	for _, part := range message.Parts {
+		if part.Type == llm.PartImageRef && part.Image != nil {
+			hasImage = true
+			break
+		}
+	}
+	if !hasImage {
+		return nil
+	}
+	modelName := normalizeCapabilityModelName(modelLabel)
+	if llm.DefaultModelCapabilities.Resolve(modelName).SupportsVision {
+		return nil
+	}
+	return fmt.Errorf("this model does not support image input; remove the image and try again")
+}
+
+func normalizeCapabilityModelName(modelLabel string) string {
+	modelLabel = strings.TrimSpace(modelLabel)
+	if modelLabel == "" {
+		return ""
+	}
+	if strings.HasPrefix(modelLabel, "(") && strings.HasSuffix(modelLabel, ")") {
+		return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(modelLabel, "("), ")"))
+	}
+	if slash := strings.LastIndex(modelLabel, "/"); slash >= 0 && slash < len(modelLabel)-1 {
+		return strings.TrimSpace(modelLabel[slash+1:])
+	}
+	return modelLabel
 }
 
 func (m *model) findAssetByImageID(imageID int) (llm.AssetID, session.ImageAssetMeta, bool) {

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -656,6 +656,9 @@ func (m *model) ingestPasteFragment(fragment, source string) tea.Cmd {
 }
 
 func (m model) handlePastePayload(payload string) (tea.Model, tea.Cmd) {
+	if m.startupGuide.Active {
+		return m.insertStartupGuideText(payload), nil
+	}
 	cleaned := trimTrailingPasteTerminators(payload)
 	candidate := strings.ReplaceAll(normalizeNewlines(cleaned), ctrlVMarkerRune, "")
 	if strings.TrimSpace(candidate) == "" {

--- a/tui/model.go
+++ b/tui/model.go
@@ -346,6 +346,7 @@ var commandItems = []commandItem{
 	{Name: "/mcp list", Usage: "/mcp list", Description: "List configured MCP servers and current status.", Kind: "command"},
 	{Name: "/mcp help", Usage: "/mcp help", Description: "Show MCP command help.", Kind: "command"},
 	{Name: "/mcp show", Usage: "/mcp show <id>", Description: "Show one MCP server config and runtime state.", Kind: "command"},
+	{Name: "/models", Usage: "/models", Description: "Show configured providers and available models.", Kind: "command"},
 	{Name: "/new", Usage: "/new", Description: "Start a fresh session in this workspace.", Kind: "command"},
 	{Name: "/compact", Usage: "/compact", Description: "Compress long session history into a continuation summary.", Kind: "command"},
 	{Name: "/commit", Usage: "/commit <message>", Description: "Stage all changes and create a local Git commit.", Kind: "command"},

--- a/tui/model.go
+++ b/tui/model.go
@@ -20,6 +20,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/mention"
 	notifypkg "github.com/1024XEngineer/bytemind/internal/notify"
 	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+	"github.com/1024XEngineer/bytemind/internal/provider"
 	"github.com/1024XEngineer/bytemind/internal/session"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -451,6 +452,7 @@ type model struct {
 	tokenOutput                int
 	tokenContext               int
 	tokenHasOfficialUsage      bool
+	discoveredModels           []provider.ModelInfo
 	tempEstimatedOutput        int
 	tokenEstimator             *realtimeTokenEstimator
 	promptHistoryLoaded        bool
@@ -602,9 +604,7 @@ func newModel(opts Options) model {
 		m.initializeStartupGuide()
 	}
 	m.restoreTokenUsageFromSession(opts.Session)
-	_ = m.tokenUsage.SetUsage(m.tokenUsedTotal, 0)
-	m.tokenUsage.SetUnavailable(!m.tokenHasOfficialUsage)
-	m.tokenUsage.SetBreakdown(m.tokenInput, m.tokenOutput, m.tokenContext)
+	m.syncTokenUsageComponent()
 	m.ensureSessionImageAssets()
 	m.ensurePastedContentState()
 	m.syncPlanActionPicker()

--- a/tui/model.go
+++ b/tui/model.go
@@ -1564,6 +1564,9 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.planActionOpen {
 		return m.handlePlanActionKey(msg)
 	}
+	if next, cmd, handled := m.handleStartupGuideKey(msg); handled {
+		return next, cmd
+	}
 	if m.consumePasteEchoKey(msg) {
 		return m, nil
 	}
@@ -1885,12 +1888,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		value := strings.TrimSpace(rawValue)
 		if m.startupGuide.Active && !strings.HasPrefix(value, "/") {
-			previousScreen := m.screen
-			if err := m.handleStartupGuideSubmission(rawValue); err != nil {
-				m.statusNote = err.Error()
-			}
-			m.screen = screenLanding
-			return m, m.startLandingGlowOnTransition(previousScreen)
+			return m.submitStartupGuideInput()
 		}
 		if value == "" {
 			return m, nil
@@ -1977,6 +1975,100 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	m.syncInputOverlays()
 	return m, cmd
+}
+
+func (m model) shouldSubmitStartupGuideInput(msg tea.KeyMsg) bool {
+	if !m.startupGuide.Active || msg.Paste || msg.Type != tea.KeyEnter || isInputNewlineKey(msg) {
+		return false
+	}
+	if m.commandOpen || m.skillsOpen || m.mentionOpen || m.sessionsOpen || m.promptSearchOpen || m.planActionOpen || m.approval != nil {
+		return false
+	}
+	return !strings.HasPrefix(strings.TrimSpace(m.input.Value()), "/")
+}
+
+func (m model) handleStartupGuideKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	if !m.startupGuide.Active {
+		return m, nil, false
+	}
+	if m.commandOpen || m.skillsOpen || m.mentionOpen || m.sessionsOpen || m.promptSearchOpen || m.planActionOpen || m.approval != nil {
+		return m, nil, false
+	}
+	if msg.Type != tea.KeyEnter && m.consumePasteEchoKey(msg) {
+		return m, nil, true
+	}
+	if m.shouldSubmitStartupGuideInput(msg) {
+		next, cmd := m.submitStartupGuideInput()
+		return next, cmd, true
+	}
+	if isInputNewlineKey(msg) {
+		next, cmd := m.updateStartupGuideInput(tea.KeyMsg{Type: tea.KeyEnter})
+		return next, cmd, true
+	}
+	if isCtrlVPasteKey(msg) {
+		if payload, ok := m.readClipboardTextForPaste(); ok {
+			next := m.insertStartupGuideText(payload)
+			next.beginPasteTransaction(payload, "startup-ctrl+v")
+			return next, nil, true
+		}
+		return m, nil, true
+	}
+	if isStartupGuideTextInputKey(msg) {
+		next, cmd := m.updateStartupGuideInput(msg)
+		return next, cmd, true
+	}
+	return m, nil, false
+}
+
+func isStartupGuideTextInputKey(msg tea.KeyMsg) bool {
+	if msg.Paste {
+		return true
+	}
+	switch msg.Type {
+	case tea.KeyRunes, tea.KeySpace, tea.KeyBackspace, tea.KeyDelete, tea.KeyCtrlH:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m model) updateStartupGuideInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	m.clearStartupGuidePasteState()
+	return m, cmd
+}
+
+func (m model) insertStartupGuideText(payload string) model {
+	if payload == "" {
+		return m
+	}
+	m.input.SetValue(m.input.Value() + normalizeNewlines(payload))
+	m.input.CursorEnd()
+	m.clearStartupGuidePasteState()
+	return m
+}
+
+func (m *model) clearStartupGuidePasteState() {
+	m.clearPasteTransaction()
+	m.clearPasteSession()
+	m.clearHiddenPasteProbe()
+	m.releasePasteSubmitSuppression()
+	m.clearVirtualPasteParts()
+	m.clearPasteConfirmPending()
+	m.clearPasteBurstCapture()
+	m.clearPasteBurstCandidate()
+}
+
+func (m model) submitStartupGuideInput() (tea.Model, tea.Cmd) {
+	previousScreen := m.screen
+	rawValue := m.input.Value()
+	m.clearStartupGuidePasteState()
+	if err := m.handleStartupGuideSubmission(rawValue); err != nil {
+		m.statusNote = err.Error()
+	}
+	m.screen = screenLanding
+	return m, m.startLandingGlowOnTransition(previousScreen)
 }
 
 func (m model) shouldSuppressEnterAfterPaste() bool {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -1468,6 +1468,252 @@ func TestStartupGuideAcceptsValidKeyAndDisablesGuide(t *testing.T) {
 	}
 }
 
+func TestStartupGuideAPIKeyEnterBypassesPasteGuards(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"provider":{"type":"openai-compatible","base_url":"`+server.URL+`","model":"gpt-5.4"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("test-key")
+	m := model{
+		input: input,
+		cfg: config.Config{
+			Provider: config.ProviderConfig{
+				Type:      "openai-compatible",
+				BaseURL:   server.URL,
+				Model:     "gpt-5.4",
+				APIKeyEnv: "BYTEMIND_API_KEY",
+			},
+		},
+		startupGuide: StartupGuide{
+			Active:       true,
+			Status:       "Bytemind needs a working API key before chat can start.",
+			ConfigPath:   configPath,
+			CurrentField: startupFieldAPIKey,
+		},
+	}
+	now := time.Now()
+	m.beginPasteTransaction("test-key", "paste-key")
+	m.lastPasteAt = now
+	m.lastInputAt = now
+	m.inputBurstSize = len("test-key")
+	m.armPasteSubmitGuard(now)
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+	if updated.startupGuide.Active {
+		t.Fatalf("expected startup guide to submit API key despite paste guard")
+	}
+	if !strings.Contains(updated.statusNote, "Provider configured and verified") {
+		t.Fatalf("unexpected status after setup: %q", updated.statusNote)
+	}
+}
+
+func TestStartupGuideEndpointFailureReturnsToBaseURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"provider":{"type":"openai-compatible","base_url":"`+server.URL+`","model":"gpt-5.4"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("test-key")
+	m := model{
+		input: input,
+		cfg: config.Config{
+			Provider: config.ProviderConfig{
+				Type:    "openai-compatible",
+				BaseURL: server.URL,
+				Model:   "gpt-5.4",
+			},
+		},
+		startupGuide: StartupGuide{
+			Active:       true,
+			Status:       "Bytemind needs a working API key before chat can start.",
+			ConfigPath:   configPath,
+			CurrentField: startupFieldAPIKey,
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+	if !updated.startupGuide.Active {
+		t.Fatalf("expected startup guide to stay active after endpoint failure")
+	}
+	if updated.startupGuide.CurrentField != startupFieldBaseURL {
+		t.Fatalf("expected endpoint failure to return to base_url step, got %q", updated.startupGuide.CurrentField)
+	}
+	if updated.cfg.Provider.APIKey != "test-key" {
+		t.Fatalf("expected API key to remain available in memory, got %q", updated.cfg.Provider.APIKey)
+	}
+	if updated.input.Value() != "" {
+		t.Fatalf("expected input to be cleared before base_url retry, got %q", updated.input.Value())
+	}
+	if !strings.Contains(updated.statusNote, "Provider endpoint path looks incorrect") {
+		t.Fatalf("expected endpoint issue hint, got %q", updated.statusNote)
+	}
+}
+
+func TestStartupGuideAPIKeyStepRetriesCurrentKeyOnEmptyEnter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"provider":{"type":"openai-compatible","base_url":"`+server.URL+`","model":"gpt-5.4","api_key":"test-key"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := textarea.New()
+	input.Focus()
+	m := model{
+		input: input,
+		cfg: config.Config{
+			Provider: config.ProviderConfig{
+				Type:    "openai-compatible",
+				BaseURL: server.URL,
+				Model:   "gpt-5.4",
+				APIKey:  "test-key",
+			},
+		},
+		startupGuide: StartupGuide{
+			Active:       true,
+			Status:       "Bytemind needs a working API key before chat can start.",
+			ConfigPath:   configPath,
+			CurrentField: startupFieldAPIKey,
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+	if updated.startupGuide.Active {
+		t.Fatalf("expected startup guide to verify current API key on empty Enter")
+	}
+	if !strings.Contains(updated.statusNote, "Provider configured and verified") {
+		t.Fatalf("unexpected status after setup: %q", updated.statusNote)
+	}
+}
+
+func TestStartupGuidePastePayloadKeepsAPIKeyLiteral(t *testing.T) {
+	apiKey := "sk-" + strings.Repeat("abcdef0123456789", 12)
+	input := textarea.New()
+	input.Focus()
+	m := model{
+		input: input,
+		startupGuide: StartupGuide{
+			Active:       true,
+			CurrentField: startupFieldAPIKey,
+		},
+	}
+
+	got, cmd := m.handlePastePayload(apiKey)
+	updated := got.(model)
+	if cmd != nil {
+		t.Fatalf("expected startup guide paste to avoid paste compression timers")
+	}
+	if updated.input.Value() != apiKey {
+		t.Fatalf("expected API key paste to stay literal, got %q", updated.input.Value())
+	}
+	if strings.Contains(updated.input.Value(), "[Paste #") || len(updated.pastedOrder) != 0 {
+		t.Fatalf("expected no compressed paste marker, got input=%q pasted=%v", updated.input.Value(), updated.pastedOrder)
+	}
+}
+
+func TestStartupGuideBulkRunesKeepAPIKeyLiteral(t *testing.T) {
+	apiKey := "sk-" + strings.Repeat("0123456789abcdef", 12)
+	input := textarea.New()
+	input.Focus()
+	m := model{
+		input: input,
+		startupGuide: StartupGuide{
+			Active:       true,
+			CurrentField: startupFieldAPIKey,
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(apiKey)})
+	updated := got.(model)
+	if updated.input.Value() != apiKey {
+		t.Fatalf("expected bulk API key input to stay literal, got %q", updated.input.Value())
+	}
+	if strings.Contains(updated.input.Value(), "[Paste #") || len(updated.pastedOrder) != 0 {
+		t.Fatalf("expected no compressed paste marker, got input=%q pasted=%v", updated.input.Value(), updated.pastedOrder)
+	}
+}
+
+func TestStartupGuideConsumesCtrlVPasteEchoWithoutDuplicatingKey(t *testing.T) {
+	apiKey := "sk-" + strings.Repeat("fedcba9876543210", 8)
+	input := textarea.New()
+	input.Focus()
+	input.SetValue(apiKey)
+	m := model{
+		input: input,
+		startupGuide: StartupGuide{
+			Active:       true,
+			CurrentField: startupFieldAPIKey,
+		},
+	}
+	m.beginPasteTransaction(apiKey, "startup-ctrl+v")
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(apiKey)})
+	updated := got.(model)
+	if updated.input.Value() != apiKey {
+		t.Fatalf("expected echoed Ctrl+V paste payload to be consumed, got %q", updated.input.Value())
+	}
+}
+
+func TestStartupGuideCtrlJInsertsNewline(t *testing.T) {
+	input := textarea.New()
+	input.Focus()
+	input.SetValue("first line")
+	input.CursorEnd()
+	m := model{
+		input: input,
+		startupGuide: StartupGuide{
+			Active:       true,
+			CurrentField: startupFieldAPIKey,
+		},
+	}
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlJ})
+	updated := got.(model)
+	if !strings.Contains(updated.input.Value(), "\n") {
+		t.Fatalf("expected Ctrl+J to insert newline in startup guide, got %q", updated.input.Value())
+	}
+	if !updated.startupGuide.Active {
+		t.Fatalf("expected newline shortcut not to submit startup guide")
+	}
+}
+
 func TestStartupGuideSupportsModelAndBaseURLInput(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	if err := os.WriteFile(configPath, []byte(`{
@@ -2540,6 +2786,31 @@ func TestEnterSubmitsPrompt(t *testing.T) {
 	}
 	if updated.chatItems[0].Body != "ship this prompt" {
 		t.Fatalf("expected submitted user prompt to match input, got %q", updated.chatItems[0].Body)
+	}
+}
+
+func TestSubmitPromptImageUnsupportedKeepsInput(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	m.cfg.Provider.Model = "text-only-model"
+	_ = mustIngestTestImage(t, m, "image")
+	assetID := findAssetIDByImageID(t, m, 1)
+	m.bindMentionImageAsset("image.png", assetID)
+	m.input.SetWidth(40)
+	m.input.SetHeight(3)
+	m.input.SetValue("please read @image.png")
+	m.input.CursorEnd()
+
+	got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+	if len(updated.chatItems) != 0 {
+		t.Fatalf("expected unsupported image prompt not to submit, got %d chat items", len(updated.chatItems))
+	}
+	if strings.TrimSpace(updated.input.Value()) != "please read @image.png" {
+		t.Fatalf("expected unsupported image prompt to keep input, got %q", updated.input.Value())
+	}
+	if !strings.Contains(strings.ToLower(updated.statusNote), "does not support image input") {
+		t.Fatalf("expected image support error, got %q", updated.statusNote)
 	}
 }
 

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/mention"
 	notifypkg "github.com/1024XEngineer/bytemind/internal/notify"
 	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+	"github.com/1024XEngineer/bytemind/internal/provider"
 	"github.com/1024XEngineer/bytemind/internal/session"
 	"github.com/1024XEngineer/bytemind/internal/tools"
 
@@ -1441,7 +1442,15 @@ func TestStartupGuideAcceptsValidKeyAndDisablesGuide(t *testing.T) {
 				Model:     "gpt-5.4",
 				APIKeyEnv: "BYTEMIND_API_KEY",
 			},
+			ProviderRuntime: config.ProviderRuntimeConfig{
+				DefaultProvider: "old",
+				DefaultModel:    "old-model",
+				Providers: map[string]config.ProviderConfig{
+					"old": {Type: "openai-compatible", Model: "old-model"},
+				},
+			},
 		},
+		discoveredModels: []provider.ModelInfo{{ProviderID: "old", ModelID: "old-model"}},
 		startupGuide: StartupGuide{
 			Active:       true,
 			Status:       "Bytemind needs a working API key before chat can start.",
@@ -1457,6 +1466,15 @@ func TestStartupGuideAcceptsValidKeyAndDisablesGuide(t *testing.T) {
 	}
 	if !strings.Contains(updated.statusNote, "Provider configured and verified") {
 		t.Fatalf("unexpected status after setup: %q", updated.statusNote)
+	}
+	if updated.cfg.ProviderRuntime.DefaultProvider != "openai" || updated.cfg.ProviderRuntime.DefaultModel != "gpt-5.4" {
+		t.Fatalf("expected startup guide to sync provider runtime defaults, got %#v", updated.cfg.ProviderRuntime)
+	}
+	if providerCfg := updated.cfg.ProviderRuntime.Providers["openai"]; providerCfg.Model != "gpt-5.4" || providerCfg.ResolveAPIKey() != "test-key" {
+		t.Fatalf("expected startup guide to sync provider runtime provider, got %#v", providerCfg)
+	}
+	if len(updated.discoveredModels) != 0 {
+		t.Fatalf("expected startup guide reconfiguration to clear discovered model cache, got %#v", updated.discoveredModels)
 	}
 
 	written, err := os.ReadFile(configPath)

--- a/tui/ports.go
+++ b/tui/ports.go
@@ -8,6 +8,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/llm"
 	"github.com/1024XEngineer/bytemind/internal/mcpctl"
 	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+	"github.com/1024XEngineer/bytemind/internal/provider"
 	"github.com/1024XEngineer/bytemind/internal/session"
 	"github.com/1024XEngineer/bytemind/internal/skills"
 )
@@ -97,6 +98,7 @@ type Runner interface {
 	ActivateSkill(sess *session.Session, name string, args map[string]string) (skills.Skill, error)
 	ClearActiveSkill(sess *session.Session) error
 	ClearSkill(name string) (skills.ClearResult, error)
+	ListModels(ctx context.Context) ([]provider.ModelInfo, []provider.Warning, error)
 }
 
 type SessionStore interface {

--- a/tui/token_monitor.go
+++ b/tui/token_monitor.go
@@ -98,6 +98,9 @@ func (c tokenUsageComponent) CompactView() string {
 }
 
 func (c tokenUsageComponent) PopupView() string {
+	if c.popup {
+		return c.popupStyle().Render(c.popupText())
+	}
 	return ""
 }
 
@@ -180,6 +183,9 @@ func (c tokenUsageComponent) usageText() string {
 		return "token: unavailable"
 	}
 	text := "token: " + formatInt(max(0, int(math.Round(c.displayUsed))))
+	if c.total > 0 {
+		text += fmt.Sprintf(" / %s", formatInt(c.total))
+	}
 	pad := max(8, len(text))
 	if c.hover {
 		text = "Used " + text
@@ -320,7 +326,21 @@ func ringGlyph(level int, full, half string) string {
 }
 
 func (c tokenUsageComponent) popupText() string {
-	return ""
+	parts := []string{
+		fmt.Sprintf("used: %s", formatInt(max(0, int(math.Round(c.displayUsed))))),
+	}
+	if c.total > 0 {
+		parts = append(parts, fmt.Sprintf("budget: %s", formatInt(c.total)))
+		parts = append(parts, fmt.Sprintf("ratio: %.0f%%", c.ratio()*100))
+	}
+	if c.input > 0 || c.output > 0 || c.context > 0 {
+		parts = append(parts,
+			fmt.Sprintf("input: %s", formatInt(c.input)),
+			fmt.Sprintf("output: %s", formatInt(c.output)),
+			fmt.Sprintf("context: %s", formatInt(c.context)),
+		)
+	}
+	return strings.Join(parts, "\n")
 }
 
 func (c tokenUsageComponent) estimatedCost() float64 {

--- a/tui/token_monitor_test.go
+++ b/tui/token_monitor_test.go
@@ -239,3 +239,74 @@ func TestMaxFloat(t *testing.T) {
 		t.Fatalf("expected max float 3.0, got %f", got)
 	}
 }
+
+func TestTokenUsagePopupTextBreakdownAndCost(t *testing.T) {
+	c := newTokenUsageComponent()
+	_ = c.SetUsage(750, 1000)
+	c.SetBreakdown(100, 200, 450)
+	c.SetPrice(-1, 2.5)
+	c.displayUsed = 750
+
+	text := c.popupText()
+	for _, want := range []string{
+		"used: 750",
+		"budget: 1,000",
+		"ratio: 75%",
+		"input: 100",
+		"output: 200",
+		"context: 450",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected popup text to contain %q, got:\n%s", want, text)
+		}
+	}
+	if got := c.estimatedCost(); got != 0.0005 {
+		t.Fatalf("expected clamped input price and output cost, got %f", got)
+	}
+}
+
+func TestTokenUsageUpdateTickSchedulesAnimationAndExpiresPopup(t *testing.T) {
+	c := newTokenUsageComponent()
+	_ = c.SetUsage(1000, 5000)
+	c.displayUsed = 0
+	c.popup = true
+	c.popupUntil = time.Now().Add(-time.Second)
+
+	cmd, consumed := c.Update(tokenMonitorTickMsg(time.Now()))
+	if consumed {
+		t.Fatal("expected tick not to consume input")
+	}
+	if cmd == nil {
+		t.Fatal("expected tick to schedule animation follow-up")
+	}
+	if c.popup {
+		t.Fatal("expected expired popup to close")
+	}
+	if c.displayUsed <= 0 {
+		t.Fatalf("expected display usage to animate upward, got %f", c.displayUsed)
+	}
+}
+
+func TestTokenUsageColorAndUnavailableCompactBranches(t *testing.T) {
+	c := newTokenUsageComponent()
+	_ = c.SetUsage(50, 100)
+	c.displayUsed = 50
+	if got := string(c.ringColor()); got != "#007AFF" {
+		t.Fatalf("expected low usage color, got %q", got)
+	}
+	_ = c.SetUsage(90, 100)
+	c.displayUsed = 90
+	if got := string(c.ringColor()); got == "#007AFF" || got == "#FF3B30" {
+		t.Fatalf("expected interpolated warning color, got %q", got)
+	}
+	_ = c.SetUsage(100, 100)
+	c.displayUsed = 100
+	if got := string(c.ringColor()); got != "#FF3B30" {
+		t.Fatalf("expected high usage color, got %q", got)
+	}
+
+	c.SetUnavailable(true)
+	if got := c.compactUsageText(); got != "token: unavailable" {
+		t.Fatalf("expected unavailable compact text, got %q", got)
+	}
+}


### PR DESCRIPTION
## 概要
- 新增最小 provider/model 注册表，并在 TUI 中提供 `/models` 命令，用于查看当前生效与默认的 provider/model
- 在 bootstrap 中接入 TokenUsageManager，并优化 token badge 的 budget 展示逻辑，支持基于模型 metadata 回退
- 为模型列表增加轻量缓存，并补充基于 context window 的回归测试

## 测试
- go test ./...