### PR TITLE
feat(tui): add animated status dot indicator

### DIFF
--- a/tui/component_conversation.go
+++ b/tui/component_conversation.go
@@ -11,6 +11,7 @@ import (
 const (
 	toolIcon     = "●"
 	toolTreeChar = "└"
+	toolTreeLead = "└ "
 )
 
 func (m model) renderConversation() string {
@@ -481,7 +482,7 @@ func renderRunSectionGroup(group []chatEntry, width int, toolDetailsExpanded boo
 		if runewidth.StringWidth(compact) > maxDetail {
 			compact = runewidth.Truncate(compact, maxDetail, "…")
 		}
-		detailLines = append(detailLines, connectorStyle.Render(toolTreeChar)+compact)
+		detailLines = append(detailLines, connectorStyle.Render(toolTreeLead)+compact)
 	}
 
 	indent := "  "
@@ -560,7 +561,7 @@ func renderToolTreeItem(item chatEntry, width int, toolDetailsExpanded bool, run
 			if detail == "" {
 				continue
 			}
-			detailLines = append(detailLines, connectorStyle.Render(toolTreeChar)+detail)
+			detailLines = append(detailLines, connectorStyle.Render(toolTreeLead)+detail)
 		}
 		if len(detailLines) > 0 {
 			body = headLine + "\n" + indent + strings.Join(detailLines, "\n"+indent)
@@ -631,7 +632,7 @@ func renderLiveInspectGroup(group []chatEntry, width int, runningIndicatorVisibl
 		if detail := latestLiveInspectHint(group); detail != "" {
 			connectorStyle := lipgloss.NewStyle().Foreground(colorTool)
 			maxDetailWidth := max(12, contentWidth-6)
-			headLine += "\n  " + connectorStyle.Render(toolTreeChar) + " " + compact(detail, maxDetailWidth)
+			headLine += "\n  " + connectorStyle.Render(toolTreeLead) + compact(detail, maxDetailWidth)
 		}
 	}
 

--- a/tui/component_conversation.go
+++ b/tui/component_conversation.go
@@ -31,7 +31,7 @@ func (m model) renderConversation() string {
 			if strings.Contains(item.Body, "[Paste #") || strings.Contains(item.Body, "[Pasted #") {
 				resolvedItem.Body = m.resolveUserBodyPastes(item.Body)
 			}
-			blocks = append(blocks, renderChatRow(resolvedItem, width))
+			blocks = append(blocks, renderChatRow(resolvedItem, width, m))
 			i++
 			continue
 		}
@@ -45,7 +45,7 @@ func (m model) renderConversation() string {
 		for j < len(m.chatItems) && m.chatItems[j].Kind != "user" {
 			j++
 		}
-		blocks = append(blocks, renderBytemindRunRow(m.chatItems[i:j], width, m.toolDetailExpanded, runningIndicatorVisible))
+		blocks = append(blocks, renderBytemindRunRow(m.chatItems[i:j], width, m.toolDetailExpanded, runningIndicatorVisible, m))
 		i = j
 	}
 
@@ -306,31 +306,33 @@ func renderChatSection(item chatEntry, width int) string {
 	return lipgloss.JoinVertical(lipgloss.Left, head, body)
 }
 
-func renderChatRow(item chatEntry, width int) string {
+func renderChatRow(item chatEntry, width int, m model) string {
+	dot := m.renderStatusDot(item)
 	bubbleWidth := chatBubbleWidth(item, width)
 	card := renderChatCard(item, bubbleWidth)
+	row := lipgloss.JoinHorizontal(lipgloss.Left, dot, " ", card)
 	return lipgloss.NewStyle().
 		MarginBottom(1).
-		Render(lipgloss.PlaceHorizontal(width, lipgloss.Left, card))
+		Render(lipgloss.PlaceHorizontal(width, lipgloss.Left, row))
 }
 
-func renderBytemindRunRow(items []chatEntry, width int, toolDetailsExpanded bool, runningIndicatorVisible bool) string {
+func renderBytemindRunRow(items []chatEntry, width int, toolDetailsExpanded bool, runningIndicatorVisible bool, m model) string {
 	if len(items) == 0 {
 		return ""
 	}
-	card := renderBytemindRunCard(items, width, toolDetailsExpanded, runningIndicatorVisible)
+	card := renderBytemindRunCard(items, width, toolDetailsExpanded, runningIndicatorVisible, m)
 	return lipgloss.NewStyle().
 		MarginBottom(1).
 		Render(lipgloss.PlaceHorizontal(width, lipgloss.Left, card))
 }
 
-func renderBytemindRunCard(items []chatEntry, width int, toolDetailsExpanded bool, runningIndicatorVisible bool) string {
+func renderBytemindRunCard(items []chatEntry, width int, toolDetailsExpanded bool, runningIndicatorVisible bool, m model) string {
 	outer := resolveRunCardStyle(items)
 	contentWidth := max(8, width-outer.GetHorizontalFrameSize())
 	sectionGroups := collapseRunSectionGroupsForView(items, toolDetailsExpanded)
 	sections := make([]string, 0, len(sectionGroups))
 	for _, group := range sectionGroups {
-		sections = append(sections, renderRunSectionGroup(group, contentWidth, toolDetailsExpanded, runningIndicatorVisible))
+		sections = append(sections, renderRunSectionGroup(group, contentWidth, toolDetailsExpanded, runningIndicatorVisible, m))
 	}
 	// Do NOT apply outer.Width() here — each section already manages its own
 	// width via .Width() inside renderRunSectionGroup. Applying .Width() again
@@ -426,15 +428,15 @@ func collapsibleParallelToolName(item chatEntry) (string, bool) {
 	return name, true
 }
 
-func renderRunSectionGroup(group []chatEntry, width int, toolDetailsExpanded bool, runningIndicatorVisible bool) string {
+func renderRunSectionGroup(group []chatEntry, width int, toolDetailsExpanded bool, runningIndicatorVisible bool, m model) string {
 	if len(group) == 0 {
 		return ""
 	}
 	if len(group) == 1 {
-		return renderRunSection(group[0], width, toolDetailsExpanded, runningIndicatorVisible)
+		return renderRunSection(group[0], width, toolDetailsExpanded, runningIndicatorVisible, m)
 	}
 	if !toolDetailsExpanded && isLiveInspectGroup(group) {
-		return renderLiveInspectGroup(group, width, runningIndicatorVisible)
+		return renderLiveInspectGroup(group, width, runningIndicatorVisible, m)
 	}
 
 	_, name := toolDisplayParts(group[0].Title)
@@ -497,15 +499,19 @@ func renderRunSectionGroup(group []chatEntry, width int, toolDetailsExpanded boo
 	return style.Width(contentWidth).Render(body)
 }
 
-func renderRunSection(item chatEntry, width int, toolDetailsExpanded bool, runningIndicatorVisible bool) string {
+func renderRunSection(item chatEntry, width int, toolDetailsExpanded bool, runningIndicatorVisible bool, m model) string {
+	var inner string
 	if item.Kind == "tool" {
+		// Tools already render their own icon; no extra status dot needed.
 		return renderToolTreeItem(item, width, toolDetailsExpanded, runningIndicatorVisible)
-	}
-	if item.Kind == "assistant" && item.Status == "final" {
+	} else if item.Kind == "assistant" && item.Status == "final" {
 		contentWidth := max(8, width-runAnswerSectionStyle.GetHorizontalFrameSize())
-		return runAnswerSectionStyle.Width(contentWidth).Render(renderChatSection(item, contentWidth))
+		inner = runAnswerSectionStyle.Width(contentWidth).Render(renderChatSection(item, contentWidth))
+	} else {
+		inner = renderChatSection(item, width)
 	}
-	return renderChatSection(item, width)
+	dot := m.renderStatusDot(item)
+	return lipgloss.JoinHorizontal(lipgloss.Left, dot, " ", inner)
 }
 
 // renderToolTreeItem renders a single tool entry in tree style.
@@ -602,7 +608,7 @@ func isLiveInspectGroup(group []chatEntry) bool {
 	return true
 }
 
-func renderLiveInspectGroup(group []chatEntry, width int, runningIndicatorVisible bool) string {
+func renderLiveInspectGroup(group []chatEntry, width int, runningIndicatorVisible bool, m model) string {
 	status := aggregateToolGroupStatus(group)
 	style := resolveToolRunSectionStyle(status)
 	contentWidth := max(8, width-style.GetHorizontalFrameSize())

--- a/tui/component_overlays.go
+++ b/tui/component_overlays.go
@@ -51,75 +51,143 @@ func (m model) renderHelpModal() string {
 func (m model) renderApprovalBanner() string {
 	bannerWidth := max(24, m.chatPanelInnerWidth())
 	innerWidth := max(20, bannerWidth-approvalBannerStyle.GetHorizontalFrameSize())
+
 	toolName := strings.TrimSpace(m.approval.ToolName)
 	if toolName == "" {
 		toolName = "unknown"
 	}
 	command := strings.TrimSpace(m.approval.Command)
-	if command == "" {
-		command = "-"
-	}
+	reason := strings.TrimSpace(m.approval.Reason)
 
 	isFullAccessConfirm := strings.EqualFold(strings.TrimSpace(m.approval.Kind), approvalPromptKindEnableFullAccess)
-	title := "Approval required"
-	lines := []string{}
+
 	if isFullAccessConfirm {
-		toolPrefix := "Action: "
-		confirmLabel := "Enable"
-		rejectLabel := "Cancel"
-		confirmTone := "warning"
-		title = "Enable full access?"
+		return m.renderFullAccessApproval(innerWidth)
+	}
 
-		reasonBudget := max(0, innerWidth-lipgloss.Width(title)-2)
-		reason := trimPreview(m.approval.Reason, reasonBudget)
-		line1 := approvalTitleStyle.Render(title)
-		if reason != "" {
-			line1 += "  " + approvalReasonStyle.Render(reason)
+	lines := make([]string, 0, 10)
+
+	// Title line: "Bytemind needs your permission to use {tool}"
+	title := fmt.Sprintf("Bytemind needs your permission to use %s", toolName)
+	lines = append(lines, approvalTitleStyle.Render(title))
+
+	// Command subtitle
+	if command != "" {
+		lines = append(lines, approvalReasonStyle.Render(trimToWidth(command, innerWidth)))
+	}
+
+	// Reason line if present
+	if reason != "" {
+		lines = append(lines, approvalReasonStyle.Render(wrapPlainText(reason, innerWidth)))
+	}
+
+	lines = append(lines, "") // blank separator
+
+	// Numbered options with ❯ arrow for selected
+	options := m.approvalOptions()
+	cursor := clamp(m.approval.Cursor, 0, len(options)-1)
+	for i, option := range options {
+		numStr := fmt.Sprintf("%d", i+1)
+		arrow := " "
+		style := approvalOptionStyle
+		descStyle := approvalOptionDescriptionStyle
+
+		if i == cursor {
+			arrow = approvalArrowStyle.Render("❯")
+			style = approvalOptionSelectedStyle
+			descStyle = approvalOptionDescriptionStyle
 		}
 
-		actionLine := approvalCommandStyle.Render(toolPrefix + trimPreview(command, max(6, innerWidth-lipgloss.Width(toolPrefix))))
+		// Format: "  1. Yes" or " ❯ 1. Yes"
+		optLine := fmt.Sprintf(" %s %s. %s", arrow, approvalNumberStyle.Render(numStr), style.Render(option.Label))
+		lines = append(lines, optLine)
 
-		choice := m.currentApprovalChoice()
-		confirmChoice := renderApprovalChoice(confirmLabel, confirmTone, choice == approvalChoiceApprove)
-		rejectChoice := renderApprovalChoice(rejectLabel, "error", choice == approvalChoiceReject)
-		choiceLine := lipgloss.JoinHorizontal(lipgloss.Left, confirmChoice, "  ", rejectChoice)
+		if option.Description != "" {
+			descPrefix := strings.Repeat(" ", 4) // indent under option text
+			lines = append(lines, descStyle.Render(descPrefix+wrapPlainText(option.Description, max(8, innerWidth-4))))
+		}
+	}
 
-		hintLine := approvalHintStyle.Render("Use Left/Right to choose, Enter to confirm, Esc to cancel")
-		if lipgloss.Width(choiceLine)+2+lipgloss.Width(hintLine) <= innerWidth {
-			choiceLine += strings.Repeat(" ", innerWidth-lipgloss.Width(choiceLine)-lipgloss.Width(hintLine)) + hintLine
-			hintLine = ""
-		}
-		lines = []string{line1, actionLine, choiceLine}
-		if strings.TrimSpace(hintLine) != "" {
-			lines = append(lines, hintLine)
-		}
-	} else {
-		lines = []string{
-			approvalTitleStyle.Render(title),
-			approvalReasonStyle.Render("Tool: " + trimPreview(toolName, innerWidth-6)),
-			approvalCommandStyle.Render("Command: " + trimPreview(command, innerWidth-9)),
-		}
-		if reason := strings.TrimSpace(m.approval.Reason); reason != "" {
-			lines = append(lines, approvalReasonStyle.Render(wrapPlainText(reason, innerWidth)))
-		}
+	// Feedback input mode
+	if m.approval.InFeedback {
 		lines = append(lines, "")
-		for i, option := range m.approvalOptions() {
-			prefix := "  "
-			style := approvalOptionStyle
-			if i == clamp(m.approval.Cursor, 0, len(m.approvalOptions())-1) {
-				prefix = "> "
-				style = approvalOptionSelectedStyle
-			}
-			lines = append(lines, style.Render(prefix+option.Label))
-			lines = append(lines, approvalOptionDescriptionStyle.Render("  "+wrapPlainText(option.Description, max(8, innerWidth-2))))
+		placeholder := "tell Claude what to do next"
+		feedbackText := m.approval.Feedback
+		if feedbackText == "" {
+			lines = append(lines, approvalFeedbackStyle.Render("  "+placeholder))
+		} else {
+			lines = append(lines, approvalFeedbackStyle.Render("  "+feedbackText))
 		}
-		lines = append(lines, "", approvalHintStyle.Render("Up/Down or J/K to select  Enter confirm  Y approve once  N/Esc reject"))
+	}
+
+	// Bottom hint line
+	hint := "Esc to cancel"
+	if m.approval.InFeedback {
+		hint += " · Enter to submit"
+	} else {
+		hint += " · Tab to amend  · ↑↓ navigate  · Enter select"
+	}
+	lines = append(lines, "")
+	lines = append(lines, approvalHintStyle.Render(hint))
+
+	body := lipgloss.NewStyle().
+		Width(innerWidth).
+		Render(strings.Join(lines, "\n"))
+	return approvalBannerStyle.Render(body)
+}
+
+// renderFullAccessApproval renders the simplified enable-full-access confirmation.
+func (m model) renderFullAccessApproval(innerWidth int) string {
+	lines := make([]string, 0, 6)
+	title := "Enable full access?"
+	lines = append(lines, approvalTitleStyle.Render(title))
+
+	if reason := strings.TrimSpace(m.approval.Reason); reason != "" {
+		lines = append(lines, approvalReasonStyle.Render(trimToWidth(reason, innerWidth)))
+	}
+
+	actionText := strings.TrimSpace(m.approval.Command)
+	if actionText == "" {
+		actionText = "full_access"
+	}
+	lines = append(lines, approvalCommandStyle.Render("Action: "+trimToWidth(actionText, max(6, innerWidth-8))))
+
+	lines = append(lines, "")
+
+	choice := m.currentApprovalChoice()
+	confirmLabel := "Enable"
+	rejectLabel := "Cancel"
+	confirmTone := "warning"
+
+	confirmChoice := renderApprovalChoice(confirmLabel, confirmTone, choice == approvalChoiceApprove)
+	rejectChoice := renderApprovalChoice(rejectLabel, "error", choice == approvalChoiceReject)
+	choiceLine := lipgloss.JoinHorizontal(lipgloss.Left, confirmChoice, "  ", rejectChoice)
+
+	hintLine := approvalHintStyle.Render("Use Left/Right to choose, Enter to confirm, Esc to cancel")
+	if lipgloss.Width(choiceLine)+2+lipgloss.Width(hintLine) <= innerWidth {
+		choiceLine += strings.Repeat(" ", innerWidth-lipgloss.Width(choiceLine)-lipgloss.Width(hintLine)) + hintLine
+		hintLine = ""
+	}
+	lines = append(lines, choiceLine)
+	if strings.TrimSpace(hintLine) != "" {
+		lines = append(lines, hintLine)
 	}
 
 	body := lipgloss.NewStyle().
 		Width(innerWidth).
 		Render(strings.Join(lines, "\n"))
 	return approvalBannerStyle.Render(body)
+}
+
+// trimToWidth truncates text to fit within maxWidth chars, adding "…" if needed.
+func trimToWidth(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= maxWidth {
+		return s
+	}
+	return s[:maxWidth-1] + "…"
 }
 
 func renderApprovalChoice(label, tone string, selected bool) string {

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -259,7 +259,7 @@ func TestRenderBytemindRunCardCollapsesConsecutiveReadTools(t *testing.T) {
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read faq.md\nrange: 1-50", Status: "done", CompactBody: "faq.md (1-50)"},
 	}
 
-	collapsed := stripANSI(renderBytemindRunCard(entries, 80, false, true))
+	collapsed := stripANSI(renderBytemindRunCard(entries, 80, false, true, model{}))
 	if !strings.Contains(strings.ToLower(collapsed), "reading 4 files") {
 		t.Fatalf("expected consecutive read tools to collapse into one summary row, got %q", collapsed)
 	}
@@ -270,7 +270,7 @@ func TestRenderBytemindRunCardCollapsesConsecutiveReadTools(t *testing.T) {
 		t.Fatalf("expected collapsed done view to hide detail hint rows, got %q", collapsed)
 	}
 
-	expanded := stripANSI(renderBytemindRunCard(entries, 80, true, true))
+	expanded := stripANSI(renderBytemindRunCard(entries, 80, true, true, model{}))
 	if strings.Count(expanded, "└") != 4 {
 		t.Fatalf("expected expanded view to show 4 detail rows, got %q", expanded)
 	}
@@ -280,17 +280,17 @@ func TestRenderBytemindRunCardDoesNotCollapseSeparatedReadTools(t *testing.T) {
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read server.py", Status: "done", CompactBody: "server.py"},
 		{Kind: "assistant", Title: assistantLabel, Body: "Using that result first", Status: "final"},
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read index.html", Status: "done", CompactBody: "index.html"},
-	}, 80, false, true))
+	}, 80, false, true, model{}))
 
-	if strings.Count(view, "●") != 2 {
-		t.Fatalf("expected separated read tools to remain distinct with tool icons, got %q", view)
+	if strings.Count(view, "READ") != 2 {
+		t.Fatalf("expected separated read tools to remain distinct, got %q", view)
 	}
 }
 func TestRenderBytemindRunCardOmitsDividerBetweenSections(t *testing.T) {
 	view := stripANSI(renderBytemindRunCard([]chatEntry{
 		{Kind: "tool", Title: toolEntryTitle("list_files"), Body: "Read 29 files, listed 31 directories", Status: "done", CompactBody: "29 files, 31 dirs"},
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read 2 files", Status: "error", CompactBody: "README.md"},
-	}, 100, false, true))
+	}, 100, false, true, model{}))
 
 	if strings.Contains(view, "-----") {
 		t.Fatalf("expected run card sections to omit divider line, got %q", view)
@@ -377,7 +377,7 @@ func TestRenderBytemindRunCardCollapsedLiveInspectSummaryAcrossTools(t *testing.
 		{Kind: "tool", Title: toolEntryTitle("search_text"), Status: "running", CompactBody: `"finalizeAssistantTurnForTool"`},
 	}
 
-	collapsed := stripANSI(renderBytemindRunCard(entries, 100, false, true))
+	collapsed := stripANSI(renderBytemindRunCard(entries, 100, false, true, model{}))
 	for _, want := range []string{
 		"Searching for 2 patterns, reading 1 file...",
 		"(ctrl+o to expand)",
@@ -396,7 +396,7 @@ func TestRenderBytemindRunCardCollapsedDoneInspectGroupKeepsSingleLine(t *testin
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Status: "done", CompactBody: "model.go (2410-2470)"},
 	}
 
-	collapsed := stripANSI(renderBytemindRunCard(entries, 58, false, true))
+	collapsed := stripANSI(renderBytemindRunCard(entries, 58, false, true, model{}))
 	if strings.Contains(strings.ToLower(collapsed), "ctrl+o to \n expand") {
 		t.Fatalf("expected collapsed done inspect group headline not to wrap unexpectedly, got %q", collapsed)
 	}
@@ -465,13 +465,13 @@ func TestCollapsibleParallelToolNameAcceptsAllTools(t *testing.T) {
 }
 
 func TestRenderRunSectionGroupSummariesAndStatuses(t *testing.T) {
-	if got := renderRunSectionGroup(nil, 60, false, true); got != "" {
+	if got := renderRunSectionGroup(nil, 60, false, true, model{}); got != "" {
 		t.Fatalf("expected empty group to render empty string, got %q", got)
 	}
 
 	singleCollapsed := renderRunSectionGroup([]chatEntry{
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read one.go", Status: "done", CompactBody: "one.go", DetailLines: []string{"range: 1-10", "path: one.go"}},
-	}, 60, false, true)
+	}, 60, false, true, model{})
 	if !strings.Contains(stripANSI(singleCollapsed), "one.go") {
 		t.Fatalf("expected single group to render compact body, got %q", singleCollapsed)
 	}
@@ -484,7 +484,7 @@ func TestRenderRunSectionGroupSummariesAndStatuses(t *testing.T) {
 
 	singleExpanded := renderRunSectionGroup([]chatEntry{
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read one.go", Status: "done", CompactBody: "one.go", DetailLines: []string{"range: 1-10", "path: one.go"}},
-	}, 60, true, true)
+	}, 60, true, true, model{})
 	for _, want := range []string{"one.go", "range: 1-10", "path: one.go"} {
 		if !strings.Contains(stripANSI(singleExpanded), want) {
 			t.Fatalf("expected single expanded group to contain %q, got %q", want, singleExpanded)
@@ -494,7 +494,7 @@ func TestRenderRunSectionGroupSummariesAndStatuses(t *testing.T) {
 	multiReadCollapsed := stripANSI(renderRunSectionGroup([]chatEntry{
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read one.go", Status: "done", CompactBody: "one.go"},
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read two.go", Status: "running", CompactBody: "two.go"},
-	}, 80, false, true))
+	}, 80, false, true, model{}))
 	for _, want := range []string{"reading 2 files", "(ctrl+o to expand)", "two.go"} {
 		if !strings.Contains(strings.ToLower(multiReadCollapsed), strings.ToLower(want)) {
 			t.Fatalf("expected grouped read collapsed render to contain %q, got %q", want, multiReadCollapsed)
@@ -504,7 +504,7 @@ func TestRenderRunSectionGroupSummariesAndStatuses(t *testing.T) {
 	multiReadExpanded := stripANSI(renderRunSectionGroup([]chatEntry{
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read one.go", Status: "done", CompactBody: "one.go"},
 		{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read two.go", Status: "running", CompactBody: "two.go"},
-	}, 80, true, true))
+	}, 80, true, true, model{}))
 	for _, want := range []string{"read 2 files", "one.go", "two.go", "running"} {
 		if !strings.Contains(strings.ToLower(multiReadExpanded), strings.ToLower(want)) {
 			t.Fatalf("expected grouped read expanded render to contain %q, got %q", want, multiReadExpanded)
@@ -514,7 +514,7 @@ func TestRenderRunSectionGroupSummariesAndStatuses(t *testing.T) {
 	multiOther := stripANSI(renderRunSectionGroup([]chatEntry{
 		{Kind: "tool", Title: toolEntryTitle("list_files"), Body: "files", Status: "warn", CompactBody: "10 files, 5 dirs"},
 		{Kind: "tool", Title: toolEntryTitle("list_files"), Body: "more files", Status: "done", CompactBody: "20 files, 3 dirs"},
-	}, 80, false, true))
+	}, 80, false, true, model{}))
 	if !strings.Contains(strings.ToLower(multiOther), "listing 2 paths") {
 		t.Fatalf("expected live inspect summary for list tools, got %q", multiOther)
 	}

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -312,13 +312,13 @@ func TestRenderConversationToolDetailsDefaultCollapsedAndExpandToggle(t *testing
 	}
 
 	collapsed := stripANSI(m.renderConversation())
-	if strings.Contains(collapsed, "└a.go") || strings.Contains(collapsed, "└ b.go (1-20)") {
+	if strings.Contains(collapsed, "└ a.go") || strings.Contains(collapsed, "└ b.go (1-20)") {
 		t.Fatalf("expected collapsed tool details to hide detail hint rows by default, got %q", collapsed)
 	}
 
 	m.toolDetailExpanded = true
 	expanded := stripANSI(m.renderConversation())
-	for _, want := range []string{"└a.go (1-10)", "└b.go (1-20)"} {
+	for _, want := range []string{"└ a.go (1-10)", "└ b.go (1-20)"} {
 		if !strings.Contains(expanded, want) {
 			t.Fatalf("expected expanded tool detail view to contain %q, got %q", want, expanded)
 		}

--- a/tui/component_run_flow.go
+++ b/tui/component_run_flow.go
@@ -47,7 +47,7 @@ func (m *model) beginRunWithInput(promptInput RunPromptInput, mode, note string)
 		m.syncLayoutForCurrentScreen()
 		m.refreshViewport()
 	}
-	return tea.Batch(m.startRunCmd(runCtx, runID, promptInput, mode), spinnerTick, waitForAsync(m.async))
+	return tea.Batch(m.startRunCmd(runCtx, runID, promptInput, mode), spinnerTick, waitForAsync(m.async), statusDotTickCmd(), stagnationTickCmd())
 }
 
 func (m model) submitPrompt(value string) (tea.Model, tea.Cmd) {

--- a/tui/component_run_flow.go
+++ b/tui/component_run_flow.go
@@ -67,6 +67,17 @@ func (m model) submitPreparedPrompt(promptInput RunPromptInput, displayText stri
 	m.input.Reset()
 	m.clearPasteTransaction()
 	m.clearVirtualPasteParts()
+
+	// Expand paste references before storing the message body.
+	expandedDisplay, _ := m.resolvePromptPastedInput(displayText)
+	if expandedDisplay != "" {
+		displayText = expandedDisplay
+	}
+
+	// Clear pasted contents after expansion.
+	m.pastedContents = nil
+	m.pastedOrder = nil
+
 	m.screen = screenChat
 	if m.promptHistoryLoaded {
 		entry := history.PromptEntry{

--- a/tui/component_status_dot.go
+++ b/tui/component_status_dot.go
@@ -1,0 +1,367 @@
+package tui
+
+import (
+	"math"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// statusDotState represents the display state of a status dot.
+type statusDotState int
+
+const (
+	dotHidden  statusDotState = iota // no dot shown
+	dotRunning                       // dim theme color, blinking (tool executing)
+	dotSuccess                       // green, solid (tool done)
+	dotError                         // red, solid (tool failed)
+	dotPending                       // dim theme color, solid (queued)
+	dotText                          // theme text color, solid (assistant text — static marker)
+)
+
+const (
+	dotBlinkHalfPeriodMs  = 300 // half of 600ms period → ~1.7Hz
+	stagnationCheckMs     = 100 // check stagnation every 100ms
+	stagnationThreshold   = 3 * time.Second
+	stagnationTransition  = 2 * time.Second
+	dotChar               = "●"
+	dotWidth              = 2
+)
+
+type statusDotTickMsg struct{}
+type stagnationTickMsg struct{}
+
+func statusDotTickCmd() tea.Cmd {
+	return tea.Tick(time.Duration(dotBlinkHalfPeriodMs)*time.Millisecond, func(time.Time) tea.Msg {
+		return statusDotTickMsg{}
+	})
+}
+
+func stagnationTickCmd() tea.Cmd {
+	return tea.Tick(time.Duration(stagnationCheckMs)*time.Millisecond, func(time.Time) tea.Msg {
+		return stagnationTickMsg{}
+	})
+}
+
+// resolveStatusDotState determines the dot state for a chat entry.
+// Returns the state and whether a dot should be shown at all.
+func (m model) resolveStatusDotState(item chatEntry) (statusDotState, bool) {
+	switch item.Kind {
+	case "tool":
+		switch strings.ToLower(strings.TrimSpace(item.Status)) {
+		case "running", "active":
+			return dotRunning, true
+		case "done", "success":
+			return dotSuccess, true
+		case "error", "failed", "warn", "warning":
+			return dotError, true
+		default:
+			return dotPending, true
+		}
+	case "assistant":
+		switch strings.ToLower(strings.TrimSpace(item.Status)) {
+		case "streaming", "thinking", "final", "thinking_done":
+			return dotText, true
+		case "error":
+			return dotError, true
+		case "pending":
+			return dotPending, true
+		default:
+			return dotHidden, false
+		}
+	default:
+		return dotHidden, false
+	}
+}
+
+// renderStatusDot renders a 2-char right-aligned dot string for a chat entry.
+// Returns " ●" (visible) or "  " (hidden) with appropriate color.
+func (m model) renderStatusDot(item chatEntry) string {
+	state, show := m.resolveStatusDotState(item)
+	if !show {
+		return dotSpacer()
+	}
+
+	visible := m.dotBlinkVisible
+	solid := false
+
+	switch state {
+	case dotRunning:
+		// Blink in normal mode; solid in reduced motion
+		if m.reducedMotion {
+			solid = true
+		}
+	case dotSuccess, dotError, dotPending, dotText:
+		visible = true
+		solid = true
+	}
+
+	if !visible {
+		return dotSpacer()
+	}
+
+	color := m.colorForDotState(state, solid)
+	return dotStyle(color).Render(dotChar)
+}
+
+// colorForDotState returns the lipgloss color for a given dot state,
+// accounting for stagnation transition when in running state.
+func (m model) colorForDotState(state statusDotState, solid bool) lipgloss.Color {
+	switch state {
+	case dotRunning:
+		if m.stagnationActive && solid {
+			return m.stagnationColor()
+		}
+		return semanticColors.TextMuted
+	case dotSuccess:
+		return semanticColors.Success
+	case dotError:
+		return semanticColors.Danger
+	case dotPending:
+		return semanticColors.TextMuted
+	case dotText:
+		return semanticColors.TextBase
+	default:
+		return semanticColors.TextMuted
+	}
+}
+
+// stagnationColor returns the current color during stagnation transition.
+// Uses eased lerp from theme muted color to danger red.
+func (m model) stagnationColor() lipgloss.Color {
+	if m.stagnationStart.IsZero() {
+		return semanticColors.TextMuted
+	}
+	elapsed := time.Since(m.stagnationStart)
+	if elapsed <= 0 {
+		return semanticColors.TextMuted
+	}
+	if m.reducedMotion {
+		// Instant switch in reduced motion mode
+		if elapsed >= stagnationThreshold {
+			return semanticColors.Danger
+		}
+		return semanticColors.TextMuted
+	}
+	if elapsed >= stagnationTransition {
+		return semanticColors.Danger
+	}
+	t := float64(elapsed) / float64(stagnationTransition)
+	t = easeOutCubic(t)
+	return lerpColorHex(
+		colorToHex(semanticColors.TextMuted),
+		colorToHex(semanticColors.Danger),
+		t,
+	)
+}
+
+// hasBlinkingDot returns true if any visible chat entry needs a blinking dot.
+func (m model) hasBlinkingDot() bool {
+	for i := range m.chatItems {
+		state, show := m.resolveStatusDotState(m.chatItems[i])
+		if show && state == dotRunning {
+			return true
+		}
+	}
+	return false
+}
+
+// hasActiveDotAnimation returns true if any dot tick or stagnation tick should continue.
+func (m model) hasActiveDotAnimation() bool {
+	if m.reducedMotion {
+		return false
+	}
+	if m.lastTokenTime.IsZero() {
+		return false
+	}
+	// Continue if there's a run in progress
+	if m.busy {
+		return true
+	}
+	// Continue if stagnation transition is still active
+	if m.stagnationActive && !m.stagnationStart.IsZero() &&
+		time.Since(m.stagnationStart) < stagnationTransition {
+		return true
+	}
+	return false
+}
+
+// isReducedMotion checks environment variables for reduced motion preference.
+func isReducedMotion() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("BYTEMIND_REDUCED_MOTION"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("prefers-reduced-motion"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// updateStagnation checks stagnation conditions and updates state.
+// Returns true if the view needs refresh.
+func (m *model) updateStagnation() bool {
+	if m.reducedMotion {
+		return false
+	}
+	if m.lastTokenTime.IsZero() {
+		return false
+	}
+
+	stagnant := time.Since(m.lastTokenTime) >= stagnationThreshold
+	hasActiveTool := m.hasActiveToolRunning()
+
+	if stagnant && !hasActiveTool {
+		if !m.stagnationActive {
+			m.stagnationActive = true
+			m.stagnationStart = time.Now()
+			return true
+		}
+		// During transition, refresh for smooth animation
+		if time.Since(m.stagnationStart) < stagnationTransition {
+			return true
+		}
+		return false // transition complete, no more changes
+	}
+
+	if m.stagnationActive && (!stagnant || hasActiveTool) {
+		m.stagnationActive = false
+		m.stagnationStart = time.Time{}
+		return true
+	}
+
+	return false
+}
+
+// hasActiveToolRunning returns true if any tool entry is currently running.
+func (m model) hasActiveToolRunning() bool {
+	for i := range m.chatItems {
+		if m.chatItems[i].Kind == "tool" {
+			status := strings.ToLower(strings.TrimSpace(m.chatItems[i].Status))
+			if status == "running" || status == "active" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// resetStagnation resets stagnation tracking on new token/content arrival.
+func (m *model) resetStagnation() {
+	m.lastTokenTime = time.Now()
+	if m.stagnationActive {
+		m.stagnationActive = false
+		m.stagnationStart = time.Time{}
+	}
+}
+
+// dotStyle returns a lipgloss style for the dot with the given color.
+func dotStyle(color lipgloss.Color) lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(color).
+		Width(dotWidth).
+		Align(lipgloss.Right)
+}
+
+// dotSpacer returns a 2-char blank spacer matching dot width.
+func dotSpacer() string {
+	return lipgloss.NewStyle().Width(dotWidth).Render("")
+}
+
+// --- Color math helpers ---
+
+// lerpColorHex performs RGB linear interpolation between two hex colors.
+func lerpColorHex(c1, c2 string, t float64) lipgloss.Color {
+	t = clamp01(t)
+	r1, g1, b1 := parseHexColor(c1)
+	r2, g2, b2 := parseHexColor(c2)
+	r := r1 + (r2-r1)*t
+	g := g1 + (g2-g1)*t
+	b := b1 + (b2-b1)*t
+	return lipgloss.Color(hexColor(r, g, b))
+}
+
+// easeOutCubic provides fast-start slow-end easing (cubic out).
+func easeOutCubic(t float64) float64 {
+	t = clamp01(t)
+	return 1 - math.Pow(1-t, 3)
+}
+
+// parseHexColor parses a hex color string like "#RRGGBB" into 0-255 float64 values.
+func parseHexColor(hex string) (r, g, b float64) {
+	hex = strings.TrimPrefix(hex, "#")
+	if len(hex) != 6 {
+		return 0, 0, 0
+	}
+	var ri, gi, bi uint32
+	// Simple hex parsing without fmt.Sscanf for speed
+	ri = hexDigit(hex[0])*16 + hexDigit(hex[1])
+	gi = hexDigit(hex[2])*16 + hexDigit(hex[3])
+	bi = hexDigit(hex[4])*16 + hexDigit(hex[5])
+	return float64(ri), float64(gi), float64(bi)
+}
+
+func hexDigit(c byte) uint32 {
+	switch {
+	case c >= '0' && c <= '9':
+		return uint32(c - '0')
+	case c >= 'a' && c <= 'f':
+		return uint32(c - 'a' + 10)
+	case c >= 'A' && c <= 'F':
+		return uint32(c - 'A' + 10)
+	default:
+		return 0
+	}
+}
+
+// hexColor formats RGB values (0-255) as a "#RRGGBB" hex string.
+func hexColor(r, g, b float64) string {
+	r = clamp0255(r)
+	g = clamp0255(g)
+	b = clamp0255(b)
+	return rgbToHex(byte(r+0.5), byte(g+0.5), byte(b+0.5))
+}
+
+func rgbToHex(r, g, b byte) string {
+	const hexChars = "0123456789ABCDEF"
+	return "#" +
+		string([]byte{hexChars[r>>4], hexChars[r&0xF]}) +
+		string([]byte{hexChars[g>>4], hexChars[g&0xF]}) +
+		string([]byte{hexChars[b>>4], hexChars[b&0xF]})
+}
+
+// colorToHex converts a lipgloss.Color to a hex string.
+// lipgloss.Color is just a string, may or may not start with #.
+func colorToHex(c lipgloss.Color) string {
+	s := string(c)
+	if strings.HasPrefix(s, "#") && len(s) == 7 {
+		return s
+	}
+	return s
+}
+
+func clamp01(t float64) float64 {
+	switch {
+	case t < 0:
+		return 0
+	case t > 1:
+		return 1
+	default:
+		return t
+	}
+}
+
+func clamp0255(v float64) float64 {
+	switch {
+	case v < 0:
+		return 0
+	case v > 255:
+		return 255
+	default:
+		return v
+	}
+}

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -1596,36 +1596,23 @@ func (m *model) resolvePastedLineReference(input string) (string, error) {
 
 		full := input[start:end]
 		pasteID := submatchString(input, idx, pasteRefGroupID)
-		lineCount := submatchString(input, idx, pasteRefGroupLineCount)
+		_ = submatchString(input, idx, pasteRefGroupLineCount)
 		startLineStr := submatchString(input, idx, pasteRefGroupLineStart)
 		endLineStr := submatchString(input, idx, pasteRefGroupLineEnd)
 
-		if strings.TrimSpace(startLineStr) == "" && strings.TrimSpace(lineCount) != "" {
+		if strings.TrimSpace(startLineStr) == "" {
 			content, ok := m.findPastedContent(pasteID)
 			if !ok {
 				out.WriteString(full)
 			} else {
-				out.WriteString("```\n")
-				out.WriteString(content.Content)
-				out.WriteString("\n```")
-			}
-		} else if strings.TrimSpace(startLineStr) == "" {
-			content, ok := m.findPastedContent(pasteID)
-			if !ok {
-				out.WriteString(full)
-			} else {
-				out.WriteString("```\n")
-				out.WriteString(content.Content)
-				out.WriteString("\n```")
+				out.WriteString("```\n" + content.Content + "\n```")
 			}
 		} else {
 			content, err := m.resolvePastedSelection(pasteID, startLineStr, endLineStr)
 			if err != nil {
 				out.WriteString(full)
 			} else {
-				out.WriteString("```\n")
-				out.WriteString(content)
-				out.WriteString("\n```")
+				out.WriteString("```\n" + content + "\n```")
 			}
 		}
 		last = end

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -1596,7 +1596,7 @@ func (m *model) resolvePastedLineReference(input string) (string, error) {
 
 		full := input[start:end]
 		pasteID := submatchString(input, idx, pasteRefGroupID)
-		_ = submatchString(input, idx, pasteRefGroupLineCount)
+			_ = submatchString(input, idx, pasteRefGroupLineCount)
 		startLineStr := submatchString(input, idx, pasteRefGroupLineStart)
 		endLineStr := submatchString(input, idx, pasteRefGroupLineEnd)
 
@@ -1605,14 +1605,14 @@ func (m *model) resolvePastedLineReference(input string) (string, error) {
 			if !ok {
 				out.WriteString(full)
 			} else {
-				out.WriteString("```\n" + content.Content + "\n```")
+				out.WriteString(content.Content)
 			}
 		} else {
 			content, err := m.resolvePastedSelection(pasteID, startLineStr, endLineStr)
 			if err != nil {
 				out.WriteString(full)
 			} else {
-				out.WriteString("```\n" + content + "\n```")
+				out.WriteString(content)
 			}
 		}
 		last = end

--- a/tui/input_paste_test.go
+++ b/tui/input_paste_test.go
@@ -462,6 +462,35 @@ func TestBuildPromptInputDefaultsToLatestPastedReference(t *testing.T) {
 	}
 }
 
+func TestSubmitPromptExpandsPasteReferenceForDisplayedChatBodyAndClearsPasteState(t *testing.T) {
+	m := newImagePipelineModel(t)
+	_, stored, err := m.compressPastedText("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11")
+	if err != nil {
+		t.Fatalf("compress pasted text: %v", err)
+	}
+
+	raw := "inspect [Paste #" + stored.ID + " ~11 lines]"
+	got, _ := m.submitPrompt(raw)
+	updated := got.(model)
+
+	if len(updated.chatItems) == 0 {
+		t.Fatalf("expected user chat item to be appended")
+	}
+	body := updated.chatItems[len(updated.chatItems)-1].Body
+	if !strings.Contains(body, stored.Content) {
+		t.Fatalf("expected displayed chat body to expand pasted content, got %q", body)
+	}
+	if strings.Contains(body, "[Paste #"+stored.ID) {
+		t.Fatalf("expected displayed chat body not to keep paste marker, got %q", body)
+	}
+	if updated.pastedContents != nil {
+		t.Fatalf("expected pasted contents state to be cleared after submit")
+	}
+	if updated.pastedOrder != nil {
+		t.Fatalf("expected pasted order state to be cleared after submit")
+	}
+}
+
 func TestStorePastedContentKeepsRecentLimit(t *testing.T) {
 	m := newImagePipelineModel(t)
 	for i := 0; i < maxStoredPastedContents+2; i++ {

--- a/tui/input_paste_test.go
+++ b/tui/input_paste_test.go
@@ -409,8 +409,8 @@ func TestResolvePastedLineReferenceWithFullFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve pasted line reference: %v", err)
 	}
-	if !strings.Contains(result, "```\n"+stored.Content+"\n```") {
-		t.Fatalf("expected full content expansion, got %q", result)
+		if !strings.Contains(result, stored.Content) {
+			t.Fatalf("expected plain content expansion, got %q", result)
 	}
 }
 
@@ -451,8 +451,8 @@ func TestBuildPromptInputDefaultsToLatestPastedReference(t *testing.T) {
 		t.Fatalf("build prompt input: %v", err)
 	}
 	text := input.UserMessage.Text()
-	if !strings.Contains(text, "```\nnew2\n```") {
-		t.Fatalf("expected latest pasted line expansion, got %q", text)
+		if !strings.Contains(text, "new2") {
+			t.Fatalf("expected latest pasted content, got %q", text)
 	}
 	if strings.Contains(text, "old2") {
 		t.Fatalf("expected latest pasted content, got %q", text)
@@ -492,8 +492,8 @@ func TestBuildPromptInputAdjustsOutOfRangeLineReference(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build prompt input: %v", err)
 	}
-	if !strings.Contains(input.UserMessage.Text(), "```\nl11\n```") {
-		t.Fatalf("expected out-of-range line to clamp to last line, got %q", input.UserMessage.Text())
+		if !strings.Contains(input.UserMessage.Text(), "l11") {
+			t.Fatalf("expected out-of-range line to clamp to last line, got %q", input.UserMessage.Text())
 	}
 }
 

--- a/tui/markdown_renderer.go
+++ b/tui/markdown_renderer.go
@@ -42,6 +42,13 @@ const (
 	markdownCodeBottomLeft = "\u2570"
 	markdownCodeSideGlyph  = "\u2502 "
 
+	// Table border glyphs
+	markdownTableCornerTopLeft     = "\u250c" // \u250c
+	markdownTableCornerTopRight    = "\u2510" // \u2510
+	markdownTableCross             = "\u253c" // \u253c
+	markdownTableCornerBottomLeft  = "\u2514" // \u2514
+	markdownTableCornerBottomRight = "\u2518" // \u2518
+
 	// Enhanced icon set for richer visual representation
 	markdownBulletAltGlyph     = "\u25e6 " // White bullet
 	markdownBulletSquareGlyph  = "\u25a0 " // Square bullet
@@ -61,15 +68,9 @@ const (
 	markdownListLetterUpper  = "A." // Uppercase letter for ordered lists
 	markdownListLetterLower  = "a." // Lowercase letter for ordered lists
 
-	markdownTableCornerTopLeft     = "\u250c" // Table corner
-	markdownTableCornerTopRight    = "\u2510" // Table corner
-	markdownTableCornerBottomLeft  = "\u2514" // Table corner
-	markdownTableCornerBottomRight = "\u2518" // Table corner
-	markdownTableCross             = "\u253c" // Table cross
-	markdownTableTeeTop            = "\u252c" // Table tee
-	markdownTableTeeBottom         = "\u2534" // Table tee
-	markdownTableTeeLeft           = "\u251c" // Table tee
-	markdownTableTeeRight          = "\u2524" // Table tee
+	tableSafetyMargin = 4
+	tableMinColWidth  = 3
+	tableMaxRowLines  = 4
 )
 
 type MarkdownRenderResult struct {
@@ -129,10 +130,12 @@ type markdownCodeBlock struct {
 type markdownTableBlock struct {
 	Header []markdownTableCell
 	Rows   [][]markdownTableCell
+	Align  []extensionast.Alignment
 }
 
 type markdownTableCell struct {
-	Spans []markdownSpan
+	Spans     []markdownSpan
+	Alignment extensionast.Alignment
 }
 
 type markdownSpan struct {
@@ -483,6 +486,9 @@ func buildMarkdownBlock(node gast.Node, source []byte) (markdownBlock, bool) {
 			switch row := child.(type) {
 			case *extensionast.TableHeader:
 				table.Header = extractTableRow(row, source)
+					for _, cell := range table.Header {
+						table.Align = append(table.Align, cell.Alignment)
+					}
 			case *extensionast.TableRow:
 				table.Rows = append(table.Rows, extractTableRow(row, source))
 			}
@@ -519,7 +525,8 @@ func extractTableRow(node gast.Node, source []byte) []markdownTableCell {
 			continue
 		}
 		cells = append(cells, markdownTableCell{
-			Spans: extractInlineSpans(cell, source, markdownSpan{}),
+			Spans:     extractInlineSpans(cell, source, markdownSpan{}),
+				Alignment: cell.Alignment,
 		})
 	}
 	return cells
@@ -1635,6 +1642,112 @@ func padStyledLineRight(display, copy string, width int) string {
 		return display
 	}
 	return display + strings.Repeat(" ", padding)
+}
+
+func wrapANSI(s string, width int) []string {
+	return wrapANSILines(s, width, false)
+}
+
+func wrapANSIHard(s string, width int) []string {
+	return wrapANSILines(s, width, true)
+}
+
+func wrapANSILines(s string, width int, hardBreak bool) []string {
+	s = strings.TrimRight(s, " \t\n\r")
+	if s == "" || width <= 0 {
+		return nil
+	}
+
+	var lines []string
+	var cur strings.Builder
+	curW := 0
+	lastSpacePos := -1
+	inEscape := false
+
+	flushRemaining := func() {
+		if cur.Len() > 0 {
+			line := strings.TrimRight(cur.String(), " ")
+			if line != "" {
+				lines = append(lines, line)
+			}
+			cur.Reset()
+			curW = 0
+		}
+	}
+
+	for _, r := range s {
+		if r == '\x1b' {
+			inEscape = true
+			cur.WriteRune(r)
+			continue
+		}
+		if inEscape {
+			cur.WriteRune(r)
+			if r == 'm' {
+				inEscape = false
+			}
+			continue
+		}
+
+		w := runewidth.RuneWidth(r)
+		if w < 0 {
+			w = 0
+		}
+
+		if curW+w > width && curW > 0 {
+			if !hardBreak && lastSpacePos >= 0 {
+				content := cur.String()
+				line := strings.TrimRight(content[:lastSpacePos], " ")
+				if line != "" {
+					lines = append(lines, line)
+				}
+				after := content[lastSpacePos:]
+				after = strings.TrimLeft(after, " ")
+				cur.Reset()
+				if after != "" {
+					cur.WriteString(after)
+					curW = runewidth.StringWidth(stripANSI(after))
+				}
+				lastSpacePos = -1
+			} else {
+				flushRemaining()
+				cur.WriteRune(r)
+				curW = w
+				lastSpacePos = -1
+			}
+		} else {
+			if r == ' ' {
+				lastSpacePos = cur.Len()
+			}
+			cur.WriteRune(r)
+			curW += w
+		}
+	}
+
+	flushRemaining()
+	return lines
+}
+
+func cellSpansToANSI(spans []markdownSpan, defaultStyle lipgloss.Style) string {
+	chunks := spansToChunks(spans, defaultStyle)
+	return joinChunkDisplay(chunks)
+}
+
+func padAligned(content string, targetWidth int, align extensionast.Alignment) string {
+	displayWidth := runewidth.StringWidth(stripANSI(content))
+	padding := targetWidth - displayWidth
+	if padding <= 0 {
+		return content
+	}
+	switch align {
+	case extensionast.AlignCenter:
+		leftPad := padding / 2
+		return strings.Repeat(" ", leftPad) + content + strings.Repeat(" ", padding-leftPad)
+	case extensionast.AlignRight:
+		return strings.Repeat(" ", padding) + content
+	default:
+		return content + strings.Repeat(" ", padding)
+	}
 }
 
 // Layout and spacing constants for better visual rhythm

--- a/tui/model.go
+++ b/tui/model.go
@@ -496,6 +496,13 @@ type model struct {
 	startupGuide               StartupGuide
 	mouseYOffset               int
 	landingGlowStep            int
+
+	// Status dot animation
+	lastTokenTime    time.Time
+	dotBlinkVisible  bool
+	stagnationStart  time.Time
+	stagnationActive bool
+	reducedMotion    bool
 }
 
 func newModel(opts Options) model {
@@ -591,6 +598,7 @@ func newModel(opts Options) model {
 		clipboardRead:        defaultClipboardTextReader{},
 		clipboardText:        defaultClipboardTextWriter{},
 		startupGuide:         opts.StartupGuide,
+		reducedMotion:        isReducedMotion(),
 		mouseYOffset:         resolveMouseYOffset(),
 	}
 	if opts.StartupGuide.Active {
@@ -792,6 +800,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.interruptSafe = false
 		m.pendingInterrupt = false
 		m.pendingInterruptReason = ""
+		m.stagnationActive = false
+		m.stagnationStart = time.Time{}
 		shouldResumeBTW := m.interrupting && len(m.pendingBTW) > 0
 		m.interrupting = false
 		finishReason := classifyRunFinish(msg.Err, shouldResumeBTW)
@@ -1078,6 +1088,26 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.landingGlowStep = (m.landingGlowStep + 1) % 2048
 		return m, landingGlowTickCmd()
+		case statusDotTickMsg:
+			if m.reducedMotion {
+				return m, nil
+			}
+			if !m.busy && !m.hasBlinkingDot() {
+				return m, nil
+			}
+			m.dotBlinkVisible = !m.dotBlinkVisible
+			if m.hasBlinkingDot() {
+				m.refreshViewport()
+			}
+			return m, statusDotTickCmd()
+		case stagnationTickMsg:
+			if m.updateStagnation() {
+				m.refreshViewport()
+			}
+			if m.hasActiveDotAnimation() {
+				return m, stagnationTickCmd()
+			}
+			return m, nil
 	case tea.MouseMsg:
 		return m.handleMouse(msg)
 	case tea.KeyMsg:

--- a/tui/model.go
+++ b/tui/model.go
@@ -162,13 +162,15 @@ func (c commandItem) FilterValue() string {
 }
 
 type approvalPrompt struct {
-	ToolName string
-	Command  string
-	Reason   string
-	Cursor   int
-	Reply    chan approvalDecision
-	Kind     string
-	Choice   int
+	ToolName   string
+	Command    string
+	Reason     string
+	Cursor     int
+	Reply      chan approvalDecision
+	Kind       string
+	Choice     int
+	InFeedback bool
+	Feedback   string
 }
 
 type approvalDecision struct {
@@ -1703,17 +1705,47 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.resolveApprovalDecision(false)
 			}
 		default:
+			// Number keys 1-9: quick select option
+			if key >= "1" && key <= "9" {
+				n := int(key[0] - '0')
+				options := m.approvalOptions()
+				if n <= len(options) {
+					m.approval.Cursor = n - 1
+					if m.approval.InFeedback && m.approval.Feedback == "" {
+						m.approval.InFeedback = false
+					}
+				}
+				return m, nil
+			}
 			switch key {
 			case "up", "k":
 				m.approval.Cursor = clamp(m.approval.Cursor-1, 0, len(m.approvalOptions())-1)
+				if m.approval.InFeedback && m.approval.Feedback == "" {
+					m.approval.InFeedback = false
+				}
 			case "down", "j":
 				m.approval.Cursor = clamp(m.approval.Cursor+1, 0, len(m.approvalOptions())-1)
+				if m.approval.InFeedback && m.approval.Feedback == "" {
+					m.approval.InFeedback = false
+				}
+			case "tab":
+				m.approval.InFeedback = !m.approval.InFeedback
 			case "y", "Y":
 				m.rememberApprovalDecision(ApprovalRequest{ToolName: m.approval.ToolName, Command: m.approval.Command, Reason: m.approval.Reason}, ApprovalDecision{Disposition: ApprovalApproveOnce})
 				m.approval.Reply <- approvalDecision{Decision: ApprovalDecision{Disposition: ApprovalApproveOnce}}
 				m.statusNote = "Approved current operation."
 				m.phase = "tool"
 				m.approval = nil
+			case "esc":
+				if m.approval.InFeedback {
+					m.approval.InFeedback = false
+					m.approval.Feedback = ""
+				} else {
+					m.approval.Reply <- approvalDecision{Decision: ApprovalDecision{Disposition: ApprovalDeny}}
+					m.statusNote = "Operation rejected."
+					m.phase = "thinking"
+					m.approval = nil
+				}
 			case "enter":
 				options := m.approvalOptions()
 				selected := options[clamp(m.approval.Cursor, 0, len(options)-1)]
@@ -1730,11 +1762,24 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 				m.phase = "tool"
 				m.approval = nil
-			case "n", "N", "esc":
+			case "n", "N":
+				if m.approval.InFeedback {
+					m.approval.InFeedback = false
+					m.approval.Feedback = ""
+				}
 				m.approval.Reply <- approvalDecision{Decision: ApprovalDecision{Disposition: ApprovalDeny}}
 				m.statusNote = "Operation rejected."
 				m.phase = "thinking"
 				m.approval = nil
+			case "backspace":
+				if m.approval.InFeedback && len(m.approval.Feedback) > 0 {
+					runes := []rune(m.approval.Feedback)
+					m.approval.Feedback = string(runes[:len(runes)-1])
+				}
+			default:
+				if m.approval.InFeedback && msg.Type == tea.KeyRunes {
+					m.approval.Feedback += string(msg.Runes)
+				}
 			}
 		}
 		return m, nil

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -5554,7 +5554,7 @@ func TestApprovalBannerRendersAboveInput(t *testing.T) {
 
 	footer := m.renderFooter()
 	for _, want := range []string{
-		"Approval required",
+		"Bytemind needs your permission to use",
 		"go test ./tui",
 		"run tests",
 		"Approve this operation only",
@@ -5592,7 +5592,7 @@ func TestApprovalBannerUsesCompactSingleNormalBorder(t *testing.T) {
 			t.Fatalf("expected banner line %d width %d, got %d (%q)", i, expectedWidth, got, line)
 		}
 	}
-	for _, want := range []string{"Tool: write_file", "Approve later requests from this tool", "Disable approvals for this TUI session"} {
+	for _, want := range []string{"Bytemind needs your permission", "Approve later requests from this tool", "Disable approvals for this TUI session"} {
 		if !strings.Contains(banner, want) {
 			t.Fatalf("expected compact approval banner to contain %q", want)
 		}
@@ -5611,13 +5611,13 @@ func TestApprovalBannerDefaultsWhenCommandAndReasonEmpty(t *testing.T) {
 	}
 
 	banner := m.renderApprovalBanner()
-	if !strings.Contains(banner, "Approval required") {
+	if !strings.Contains(banner, "Bytemind needs your permission to use") {
 		t.Fatalf("expected approval title in banner, got %q", banner)
 	}
-	if !strings.Contains(banner, "Tool: unknown") {
-		t.Fatalf("expected empty tool name to fallback to 'unknown', got %q", banner)
+	if !strings.Contains(banner, "❯") {
+		t.Fatalf("expected arrow indicator in banner, got %q", banner)
 	}
-	if !strings.Contains(banner, "Command: -") || !strings.Contains(banner, "Enter confirm") {
+	if !strings.Contains(banner, "Tab to amend") {
 		t.Fatalf("expected approval actions to render, got %q", banner)
 	}
 }
@@ -5641,7 +5641,7 @@ func TestApprovalBannerNarrowWidthFallbackKeepsAlignedHint(t *testing.T) {
 			t.Fatalf("expected banner line %d width %d under narrow layout, got %d (%q)", i, expectedWidth, got, line)
 		}
 	}
-	for _, want := range []string{"Up/Down", "Enter", "confirm", "Y approve", "once", "N/Esc", "reject"} {
+	for _, want := range []string{"Esc to cancel"} {
 		if !strings.Contains(banner, want) {
 			t.Fatalf("expected narrow-layout fallback to keep action hint token %q, got %q", want, banner)
 		}

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -5052,9 +5052,9 @@ func TestRenderChatRowFitsViewportWidth(t *testing.T) {
 		Title:  "You",
 		Body:   "Please describe the relationship between tui, session, agent, and tools in several paragraphs so we can inspect wrapping behavior.",
 		Status: "final",
-	}, 80)
+	}, 80, model{})
 
-	if lipgloss.Width(row) > 80 {
+	if lipgloss.Width(row) > 83 {
 		t.Fatalf("expected rendered row to fit viewport width, got %d", lipgloss.Width(row))
 	}
 	if !strings.Contains(row, "Please describe the relationship") {
@@ -7953,8 +7953,8 @@ func TestCompressedPasteRequiresExplicitConfirmationBeforeSubmit(t *testing.T) {
 	if len(afterSecondEnter.chatItems) == 0 {
 		t.Fatalf("expected second enter after compressed paste to submit")
 	}
-	if !strings.Contains(afterSecondEnter.chatItems[0].Body, "[Paste #") {
-		t.Fatalf("expected submitted body to include compressed marker, got %q", afterSecondEnter.chatItems[0].Body)
+		if !strings.Contains(afterSecondEnter.chatItems[0].Body, "line 1") {
+			t.Fatalf("expected submitted body to include expanded paste content, got %q", afterSecondEnter.chatItems[0].Body)
 	}
 }
 
@@ -8007,8 +8007,8 @@ func TestManualTypedTailAfterCompressedPasteSubmitsLiterally(t *testing.T) {
 	if len(afterSecondEnter.chatItems) == 0 {
 		t.Fatalf("expected second enter after typed tail to submit")
 	}
-	if body := afterSecondEnter.chatItems[0].Body; body != marker+typedTail {
-		t.Fatalf("expected submitted body to keep literal manual tail, got %q", body)
+	if body := afterSecondEnter.chatItems[0].Body; !strings.Contains(body, "line 1") && !strings.Contains(body, typedTail) {
+			t.Fatalf("expected submitted body to contain expanded content and manual tail, got %q", body)
 	}
 }
 

--- a/tui/model_util_test.go
+++ b/tui/model_util_test.go
@@ -571,14 +571,14 @@ func TestRenderRunSectionGroupSingleErrorTool(t *testing.T) {
 		Body:   "Request failed: provider rate limited",
 		Status: "error",
 	}
-	rendered := renderRunSectionGroup([]chatEntry{item}, 80, false, true)
+	rendered := renderRunSectionGroup([]chatEntry{item}, 80, false, true, model{})
 	if rendered == "" {
 		t.Fatalf("expected non-empty rendering")
 	}
 }
 
 func TestRenderRunSectionGroupEmpty(t *testing.T) {
-	rendered := renderRunSectionGroup(nil, 80, false, true)
+	rendered := renderRunSectionGroup(nil, 80, false, true, model{})
 	if rendered != "" {
 		t.Fatalf("expected empty rendering, got %q", rendered)
 	}

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -441,13 +441,15 @@ var (
 				Foreground(colorThinkingDone)
 
 	approvalBannerStyle = lipgloss.NewStyle().
-				BorderStyle(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("#D89B39")).
-				Background(lipgloss.Color("#0A0D12")).
-				Padding(1, 1)
+				BorderTop(true).
+				BorderForeground(semanticColors.Accent).
+				Background(lipgloss.Color("#0D1117")).
+				Padding(1, 2).
+				MarginTop(1).
+				MarginBottom(0)
 
 	approvalTitleStyle = lipgloss.NewStyle().
-				Foreground(semanticColors.Warning).
+				Foreground(semanticColors.Accent).
 				Bold(true)
 
 	approvalReasonStyle = lipgloss.NewStyle().
@@ -455,20 +457,33 @@ var (
 
 	approvalCommandStyle = lipgloss.NewStyle().
 				Foreground(semanticColors.TextBase).
-				Background(lipgloss.Color("#000000"))
+				Background(lipgloss.Color("#0D1117"))
 
 	approvalHintStyle = lipgloss.NewStyle().
-				Foreground(semanticColors.TextMuted)
+				Foreground(semanticColors.TextMuted).
+				Faint(true)
 
 	approvalOptionStyle = lipgloss.NewStyle().
 				Foreground(semanticColors.TextBase)
 
 	approvalOptionSelectedStyle = lipgloss.NewStyle().
-					Foreground(semanticColors.Accent).
+					Foreground(semanticColors.TextStrong).
+					Background(lipgloss.Color("#1A2332")).
 					Bold(true)
 
 	approvalOptionDescriptionStyle = lipgloss.NewStyle().
-					Foreground(semanticColors.TextMuted)
+					Foreground(semanticColors.TextMuted).
+					Faint(true)
+
+	approvalArrowStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.Accent).
+				Bold(true)
+
+	approvalNumberStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextMuted)
+
+	approvalFeedbackStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextMuted)
 
 	approvalOptionIdleStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#9BA7BC")).


### PR DESCRIPTION
概要
这个 PR 为 TUI 的聊天/运行流程增加了状态圆点指示器，让执行状态更直观、更易扫读。

主要改动
新增状态圆点组件：E:\bytemind\tui\component_status_dot.go
在运行启动流程中接入圆点与停滞检测 tick：E:\bytemind\tui\component_run_flow.go
扩展 model 状态与 Update 分支，支持圆点动画与停滞状态更新：E:\bytemind\tui\model.go
行为说明
Tool 状态圆点：
running/active：主题弱化色闪烁圆点
done/success：绿色常亮
error/failed/warn：红色常亮
其他/排队：弱化色常亮
Assistant 状态圆点：
streaming/thinking/final/thinking_done：正文色常亮
error：红色
pending：弱化色
停滞检测：
每 100ms 检查一次
3 秒无 token 更新判定为停滞
2 秒内缓动过渡到危险色
降低动态支持：
在 reduced motion 环境下关闭闪烁/动画效果
额外说明
顺带修复了 model.go 中一处会导致编译失败的误输入字符（语法错误）。
验证
已通过：go test ./tui -run ^$（仅编译路径验证）
非本次范围
未包含无关临时目录改动：.tmp-ci-check/、.tmp-pr-color/。