### PR TITLE
fix: agent缺少现实校验 （暂保留）

### DIFF
--- a/internal/agent/engine_run_loop.go
+++ b/internal/agent/engine_run_loop.go
@@ -62,6 +62,7 @@ func (e *defaultEngine) runPromptTurns(ctx context.Context, sess *session.Sessio
 			Approval:         approvalHandler,
 			SandboxAudit:     sandboxAudit,
 			TaskReport:       taskReport,
+			WebRequirement:   setup.WebLookupRequirement,
 			Out:              out,
 		})
 		if err != nil {
@@ -83,9 +84,9 @@ func (e *defaultEngine) runPromptTurns(ctx context.Context, sess *session.Sessio
 }
 
 const (
-	maxRateLimitRetry      = 8
-	rateLimitBaseDelay     = 3 * time.Second
-	rateLimitMaxDelay      = 60 * time.Second
+	maxRateLimitRetry  = 8
+	rateLimitBaseDelay = 3 * time.Second
+	rateLimitMaxDelay  = 60 * time.Second
 )
 
 func (e *defaultEngine) processTurnWithReactiveCompaction(ctx context.Context, setup runPromptSetup, params turnProcessParams) (string, bool, error) {

--- a/internal/agent/engine_run_setup.go
+++ b/internal/agent/engine_run_setup.go
@@ -105,6 +105,7 @@ func (e *defaultEngine) prepareRunPrompt(sess *session.Session, input RunPromptI
 		SubAgentDefinition:           promptSubAgentDefinition(input.SubAgent),
 		InstructionText:              loadAGENTSInstruction(runner.workspace),
 		WebLookupInstruction:         promptHint.Instruction,
+		WebLookupRequirement:         promptHint.Requirement,
 		PromptTokens:                 contextpkg.EstimateRequestTokens([]llm.Message{input.UserMessage}),
 	}, nil
 }

--- a/internal/agent/run_setup.go
+++ b/internal/agent/run_setup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/1024XEngineer/bytemind/internal/llm"
 	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+	policypkg "github.com/1024XEngineer/bytemind/internal/policy"
 	"github.com/1024XEngineer/bytemind/internal/session"
 )
 
@@ -34,6 +35,7 @@ type runPromptSetup struct {
 	SubAgentDefinition           string
 	InstructionText              string
 	WebLookupInstruction         string
+	WebLookupRequirement         policypkg.WebLookupRequirement
 	PromptTokens                 int
 }
 

--- a/internal/agent/turn_processing.go
+++ b/internal/agent/turn_processing.go
@@ -12,6 +12,7 @@ import (
 	corepkg "github.com/1024XEngineer/bytemind/internal/core"
 	"github.com/1024XEngineer/bytemind/internal/llm"
 	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+	policypkg "github.com/1024XEngineer/bytemind/internal/policy"
 	"github.com/1024XEngineer/bytemind/internal/session"
 	"github.com/1024XEngineer/bytemind/internal/tokenusage"
 	"github.com/1024XEngineer/bytemind/internal/tools"
@@ -32,6 +33,7 @@ type turnProcessParams struct {
 	Approval         tools.ApprovalHandler
 	SandboxAudit     sandboxAuditContext
 	TaskReport       *TaskReport
+	WebRequirement   policypkg.WebLookupRequirement
 	Out              io.Writer
 }
 
@@ -74,6 +76,54 @@ func (e *defaultEngine) processTurn(ctx context.Context, p turnProcessParams) (s
 	if len(reply.ToolCalls) == 0 {
 		// No tool calls — finalize the turn. Safety nets only for specific claim patterns.
 		latestUser := latestHumanUserMessageText(p.Session.Messages)
+		if shouldRepairMissingRequiredWebLookup(p.WebRequirement, p.ExecutedTools) {
+			if !webLookupToolsAvailable(availableToolNames) {
+				if p.TaskReport != nil {
+					p.TaskReport.RecordEscalation("web lookup was required but web_search/web_fetch were unavailable under the current tool policy")
+				}
+				summary := BuildStopSummary(StopSummaryInput{
+					SessionID:     corepkg.SessionID(p.Session.ID),
+					Reason:        "I paused because this request requires current or external web evidence, but web_search/web_fetch are unavailable in the current run.",
+					ExecutedTools: executedToolNamesSnapshot(p.ExecutedTools),
+					TaskReport:    p.TaskReport,
+				})
+				answer, summaryErr := e.finishWithSummary(p.Session, summary, p.Out, streamedText)
+				return answer, true, summaryErr
+			}
+
+			attempt := 0
+			maxAttempts := 0
+			if p.AdaptiveState != nil {
+				p.AdaptiveState.recordNoProgressTurn()
+				attempt = p.AdaptiveState.recordSemanticRepairAttempt()
+				maxAttempts = p.AdaptiveState.maxSemanticRepairs
+			}
+			if p.TaskReport != nil {
+				p.TaskReport.RecordNoProgressTurn()
+				p.TaskReport.RecordRetry("required_web_lookup_missing")
+				p.TaskReport.RecordStrategyAdjustment("assistant tried to finalize without required web_search/web_fetch evidence; injected correction prompt")
+			}
+			if p.AdaptiveState != nil {
+				if p.AdaptiveState.exceededSemanticRepairLimit() || p.AdaptiveState.exceededNoProgressLimit() {
+					if p.TaskReport != nil {
+						p.TaskReport.RecordEscalation("required web lookup repair retries exceeded while waiting for web_search/web_fetch")
+					}
+					summary := BuildStopSummary(StopSummaryInput{
+						SessionID:     corepkg.SessionID(p.Session.ID),
+						Reason:        fmt.Sprintf("I paused because this request requires current or external web evidence, but the assistant kept trying to answer without web_search/web_fetch (attempts=%d).", attempt),
+						ExecutedTools: executedToolNamesSnapshot(p.ExecutedTools),
+						TaskReport:    p.TaskReport,
+					})
+					answer, summaryErr := e.finishWithSummary(p.Session, summary, p.Out, streamedText)
+					return answer, true, summaryErr
+				}
+				p.AdaptiveState.schedulePendingControlNote(buildRequiredWebLookupRepairInstruction(latestUser, attempt, maxAttempts, availableToolNames))
+			}
+			if p.Out != nil {
+				fmt.Fprintf(p.Out, "%srequired web evidence missing; retrying with a correction prompt%s\n", ansiDim, ansiReset)
+			}
+			return "", false, nil
+		}
 		if shouldRepairUnexecutedToolClaimTurn(p.RunMode, reply, p.Session.Messages, availableToolNames) {
 			attempt := 0
 			maxAttempts := 0

--- a/internal/agent/web_lookup_guard.go
+++ b/internal/agent/web_lookup_guard.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	policypkg "github.com/1024XEngineer/bytemind/internal/policy"
+)
+
+func shouldRepairMissingRequiredWebLookup(requirement policypkg.WebLookupRequirement, executedTools *[]string) bool {
+	if requirement != policypkg.WebLookupRequirementMust {
+		return false
+	}
+	return !hasWebLookupToolActivity(executedToolNamesSnapshot(executedTools))
+}
+
+func webLookupToolsAvailable(availableTools []string) bool {
+	return containsToolName(availableTools, "web_search") || containsToolName(availableTools, "web_fetch")
+}
+
+func hasWebLookupToolActivity(toolNames []string) bool {
+	return containsToolName(toolNames, "web_search") || containsToolName(toolNames, "web_fetch")
+}
+
+func executedToolNamesSnapshot(executedTools *[]string) []string {
+	if executedTools == nil || *executedTools == nil {
+		return nil
+	}
+	return append([]string(nil), (*executedTools)...)
+}
+
+func buildRequiredWebLookupRepairInstruction(latestUser string, attempt, maxAttempts int, availableTools []string) string {
+	latestUser = strings.TrimSpace(latestUser)
+	if latestUser == "" {
+		latestUser = "(empty user input)"
+	}
+
+	toolList := strings.TrimSpace(strings.Join(availableTools, ", "))
+	if toolList == "" {
+		toolList = "(none)"
+	}
+	toolList = truncateRunes(toolList, 240)
+
+	return strings.TrimSpace(fmt.Sprintf(
+		`The previous assistant turn tried to answer without web_search/web_fetch, but this user request requires current or external web evidence.
+Attempt %d/%d.
+
+Latest user input:
+%s
+
+Available tools in this run:
+%s
+
+For this next turn:
+1) Use web_fetch for explicit URLs, or web_search followed by web_fetch for current, volatile, provider, model, version, pricing, or official-source facts.
+2) Do not finalize until at least one real web_search or web_fetch tool call has run in this request.
+3) If web results are weak, unavailable, or policy-denied, state that clearly instead of asserting unsupported facts.`,
+		attempt,
+		maxAttempts,
+		latestUser,
+		toolList,
+	))
+}

--- a/internal/agent/web_lookup_guard_test.go
+++ b/internal/agent/web_lookup_guard_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/bytemind/internal/config"
+	"github.com/1024XEngineer/bytemind/internal/llm"
+	"github.com/1024XEngineer/bytemind/internal/session"
+	"github.com/1024XEngineer/bytemind/internal/tools"
+)
+
+type guardWebSearchTool struct{}
+
+func (guardWebSearchTool) Definition() llm.ToolDefinition {
+	return llm.ToolDefinition{
+		Type: "function",
+		Function: llm.FunctionDefinition{
+			Name:        "web_search",
+			Description: "test web search",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"query": map[string]any{"type": "string"}},
+				"required":   []string{"query"},
+			},
+		},
+	}
+}
+
+func (guardWebSearchTool) Run(_ context.Context, raw json.RawMessage, _ *tools.ExecutionContext) (string, error) {
+	var args struct {
+		Query string `json:"query"`
+	}
+	_ = json.Unmarshal(raw, &args)
+	return `{"ok":true,"query":"` + args.Query + `","results":[{"title":"Official model page","url":"https://example.com/models"}]}`, nil
+}
+
+func TestRunPromptRepairsRequiredWebLookupBeforeFinalizing(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+
+	registry := &tools.Registry{}
+	if err := registry.Register(guardWebSearchTool{}, tools.RegisterOptions{Source: tools.RegistrationSourceBuiltin}); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role:    llm.RoleAssistant,
+			Content: "gpt-5.4-mini does not exist.",
+		},
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-web-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "web_search",
+					Arguments: `{"query":"gpt-5.4-mini official model page"}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "<turn_intent>finalize</turn_intent>Verified with web evidence.",
+		},
+	}}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 5,
+			Stream:        false,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: registry,
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "gpt-5.4-mini 是否存在？", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "Verified with web evidence." {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+	if len(client.requests) != 3 {
+		t.Fatalf("expected repair request, web tool request, and final request; got %d", len(client.requests))
+	}
+
+	secondRequest := client.requests[1]
+	lastMessage := secondRequest.Messages[len(secondRequest.Messages)-1]
+	if lastMessage.Role != llm.RoleUser || !strings.Contains(lastMessage.Text(), "requires current or external web evidence") {
+		t.Fatalf("expected required-web repair note in second request, got %#v", lastMessage)
+	}
+
+	if len(sess.Messages) != 4 {
+		t.Fatalf("expected user + web tool call + tool result + final assistant, got %#v", sess.Messages)
+	}
+	if len(sess.Messages[1].ToolCalls) != 1 || sess.Messages[1].ToolCalls[0].Function.Name != "web_search" {
+		t.Fatalf("expected repaired turn to execute web_search, got %#v", sess.Messages[1])
+	}
+	if sess.Messages[2].Role != llm.RoleUser || !strings.Contains(sess.Messages[2].Content, "Official model page") {
+		t.Fatalf("expected web_search result message, got %#v", sess.Messages[2])
+	}
+}

--- a/internal/policy/decision.go
+++ b/internal/policy/decision.go
@@ -49,6 +49,7 @@ type PromptHintResult struct {
 	ReasonCode  ReasonCode
 	Reason      string
 	Instruction string
+	Requirement WebLookupRequirement
 }
 
 type Evaluation struct {
@@ -146,19 +147,21 @@ func needsApproval(policy string) bool {
 }
 
 func EvaluatePromptHint(userInput string) PromptHintResult {
-	instruction := ExplicitWebLookupInstruction(userInput)
-	if strings.TrimSpace(instruction) == "" {
+	requirement := EvaluateWebLookupRequirement(userInput)
+	if strings.TrimSpace(requirement.Instruction) == "" {
 		return PromptHintResult{
-			Decision:   PromptHintDecisionNone,
-			ReasonCode: ReasonPromptHintSkipped,
-			Reason:     "no explicit web lookup request detected",
+			Decision:    PromptHintDecisionNone,
+			ReasonCode:  ReasonPromptHintSkipped,
+			Reason:      strings.TrimSpace(requirement.Reason),
+			Requirement: requirement.Requirement,
 		}
 	}
 	return PromptHintResult{
 		Decision:    PromptHintDecisionHint,
 		ReasonCode:  ReasonWebLookupHintInjected,
-		Reason:      "explicit web lookup request detected",
-		Instruction: instruction,
+		Reason:      strings.TrimSpace(requirement.Reason),
+		Instruction: requirement.Instruction,
+		Requirement: requirement.Requirement,
 	}
 }
 

--- a/internal/policy/decision_test.go
+++ b/internal/policy/decision_test.go
@@ -18,6 +18,9 @@ func TestEvaluatePromptHintInjected(t *testing.T) {
 	if result.Instruction == "" {
 		t.Fatalf("expected non-empty instruction, got %#v", result)
 	}
+	if result.Requirement != WebLookupRequirementMust {
+		t.Fatalf("expected must web lookup requirement, got %#v", result)
+	}
 }
 
 func TestEvaluatePromptHintSkipped(t *testing.T) {
@@ -27,6 +30,9 @@ func TestEvaluatePromptHintSkipped(t *testing.T) {
 	}
 	if result.ReasonCode != ReasonPromptHintSkipped {
 		t.Fatalf("expected hint skipped reason code, got %#v", result)
+	}
+	if result.Requirement != WebLookupRequirementNone {
+		t.Fatalf("expected no web lookup requirement, got %#v", result)
 	}
 }
 

--- a/internal/policy/web_lookup.go
+++ b/internal/policy/web_lookup.go
@@ -1,32 +1,127 @@
 package policy
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+type WebLookupRequirement string
+
+const (
+	WebLookupRequirementNone   WebLookupRequirement = "none"
+	WebLookupRequirementShould WebLookupRequirement = "should"
+	WebLookupRequirementMust   WebLookupRequirement = "must"
+)
+
+type WebLookupRequirementResult struct {
+	Requirement WebLookupRequirement
+	Reason      string
+	Instruction string
+}
+
+var (
+	webURLPattern     = regexp.MustCompile(`(?i)\bhttps?://|www\.`)
+	llmModelIDPattern = regexp.MustCompile(`(?i)\b(gpt|claude|gemini|deepseek|qwen|llama|mistral|o[0-9])[-._[:alnum:]]*\b`)
+)
 
 // ExplicitWebLookupInstruction returns an extra system hint when the user
 // explicitly asks for online/source-website lookup instead of local workspace
 // inspection.
 func ExplicitWebLookupInstruction(userInput string) string {
+	return EvaluateWebLookupRequirement(userInput).Instruction
+}
+
+func EvaluateWebLookupRequirement(userInput string) WebLookupRequirementResult {
 	text := strings.ToLower(strings.TrimSpace(userInput))
 	if text == "" {
-		return ""
+		return WebLookupRequirementResult{
+			Requirement: WebLookupRequirementNone,
+			Reason:      "empty user input",
+		}
+	}
+
+	if webURLPattern.MatchString(text) {
+		return requiredWebLookup("user included an explicit web URL")
 	}
 
 	directSignals := []string{
 		"github", "gitlab", "bitbucket",
 		"联网", "上网", "互联网", "网上",
 		"源码", "源代码",
-		"official website", "官网",
+		"official website", "official docs", "search web", "browse web",
+		"online", "web_search", "web fetch", "官网", "官方文档",
 	}
 	for _, signal := range directSignals {
 		if strings.Contains(text, signal) {
-			return "The user explicitly requested online or GitHub-source lookup. Use web_search/web_fetch first. Do not substitute local-workspace tools (list_files/read_file/search_text) for this request unless the user explicitly asks to inspect the current workspace repository."
+			return requiredWebLookup("user explicitly requested online or source-website lookup")
 		}
 	}
 
 	hasRepoWord := strings.Contains(text, "repo") || strings.Contains(text, "repository")
 	hasRemoteQualifier := strings.Contains(text, "github") || strings.Contains(text, "gitlab") || strings.Contains(text, "bitbucket") || strings.Contains(text, "online") || strings.Contains(text, "remote")
 	if hasRepoWord && hasRemoteQualifier {
-		return "The user explicitly requested online or GitHub-source lookup. Use web_search/web_fetch first. Do not substitute local-workspace tools (list_files/read_file/search_text) for this request unless the user explicitly asks to inspect the current workspace repository."
+		return requiredWebLookup("user explicitly requested a remote repository lookup")
 	}
-	return ""
+
+	if looksLocalWorkspaceOnly(text) && !llmModelIDPattern.MatchString(text) {
+		return WebLookupRequirementResult{
+			Requirement: WebLookupRequirementNone,
+			Reason:      "user requested local workspace inspection",
+		}
+	}
+
+	if containsFreshnessSignal(text) {
+		return requiredWebLookup("user asked for current or time-sensitive information")
+	}
+	if llmModelIDPattern.MatchString(text) && containsModelRealitySignal(text) {
+		return requiredWebLookup("user asked about a current model or provider fact")
+	}
+
+	return WebLookupRequirementResult{
+		Requirement: WebLookupRequirementNone,
+		Reason:      "no web lookup requirement detected",
+	}
+}
+
+func requiredWebLookup(reason string) WebLookupRequirementResult {
+	return WebLookupRequirementResult{
+		Requirement: WebLookupRequirementMust,
+		Reason:      strings.TrimSpace(reason),
+		Instruction: "The user request requires current or external web evidence. Use web_search/web_fetch before finalizing, ground volatile claims in fetched sources, and clearly state when web results are weak or unavailable instead of asserting unsupported facts.",
+	}
+}
+
+func containsFreshnessSignal(text string) bool {
+	return containsAnyText(text,
+		"latest", "current", "currently", "today", "now", "recent", "newest", "up-to-date", "as of",
+		"最新", "当前", "现在", "今天", "目前", "近期", "最近", "现行", "最新版",
+	)
+}
+
+func containsModelRealitySignal(text string) bool {
+	return containsAnyText(text,
+		"exists", "exist", "available", "availability", "supported", "support", "real model", "model id",
+		"是否存在", "存在", "可用", "支持", "真实", "模型",
+	)
+}
+
+func looksLocalWorkspaceOnly(text string) bool {
+	return containsAnyText(text,
+		"current workspace", "local workspace", "current repo", "local repo", "search_text", "read_file", "list_files",
+		"recent commit", "latest commit", "commit", "diff", "staged", "unstaged", "/review",
+		"当前工作区", "本地工作区", "当前仓库", "本地仓库", "当前项目", "最近提交", "本地提交",
+	)
+}
+
+func containsAnyText(text string, tokens ...string) bool {
+	for _, token := range tokens {
+		token = strings.ToLower(strings.TrimSpace(token))
+		if token == "" {
+			continue
+		}
+		if strings.Contains(text, token) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/policy/web_lookup_test.go
+++ b/internal/policy/web_lookup_test.go
@@ -12,6 +12,23 @@ func TestExplicitWebLookupInstructionReturnsHintForSourceLookup(t *testing.T) {
 	}
 }
 
+func TestEvaluateWebLookupRequirementRequiresWebForModelReality(t *testing.T) {
+	got := EvaluateWebLookupRequirement("gpt-5.4-mini 是否存在？")
+	if got.Requirement != WebLookupRequirementMust {
+		t.Fatalf("expected must web lookup requirement, got %#v", got)
+	}
+	if got.Instruction == "" {
+		t.Fatalf("expected web lookup instruction, got %#v", got)
+	}
+}
+
+func TestEvaluateWebLookupRequirementRequiresWebForURL(t *testing.T) {
+	got := EvaluateWebLookupRequirement("https://example.com 这个页面有没有不合理的地方")
+	if got.Requirement != WebLookupRequirementMust {
+		t.Fatalf("expected must web lookup requirement for URL, got %#v", got)
+	}
+}
+
 func TestExplicitWebLookupInstructionSupportsChineseSignals(t *testing.T) {
 	got := ExplicitWebLookupInstruction("请联网查一下这个功能的源码")
 	if !strings.Contains(got, "web_search/web_fetch") {
@@ -30,5 +47,12 @@ func TestExplicitWebLookupInstructionReturnsEmptyWhenLocalOnly(t *testing.T) {
 	got := ExplicitWebLookupInstruction("Use search_text in current workspace")
 	if got != "" {
 		t.Fatalf("expected empty instruction, got %q", got)
+	}
+}
+
+func TestEvaluateWebLookupRequirementReturnsNoneForLocalOnly(t *testing.T) {
+	got := EvaluateWebLookupRequirement("Use search_text in current workspace")
+	if got.Requirement != WebLookupRequirementNone {
+		t.Fatalf("expected no web lookup requirement, got %#v", got)
 	}
 }


### PR DESCRIPTION
解决 #389  保留更改暂不合并
#389 问题归并到新issue #394 里 待修复
## 解决的是：
当用户问题明显需要现实/最新/外部信息时，模型不能再直接凭记忆给最终答案。比如“gpt-5.4-mini 是否存在”“这个 URL 页面是否合理”“官网/联网查一下”等场景，现在会被判定为必须先使用 web_search 或 web_fetch。
## 参考其他产品

Agent/平台 | 解决思路 | 关键点
-- | -- | --
OpenAI Responses/Agents | 托管 web_search，带 citations/sources；必须检索时可用 tool_choice: required | 官方文档也提醒 auto 下搜索是可选的，必须检索要强制：[OpenAI Web Search](https://developers.openai.com/api/docs/guides/tools-web-search)
Claude | Server-side web_search/web_fetch，搜索结果默认带引用；可限制 max_uses、域名；fetch 只能取用户或搜索结果里出现过的 URL | 更像“检索是模型流程的一部分”，并带安全边界：[Claude Web Search](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool)、[Claude Web Fetch](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-fetch-tool)
Gemini | Grounding with Google Search，返回 groundingMetadata，包含查询、结果和 citations | 把“搜索、处理、引用”作为 grounding 元数据闭环：[Gemini Grounding](https://ai.google.dev/gemini-api/docs/google-search)
Cursor | 显式 @Web/@Docs/MCP，把外部资料作为上下文；Web search 默认可控 | 偏“用户显式拉入上下文”，减少模型自作主张
GitHub Copilot coding agent | Web search 用于补充训练截止后的库变更、异常错误、最佳实践 | 明确把联网定位成弥补 cutoff：[GitHub changelog](https://github.blog/changelog/2025-10-16-copilot-coding-agent-can-now-search-the-web/)
Perplexity/Sonar | 产品/API 本身就是 web-grounded，默认输出 cited answers | 检索不是外挂，而是答案生成主路径：[Perplexity API](https://www.perplexity.ai/help-center/en/articles/10354842-what-is-the-perplexity-api-platform)


## 修改内容

**对输入进行分类**

在 internal/policy/web_lookup.go 增加 EvaluateWebLookupRequirement
把请求分成 none/should/must，当前先重点使用 must。触发条件包括 URL、联网/官网/GitHub、最新/当前、模型 ID 现实性问题等。

**执行层面进行约束**
internal/policy/decision.go 把 requirement 放进 PromptHintResult，再通过 engine_run_setup.go 和 run_setup.go 传到每轮执行。

**在最终回答前加守门**
internal/agent/turn_processing.go 在“没有工具调用就 finalize”的分支前检查：如果本轮是 must web，但还没执行过 web_search/web_fetch，就不允许 finalize。

**增加 repair 机制**
新增 internal/agent/web_lookup_guard.go。当模型想跳过联网直接回答时，会注入一条控制提示，让下一轮必须先调用 web 工具。如果 web 工具不可用，则暂停并说明当前 tool policy 不允许完成这个请求。

**测试也补了：**

policy 分类测试
gpt-5.4-mini 是否存在？ 这种场景下，先拦截直接答案，再强制走 web_search，最后才允许 finalize
验证已通过：go test ./internal/agent、go test ./internal/policy、go test ./internal/context -v。