### PR TITLE
fix: optimize diff_preview rendering alignment and background highlighting

### DIFF
--- a/tui/component_conversation.go
+++ b/tui/component_conversation.go
@@ -931,12 +931,12 @@ func renderDiffDetailLine(line string, width int) string {
 		return toolDiffHunkHeaderStyle.Render(line[1:])
 	}
 
-	// Diff content lines: all start with space. Marker at position 9
-	// Format: " NNNNNNN X code" (1+7+1+1 = 10 chars prefix, marker at [9])
-	if len(line) < 11 {
+	// Diff content lines: 7-char line num, space, marker, space, code
+	// Format: "NNNNNNN X code" (7+1+1=9 chars prefix, marker at [8])
+	if len(line) < 10 {
 		return line
 	}
-	diffMarker := line[9]
+	diffMarker := line[8]
 	if diffMarker != '+' && diffMarker != '-' && diffMarker != ' ' {
 		return line
 	}

--- a/tui/diff_preview_util.go
+++ b/tui/diff_preview_util.go
@@ -85,14 +85,14 @@ func diffExpandedDetailLines(dp diffPreviewLocal) []string {
 				content := l[1:]
 				switch prefix {
 				case ' ':
-					lines = append(lines, " "+lineNumStr(oldLine)+"   "+content)
+					lines = append(lines, lineNumStr(oldLine)+"   "+content)
 					oldLine++
 					newLine++
 				case '-':
-					lines = append(lines, " "+lineNumStr(oldLine)+" - "+content)
+					lines = append(lines, lineNumStr(oldLine)+" - "+content)
 					oldLine++
 				case '+':
-					lines = append(lines, " "+lineNumStr(newLine)+" + "+content)
+					lines = append(lines, lineNumStr(newLine)+" + "+content)
 					newLine++
 				}
 			}

--- a/tui/diff_preview_util.go
+++ b/tui/diff_preview_util.go
@@ -37,12 +37,19 @@ const (
 	diffHunkHdr = "\x02" // @@ hunk header (cyan)
 )
 
-func lineNumStr(n int) string {
-	return fmt.Sprintf("%7d", n)
-}
-
 func diffDetailLine(prefix, text string) string {
 	return prefix + text
+}
+
+// formatDiffLine produces a single diff content line with fixed layout:
+//
+//	"NNNNNNN M content"
+//
+// N = 7-char right-aligned line number (space padded)
+// M = diff marker (' ', '+', or '-')
+// content = code text starting from position 10
+func formatDiffLine(n int, marker byte, content string) string {
+	return fmt.Sprintf("%7d %c %s", n, marker, content)
 }
 
 // diffExpandedDetailLines generates detail lines for the TUI card.
@@ -85,14 +92,14 @@ func diffExpandedDetailLines(dp diffPreviewLocal) []string {
 				content := l[1:]
 				switch prefix {
 				case ' ':
-					lines = append(lines, lineNumStr(oldLine)+"   "+content)
+					lines = append(lines, formatDiffLine(oldLine, ' ', content))
 					oldLine++
 					newLine++
 				case '-':
-					lines = append(lines, lineNumStr(oldLine)+" - "+content)
+					lines = append(lines, formatDiffLine(oldLine, '-', content))
 					oldLine++
 				case '+':
-					lines = append(lines, lineNumStr(newLine)+" + "+content)
+					lines = append(lines, formatDiffLine(newLine, '+', content))
 					newLine++
 				}
 			}

--- a/tui/diff_render_test.go
+++ b/tui/diff_render_test.go
@@ -24,21 +24,21 @@ func TestRenderDiffDetailLineAllPaths(t *testing.T) {
 		t.Errorf("hunk header should contain @@, got %q", result)
 	}
 
-	// Diff content: added line
-	result = renderDiffDetailLine("       1 + package main", 80)
-	if result == "       1 + package main" {
+	// Diff content: added line (7-char line num, space, marker, space, code)
+	result = renderDiffDetailLine("      1 + package main", 80)
+	if result == "      1 + package main" {
 		t.Errorf("added line should be styled, got plain text %q", result)
 	}
 
 	// Diff content: removed line
-	result = renderDiffDetailLine("       2 - func old()", 80)
-	if result == "       2 - func old()" {
+	result = renderDiffDetailLine("      2 - func old()", 80)
+	if result == "      2 - func old()" {
 		t.Errorf("removed line should be styled, got plain text %q", result)
 	}
 
 	// Diff content: context line
-	result = renderDiffDetailLine("       3   unchanged", 80)
-	if result == "       3   unchanged" {
+	result = renderDiffDetailLine("      3   unchanged", 80)
+	if result == "      3   unchanged" {
 		t.Errorf("context line should be styled, got plain text %q", result)
 	}
 
@@ -54,16 +54,16 @@ func TestRenderDiffDetailLineAllPaths(t *testing.T) {
 		t.Errorf("empty line should be empty, got %q", result)
 	}
 
-	// Short line (< 11 chars) passes through
-	result = renderDiffDetailLine("   short", 80)
-	if result != "   short" {
+	// Short line (< 10 chars) passes through
+	result = renderDiffDetailLine("  short", 80)
+	if result != "  short" {
 		t.Errorf("short line should pass through, got %q", result)
 	}
 
 	// Padding to width
-	result = renderDiffDetailLine("       1 + pkg", 80)
+	result = renderDiffDetailLine("      1 + pkg", 80)
 	if len(result) < 80 {
-		t.Errorf("line should be padded to >= width, got len=%d", len(result))
+		t.Errorf("line should be padded to >= width, got len=%d, content=%q", len(result), result)
 	}
 }
 
@@ -165,20 +165,20 @@ func TestRenderToolPayloadDiffPaths(t *testing.T) {
 }
 
 func TestRenderDiffDetailLineEdgeCases(t *testing.T) {
-	// Line exactly at minimum length
-	result := renderDiffDetailLine("       1   x", 80)
+	// Line exactly at minimum length (10 chars)
+	result := renderDiffDetailLine("      1   x", 80)
 	if len(result) < 80 {
 		t.Errorf("min length diff line should be padded, got len=%d", len(result))
 	}
 
-	// Line with marker at wrong position (not at 9)
-	result2 := renderDiffDetailLine("1234567890abc", 80)
-	if result2 != "1234567890abc" {
+	// Line with marker at wrong position (not at 8)
+	result2 := renderDiffDetailLine("12345678abc", 80)
+	if result2 != "12345678abc" {
 		t.Errorf("line without valid marker should pass through")
 	}
 
 	// Very long line gets padded
-	long := "       1 + " + strings.Repeat("x", 200)
+	long := "      1 + " + strings.Repeat("x", 200)
 	result3 := renderDiffDetailLine(long, 80)
 	if len(result3) < 80 {
 		t.Errorf("long line should not be shortened below width")

--- a/tui/diff_selfcheck_test.go
+++ b/tui/diff_selfcheck_test.go
@@ -50,8 +50,8 @@ func TestSelfCheckDiffRendering(t *testing.T) {
 				fmt.Printf("    STATS: %s\n", dl[1:])
 			case len(dl) > 0 && dl[0] == 0x02:
 				fmt.Printf("    HUNK:  %s\n", dl[1:])
-			case len(dl) >= 10:
-				switch dl[9] {
+			case len(dl) >= 9:
+				switch dl[8] {
 				case '+':
 					fmt.Printf("    ADD:   %q\n", dl)
 				case '-':


### PR DESCRIPTION
 修复 diff 渲染的行对齐、背景高亮、标记位置等问题。

  ## 修复内容
  - 统一 `formatDiffLine("%7d %c %s")` 保证每行格式一致
  - 行号固定 7 位右对齐，标记固定 p8，代码从 p10 开始
  - 增行白字绿底、删行白字红底，背景铺满卡片行宽
  - 修复 TrimSpace 导致标记检测失效
  - 修复 isSensitivePath `*.pem`/`*.key` 通配符匹配
  - 修复 newFileDiff 空文件返回 nil
  - 补充 renderDiffDetailLine / buildReplaceDiff / truncateDiff 等测试覆盖

  ## 文件
  tui/diff_preview_util.go  tui/component_conversation.go  tui/styles.go
  internal/tools/diff_preview.go  internal/tools/write_file.go
  tui/diff_render_test.go  internal/tools/diff_preview_test.go

## 效果展示
### 示例任务：
<img width="1205" height="400" alt="image" src="https://github.com/user-attachments/assets/9fbfb267-5fa5-4e28-b41c-72ad34e7ac34" />

### 示例任务输出
<img width="2509" height="958" alt="image" src="https://github.com/user-attachments/assets/75e55ab3-e619-4839-8a46-98ca71a3c84b" />
