### PR TITLE
fix(tui): add spacing after tree marker in tool details

### DIFF
--- a/tui/component_conversation.go
+++ b/tui/component_conversation.go
@@ -11,6 +11,7 @@ import (
 const (
 	toolIcon     = "●"
 	toolTreeChar = "└"
+	toolTreeLead = "└ "
 )
 
 func (m model) renderConversation() string {
@@ -479,7 +480,7 @@ func renderRunSectionGroup(group []chatEntry, width int, toolDetailsExpanded boo
 		if runewidth.StringWidth(compact) > maxDetail {
 			compact = runewidth.Truncate(compact, maxDetail, "…")
 		}
-		detailLines = append(detailLines, connectorStyle.Render(toolTreeChar)+compact)
+		detailLines = append(detailLines, connectorStyle.Render(toolTreeLead)+compact)
 	}
 
 	indent := "  "
@@ -554,7 +555,7 @@ func renderToolTreeItem(item chatEntry, width int, toolDetailsExpanded bool, run
 			if detail == "" {
 				continue
 			}
-			detailLines = append(detailLines, connectorStyle.Render(toolTreeChar)+detail)
+			detailLines = append(detailLines, connectorStyle.Render(toolTreeLead)+detail)
 		}
 		if len(detailLines) > 0 {
 			body = headLine + "\n" + indent + strings.Join(detailLines, "\n"+indent)
@@ -625,7 +626,7 @@ func renderLiveInspectGroup(group []chatEntry, width int, runningIndicatorVisibl
 		if detail := latestLiveInspectHint(group); detail != "" {
 			connectorStyle := lipgloss.NewStyle().Foreground(colorTool)
 			maxDetailWidth := max(12, contentWidth-6)
-			headLine += "\n  " + connectorStyle.Render(toolTreeChar) + " " + compact(detail, maxDetailWidth)
+			headLine += "\n  " + connectorStyle.Render(toolTreeLead) + compact(detail, maxDetailWidth)
 		}
 	}
 

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -389,6 +389,17 @@ func TestRenderBytemindRunCardCollapsedLiveInspectSummaryAcrossTools(t *testing.
 	}
 }
 
+func TestRenderLiveInspectGroupDetailPrefixHasSpace(t *testing.T) {
+	group := []chatEntry{
+		{Kind: "tool", Title: toolEntryTitle("search_text"), Status: "running", CompactBody: `"finalizeAssistantTurnForTool"`},
+	}
+
+	view := stripANSI(renderLiveInspectGroup(group, 100, true))
+	if !strings.Contains(view, `└ "finalizeAssistantTurnForTool"`) {
+		t.Fatalf("expected live inspect detail prefix to include a space after tree marker, got %q", view)
+	}
+}
+
 func TestRenderBytemindRunCardCollapsedDoneInspectGroupKeepsSingleLine(t *testing.T) {
 	entries := []chatEntry{
 		{Kind: "tool", Title: toolEntryTitle("search_text"), Status: "done", CompactBody: `17 matches for "toolDetailsExpanded"`},

--- a/tui/component_render_test.go
+++ b/tui/component_render_test.go
@@ -312,13 +312,13 @@ func TestRenderConversationToolDetailsDefaultCollapsedAndExpandToggle(t *testing
 	}
 
 	collapsed := stripANSI(m.renderConversation())
-	if strings.Contains(collapsed, "└a.go") || strings.Contains(collapsed, "└ b.go (1-20)") {
+	if strings.Contains(collapsed, "└ a.go") || strings.Contains(collapsed, "└ b.go (1-20)") {
 		t.Fatalf("expected collapsed tool details to hide detail hint rows by default, got %q", collapsed)
 	}
 
 	m.toolDetailExpanded = true
 	expanded := stripANSI(m.renderConversation())
-	for _, want := range []string{"└a.go (1-10)", "└b.go (1-20)"} {
+	for _, want := range []string{"└ a.go (1-10)", "└ b.go (1-20)"} {
 		if !strings.Contains(expanded, want) {
 			t.Fatalf("expected expanded tool detail view to contain %q, got %q", want, expanded)
 		}


### PR DESCRIPTION
## 变更说明
本次修复了 TUI 中工具详情行树形前缀的可读性问题。

- 新增统一前缀 `toolTreeLead = "└ "`（包含一个空格）
- 将工具详情行从 `└xxx` 调整为 `└ xxx`
- 在 grouped tool details 与 live-inspect detail hint 两处统一使用该前缀
- 更新对应渲染测试断言，确保格式稳定

## 影响范围
- `tui/component_conversation.go`
- `tui/component_render_test.go`

## 验证
已执行：
- `go test ./tui -run "TestRenderConversationToolDetailsDefaultCollapsedAndExpandToggle|TestRenderBytemindRunCardCollapsesConsecutiveReadTools" -v`

结果：通过
