### PR TITLE
fix: 恢复结构化计划协议，还原移除 update_plan 和修复启发式逻辑的操作

### DIFF
--- a/internal/agent/build_handoff_repair.go
+++ b/internal/agent/build_handoff_repair.go
@@ -1,0 +1,196 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/1024XEngineer/bytemind/internal/llm"
+	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+)
+
+func shouldRepairBuildHandoffTurn(runMode planpkg.AgentMode, state planpkg.State, intent assistantTurnIntent, reply llm.Message, messages []llm.Message) bool {
+	if runMode != planpkg.ModeBuild || len(reply.ToolCalls) > 0 {
+		return false
+	}
+
+	state = planpkg.NormalizeState(state)
+	if !planpkg.HasStructuredPlan(state) {
+		return false
+	}
+	phase := planpkg.NormalizePhase(string(state.Phase))
+	if phase != planpkg.PhaseExecuting && !planpkg.CanStartExecution(state) {
+		return false
+	}
+
+	latestUser := latestUserMessageText(messages)
+	if !looksLikeExecutionHandoffInput(latestUser) {
+		return false
+	}
+
+	text := strings.TrimSpace(reply.Content)
+	if text == "" || intent == turnIntentContinueWork {
+		return false
+	}
+	return looksLikeRedundantBuildHandoffBlocker(text) || looksLikeExecutionHandoffAcknowledgement(text)
+}
+
+func buildBuildHandoffRepairInstruction(state planpkg.State, reply llm.Message, latestUser string, attempt, maxAttempts int) string {
+	state = planpkg.NormalizeState(state)
+	preview := strings.TrimSpace(reply.Content)
+	if preview == "" {
+		preview = "(empty assistant text)"
+	}
+	preview = truncateRunes(preview, 240)
+	latestUser = strings.TrimSpace(latestUser)
+	if latestUser == "" {
+		latestUser = "(empty user text)"
+	}
+	nextStep := strings.TrimSpace(state.NextAction)
+	if nextStep == "" {
+		nextStep = planpkg.DefaultNextAction(state)
+	}
+
+	return strings.TrimSpace(fmt.Sprintf(
+		`The previous assistant turn responded to an execution handoff after the session had already switched to build mode.
+Attempt %d/%d.
+
+Latest user handoff input:
+%s
+
+Reply text preview:
+%s
+
+Current mode is build and the plan handoff is already approved. For this next turn:
+1) Do not ask the user to send continue execution/start execution again.
+2) Do not claim the session is still in plan mode, stuck in plan confirmation, or limited to a plan-mode read-only shell policy.
+3) Start from the current plan baseline and the next execution step: %s
+4) Emit structured tool calls in this turn unless a real missing requirement blocks execution.
+5) If an action genuinely needs approval, rely on the tool approval flow instead of asking the user to switch modes again.`,
+		attempt,
+		maxAttempts,
+		latestUser,
+		preview,
+		nextStep,
+	))
+}
+
+func latestUserMessageText(messages []llm.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.Role != llm.RoleUser {
+			continue
+		}
+		text := strings.TrimSpace(msg.Text())
+		if text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func looksLikeExecutionHandoffInput(text string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	return containsAnyToken(normalized,
+		"start execution",
+		"continue execution",
+		"start build",
+		"begin execution",
+		"resume execution",
+		"\u5f00\u59cb\u6267\u884c",
+		"\u7ee7\u7eed\u6267\u884c",
+		"\u6309\u8ba1\u5212\u6267\u884c",
+	)
+}
+
+func looksLikeRedundantBuildHandoffBlocker(text string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	if normalized == "" {
+		return false
+	}
+	if containsAnyToken(normalized,
+		"plan confirmation",
+		"still in plan",
+		"still stuck in plan",
+		"read-only",
+		"run_shell",
+		"strict read-only allowlist",
+		"switch to build",
+		"switch the ui",
+		"toggle the ui",
+		"send continue execution",
+		"send start execution",
+		"\u8ba1\u5212\u786e\u8ba4",
+		"\u4ecd\u505c\u5728\u8ba1\u5212",
+		"\u53ea\u8bfb",
+		"\u5207\u5230 build",
+		"\u5207\u6362\u5230 build",
+		"\u518d\u53d1 continue execution",
+		"\u518d\u53d1 start execution",
+	) {
+		return true
+	}
+	return hasAskUserSignal(normalized) &&
+		containsAnyToken(normalized,
+			"continue execution",
+			"start execution",
+			"switch to build",
+			"build mode",
+			"\u7ee7\u7eed\u6267\u884c",
+			"\u5f00\u59cb\u6267\u884c",
+		)
+}
+
+func looksLikeExecutionHandoffAcknowledgement(text string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	if normalized == "" {
+		return false
+	}
+	if containsAnyToken(normalized,
+		"need you",
+		"need your",
+		"please confirm",
+		"confirm whether",
+		"confirm if",
+		"do you accept",
+		"accept me",
+		"reply with",
+		"回复",
+		"请确认",
+		"是否接受",
+		"是否同意",
+		"我需要你确认",
+		"请先确认",
+	) {
+		return true
+	}
+	if hasAskUserSignal(normalized) || containsAnyToken(normalized,
+		"missing ",
+		"need ",
+		"blocked",
+		"cannot",
+		"can't",
+		"unable",
+		"\u7f3a\u5c11",
+		"\u9700\u8981",
+		"\u963b\u585e",
+		"\u65e0\u6cd5",
+	) {
+		return false
+	}
+	if strings.Count(normalized, "\n") > 4 || len([]rune(normalized)) > 160 {
+		return false
+	}
+	return containsAnyToken(normalized,
+		"started execution",
+		"starting execution",
+		"start execution",
+		"beginning execution",
+		"begin execution",
+		"starting now",
+		"\u5df2\u5f00\u59cb\u6267\u884c",
+		"\u5f00\u59cb\u6267\u884c",
+		"\u51c6\u5907\u5f00\u5de5",
+		"\u9a6c\u4e0a\u5f00\u59cb",
+		"\u5f00\u59cb\u52a8\u624b",
+	)
+}

--- a/internal/agent/final_reply.go
+++ b/internal/agent/final_reply.go
@@ -22,6 +22,21 @@ func (e *defaultEngine) finalizeTurnWithoutTools(runMode planpkg.AgentMode, sess
 		answer = emptyReplyFallback
 	}
 
+	latestUser := latestHumanUserMessageText(sess.Messages)
+	if shouldCondensePlanRevisionAnswer(runMode, sess.Plan, sess.Messages) {
+		condensed := condensePlanRevisionAnswer(answer, latestUser)
+		if strings.TrimSpace(condensed) != "" && condensed != answer {
+			answer = condensed
+			reply = llm.NewAssistantTextMessage(answer)
+		}
+	}
+
+	policyAnswer := planpkg.FinalizeAssistantAnswer(runMode, sess.Plan, answer)
+	if policyAnswer != answer {
+		answer = policyAnswer
+		reply = llm.NewAssistantTextMessage(answer)
+	}
+
 	if err := e.persistAssistantReply(sess, reply); err != nil {
 		return "", err
 	}

--- a/internal/agent/plan_bootstrap_repair.go
+++ b/internal/agent/plan_bootstrap_repair.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/1024XEngineer/bytemind/internal/llm"
+	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+)
+
+func shouldRepairPlanBootstrapTurn(runMode planpkg.AgentMode, state planpkg.State, reply llm.Message) bool {
+	if runMode != planpkg.ModePlan || len(reply.ToolCalls) > 0 {
+		return false
+	}
+	state = planpkg.NormalizeState(state)
+	if planpkg.HasStructuredPlan(state) {
+		return false
+	}
+	return strings.TrimSpace(reply.Content) != "" || strings.TrimSpace(reply.Text()) != ""
+}
+
+func buildPlanBootstrapRepairInstruction(reply llm.Message, latestUser string, attempt, maxAttempts int, messages []llm.Message, availableTools []string) string {
+	preview := strings.TrimSpace(reply.Content)
+	if preview == "" {
+		preview = "(empty assistant text)"
+	}
+	preview = truncateRunes(preview, 240)
+
+	latestUser = strings.TrimSpace(latestUser)
+	if latestUser == "" {
+		latestUser = "(empty user input)"
+	}
+
+	observedActivity := "(none yet)"
+	if hasToolActivitySinceLatestHumanUser(messages) {
+		observedActivity = "read-only tool results already exist in this planning cycle"
+	}
+
+	recommendedTools := make([]string, 0, 5)
+	for _, toolName := range []string{"list_files", "search_text", "read_file", "web_search", "web_fetch"} {
+		if containsToolName(availableTools, toolName) {
+			recommendedTools = append(recommendedTools, toolName)
+		}
+	}
+	toolHint := "(none)"
+	if len(recommendedTools) > 0 {
+		toolHint = strings.Join(recommendedTools, ", ")
+	}
+
+	return strings.TrimSpace(fmt.Sprintf(
+		`The previous assistant turn stayed in plan mode without creating the initial structured plan state.
+Attempt %d/%d.
+
+Latest user planning request:
+%s
+
+Reply text preview:
+%s
+
+Observed tool activity in this planning cycle:
+%s
+
+Recommended read-only investigation tools for this turn:
+%s
+
+For this next turn:
+1) Start working immediately. Do not ask the user for permission to inspect the repo or gather evidence.
+2) If you do not yet have enough evidence, emit focused read-only tool calls now. Prefer local inspection first, and use web_search/web_fetch only when current or external evidence is actually needed.
+3) After enough evidence is gathered, call update_plan before finalizing. Create a real plan skeleton with 3 to 7 ordered steps, summary, phase, decision_gaps, and verification/risks when known.
+4) If a key decision is still open, store it in active_choice inside update_plan and then ask only that one focused question with <turn_intent>ask_user</turn_intent>.
+5) If the plan is ready to show, finalize with a short acknowledgement only after update_plan succeeds. Do not end a plan-mode turn with plain prose before the structured plan exists.`,
+		attempt,
+		maxAttempts,
+		latestUser,
+		preview,
+		observedActivity,
+		toolHint,
+	))
+}

--- a/internal/agent/plan_revision_response.go
+++ b/internal/agent/plan_revision_response.go
@@ -2,8 +2,11 @@ package agent
 
 import (
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/1024XEngineer/bytemind/internal/llm"
+	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
 )
 
 func latestHumanUserMessageText(messages []llm.Message) string {
@@ -41,6 +44,96 @@ func hasToolActivitySinceIndex(messages []llm.Message, index int) bool {
 		}
 	}
 	return false
+}
+
+func shouldCondensePlanRevisionAnswer(runMode planpkg.AgentMode, state planpkg.State, messages []llm.Message) bool {
+	if runMode != planpkg.ModePlan {
+		return false
+	}
+	state = planpkg.NormalizeState(state)
+	if !planpkg.CanStartExecution(state) {
+		return false
+	}
+	index, latestUser := latestHumanUserMessage(messages)
+	if index < 0 || !looksLikePlanRevisionInput(latestUser) {
+		return false
+	}
+	return hasToolActivitySinceIndex(messages, index)
+}
+
+func condensePlanRevisionAnswer(answer string, latestUser string) string {
+	trimmed := strings.TrimSpace(answer)
+	if isShortPlanRevisionAcknowledgement(trimmed) {
+		return trimmed
+	}
+	return localizedPlanRevisionAcknowledgement(latestUser)
+}
+
+func localizedPlanRevisionAcknowledgement(source string) string {
+	if looksMostlyChinese(source) {
+		return "已按你的反馈更新计划，下面是修订后的完整版本。"
+	}
+	return "Updated the plan with your feedback. The revised full plan is below."
+}
+
+func isShortPlanRevisionAcknowledgement(text string) bool {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return false
+	}
+	if strings.Contains(text, "\n") || utf8.RuneCountInString(text) > 80 {
+		return false
+	}
+	normalized := strings.ToLower(text)
+	if strings.Count(text, "，")+strings.Count(text, ",")+strings.Count(text, ";")+strings.Count(text, "；") > 1 {
+		return false
+	}
+	if containsAnyToken(normalized,
+		"建议",
+		"比如",
+		"页面",
+		"功能",
+		"布局",
+		"交互",
+		"细节",
+		"设计",
+		"feature",
+		"features",
+		"layout",
+		"interaction",
+		"spec",
+		"specification",
+		"design",
+		"suggest",
+		"recommend",
+		"proposal",
+	) {
+		return false
+	}
+	return !strings.Contains(normalized, "- ") &&
+		!strings.Contains(normalized, "##") &&
+		!strings.Contains(normalized, "###") &&
+		!strings.Contains(normalized, "1.") &&
+		!strings.Contains(normalized, "2.")
+}
+
+func looksMostlyChinese(text string) bool {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return false
+	}
+	total := 0
+	han := 0
+	for _, r := range text {
+		if unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r) {
+			continue
+		}
+		total++
+		if unicode.Is(unicode.Han, r) {
+			han++
+		}
+	}
+	return total > 0 && han*2 >= total
 }
 
 func isToolResultMessage(msg llm.Message) bool {

--- a/internal/agent/plan_state_repair.go
+++ b/internal/agent/plan_state_repair.go
@@ -1,0 +1,388 @@
+package agent
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/1024XEngineer/bytemind/internal/llm"
+	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+)
+
+var clarifyChoiceShortcutPattern = regexp.MustCompile(`(?i)(^|[\s/|,，;；:：\-])([a-d]|1|2|3|4)([.)：:\s]|$)`)
+
+// These repair heuristics intentionally mirror the small set of execution-choice
+// labels exposed by the plan prompt/runtime once a plan is converged.
+var (
+	planAdjustmentOnlyInputs = []string{
+		"adjust",
+		"adjust plan",
+		"continue adjusting plan",
+		"continue plan",
+		"option 2",
+		"option b",
+		"2",
+		"2.",
+		"b",
+		"b.",
+		"继续微调计划",
+		"微调计划",
+		"继续调整计划",
+		"调整计划",
+	}
+	executionActionChoicePromptTokens = []string{
+		"choose next step",
+		"choose next action",
+		"next step",
+		"next action",
+		"start execution",
+		"continue execution",
+		"switch to build",
+		"build mode",
+		"adjust plan",
+		"reply with 1",
+		"reply with 2",
+		"下一步",
+		"可选下一步",
+		"开始执行",
+		"继续执行",
+		"切到 build",
+		"切换到 build",
+		"调整计划",
+		"继续微调计划",
+	}
+	planDecisionAcknowledgementTokens = []string{
+		"adopt",
+		"adopted",
+		"go with",
+		"going with",
+		"chosen",
+		"choose ",
+		"recorded",
+		"using option",
+		"start execution",
+		"adjust plan",
+		"switch to build",
+		"采用",
+		"已收到",
+		"已记录",
+		"记录为",
+		"选用",
+		"选择",
+		"开始执行",
+		"调整计划",
+		"切到 build",
+		"切换到 build",
+	}
+)
+
+func shouldRepairPlanRevisionTurn(runMode planpkg.AgentMode, state planpkg.State, latestUser string, reply llm.Message) bool {
+	if runMode != planpkg.ModePlan || len(reply.ToolCalls) > 0 {
+		return false
+	}
+
+	state = planpkg.NormalizeState(state)
+	if !planpkg.CanStartExecution(state) {
+		return false
+	}
+
+	latestUser = strings.TrimSpace(latestUser)
+	if latestUser == "" || !looksLikePlanRevisionInput(latestUser) {
+		return false
+	}
+
+	return strings.TrimSpace(reply.Content) != ""
+}
+
+func buildPlanRevisionRepairInstruction(state planpkg.State, latestUser string, reply llm.Message, attempt, maxAttempts int) string {
+	state = planpkg.NormalizeState(state)
+	preview := strings.TrimSpace(reply.Content)
+	if preview == "" {
+		preview = "(empty assistant text)"
+	}
+	preview = truncateRunes(preview, 240)
+
+	latestUser = strings.TrimSpace(latestUser)
+	if latestUser == "" {
+		latestUser = "(empty user text)"
+	}
+
+	return strings.TrimSpace(fmt.Sprintf(
+		`The previous assistant turn responded to plan-refinement feedback without updating the structured plan first.
+Attempt %d/%d.
+
+Latest user refinement input:
+%s
+
+Reply text preview:
+%s
+
+For this next turn:
+1) Call update_plan before finalizing.
+2) Merge the new details into the structured plan state, especially summary, implementation_brief, steps, verification, and decision_log when relevant.
+3) If the refinement introduces a new unresolved decision, record it in decision_gaps, populate active_choice, and ask only that next question.
+4) If the plan remains converged after the update, keep the visible assistant reply to one short acknowledgement only and let the refreshed structured plan carry the detailed content.
+5) Do not answer with a standalone design memo or suggestion block outside the updated plan document.`,
+		attempt,
+		maxAttempts,
+		latestUser,
+		preview,
+	))
+}
+
+func shouldRepairPlanClarifyTurn(runMode planpkg.AgentMode, state planpkg.State, intent assistantTurnIntent, reply llm.Message) bool {
+	if runMode != planpkg.ModePlan || len(reply.ToolCalls) > 0 {
+		return false
+	}
+
+	state = planpkg.NormalizeState(state)
+	if !planpkg.HasStructuredPlan(state) || planpkg.HasActiveChoice(state) {
+		return false
+	}
+	text := strings.TrimSpace(reply.Content)
+	if text == "" {
+		return false
+	}
+	inlineChoicePrompt := looksLikeInlineClarifyChoicePrompt(text)
+	if planpkg.CanStartExecution(state) {
+		return inlineChoicePrompt && !looksLikeExecutionActionChoicePrompt(text)
+	}
+
+	if intent == turnIntentAskUser {
+		return planpkg.HasDecisionGaps(state) || inlineChoicePrompt
+	}
+	return inlineChoicePrompt
+}
+
+func buildPlanClarifyRepairInstruction(state planpkg.State, reply llm.Message, attempt, maxAttempts int) string {
+	state = planpkg.NormalizeState(state)
+	preview := strings.TrimSpace(reply.Content)
+	if preview == "" {
+		preview = "(empty assistant text)"
+	}
+	preview = truncateRunes(preview, 240)
+
+	gaps := "(none recorded)"
+	if len(state.DecisionGaps) > 0 {
+		items := make([]string, 0, len(state.DecisionGaps))
+		for _, gap := range state.DecisionGaps {
+			gap = strings.TrimSpace(gap)
+			if gap != "" {
+				items = append(items, "- "+gap)
+			}
+		}
+		if len(items) > 0 {
+			gaps = strings.Join(items, "\n")
+		}
+	}
+
+	return strings.TrimSpace(fmt.Sprintf(
+		`The previous assistant turn asked the user to choose among plan options in prose without storing active_choice first.
+Attempt %d/%d.
+
+Reply text preview:
+%s
+
+Current unresolved decision gaps:
+%s
+
+For this next turn:
+1) Call update_plan before finalizing.
+2) Populate active_choice with a stable id, kind="clarify", one question, and 2 to 4 mutually exclusive options.
+3) Put the recommended option first and include explicit shortcuts such as A/B/C. Use one freeform option only if custom input is truly needed.
+4) Keep phase in clarify unless this decision fully converges the plan.
+5) Keep the visible assistant reply to one short lead sentence only. Do not inline the full A/B/C choice block in prose when the UI can render it.`,
+		attempt,
+		maxAttempts,
+		preview,
+		gaps,
+	))
+}
+
+func shouldRepairPlanDecisionTurn(runMode planpkg.AgentMode, state planpkg.State, intent assistantTurnIntent, reply llm.Message) bool {
+	if runMode != planpkg.ModePlan || len(reply.ToolCalls) > 0 {
+		return false
+	}
+
+	state = planpkg.NormalizeState(state)
+	if !planpkg.HasStructuredPlan(state) || !planpkg.HasDecisionGaps(state) {
+		return false
+	}
+
+	text := strings.TrimSpace(reply.Content)
+	if text == "" || looksLikeClarifyingQuestion(text) {
+		return false
+	}
+
+	if intent == turnIntentFinalize {
+		return true
+	}
+	return looksLikePlanDecisionAcknowledgement(text)
+}
+
+func buildPlanDecisionRepairInstruction(state planpkg.State, reply llm.Message, attempt, maxAttempts int) string {
+	state = planpkg.NormalizeState(state)
+	preview := strings.TrimSpace(reply.Content)
+	if preview == "" {
+		preview = "(empty assistant text)"
+	}
+	preview = truncateRunes(preview, 240)
+
+	gaps := "(none recorded)"
+	if len(state.DecisionGaps) > 0 {
+		items := make([]string, 0, len(state.DecisionGaps))
+		for _, gap := range state.DecisionGaps {
+			gap = strings.TrimSpace(gap)
+			if gap != "" {
+				items = append(items, "- "+gap)
+			}
+		}
+		if len(items) > 0 {
+			gaps = strings.Join(items, "\n")
+		}
+	}
+
+	return strings.TrimSpace(fmt.Sprintf(
+		`The previous assistant turn appears to have accepted or acted on a user decision in plan mode without calling update_plan first.
+Attempt %d/%d.
+
+Reply text preview:
+%s
+
+Current unresolved decision gaps:
+%s
+
+For this next turn:
+1) If the user's latest reply resolves one of these decisions, call update_plan first.
+2) Record the chosen option in decision_log and remove or replace the resolved decision_gaps.
+3) If no decision gaps remain, populate implementation_brief, set phase to draft or converge_ready as appropriate, and then finalize so the full proposed plan is shown.
+4) If another decision is still required, include <turn_intent>ask_user</turn_intent> and ask only the next question.
+5) Do not reply with choice-acknowledgement or start-execution text in plan mode without updating plan state first.`,
+		attempt,
+		maxAttempts,
+		preview,
+		gaps,
+	))
+}
+
+func looksLikeClarifyingQuestion(text string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	if normalized == "" {
+		return false
+	}
+	if strings.Contains(normalized, "question:") ||
+		strings.Contains(normalized, "question：") ||
+		strings.Contains(normalized, "问题:") ||
+		strings.Contains(normalized, "问题：") {
+		return true
+	}
+	hasOptions := strings.Contains(normalized, "a.") && strings.Contains(normalized, "b.")
+	if hasOptions && (strings.Contains(normalized, "other:") || strings.Contains(normalized, "other：")) {
+		return true
+	}
+	return false
+}
+
+func looksLikeInlineClarifyChoicePrompt(text string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	if normalized == "" {
+		return false
+	}
+	if looksLikeClarifyingQuestion(text) {
+		return true
+	}
+	if countChoiceShortcuts(normalized) < 2 {
+		return false
+	}
+	if strings.Contains(normalized, "/") || strings.Contains(normalized, "\n") {
+		return true
+	}
+	return containsAnyToken(normalized,
+		"choose",
+		"pick",
+		"select",
+		"option",
+		"which",
+		"prefer",
+		"please choose",
+		"please pick",
+		"please select",
+		"\u8bf7\u76f4\u63a5\u9009",
+		"\u76f4\u63a5\u9009",
+		"\u9009\u4e00\u4e2a",
+		"\u9009\u4e00\u4e2a\u65b9\u6848",
+		"\u9009\u4e2a\u65b9\u6848",
+		"请选择",
+		"请先选",
+		"先选",
+		"选择",
+		"选哪个",
+		"选目录",
+		"选路线",
+		"选方案",
+	)
+}
+
+func looksLikePlanRevisionInput(text string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	if normalized == "" {
+		return false
+	}
+	if looksLikeExecutionHandoffInput(normalized) || looksLikePlanAdjustmentOnlyInput(normalized) || looksLikeRawPlanChoiceSelection(normalized) {
+		return false
+	}
+	return true
+}
+
+func looksLikePlanAdjustmentOnlyInput(text string) bool {
+	return matchesNormalizedExactText(text, planAdjustmentOnlyInputs...)
+}
+
+func looksLikeExecutionActionChoicePrompt(text string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	if normalized == "" || countChoiceShortcuts(normalized) < 2 {
+		return false
+	}
+	if containsAnyToken(normalized, executionActionChoicePromptTokens...) {
+		return true
+	}
+	return strings.Contains(normalized, "start execution") && strings.Contains(normalized, "adjust plan")
+}
+
+func looksLikeRawPlanChoiceSelection(text string) bool {
+	switch strings.ToLower(strings.TrimSpace(text)) {
+	case "a", "a.", "1", "1.", "c", "c.", "3", "3.", "other":
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(text)), "selected_choice:")
+}
+
+func countChoiceShortcuts(text string) int {
+	matches := clarifyChoiceShortcutPattern.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return 0
+	}
+	seen := make(map[string]struct{}, len(matches))
+	for _, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+		seen[strings.ToLower(strings.TrimSpace(match[2]))] = struct{}{}
+	}
+	return len(seen)
+}
+
+func looksLikePlanDecisionAcknowledgement(text string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	return containsAnyToken(normalized, planDecisionAcknowledgementTokens...)
+}
+
+func matchesNormalizedExactText(text string, options ...string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	for _, option := range options {
+		if normalized == option {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/plan_state_repair_regex_fix.go
+++ b/internal/agent/plan_state_repair_regex_fix.go
@@ -1,0 +1,9 @@
+package agent
+
+import "regexp"
+
+func init() {
+	// Support compact clarify prompts such as:
+	// "请选择一个方案：A（推荐）、B（Flask）、或 C（自定义）"
+	clarifyChoiceShortcutPattern = regexp.MustCompile("(?i)(^|[\\s/|,;:\\-\u3001\uFF0C\uFF1A])([a-d]|1|2|3|4)([.)\\s:/,;\\-()\uFF08\uFF09\u3001\uFF0C\uFF1A]|$)")
+}

--- a/internal/agent/plan_state_repair_test.go
+++ b/internal/agent/plan_state_repair_test.go
@@ -1,0 +1,190 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/bytemind/internal/config"
+	"github.com/1024XEngineer/bytemind/internal/llm"
+	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+	"github.com/1024XEngineer/bytemind/internal/session"
+	"github.com/1024XEngineer/bytemind/internal/tools"
+)
+
+func TestLooksLikeInlineClarifyChoicePromptMatchesCompactChineseChoiceSentence(t *testing.T) {
+	text := "\u8bf7\u76f4\u63a5\u9009\u4e00\u4e2a\u65b9\u6848\uff1aA\uff08\u63a8\u8350\uff0c\u96f6\u4f9d\u8d56\u6807\u51c6\u5e93\uff09\u3001B\uff08Flask\uff09\uff0c\u6216 C\uff08\u4f60\u81ea\u5b9a\u4e49\u7ea6\u675f\uff09\u3002"
+	if !looksLikeInlineClarifyChoicePrompt(text) {
+		t.Fatalf("expected compact Chinese clarify prompt to be detected, got %q", text)
+	}
+}
+
+func TestShouldRepairPlanClarifyTurnIgnoresExecutionActionChoices(t *testing.T) {
+	state := planpkg.State{
+		Goal:                "Ship the feature",
+		Phase:               planpkg.PhaseConvergeReady,
+		Steps:               []planpkg.Step{{Title: "Implement the feature", Status: planpkg.StepPending}},
+		ScopeDefined:        true,
+		RiskRollbackDefined: true,
+		VerificationDefined: true,
+	}
+	reply := llm.Message{
+		Role:    llm.RoleAssistant,
+		Content: "A. Start execution\nB. Adjust plan",
+	}
+	if shouldRepairPlanClarifyTurn(planpkg.ModePlan, state, turnIntentAskUser, reply) {
+		t.Fatalf("expected execution action choices not to trigger clarify repair")
+	}
+}
+
+func TestLooksLikeExecutionActionChoicePromptMatchesChineseConvergedActions(t *testing.T) {
+	text := "可选下一步：\nA. 切到 Build 模式，开始执行\nB. 继续微调计划"
+	if !looksLikeExecutionActionChoicePrompt(text) {
+		t.Fatalf("expected converged Chinese action choices to be detected, got %q", text)
+	}
+}
+
+func TestLooksLikePlanDecisionAcknowledgementMatchesChineseChoiceAcknowledgement(t *testing.T) {
+	text := "已记录，采用 B：Streamlit。接下来切到 build。"
+	if !looksLikePlanDecisionAcknowledgement(text) {
+		t.Fatalf("expected Chinese decision acknowledgement to be detected, got %q", text)
+	}
+}
+
+func TestShouldRepairPlanClarifyTurnRepairsInlineChoicesEvenWhenStateLooksConverged(t *testing.T) {
+	state := planpkg.State{
+		Goal:                "Ship the feature",
+		Phase:               planpkg.PhaseConvergeReady,
+		Steps:               []planpkg.Step{{Title: "Implement the feature", Status: planpkg.StepPending}},
+		ScopeDefined:        true,
+		RiskRollbackDefined: true,
+		VerificationDefined: true,
+	}
+	reply := llm.Message{
+		Role:    llm.RoleAssistant,
+		Content: "请直接选一个方案：A（标准库）、B（Flask），或 C（自定义约束）。",
+	}
+	if !shouldRepairPlanClarifyTurn(planpkg.ModePlan, state, turnIntentAskUser, reply) {
+		t.Fatalf("expected non-execution inline choices to trigger clarify repair even from a false converge state")
+	}
+}
+
+func TestRunPromptRepairsInlineClarifyChoiceWhenStateIncorrectlyLooksConverged(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	sess.Mode = planpkg.ModePlan
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name: "update_plan",
+					Arguments: `{
+						"summary":"The plan looks converged, but the frontend stack is still unresolved.",
+						"phase":"converge_ready",
+						"scope_defined":true,
+						"risk_and_rollback_defined":true,
+						"verification_defined":true,
+						"decision_gaps":[],
+						"plan":[
+							{"step":"Choose the frontend stack","status":"pending"},
+							{"step":"Draft the implementation plan","status":"pending"},
+							{"step":"Define the verification path","status":"pending"}
+						]
+					}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "\u8bf7\u76f4\u63a5\u9009\u4e00\u4e2a\u65b9\u6848\uff1aA\uff08\u63a8\u8350\uff0c\u96f6\u4f9d\u8d56\u6807\u51c6\u5e93\uff09\u3001B\uff08Flask\uff09\uff0c\u6216 C\uff08\u4f60\u81ea\u5b9a\u4e49\u7ea6\u675f\uff09\u3002",
+		},
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-2",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name: "update_plan",
+					Arguments: `{
+						"summary":"The frontend stack choice is waiting on the user.",
+						"phase":"clarify",
+						"decision_gaps":["Choose the frontend stack."],
+						"active_choice":{
+							"id":"frontend_stack",
+							"kind":"clarify",
+							"question":"Choose the frontend stack.",
+							"gap_key":"Choose the frontend stack.",
+							"options":[
+								{"id":"stdlib","shortcut":"A","title":"Standard library only","description":"Recommended for the lowest dependency footprint.","recommended":true},
+								{"id":"flask","shortcut":"B","title":"Flask","description":"Use Flask for faster templated delivery."},
+								{"id":"custom","shortcut":"C","title":"Custom constraints","description":"Capture a different path or constraint.","freeform":true}
+							]
+						},
+						"plan":[
+							{"step":"Choose the frontend stack","status":"pending"},
+							{"step":"Draft the implementation plan","status":"pending"},
+							{"step":"Define the verification path","status":"pending"}
+						]
+					}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "<turn_intent>ask_user</turn_intent>Please use the on-screen picker below.",
+		},
+	}}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 8,
+			Stream:        false,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "continue planning", "plan", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.requests) != 4 {
+		t.Fatalf("expected four requests (initial plan + bad inline choice + repair + ask_user), got %d", len(client.requests))
+	}
+
+	repairTurnMessages := client.requests[2].Messages
+	last := repairTurnMessages[len(repairTurnMessages)-1]
+	if last.Role != llm.RoleUser || !strings.Contains(strings.ToLower(last.Text()), "without storing active_choice first") {
+		t.Fatalf("expected clarify repair note to be appended as a user message, got %#v", repairTurnMessages)
+	}
+
+	if sess.Plan.ActiveChoice == nil {
+		t.Fatalf("expected session plan to store active_choice after repair, got %#v", sess.Plan)
+	}
+	if sess.Plan.Phase != planpkg.PhaseClarify {
+		t.Fatalf("expected repaired plan to return to clarify phase, got %#v", sess.Plan.Phase)
+	}
+	if len(sess.Plan.DecisionGaps) != 1 || sess.Plan.DecisionGaps[0] != "Choose the frontend stack." {
+		t.Fatalf("expected repaired plan to restore the missing decision gap, got %#v", sess.Plan.DecisionGaps)
+	}
+	if !strings.Contains(answer, "on-screen picker") {
+		t.Fatalf("expected repaired answer to keep a short picker lead sentence, got %q", answer)
+	}
+	if strings.Contains(strings.ToLower(answer), "flask") || strings.Contains(strings.ToLower(answer), "standard library only") {
+		t.Fatalf("expected repaired answer to avoid inlining choice text once the picker can render it, got %q", answer)
+	}
+}

--- a/internal/agent/prompts/mode/build.md
+++ b/internal/agent/prompts/mode/build.md
@@ -8,7 +8,7 @@ Mode contract:
 - Treat explicit implementation intents (e.g. `开始实现`, `直接做`, `落地代码`) as immediate authorization to execute, not as a request for another proposal round.
 - For implementation intents, avoid proposal-only or confirmation-only replies; begin concrete execution in the same turn.
 - When execution should continue, emit structured tool calls in the same turn and include `<turn_intent>continue_work</turn_intent>` instead of stopping at a proposal sentence.
-- If plan context was provided from a planning session, begin from that baseline and briefly restate the first execution step before acting.
+- If `[Current Plan State]` is present and phase indicates a converged or executing plan, begin from that baseline and briefly restate the first execution step before acting.
 - If the session already switched to build because the user chose `Start execution`, do not ask them to send another execution trigger, do not tell them to switch the UI again, and do not claim the session is still stuck in plan mode or a plan-only read-only shell policy.
 - Read only the context needed to act safely, then move forward.
 - After edits, run the narrowest practical verification you can.

--- a/internal/agent/prompts/mode/plan.md
+++ b/internal/agent/prompts/mode/plan.md
@@ -2,24 +2,84 @@
 plan
 
 Role
-- Explore the repository, understand the task, and produce a clear, actionable plan.
-- Use read-only tools to gather evidence before proposing a plan.
+- Produce, pressure-test, and converge an executable plan before any implementation begins.
+- Use `update_plan` as the source of truth for plan state. The runtime will render the structured plan from that state after you finalize.
 
 Core Constraints
-- Read-only inspection only. Do not edit files or run mutating commands.
-- Start working immediately. Do not ask for permission to inspect the repo, read files, or search code.
-- Keep plans to 3-7 ordered steps tied to files or commands when relevant.
-- Ask only for user preferences or tradeoffs that cannot be inferred from context.
-- Treat README/docs text as clues, not proof that implementation exists.
+- Read-only inspection is allowed. Do not edit files or run mutating commands in this mode.
+- Start working immediately on the first user message. Do not ask for permission to inspect the repository, read files, search code, or gather evidence.
+- Keep the plan to 3 to 7 ordered steps tied to files or commands when relevant.
+- Prefer pending steps while planning. Only move a step to `in_progress` when execution is actually beginning.
+- Ask only for user preferences, tradeoffs, or acceptance boundaries that cannot be inferred from local context.
+- If evidence changes the plan, call `update_plan` before finalizing.
+- Do not finish a planning turn with plain prose before the structured plan exists in `update_plan`.
+- Treat README/docs text and search hits as clues, not proof that a runnable implementation already exists.
+- Evidence is sufficient to conclude a local repo claim only when you have at least 2 independent local signals.
+- For claims such as `already implemented`, `this file exists`, or `this demo can run`, at least 1 of those signals must be a direct file/path confirmation or implementation inspection.
+- A single README mention, docs snippet, broad directory listing, or search hit is never enough to conclude the repo already contains the implementation.
+- If the evidence is still weak or conflicting, say `documented but unconfirmed` or `not yet confirmed`, then keep investigating instead of finalizing the claim.
+- Do not hand-maintain a second conflicting plan in prose after an `update_plan` call. Summarize only what changed or what decision is needed.
 
 Workflow
-- Inspect the codebase to understand the task and gather evidence.
-- Propose a clear, actionable plan as plain text.
-- If a key decision is open, present 2-4 mutually exclusive options and ask the user directly.
-- When the plan is ready, tell the user they can start execution.
+- Move through plan phases explicitly with `update_plan`: `explore -> clarify -> draft -> converge_ready -> approved_to_build`.
+- First turn default:
+  - summarize the task understanding
+  - inspect enough local context to avoid obvious mistakes
+  - emit the necessary read-only tool calls in the same turn when context is still missing
+  - produce a candidate plan skeleton
+  - record unresolved `decision_gaps`
+  - ask one high-value clarification block only if a key decision is still open
+- Preferred investigation tools in this mode:
+  - local repo evidence: `list_files`, `search_text`, `read_file`
+  - external or current evidence when actually needed: `web_search`, `web_fetch`
+- When you want to claim a local entrypoint, file path, or runnable demo exists, confirm that exact path directly and inspect at least one implementation file before concluding the repo already has it.
+- Do not stop evidence collection after the first weak signal. Keep going until the sufficiency rules above are met or you can explicitly state why the claim remains unconfirmed.
+- Keep the clarification loop conditional:
+  - if architecture, scope boundary, rollout, or acceptance criteria is still open, stay in `clarify`
+  - if those decisions are closed, advance toward `draft` or `converge_ready`
+- Each clarification round should ask at most 1 to 2 mutually exclusive questions.
+- Put the recommended option first and keep the choices cheap to answer.
+- If the repository context answers the question, do not ask the user.
 
-Output
-- Present the plan as a numbered list of steps.
-- For each step, include the files or areas affected and a brief description.
-- Keep explanations concise.
-- When asking a decision question, present options clearly with recommended choice first.
+Output Structure
+- If waiting on user input, ask for the decision directly without a plan recap or convergence summary above it.
+- In a clarification turn:
+  - store the current question in `active_choice`
+  - keep the visible reply to one short lead sentence only
+  - do not restate a full `Question / A / B / Other` block when the UI can render the picker
+- `active_choice` should include:
+  - `id` with a stable decision key
+  - `kind="clarify"`
+  - `question`
+  - 2 to 4 mutually exclusive `options`
+  - the recommended option first
+  - explicit `shortcut` labels such as `A`, `B`, `C`
+  - at most one `freeform=true` option when custom input is genuinely needed
+- Record stable plan data in `update_plan`, including:
+  - `implementation_brief` when the plan is ready for handoff
+  - `decision_log` for key decisions and why they were made
+  - `decision_gaps` for unresolved items
+  - `active_choice` for the current clarification decision
+  - `risks`
+  - `verification`
+  - the three execution-readiness booleans
+- Do not emit or restate the full plan while `decision_gaps` are still open.
+- If the plan is already converged and the user asks to refine or detail it further, treat that as a plan revision: update the structured plan first and merge the new detail into `summary`, `implementation_brief`, `plan`, `verification`, and `decision_log` as needed.
+- In a revision turn, keep the visible reply to one short acknowledgement and let the refreshed structured plan carry the detailed content.
+- Once the current decision gap is closed, synthesize `implementation_brief` as a handoff-ready requirements document that another coding model could implement directly.
+- That brief should cover objective, chosen technical direction, scope, deliverables, implementation expectations, risks, and verification.
+- Then present the full structured plan and explicitly state whether the plan has converged.
+- If you mention next actions in prose, keep them terse and place them after the full plan document, not before it.
+- The runtime will append a canonical `<proposed_plan>...</proposed_plan>` block only after the plan is ready to be shown. Keep your prose aligned with that state.
+
+Convergence And Switch Standard
+- A plan is converged only when all three readiness checks are true in `update_plan`:
+  - `scope_defined=true`
+  - `risk_and_rollback_defined=true`
+  - `verification_defined=true`
+- Use `converge_ready` only when the plan is executable and there are no unresolved `decision_gaps`.
+- When converged, the UI will present two execution actions separately. Do not ask the user to type trigger phrases like `start execution` or `continue execution`.
+- If you mention the actions in prose, use the exact labels below and keep it to one short sentence:
+  - `A. 切到 Build 模式，开始执行`
+  - `B. 继续微调计划`
+- After an explicit execution choice, advance the plan toward `approved_to_build`/execution and let Build mode start from the current plan baseline plus the first pending or in-progress step.

--- a/internal/agent/runner_complex_test.go
+++ b/internal/agent/runner_complex_test.go
@@ -227,7 +227,7 @@ func TestRunPromptExecutesMultipleToolCallsInOrder(t *testing.T) {
 	}
 }
 
-func TestRunPromptToolCallEventsEmitted(t *testing.T) {
+func TestRunPromptUpdatePlanSyncsSessionAndEmitsPlanEvent(t *testing.T) {
 	workspace := t.TempDir()
 	store, err := session.NewStore(t.TempDir())
 	if err != nil {
@@ -238,17 +238,17 @@ func TestRunPromptToolCallEventsEmitted(t *testing.T) {
 		{
 			Role: "assistant",
 			ToolCalls: []llm.ToolCall{{
-				ID:   "call-list",
+				ID:   "call-plan",
 				Type: "function",
 				Function: llm.ToolFunctionCall{
-					Name:      "list_files",
-					Arguments: `{}`,
+					Name:      "update_plan",
+					Arguments: `{"explanation":"starting","plan":[{"step":"Inspect provider","status":"completed"},{"step":"Add tests","status":"in_progress"}]}`,
 				},
 			}},
 		},
 		{
 			Role:    "assistant",
-			Content: "Files listed.",
+			Content: "Plan updated.",
 		},
 	}}
 
@@ -271,12 +271,15 @@ func TestRunPromptToolCallEventsEmitted(t *testing.T) {
 		Stdout: io.Discard,
 	})
 
-	answer, err := runner.RunPrompt(context.Background(), sess, "list files", "build", io.Discard)
+	answer, err := runner.RunPrompt(context.Background(), sess, "make a plan", "build", io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if answer != "Files listed." {
+	if answer != "Plan updated." {
 		t.Fatalf("unexpected answer: %q", answer)
+	}
+	if len(sess.Plan.Steps) != 2 || sess.Plan.Steps[1].Title != "Add tests" || sess.Plan.Steps[1].Status != planpkg.StepInProgress {
+		t.Fatalf("unexpected session plan: %#v", sess.Plan)
 	}
 
 	eventTypes := make([]EventType, 0, len(events))
@@ -288,11 +291,22 @@ func TestRunPromptToolCallEventsEmitted(t *testing.T) {
 		EventRunStarted,
 		EventToolCallStarted,
 		EventToolCallCompleted,
+		EventPlanUpdated,
 		EventAssistantMessage,
 		EventRunFinished,
 	}
 	if !slices.Equal(eventTypes, wantTypes) {
 		t.Fatalf("unexpected event sequence: got=%v want=%v", eventTypes, wantTypes)
+	}
+	var planEvent *Event
+	for i := range events {
+		if events[i].Type == EventPlanUpdated {
+			planEvent = &events[i]
+			break
+		}
+	}
+	if planEvent == nil || len(planEvent.Plan.Steps) != 2 || planEvent.Plan.Steps[1].Title != "Add tests" {
+		t.Fatalf("expected plan in event, got %#v", events)
 	}
 }
 
@@ -321,17 +335,17 @@ func TestRunPromptSystemPromptIncludesToolCatalog(t *testing.T) {
 		{
 			Role: "assistant",
 			ToolCalls: []llm.ToolCall{{
-				ID:   "call-list",
+				ID:   "call-plan",
 				Type: "function",
 				Function: llm.ToolFunctionCall{
-					Name:      "list_files",
-					Arguments: `{}`,
+					Name:      "update_plan",
+					Arguments: `{"plan":[{"step":"Inspect provider","status":"completed"},{"step":"Add tests","status":"in_progress"}]}`,
 				},
 			}},
 		},
 		{
 			Role:    "assistant",
-			Content: "Files listed.",
+			Content: "Plan acknowledged.",
 		},
 	}}
 
@@ -350,7 +364,7 @@ func TestRunPromptSystemPromptIncludesToolCatalog(t *testing.T) {
 		Stdout:   io.Discard,
 	})
 
-	if _, err := runner.RunPrompt(context.Background(), sess, "list files", "build", io.Discard); err != nil {
+	if _, err := runner.RunPrompt(context.Background(), sess, "make a plan", "build", io.Discard); err != nil {
 		t.Fatal(err)
 	}
 	if len(client.requests) != 2 {

--- a/internal/agent/runner_input_test.go
+++ b/internal/agent/runner_input_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/1024XEngineer/bytemind/internal/config"
 	"github.com/1024XEngineer/bytemind/internal/llm"
+	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
 	"github.com/1024XEngineer/bytemind/internal/session"
 	"github.com/1024XEngineer/bytemind/internal/tools"
 )
@@ -206,6 +207,26 @@ func TestRunPromptWithInputPlanModeSetsGoalFromUserMessageWhenDisplayTextBlank(t
 
 	client := &fakeClient{
 		replies: []llm.Message{
+			{
+				Role: llm.RoleAssistant,
+				ToolCalls: []llm.ToolCall{{
+					ID:   "call-1",
+					Type: "function",
+					Function: llm.ToolFunctionCall{
+						Name: "update_plan",
+						Arguments: `{
+							"summary":"Drafted the initial plan from the structured user prompt.",
+							"phase":"draft",
+							"decision_gaps":[],
+							"plan":[
+								{"step":"Inspect the relevant repo area","status":"pending"},
+								{"step":"Draft the implementation approach","status":"pending"},
+								{"step":"Define verification","status":"pending"}
+							]
+						}`,
+					},
+				}},
+			},
 			llm.NewAssistantTextMessage("drafted plan"),
 		},
 	}
@@ -237,6 +258,12 @@ func TestRunPromptWithInputPlanModeSetsGoalFromUserMessageWhenDisplayTextBlank(t
 	}
 	if !strings.Contains(answer, "drafted plan") {
 		t.Fatalf("unexpected answer: %q", answer)
+	}
+	if strings.Contains(answer, planpkg.StructuredPlanReminder) {
+		t.Fatalf("expected structured plan repair flow instead of reminder-only answer, got %q", answer)
+	}
+	if !strings.Contains(answer, "<proposed_plan>") {
+		t.Fatalf("expected structured plan block in answer, got %q", answer)
 	}
 	if sess.Plan.Goal != "plan from structured prompt" {
 		t.Fatalf("expected plan goal from structured user message text, got %q", sess.Plan.Goal)

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -284,7 +284,7 @@ func TestRunPromptCompletesMinimalToolLoop(t *testing.T) {
 	}
 }
 
-func TestRunPromptFinalizesContinueWorkWithoutToolCalls(t *testing.T) {
+func TestRunPromptRepairsContinueWorkWithoutToolCalls(t *testing.T) {
 	workspace := t.TempDir()
 	store, err := session.NewStore(t.TempDir())
 	if err != nil {
@@ -294,7 +294,22 @@ func TestRunPromptFinalizesContinueWorkWithoutToolCalls(t *testing.T) {
 	client := &fakeClient{replies: []llm.Message{
 		{
 			Role:    "assistant",
-			Content: "I will inspect files first.",
+			Content: "<turn_intent>continue_work</turn_intent>I will inspect files first.",
+		},
+		{
+			Role: "assistant",
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "list_files",
+					Arguments: `{}`,
+				},
+			}},
+		},
+		{
+			Role:    "assistant",
+			Content: "<turn_intent>finalize</turn_intent>Workspace inspected.",
 		},
 	}}
 	runner := NewRunner(Options{
@@ -315,11 +330,23 @@ func TestRunPromptFinalizesContinueWorkWithoutToolCalls(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if answer != "I will inspect files first." {
+	if answer != "Workspace inspected." {
 		t.Fatalf("unexpected answer: %q", answer)
 	}
-	if len(client.requests) != 1 {
-		t.Fatalf("expected one request (finalize), got %d", len(client.requests))
+	if len(client.requests) != 3 {
+		t.Fatalf("expected three requests (repair + tool + finalize), got %d", len(client.requests))
+	}
+	secondTurnMessages := client.requests[1].Messages
+	if len(secondTurnMessages) == 0 || secondTurnMessages[0].Role != llm.RoleSystem {
+		t.Fatalf("expected second request to keep system prompt first, got %#v", secondTurnMessages)
+	}
+	lastMsg := secondTurnMessages[len(secondTurnMessages)-1]
+	if lastMsg.Role != llm.RoleUser ||
+		!strings.Contains(strings.ToLower(lastMsg.Text()), "ongoing work but returned no structured tool calls") {
+		t.Fatalf("expected repair control note to be appended as user message, got %#v", secondTurnMessages)
+	}
+	if len(sess.Messages) != 4 {
+		t.Fatalf("expected user + tool call + tool result + final assistant, got %#v", sess.Messages)
 	}
 }
 
@@ -333,7 +360,7 @@ func TestRunPromptRepairsUnavailableRunShellClaimWithoutToolCall(t *testing.T) {
 	client := &fakeClient{replies: []llm.Message{
 		{
 			Role:    "assistant",
-			Content: "run_shell 看起来超时了，而且我当前没法继续调用 shell 工具执行命令。",
+			Content: "run_shell seems unavailable or timed out, and I cannot continue shell checks right now.",
 		},
 		{
 			Role: "assistant",
@@ -388,49 +415,148 @@ func TestRunPromptRepairsUnavailableRunShellClaimWithoutToolCall(t *testing.T) {
 		t.Fatalf("expected repaired turn to execute run_shell, got %#v", sess.Messages[1])
 	}
 }
-
-func TestRunPromptFinalizesConcreteRepoClaimWithoutRepair(t *testing.T) {
+func TestRunPromptRepairsPlanDecisionAcknowledgementWithoutUpdatePlan(t *testing.T) {
 	workspace := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(workspace, "demos"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(workspace, "README.md"), []byte("Documented command: python demos/backend/server.py\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(workspace, "demos", "README.md"), []byte("Only documentation exists here.\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
 	store, err := session.NewStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
 	sess := session.New(workspace)
+	sess.Mode = planpkg.ModePlan
+	sess.Plan = planpkg.State{
+		Goal:         "Implement the first RAG demo",
+		Summary:      "Need to lock the frontend choice before convergence.",
+		Phase:        planpkg.PhaseClarify,
+		DecisionGaps: []string{"Choose the first frontend stack."},
+		Steps: []planpkg.Step{
+			{Title: "Freeze the frontend stack", Status: planpkg.StepPending},
+			{Title: "Implement the minimal flow", Status: planpkg.StepPending},
+		},
+	}
+
 	client := &fakeClient{replies: []llm.Message{
 		{
+			Role:    "assistant",
+			Content: "<turn_intent>finalize</turn_intent>Choice B is noted: Streamlit + LangChain. Reply `start execution` and I will switch to build mode.",
+		},
+		{
 			Role: "assistant",
-			ToolCalls: []llm.ToolCall{
-				{
-					ID:   "call-1",
-					Type: "function",
-					Function: llm.ToolFunctionCall{
-						Name:      "list_files",
-						Arguments: `{}`,
-					},
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name: "update_plan",
+					Arguments: `{
+						"summary":"Frontend choice is locked and the plan is ready for execution review.",
+						"implementation_brief":"Objective: deliver the first local RAG demo in demos/ with Streamlit + LangChain.\nTechnical direction: keep the existing local Python stack, use Streamlit for UI, LangChain for orchestration, and a local vector store path.\nDeliverables: a runnable demo app, document ingestion flow, retrieval + answer generation flow, and basic local verification.\nAcceptance: another coding model should be able to implement directly from this brief.",
+						"phase":"converge_ready",
+						"decision_log":[{"decision":"Adopt Streamlit + LangChain for the first frontend stack","reason":"User selected option B for faster UI delivery."}],
+						"decision_gaps":[],
+						"scope_defined":true,
+						"risk_and_rollback_defined":true,
+						"verification_defined":true,
+						"risks":["Frontend stack change may require adapter refactors."],
+						"verification":["Run the local Streamlit app and validate one ingest + one query flow."],
+						"next_action":"Present the full handoff-ready plan and ask whether to start execution.",
+						"plan":[
+							{"step":"Freeze the frontend stack", "status":"pending"},
+							{"step":"Implement the minimal flow", "status":"pending"}
+						]
+					}`,
 				},
-				{
-					ID:   "call-2",
-					Type: "function",
-					Function: llm.ToolFunctionCall{
-						Name:      "search_text",
-						Arguments: `{"query":"demos/backend/server.py"}`,
-					},
-				},
-			},
+			}},
 		},
 		{
 			Role:    "assistant",
-			Content: "仓库里已经有最小闭环实现了，可以直接运行 `python demos/backend/server.py`。",
+			Content: "<turn_intent>finalize</turn_intent>Recorded: use Streamlit + LangChain.\nNext:\n- Start execution\n- Adjust plan",
+		},
+	}}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 6,
+			Stream:        false,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "b", "plan", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.requests) != 3 {
+		t.Fatalf("expected three requests (repair + update_plan + finalize), got %d", len(client.requests))
+	}
+	secondTurnMessages := client.requests[1].Messages
+	lastMsg := secondTurnMessages[len(secondTurnMessages)-1]
+	if lastMsg.Role != llm.RoleUser || !strings.Contains(strings.ToLower(lastMsg.Text()), "without calling update_plan first") {
+		t.Fatalf("expected plan-state repair note to be appended as user message, got %#v", secondTurnMessages)
+	}
+	if sess.Plan.Phase != planpkg.PhaseConvergeReady {
+		t.Fatalf("expected session plan to converge after repair, got %#v", sess.Plan)
+	}
+	for _, want := range []string{"<proposed_plan>", "Implementation Brief", "Start execution"} {
+		if !strings.Contains(answer, want) {
+			t.Fatalf("expected repaired answer to include %q, got %q", want, answer)
+		}
+	}
+}
+func TestRunPromptRepairsInitialPlanTurnBeforeStructuredPlanExists(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	sess.Mode = planpkg.ModePlan
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role:    llm.RoleAssistant,
+			Content: "I will quickly inspect demos first, then provide an executable plan.",
+		},
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "list_files",
+					Arguments: `{"path":"demos"}`,
+				},
+			}},
+		},
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-2",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name: "update_plan",
+					Arguments: `{
+						"goal":"Review the demos area and produce an executable plan.",
+						"summary":"Inspected the demos directory and created the first plan skeleton.",
+						"phase":"draft",
+						"decision_gaps":[],
+						"risks":["The existing demos layout may constrain where the new work should land."],
+						"verification":["Inspect the target demo path and confirm the first runnable slice before switching to Build."],
+						"plan":[
+							{"step":"Inspect the demos directory and relevant entrypoints","status":"pending"},
+							{"step":"Choose the target demo slice and define scope","status":"pending"},
+							{"step":"Draft the implementation and verification path","status":"pending"}
+						]
+					}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "<turn_intent>finalize</turn_intent>Initial plan created.",
 		},
 	}}
 
@@ -448,19 +574,29 @@ func TestRunPromptFinalizesConcreteRepoClaimWithoutRepair(t *testing.T) {
 		Stdout:   io.Discard,
 	})
 
-	answer, err := runner.RunPrompt(context.Background(), sess, "看看 demos 里是不是已经有现成可跑的最小 demo。", "build", io.Discard)
+	answer, err := runner.RunPrompt(context.Background(), sess, "Inspect demos first, then produce an executable plan.", "plan", io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(answer, "仓库里已经有最小闭环实现了") {
-		t.Fatalf("unexpected answer: %q", answer)
+	if len(client.requests) != 4 {
+		t.Fatalf("expected four requests (repair + investigate + update_plan + finalize), got %d", len(client.requests))
 	}
-	if len(client.requests) != 2 {
-		t.Fatalf("expected two requests (investigate + finalize), got %d", len(client.requests))
+	repairTurnMessages := client.requests[1].Messages
+	lastMsg := repairTurnMessages[len(repairTurnMessages)-1]
+	if lastMsg.Role != llm.RoleUser || !strings.Contains(strings.ToLower(lastMsg.Text()), "without creating the initial structured plan state") {
+		t.Fatalf("expected bootstrap repair note to be appended as user message, got %#v", repairTurnMessages)
+	}
+	if !planpkg.HasStructuredPlan(sess.Plan) {
+		t.Fatalf("expected session plan to be structured after repair, got %#v", sess.Plan)
+	}
+	if sess.Plan.Phase != planpkg.PhaseDraft {
+		t.Fatalf("expected repaired plan to reach draft phase, got %#v", sess.Plan.Phase)
+	}
+	if strings.Contains(answer, planpkg.StructuredPlanReminder) {
+		t.Fatalf("expected repaired answer not to fall back to structured plan reminder, got %q", answer)
 	}
 }
-
-func TestRunPromptPlanModeFinalizesWithoutUpdatePlan(t *testing.T) {
+func TestRunPromptRepairsClarifyQuestionWithoutActiveChoice(t *testing.T) {
 	workspace := t.TempDir()
 	store, err := session.NewStore(t.TempDir())
 	if err != nil {
@@ -468,167 +604,57 @@ func TestRunPromptPlanModeFinalizesWithoutUpdatePlan(t *testing.T) {
 	}
 	sess := session.New(workspace)
 	sess.Mode = planpkg.ModePlan
+	sess.Plan = planpkg.State{
+		Goal:         "Implement the first paper RAG demo",
+		Summary:      "Need to choose the target demo directory before the rest of the plan converges.",
+		Phase:        planpkg.PhaseClarify,
+		DecisionGaps: []string{"Choose the target demo directory."},
+		Steps: []planpkg.Step{
+			{Title: "Choose the target demo directory", Status: planpkg.StepPending},
+			{Title: "Lock the technical path", Status: planpkg.StepPending},
+			{Title: "Define the runnable acceptance path", Status: planpkg.StepPending},
+		},
+	}
 
 	client := &fakeClient{replies: []llm.Message{
 		{
-			Role:    llm.RoleAssistant,
-			Content: "I've analyzed the codebase. Here's my plan:\n1. Read the main entry point\n2. Check the config files\n3. Implement the changes",
+			Role:    "assistant",
+			Content: "Please choose first: A reuse demos/paper_rag_minimal (recommended), B reuse demos/paper_rag, or C create demos/paper_rag_mvp.",
 		},
-	}}
-	runner := NewRunner(Options{
-		Workspace: workspace,
-		Config: config.Config{
-			Provider:      config.ProviderConfig{Model: "test-model"},
-			MaxIterations: 4,
-			Stream:        false,
-		},
-		Client:   client,
-		Store:    store,
-		Registry: tools.DefaultRegistry(),
-		Stdin:    strings.NewReader(""),
-		Stdout:   io.Discard,
-	})
-
-	answer, err := runner.RunPrompt(context.Background(), sess, "analyze the codebase and create a plan", "plan", io.Discard)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(answer, "I've analyzed the codebase") {
-		t.Fatalf("unexpected answer: %q", answer)
-	}
-	if len(client.requests) != 1 {
-		t.Fatalf("expected one request (finalize), got %d", len(client.requests))
-	}
-	// Verify no update_plan tool was called
-	for _, msg := range sess.Messages {
-		for _, tc := range msg.ToolCalls {
-			if tc.Function.Name == "update_plan" {
-				t.Fatal("expected no update_plan tool calls in plan mode")
-			}
-		}
-	}
-}
-
-func TestRunPromptPlanModeWithToolCallsFinalizesWithoutRepair(t *testing.T) {
-	workspace := t.TempDir()
-	store, err := session.NewStore(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	sess := session.New(workspace)
-	sess.Mode = planpkg.ModePlan
-
-	client := &fakeClient{replies: []llm.Message{
 		{
 			Role: "assistant",
 			ToolCalls: []llm.ToolCall{{
 				ID:   "call-1",
 				Type: "function",
 				Function: llm.ToolFunctionCall{
-					Name:      "list_files",
-					Arguments: `{}`,
-				},
-			}},
-		},
-		{
-			Role: "assistant",
-			ToolCalls: []llm.ToolCall{{
-				ID:   "call-2",
-				Type: "function",
-				Function: llm.ToolFunctionCall{
-					Name:      "read_file",
-					Arguments: `{"path":"main.go"}`,
-				},
-			}},
-		},
-		{
-			Role:    llm.RoleAssistant,
-			Content: "Based on my analysis, here's the plan:\n1. Modify the config\n2. Update the main function\n3. Add tests",
-		},
-	}}
-	runner := NewRunner(Options{
-		Workspace: workspace,
-		Config: config.Config{
-			Provider:      config.ProviderConfig{Model: "test-model"},
-			MaxIterations: 6,
-			Stream:        false,
-		},
-		Client:   client,
-		Store:    store,
-		Registry: tools.DefaultRegistry(),
-		Stdin:    strings.NewReader(""),
-		Stdout:   io.Discard,
-	})
-
-	answer, err := runner.RunPrompt(context.Background(), sess, "analyze the codebase and create a plan", "plan", io.Discard)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(answer, "Based on my analysis") {
-		t.Fatalf("unexpected answer: %q", answer)
-	}
-	if len(client.requests) != 3 {
-		t.Fatalf("expected three requests (list_files + read_file + finalize), got %d", len(client.requests))
-	}
-	// Verify no update_plan tool was called
-	for _, msg := range sess.Messages {
-		for _, tc := range msg.ToolCalls {
-			if tc.Function.Name == "update_plan" {
-				t.Fatal("expected no update_plan tool calls in plan mode")
-			}
-		}
-	}
-	// Verify tool calls were executed
-	if len(sess.Messages) < 6 {
-		t.Fatalf("expected at least 6 session messages, got %d", len(sess.Messages))
-	}
-}
-
-func TestRunPromptBuildModeWithMultipleToolCalls(t *testing.T) {
-	workspace := t.TempDir()
-	store, err := session.NewStore(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	sess := session.New(workspace)
-	sess.Mode = planpkg.ModeBuild
-
-	client := &fakeClient{replies: []llm.Message{
-		{
-			Role: "assistant",
-			ToolCalls: []llm.ToolCall{
-				{
-					ID:   "call-1",
-					Type: "function",
-					Function: llm.ToolFunctionCall{
-						Name:      "list_files",
-						Arguments: `{}`,
-					},
-				},
-				{
-					ID:   "call-2",
-					Type: "function",
-					Function: llm.ToolFunctionCall{
-						Name:      "search_text",
-						Arguments: `{"query":"func main"}`,
-					},
-				},
-			},
-		},
-		{
-			Role: "assistant",
-			ToolCalls: []llm.ToolCall{{
-				ID:   "call-3",
-				Type: "function",
-				Function: llm.ToolFunctionCall{
-					Name:      "read_file",
-					Arguments: `{"path":"main.go"}`,
+					Name: "update_plan",
+					Arguments: `{
+						"summary":"The first directory choice is waiting on the user before plan convergence.",
+						"phase":"clarify",
+						"decision_gaps":["Choose the target demo directory."],
+						"active_choice":{
+							"id":"target_demo_directory",
+							"kind":"clarify",
+							"question":"Please choose the target directory:",
+							"gap_key":"Choose the target demo directory.",
+							"options":[
+								{"id":"reuse_paper_rag_minimal","shortcut":"A","title":"Reuse demos/paper_rag_minimal","description":"Recommended minimal baseline.","recommended":true},
+								{"id":"reuse_paper_rag","shortcut":"B","title":"Reuse demos/paper_rag","description":"Reuse an existing directory with broader changes."},
+								{"id":"new_paper_rag_mvp","shortcut":"C","title":"Create demos/paper_rag_mvp","description":"Stronger isolation but more scaffolding."}
+							]
+						},
+						"plan":[
+							{"step":"Choose the target demo directory", "status":"pending"},
+							{"step":"Lock the technical path", "status":"pending"},
+							{"step":"Define the runnable acceptance path", "status":"pending"}
+						]
+					}`,
 				},
 			}},
 		},
 		{
 			Role:    "assistant",
-			Content: "Implementation complete. Modified main.go and updated config.",
+			Content: "<turn_intent>ask_user</turn_intent>Please reply with A, B, or C for the active choice shown above.",
 		},
 	}}
 	runner := NewRunner(Options{
@@ -645,30 +671,26 @@ func TestRunPromptBuildModeWithMultipleToolCalls(t *testing.T) {
 		Stdout:   io.Discard,
 	})
 
-	answer, err := runner.RunPrompt(context.Background(), sess, "implement the feature", "build", io.Discard)
+	answer, err := runner.RunPrompt(context.Background(), sess, "continue planning", "plan", io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(answer, "Implementation complete") {
-		t.Fatalf("unexpected answer: %q", answer)
-	}
 	if len(client.requests) != 3 {
-		t.Fatalf("expected three requests (parallel tools + read_file + finalize), got %d", len(client.requests))
+		t.Fatalf("expected three requests (repair + update_plan + ask_user), got %d", len(client.requests))
 	}
-	// Verify all tool calls were executed
-	toolCalls := make([]string, 0)
-	for _, msg := range sess.Messages {
-		for _, tc := range msg.ToolCalls {
-			toolCalls = append(toolCalls, tc.Function.Name)
-		}
+	secondTurnMessages := client.requests[1].Messages
+	lastMsg := secondTurnMessages[len(secondTurnMessages)-1]
+	if lastMsg.Role != llm.RoleUser || !strings.Contains(strings.ToLower(lastMsg.Text()), "without storing active_choice first") {
+		t.Fatalf("expected clarify repair note to be appended as user message, got %#v", secondTurnMessages)
 	}
-	expectedTools := []string{"list_files", "search_text", "read_file"}
-	if len(toolCalls) != len(expectedTools) {
-		t.Fatalf("expected %d tool calls, got %d: %v", len(expectedTools), len(toolCalls), toolCalls)
+	if sess.Plan.ActiveChoice == nil {
+		t.Fatalf("expected active_choice to be persisted after repair, got %#v", sess.Plan)
+	}
+	if !strings.Contains(answer, "A, B, or C") {
+		t.Fatalf("expected repaired ask_user answer to keep explicit choice guidance, got %q", answer)
 	}
 }
-
-func TestRunPromptNoLoopWhenLLMDoesNotFollowProtocol(t *testing.T) {
+func TestRunPromptRepairsPlanRevisionAndReturnsRevisedPlanDocument(t *testing.T) {
 	workspace := t.TempDir()
 	store, err := session.NewStore(t.TempDir())
 	if err != nil {
@@ -676,27 +698,72 @@ func TestRunPromptNoLoopWhenLLMDoesNotFollowProtocol(t *testing.T) {
 	}
 	sess := session.New(workspace)
 	sess.Mode = planpkg.ModePlan
+	sess.Plan = planpkg.State{
+		Goal:                "Implement the first paper RAG demo",
+		Summary:             "The plan is converged and ready to execute.",
+		ImplementationBrief: "Objective: deliver the first local paper RAG demo.\nDeliverables: upload, retrieval, answer generation, and a minimal HTML page.",
+		Phase:               planpkg.PhaseConvergeReady,
+		DecisionLog: []planpkg.Decision{
+			{Decision: "Use FastAPI + Jinja2 HTML for the first UI path", Reason: "Keeps the HTML GUI simple and local."},
+		},
+		Steps: []planpkg.Step{
+			{Title: "Freeze the MVP scope", Status: planpkg.StepPending},
+			{Title: "Implement the minimal UI flow", Status: planpkg.StepPending},
+		},
+		Verification:        []string{"Start the local app and validate one upload + one answer flow."},
+		ScopeDefined:        true,
+		RiskRollbackDefined: true,
+		VerificationDefined: true,
+		NextAction:          "Ask whether to start execution or keep adjusting the plan.",
+	}
 
-	// Simulate LLM that says "I will do X" without tool calls multiple times
 	client := &fakeClient{replies: []llm.Message{
 		{
 			Role:    "assistant",
-			Content: "I will read the main.go file first.",
+			Content: "Great point. We should split the HTML GUI details into page regions, layout, and interaction flow before execution.",
+		},
+		{
+			Role: "assistant",
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name: "update_plan",
+					Arguments: `{
+						"summary":"The plan stays converged and now includes a more detailed HTML GUI specification.",
+						"implementation_brief":"Objective: deliver the first local paper RAG demo in demos/.\nUI Specification: refine the HTML GUI into explicit page regions and interactions.\nLayout: top bar with title and current model tag; left column for paper management and system status; right upper panel for QA; right lower panel for synthesis and retrieval results.\nInteraction Flow: upload triggers indexing with progress states; answer and synthesis are split into separate tabs; each answer lists its cited source papers.\nDeliverables: runnable FastAPI app, HTML templates, upload/index/qa/synthesis flows, and verification notes.",
+						"phase":"converge_ready",
+						"decision_log":[
+							{"decision":"Use FastAPI + Jinja2 HTML for the first UI path","reason":"Keeps the HTML GUI simple and local."},
+							{"decision":"Expand the HTML GUI spec into concrete layout and interaction sections","reason":"User asked for a more detailed UI design before execution."}
+						],
+						"decision_gaps":[],
+						"scope_defined":true,
+						"risk_and_rollback_defined":true,
+						"verification_defined":true,
+						"verification":[
+							"Start the local app and validate one upload + one answer flow.",
+							"Confirm the HTML page shows the top bar, paper panel, QA tab, and synthesis tab."
+						],
+						"next_action":"Ask whether to start execution or keep adjusting the plan.",
+						"plan":[
+							{"step":"Freeze the MVP scope", "status":"pending", "description":"Lock the minimal local paper-RAG scope and the refined HTML GUI boundaries."},
+							{"step":"Implement the HTML GUI flow", "status":"pending", "description":"Build the top bar, paper management area, QA tab, and synthesis tab with clear state feedback."}
+						]
+					}`,
+				},
+			}},
 		},
 		{
 			Role:    "assistant",
-			Content: "I will check the config files next.",
-		},
-		{
-			Role:    "assistant",
-			Content: "I will implement the changes.",
+			Content: "<turn_intent>finalize</turn_intent>Updated. The plan now includes a detailed HTML GUI section for regions, layout, and interaction flow.",
 		},
 	}}
 	runner := NewRunner(Options{
 		Workspace: workspace,
 		Config: config.Config{
 			Provider:      config.ProviderConfig{Model: "test-model"},
-			MaxIterations: 4,
+			MaxIterations: 6,
 			Stream:        false,
 		},
 		Client:   client,
@@ -706,21 +773,29 @@ func TestRunPromptNoLoopWhenLLMDoesNotFollowProtocol(t *testing.T) {
 		Stdout:   io.Discard,
 	})
 
-	answer, err := runner.RunPrompt(context.Background(), sess, "analyze the codebase", "plan", io.Discard)
+	answer, err := runner.RunPrompt(context.Background(), sess, "The HTML UI still needs more detail, especially page regions and interactions.", "plan", io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The agent should finalize on first response (no tool calls = finalize)
-	if !strings.Contains(answer, "I will read the main.go file first") {
-		t.Fatalf("unexpected answer: %q", answer)
+	if len(client.requests) != 3 {
+		t.Fatalf("expected three requests (repair + update_plan + finalize), got %d", len(client.requests))
 	}
-	// Should only make 1 request (finalize), not loop
-	if len(client.requests) != 1 {
-		t.Fatalf("expected one request (finalize), got %d", len(client.requests))
+	secondTurnMessages := client.requests[1].Messages
+	lastMsg := secondTurnMessages[len(secondTurnMessages)-1]
+	if lastMsg.Role != llm.RoleUser || !strings.Contains(strings.ToLower(lastMsg.Text()), "plan-refinement feedback without updating the structured plan first") {
+		t.Fatalf("expected plan-revision repair note to be appended as user message, got %#v", secondTurnMessages)
+	}
+	if sess.Plan.Phase != planpkg.PhaseConvergeReady {
+		t.Fatalf("expected plan to remain converge_ready after revision repair, got %#v", sess.Plan.Phase)
+	}
+	if !strings.Contains(answer, "<proposed_plan>") {
+		t.Fatalf("expected revised plan answer to stay in proposed plan format, got %q", answer)
+	}
+	if !strings.Contains(answer, "Implementation Brief") {
+		t.Fatalf("expected revised plan output to include implementation brief, got %q", answer)
 	}
 }
-
-func TestRunPromptPreservesBlockerQuestionWithoutRepair(t *testing.T) {
+func TestRunPromptRepairsBuildHandoffWithoutRestartingPlanConfirmation(t *testing.T) {
 	workspace := t.TempDir()
 	store, err := session.NewStore(t.TempDir())
 	if err != nil {
@@ -742,7 +817,22 @@ func TestRunPromptPreservesBlockerQuestionWithoutRepair(t *testing.T) {
 	client := &fakeClient{replies: []llm.Message{
 		{
 			Role:    "assistant",
-			Content: "I need to check if there is a config file first. Could you confirm?",
+			Content: "<turn_intent>finalize</turn_intent>I am still treating this as plan confirmation. Please reply with continue execution or switch to build mode.",
+		},
+		{
+			Role: "assistant",
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "list_files",
+					Arguments: `{}`,
+				},
+			}},
+		},
+		{
+			Role:    "assistant",
+			Content: "<turn_intent>finalize</turn_intent>I inspected the workspace entrypoints and continued implementation.",
 		},
 	}}
 	runner := NewRunner(Options{
@@ -763,11 +853,187 @@ func TestRunPromptPreservesBlockerQuestionWithoutRepair(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(client.requests) != 1 {
-		t.Fatalf("expected one request (finalize), got %d requests", len(client.requests))
+	if len(client.requests) != 3 {
+		t.Fatalf("expected three requests (repair + tool + finalize), got %d", len(client.requests))
 	}
-	if !strings.Contains(answer, "config file") {
-		t.Fatalf("expected blocker question preserved, got %q", answer)
+	secondTurnMessages := client.requests[1].Messages
+	lastMsg := secondTurnMessages[len(secondTurnMessages)-1]
+	if lastMsg.Role != llm.RoleUser || !strings.Contains(strings.ToLower(lastMsg.Text()), "already switched to build mode") {
+		t.Fatalf("expected build-handoff repair note to be appended as user message, got %#v", secondTurnMessages)
+	}
+	if !strings.Contains(answer, "inspected the workspace entrypoints") {
+		t.Fatalf("expected repaired build answer, got %q", answer)
+	}
+}
+func TestRunPromptRepairsBuildHandoffAcknowledgementWithoutToolCalls(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	sess.Mode = planpkg.ModeBuild
+	sess.Plan = planpkg.State{
+		Goal:                "Implement the first RAG demo",
+		Summary:             "Plan is converged and execution should begin from the repo baseline.",
+		Phase:               planpkg.PhaseExecuting,
+		NextAction:          "Inspect the workspace entrypoints before editing.",
+		Steps:               []planpkg.Step{{Title: "Inspect the workspace entrypoints", Status: planpkg.StepInProgress}},
+		ScopeDefined:        true,
+		RiskRollbackDefined: true,
+		VerificationDefined: true,
+	}
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role:    "assistant",
+			Content: "Started execution.",
+		},
+		{
+			Role: "assistant",
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "list_files",
+					Arguments: `{}`,
+				},
+			}},
+		},
+		{
+			Role:    "assistant",
+			Content: "<turn_intent>finalize</turn_intent>Inspected the workspace entrypoints and continued implementation.",
+		},
+	}}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 6,
+			Stream:        false,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "start execution", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.requests) != 3 {
+		t.Fatalf("expected three requests (repair + tool + finalize), got %d requests", len(client.requests))
+	}
+	secondTurnMessages := client.requests[1].Messages
+	lastMsg := secondTurnMessages[len(secondTurnMessages)-1]
+	if lastMsg.Role != llm.RoleUser || !strings.Contains(strings.ToLower(lastMsg.Text()), "already switched to build mode") {
+		t.Fatalf("expected build-handoff repair note to be appended as user message, got %#v", secondTurnMessages)
+	}
+	if !strings.Contains(answer, "Inspected the workspace entrypoints") {
+		t.Fatalf("expected repaired build answer, got %q", answer)
+	}
+}
+
+func TestRunPromptDoesNotRepairBuildHandoffWhenAssistantRequestsRealBlockerInfo(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	sess.Mode = planpkg.ModeBuild
+	sess.Plan = planpkg.State{
+		Goal:                "Implement the first RAG demo",
+		Summary:             "Plan is converged and execution should continue from the repo baseline.",
+		Phase:               planpkg.PhaseExecuting,
+		NextAction:          "Run the first execution step.",
+		Steps:               []planpkg.Step{{Title: "Run the first execution step", Status: planpkg.StepInProgress}},
+		ScopeDefined:        true,
+		RiskRollbackDefined: true,
+		VerificationDefined: true,
+	}
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role:    "assistant",
+			Content: "<turn_intent>ask_user</turn_intent>Before I proceed, I need the missing API token for the target service.",
+		},
+	}}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 4,
+			Stream:        false,
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "start execution", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.requests) != 1 {
+		t.Fatalf("expected direct ask_user response without build-handoff repair retry, got %d requests", len(client.requests))
+	}
+	if !strings.Contains(strings.ToLower(answer), "missing api token") {
+		t.Fatalf("expected answer to preserve the genuine blocker clarification, got %q", answer)
+	}
+	if len(sess.Messages) != 2 {
+		t.Fatalf("expected user + assistant messages only, got %#v", sess.Messages)
+	}
+}
+
+func TestRunPromptStopsWhenContinueWorkWithoutToolCallsKeepsRepeating(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role:    "assistant",
+			Content: "<turn_intent>continue_work</turn_intent>I will continue now.",
+		},
+	}}
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 8,
+			Stream:        false,
+			ContextBudget: config.ContextBudgetConfig{
+				WarningRatio:     config.DefaultContextBudgetWarningRatio,
+				CriticalRatio:    config.DefaultContextBudgetCriticalRatio,
+				MaxReactiveRetry: 1,
+			},
+		},
+		Client:   client,
+		Store:    store,
+		Registry: tools.DefaultRegistry(),
+		Stdin:    strings.NewReader(""),
+		Stdout:   io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "keep going", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(answer, "ongoing work without structured tool calls") {
+		t.Fatalf("expected stop summary for repeated no-tool continue turns, got %q", answer)
+	}
+	if len(sess.Messages) != 2 {
+		t.Fatalf("expected user + summary assistant messages, got %#v", sess.Messages)
 	}
 }
 
@@ -1766,7 +2032,6 @@ func TestRunPromptEmitsUsageUpdatedEventWhenUsageAvailable(t *testing.T) {
 		t.Fatalf("expected EventUsageUpdated to be emitted, got %+v", events)
 	}
 }
-
 
 func TestCompactWhitespacePreservesUTF8WhenTruncating(t *testing.T) {
 	text := "Continue previous context and list the key MVP test points."

--- a/internal/agent/skills_bridge_runtime.go
+++ b/internal/agent/skills_bridge_runtime.go
@@ -18,6 +18,7 @@ var nonBridgedBuiltinTools = map[string]struct{}{
 	"write_file":      {},
 	"replace_in_file": {},
 	"apply_patch":     {},
+	"update_plan":     {},
 	"run_shell":       {},
 }
 

--- a/internal/agent/tool_execution.go
+++ b/internal/agent/tool_execution.go
@@ -346,6 +346,13 @@ func (e *defaultEngine) executeToolCall(
 			toolMessage.Meta["subagent_tool_calls"] = toolCalls
 		}
 	}
+	if call.Function.Name == "update_plan" {
+		runner.emit(Event{
+			Type:      EventPlanUpdated,
+			SessionID: sessionID,
+			Plan:      planpkg.CloneState(sess.Plan),
+		})
+	}
 	if err := llm.ValidateMessage(toolMessage); err != nil {
 		return toolCallResult{}, err
 	}
@@ -379,7 +386,7 @@ func (e *defaultEngine) toolSafetyClass(name string) tools.SafetyClass {
 func shouldExecuteToolDirectly(name string) bool {
 	switch strings.TrimSpace(name) {
 	case "list_files", "read_file", "search_text", "web_search", "web_fetch",
-		"write_file", "replace_in_file", "apply_patch", "delegate_subagent",
+		"write_file", "replace_in_file", "apply_patch", "update_plan", "delegate_subagent",
 		"task_output", "task_stop":
 		return true
 	default:

--- a/internal/agent/tool_execution_audit_test.go
+++ b/internal/agent/tool_execution_audit_test.go
@@ -190,6 +190,7 @@ func TestShouldExecuteToolDirectlyRoutesSynchronousBuiltins(t *testing.T) {
 		"write_file",
 		"replace_in_file",
 		"apply_patch",
+		"update_plan",
 		"delegate_subagent",
 		"task_output",
 		"task_stop",
@@ -387,6 +388,104 @@ func TestRunPromptExecutesWriteFileDirectly(t *testing.T) {
 	}
 }
 
+func TestRunPromptExecutesUpdatePlanDirectly(t *testing.T) {
+	workspace := t.TempDir()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := session.New(workspace)
+	auditStore := &toolExecutionAuditStore{}
+	events := make([]Event, 0, 6)
+
+	client := &fakeClient{replies: []llm.Message{
+		{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   "tool-direct-plan",
+				Type: "function",
+				Function: llm.ToolFunctionCall{
+					Name:      "update_plan",
+					Arguments: `{"explanation":"starting","plan":[{"step":"Inspect provider","status":"completed"},{"step":"Add tests","status":"in_progress"}]}`,
+				},
+			}},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: "done",
+		},
+	}}
+	gateway := &stubRuntimeGateway{}
+
+	runner := NewRunner(Options{
+		Workspace: workspace,
+		Config: config.Config{
+			Provider:      config.ProviderConfig{Model: "test-model"},
+			MaxIterations: 4,
+			Stream:        false,
+		},
+		Client:     client,
+		Store:      store,
+		Registry:   tools.DefaultRegistry(),
+		Runtime:    gateway,
+		AuditStore: auditStore,
+		Observer: ObserverFunc(func(event Event) {
+			events = append(events, event)
+		}),
+		Stdin:  strings.NewReader(""),
+		Stdout: io.Discard,
+	})
+
+	answer, err := runner.RunPrompt(context.Background(), sess, "update plan", "build", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "done" {
+		t.Fatalf("unexpected answer: %q", answer)
+	}
+
+	gateway.mu.Lock()
+	callCount := len(gateway.calls)
+	gateway.mu.Unlock()
+	if callCount != 0 {
+		t.Fatalf("expected update_plan to bypass runtime gateway, got %d calls", callCount)
+	}
+	if len(sess.Plan.Steps) != 2 || sess.Plan.Steps[1].Title != "Add tests" {
+		t.Fatalf("unexpected session plan: %#v", sess.Plan)
+	}
+	seenPlanUpdated := false
+	for _, event := range events {
+		if event.Type == EventPlanUpdated {
+			seenPlanUpdated = true
+			break
+		}
+	}
+	if !seenPlanUpdated {
+		t.Fatalf("expected EventPlanUpdated, got %+v", events)
+	}
+
+	auditEvents := auditStore.snapshot()
+	for _, event := range auditEvents {
+		if event.Action == "task_state_changed" {
+			t.Fatalf("did not expect task_state_changed for direct update_plan, got %+v", event)
+		}
+	}
+	var resultEvent *storagepkg.AuditEvent
+	for i := range auditEvents {
+		if auditEvents[i].Action == "tool_execute_result" && auditEvents[i].Metadata["tool_name"] == "update_plan" {
+			resultEvent = &auditEvents[i]
+		}
+	}
+	if resultEvent == nil {
+		t.Fatalf("expected tool_execute_result audit event, got %+v", auditEvents)
+	}
+	if resultEvent.TaskID != "" {
+		t.Fatalf("expected direct update_plan audit to omit task id, got %+v", resultEvent)
+	}
+	if resultEvent.TraceID != corepkg.TraceID("tool-direct-plan") {
+		t.Fatalf("expected trace id %q, got %q", "tool-direct-plan", resultEvent.TraceID)
+	}
+}
 
 func TestRunPromptKeepsNonDirectToolOnRuntimeGateway(t *testing.T) {
 	workspace := t.TempDir()

--- a/internal/agent/turn_processing.go
+++ b/internal/agent/turn_processing.go
@@ -151,13 +151,185 @@ func (e *defaultEngine) processTurn(ctx context.Context, p turnProcessParams) (s
 		return "", false, err
 	}
 	reply.Normalize()
-	_, cleanedReply, _ := parseAssistantTurnIntent(reply)
+	intent, cleanedReply, explicitIntent := parseAssistantTurnIntent(reply)
 	reply = cleanedReply
 	runner.emitUsageEvent(p.Session, reply.Usage)
 
 	if len(reply.ToolCalls) == 0 {
-		// No tool calls — finalize the turn. Safety nets only for specific claim patterns.
+		if intent == turnIntentUnknown {
+			intent = inferAssistantTurnIntent(reply.Content)
+		}
 		latestUser := latestHumanUserMessageText(p.Session.Messages)
+		if shouldRepairPlanBootstrapTurn(p.RunMode, p.Session.Plan, reply) {
+			attempt := 0
+			maxAttempts := 0
+			if p.AdaptiveState != nil {
+				p.AdaptiveState.recordNoProgressTurn()
+				attempt = p.AdaptiveState.recordSemanticRepairAttempt()
+				maxAttempts = p.AdaptiveState.maxSemanticRepairs
+			}
+			if p.TaskReport != nil {
+				p.TaskReport.RecordNoProgressTurn()
+				p.TaskReport.RecordRetry("plan_bootstrap_missing_update")
+				p.TaskReport.RecordStrategyAdjustment("assistant replied in plan mode before creating any structured plan state; injected correction prompt")
+			}
+			if p.AdaptiveState != nil {
+				if p.AdaptiveState.exceededSemanticRepairLimit() || p.AdaptiveState.exceededNoProgressLimit() {
+					if p.TaskReport != nil {
+						p.TaskReport.RecordEscalation("plan bootstrap repair retries exceeded while waiting for initial investigation or update_plan")
+					}
+					summary := BuildStopSummary(StopSummaryInput{
+						SessionID:     corepkg.SessionID(p.Session.ID),
+						Reason:        fmt.Sprintf("I paused because the assistant kept replying in plan mode without creating the initial structured plan state first (attempts=%d, explicit_intent=%t).", attempt, explicitIntent),
+						ExecutedTools: *p.ExecutedTools,
+						TaskReport:    p.TaskReport,
+					})
+					answer, summaryErr := e.finishWithSummary(p.Session, summary, p.Out, streamedText)
+					return answer, true, summaryErr
+				}
+				p.AdaptiveState.schedulePendingControlNote(buildPlanBootstrapRepairInstruction(reply, latestUser, attempt, maxAttempts, p.Session.Messages, availableToolNames))
+			}
+			if p.Out != nil {
+				fmt.Fprintf(p.Out, "%sassistant replied in plan mode before creating structured plan state; retrying with a correction prompt%s\n", ansiDim, ansiReset)
+			}
+			return "", false, nil
+		}
+		if !hasToolActivitySinceLatestHumanUser(p.Session.Messages) && shouldRepairPlanRevisionTurn(p.RunMode, p.Session.Plan, latestUser, reply) {
+			attempt := 0
+			maxAttempts := 0
+			if p.AdaptiveState != nil {
+				p.AdaptiveState.recordNoProgressTurn()
+				attempt = p.AdaptiveState.recordSemanticRepairAttempt()
+				maxAttempts = p.AdaptiveState.maxSemanticRepairs
+			}
+			if p.TaskReport != nil {
+				p.TaskReport.RecordNoProgressTurn()
+				p.TaskReport.RecordRetry("plan_revision_missing_update")
+				p.TaskReport.RecordStrategyAdjustment("assistant responded to converged-plan refinement feedback without update_plan; injected correction prompt")
+			}
+			if p.AdaptiveState != nil {
+				if p.AdaptiveState.exceededSemanticRepairLimit() || p.AdaptiveState.exceededNoProgressLimit() {
+					if p.TaskReport != nil {
+						p.TaskReport.RecordEscalation("plan revision repair retries exceeded while waiting for update_plan")
+					}
+					summary := BuildStopSummary(StopSummaryInput{
+						SessionID:     corepkg.SessionID(p.Session.ID),
+						Reason:        fmt.Sprintf("I paused because the assistant kept responding to plan-refinement feedback without updating the structured plan first (attempts=%d, explicit_intent=%t).", attempt, explicitIntent),
+						ExecutedTools: *p.ExecutedTools,
+						TaskReport:    p.TaskReport,
+					})
+					answer, summaryErr := e.finishWithSummary(p.Session, summary, p.Out, streamedText)
+					return answer, true, summaryErr
+				}
+				p.AdaptiveState.schedulePendingControlNote(buildPlanRevisionRepairInstruction(p.Session.Plan, latestUser, reply, attempt, maxAttempts))
+			}
+			if p.Out != nil {
+				fmt.Fprintf(p.Out, "%sassistant replied to plan refinement feedback without update_plan; retrying with a correction prompt%s\n", ansiDim, ansiReset)
+			}
+			return "", false, nil
+		}
+		if shouldRepairPlanClarifyTurn(p.RunMode, p.Session.Plan, intent, reply) {
+			attempt := 0
+			maxAttempts := 0
+			if p.AdaptiveState != nil {
+				p.AdaptiveState.recordNoProgressTurn()
+				attempt = p.AdaptiveState.recordSemanticRepairAttempt()
+				maxAttempts = p.AdaptiveState.maxSemanticRepairs
+			}
+			if p.TaskReport != nil {
+				p.TaskReport.RecordNoProgressTurn()
+				p.TaskReport.RecordRetry("plan_clarify_missing_active_choice")
+				p.TaskReport.RecordStrategyAdjustment("assistant asked a plan clarification question without update_plan.active_choice; injected correction prompt")
+			}
+			if p.AdaptiveState != nil {
+				if p.AdaptiveState.exceededSemanticRepairLimit() || p.AdaptiveState.exceededNoProgressLimit() {
+					if p.TaskReport != nil {
+						p.TaskReport.RecordEscalation("plan clarify repair retries exceeded while waiting for active_choice")
+					}
+					summary := BuildStopSummary(StopSummaryInput{
+						SessionID:     corepkg.SessionID(p.Session.ID),
+						Reason:        fmt.Sprintf("I paused because the assistant kept asking plan clarification questions without storing active_choice first (attempts=%d, explicit_intent=%t).", attempt, explicitIntent),
+						ExecutedTools: *p.ExecutedTools,
+						TaskReport:    p.TaskReport,
+					})
+					answer, summaryErr := e.finishWithSummary(p.Session, summary, p.Out, streamedText)
+					return answer, true, summaryErr
+				}
+				p.AdaptiveState.schedulePendingControlNote(buildPlanClarifyRepairInstruction(p.Session.Plan, reply, attempt, maxAttempts))
+			}
+			if p.Out != nil {
+				fmt.Fprintf(p.Out, "%sassistant asked a plan clarification question without active_choice; retrying with a correction prompt%s\n", ansiDim, ansiReset)
+			}
+			return "", false, nil
+		}
+		if shouldRepairPlanDecisionTurn(p.RunMode, p.Session.Plan, intent, reply) {
+			attempt := 0
+			maxAttempts := 0
+			if p.AdaptiveState != nil {
+				p.AdaptiveState.recordNoProgressTurn()
+				attempt = p.AdaptiveState.recordSemanticRepairAttempt()
+				maxAttempts = p.AdaptiveState.maxSemanticRepairs
+			}
+			if p.TaskReport != nil {
+				p.TaskReport.RecordNoProgressTurn()
+				p.TaskReport.RecordRetry("plan_state_not_updated_after_user_decision")
+				p.TaskReport.RecordStrategyAdjustment("assistant acknowledged a plan decision without update_plan; injected correction prompt")
+			}
+			if p.AdaptiveState != nil {
+				if p.AdaptiveState.exceededSemanticRepairLimit() || p.AdaptiveState.exceededNoProgressLimit() {
+					if p.TaskReport != nil {
+						p.TaskReport.RecordEscalation("plan-state repair retries exceeded while waiting for update_plan")
+					}
+					summary := BuildStopSummary(StopSummaryInput{
+						SessionID:     corepkg.SessionID(p.Session.ID),
+						Reason:        fmt.Sprintf("I paused because the assistant kept acknowledging plan decisions without updating the structured plan state first (attempts=%d, explicit_intent=%t).", attempt, explicitIntent),
+						ExecutedTools: *p.ExecutedTools,
+						TaskReport:    p.TaskReport,
+					})
+					answer, summaryErr := e.finishWithSummary(p.Session, summary, p.Out, streamedText)
+					return answer, true, summaryErr
+				}
+				p.AdaptiveState.schedulePendingControlNote(buildPlanDecisionRepairInstruction(p.Session.Plan, reply, attempt, maxAttempts))
+			}
+			if p.Out != nil {
+				fmt.Fprintf(p.Out, "%sassistant acknowledged a plan decision without update_plan; retrying with a correction prompt%s\n", ansiDim, ansiReset)
+			}
+			return "", false, nil
+		}
+		if shouldRepairBuildHandoffTurn(p.RunMode, p.Session.Plan, intent, reply, p.Session.Messages) {
+			attempt := 0
+			maxAttempts := 0
+			if p.AdaptiveState != nil {
+				p.AdaptiveState.recordNoProgressTurn()
+				attempt = p.AdaptiveState.recordSemanticRepairAttempt()
+				maxAttempts = p.AdaptiveState.maxSemanticRepairs
+			}
+			if p.TaskReport != nil {
+				p.TaskReport.RecordNoProgressTurn()
+				p.TaskReport.RecordRetry("build_handoff_not_started")
+				p.TaskReport.RecordStrategyAdjustment("assistant treated an already-switched build handoff as if plan confirmation were still pending; injected correction prompt")
+			}
+			if p.AdaptiveState != nil {
+				if p.AdaptiveState.exceededSemanticRepairLimit() || p.AdaptiveState.exceededNoProgressLimit() {
+					if p.TaskReport != nil {
+						p.TaskReport.RecordEscalation("build-handoff repair retries exceeded while waiting for execution to start")
+					}
+					summary := BuildStopSummary(StopSummaryInput{
+						SessionID:     corepkg.SessionID(p.Session.ID),
+						Reason:        fmt.Sprintf("I paused because the assistant kept treating an already-approved build handoff as if plan confirmation were still pending (attempts=%d, explicit_intent=%t).", attempt, explicitIntent),
+						ExecutedTools: *p.ExecutedTools,
+						TaskReport:    p.TaskReport,
+					})
+					answer, summaryErr := e.finishWithSummary(p.Session, summary, p.Out, streamedText)
+					return answer, true, summaryErr
+				}
+				p.AdaptiveState.schedulePendingControlNote(buildBuildHandoffRepairInstruction(p.Session.Plan, reply, latestUser, attempt, maxAttempts))
+			}
+			if p.Out != nil {
+				fmt.Fprintf(p.Out, "%sassistant treated an already-switched build handoff as pending plan confirmation; retrying with a correction prompt%s\n", ansiDim, ansiReset)
+			}
+			return "", false, nil
+		}
 		if shouldRepairUnexecutedToolClaimTurn(p.RunMode, reply, p.Session.Messages, availableToolNames) {
 			attempt := 0
 			maxAttempts := 0
@@ -178,7 +350,7 @@ func (e *defaultEngine) processTurn(ctx context.Context, p turnProcessParams) (s
 					}
 					summary := BuildStopSummary(StopSummaryInput{
 						SessionID:     corepkg.SessionID(p.Session.ID),
-						Reason:        fmt.Sprintf("I paused because the assistant kept claiming run_shell was unavailable or timed out without issuing a structured tool call (attempts=%d).", attempt),
+						Reason:        fmt.Sprintf("I paused because the assistant kept claiming run_shell was unavailable or timed out without issuing a structured tool call (attempts=%d, explicit_intent=%t).", attempt, explicitIntent),
 						ExecutedTools: *p.ExecutedTools,
 						TaskReport:    p.TaskReport,
 					})
@@ -192,8 +364,48 @@ func (e *defaultEngine) processTurn(ctx context.Context, p turnProcessParams) (s
 			}
 			return "", false, nil
 		}
-		if p.AdaptiveState != nil {
-			p.AdaptiveState.recordProgress()
+		switch intent {
+		case turnIntentContinueWork:
+			attempt := 0
+			maxAttempts := 0
+			if p.AdaptiveState != nil {
+				p.AdaptiveState.recordNoProgressTurn()
+				attempt = p.AdaptiveState.recordSemanticRepairAttempt()
+				maxAttempts = p.AdaptiveState.maxSemanticRepairs
+			}
+			if p.TaskReport != nil {
+				p.TaskReport.RecordNoProgressTurn()
+				p.TaskReport.RecordRetry("missing_structured_tool_call")
+				p.TaskReport.RecordStrategyAdjustment("assistant declared continue_work without structured tool calls; injected correction prompt")
+			}
+			if p.AdaptiveState != nil {
+				if p.AdaptiveState.exceededSemanticRepairLimit() || p.AdaptiveState.exceededNoProgressLimit() {
+					if p.TaskReport != nil {
+						p.TaskReport.RecordEscalation("semantic repair retries exceeded while waiting for structured tool calls")
+					}
+					summary := BuildStopSummary(StopSummaryInput{
+						SessionID:     corepkg.SessionID(p.Session.ID),
+						Reason:        fmt.Sprintf("I paused because the assistant kept signaling ongoing work without structured tool calls (attempts=%d, explicit_intent=%t).", attempt, explicitIntent),
+						ExecutedTools: *p.ExecutedTools,
+						TaskReport:    p.TaskReport,
+					})
+					answer, summaryErr := e.finishWithSummary(p.Session, summary, p.Out, streamedText)
+					return answer, true, summaryErr
+				}
+				p.AdaptiveState.schedulePendingControlNote(buildSemanticRepairInstruction(reply, attempt, maxAttempts))
+			}
+			if p.Out != nil {
+				fmt.Fprintf(p.Out, "%sassistant indicated ongoing work but emitted no structured tool calls; retrying with a correction prompt%s\n", ansiDim, ansiReset)
+			}
+			return "", false, nil
+		case turnIntentAskUser, turnIntentFinalize:
+			if p.AdaptiveState != nil {
+				p.AdaptiveState.recordProgress()
+			}
+		default:
+			if p.AdaptiveState != nil {
+				p.AdaptiveState.recordProgress()
+			}
 		}
 		answer, finalizeErr := e.finalizeTurnWithoutTools(p.RunMode, p.Session, reply, p.Out, streamedText)
 		return answer, true, finalizeErr

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -118,6 +118,7 @@ func DefaultRegistry(agentInfos ...[]AgentInfo) *Registry {
 	r.mustRegisterBuiltin(WriteFileTool{})
 	r.mustRegisterBuiltin(ReplaceInFileTool{})
 	r.mustRegisterBuiltin(ApplyPatchTool{})
+	r.mustRegisterBuiltin(UpdatePlanTool{})
 	r.mustRegisterBuiltin(RunShellTool{})
 	r.mustRegisterBuiltin(NewDelegateSubAgentTool(agents))
 	r.mustRegisterBuiltin(TaskOutputTool{})

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -31,6 +31,7 @@ func TestDefaultRegistryDefinitionsAreSortedAndComplete(t *testing.T) {
 		"search_text",
 		"task_output",
 		"task_stop",
+		"update_plan",
 		"web_fetch",
 		"web_search",
 		"write_file",
@@ -72,7 +73,7 @@ func TestDefaultRegistryDefinitionsForPlanModeIncludeWebTools(t *testing.T) {
 		names = append(names, def.Function.Name)
 	}
 
-	for _, allowed := range []string{"list_files", "read_file", "search_text", "web_search", "web_fetch", "run_shell", "delegate_subagent", "task_output", "task_stop"} {
+	for _, allowed := range []string{"list_files", "read_file", "search_text", "web_search", "web_fetch", "update_plan", "run_shell", "delegate_subagent", "task_output", "task_stop"} {
 		if !slices.Contains(names, allowed) {
 			t.Fatalf("expected %q in plan mode definitions, got %v", allowed, names)
 		}

--- a/internal/tools/spec.go
+++ b/internal/tools/spec.go
@@ -83,6 +83,11 @@ func DefaultToolSpec(def llm.ToolDefinition) ToolSpec {
 	case "list_files", "read_file", "search_text", "web_search", "web_fetch":
 		spec.ReadOnly = true
 		spec.SafetyClass = SafetyClassSafe
+	case "update_plan":
+		spec.SafetyClass = SafetyClassModerate
+		spec.DefaultTimeoutS = 10
+		spec.MaxTimeoutS = 10
+		spec.MaxResultChars = 32 * 1024
 	case "run_shell":
 		spec.SafetyClass = SafetyClassSensitive
 	case "write_file", "replace_in_file", "apply_patch":
@@ -189,7 +194,7 @@ func modeAllowed(spec ToolSpec, mode planpkg.AgentMode) bool {
 
 func defaultAllowedModes(name string) []planpkg.AgentMode {
 	switch name {
-	case "list_files", "read_file", "search_text", "web_search", "web_fetch", "run_shell":
+	case "list_files", "read_file", "search_text", "web_search", "web_fetch", "update_plan", "run_shell":
 		return []planpkg.AgentMode{planpkg.ModeBuild, planpkg.ModePlan}
 	default:
 		return []planpkg.AgentMode{planpkg.ModeBuild}

--- a/internal/tools/update_plan.go
+++ b/internal/tools/update_plan.go
@@ -1,0 +1,327 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/bytemind/internal/llm"
+	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+)
+
+type UpdatePlanTool struct{}
+
+func (UpdatePlanTool) Definition() llm.ToolDefinition {
+	return llm.ToolDefinition{
+		Type: "function",
+		Function: llm.FunctionDefinition{
+			Name:        "update_plan",
+			Description: "Update the task plan for multi-step work. Use it when a task has several meaningful steps.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"goal":    map[string]any{"type": "string"},
+					"summary": map[string]any{"type": "string"},
+					"phase": map[string]any{"type": "string", "enum": []string{
+						"none",
+						"explore",
+						"clarify",
+						"draft",
+						"converge_ready",
+						"approved_to_build",
+						"drafting",
+						"ready",
+						"approved",
+						"executing",
+						"blocked",
+						"completed",
+					}},
+					"implementation_brief": map[string]any{"type": "string"},
+					"risks": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+					"verification": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+					"decision_log": map[string]any{
+						"type": "array",
+						"items": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"decision": map[string]any{"type": "string"},
+								"reason":   map[string]any{"type": "string"},
+							},
+							"required": []string{"decision"},
+						},
+					},
+					"decision_gaps": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+					"active_choice": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"id":       map[string]any{"type": "string"},
+							"kind":     map[string]any{"type": "string"},
+							"question": map[string]any{"type": "string"},
+							"gap_key":  map[string]any{"type": "string"},
+							"options": map[string]any{
+								"type": "array",
+								"items": map[string]any{
+									"type": "object",
+									"properties": map[string]any{
+										"id":          map[string]any{"type": "string"},
+										"shortcut":    map[string]any{"type": "string"},
+										"title":       map[string]any{"type": "string"},
+										"description": map[string]any{"type": "string"},
+										"recommended": map[string]any{"type": "boolean"},
+										"freeform":    map[string]any{"type": "boolean"},
+									},
+									"required": []string{"title"},
+								},
+							},
+						},
+						"required": []string{"question", "options"},
+					},
+					"scope_defined":             map[string]any{"type": "boolean"},
+					"risk_and_rollback_defined": map[string]any{"type": "boolean"},
+					"verification_defined":      map[string]any{"type": "boolean"},
+					"next_action":               map[string]any{"type": "string"},
+					"block_reason":              map[string]any{"type": "string"},
+					"explanation": map[string]any{
+						"type":        "string",
+						"description": "Optional short explanation of why the plan changed.",
+					},
+					"plan": map[string]any{
+						"type": "array",
+						"items": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"id":          map[string]any{"type": "string"},
+								"step":        map[string]any{"type": "string"},
+								"title":       map[string]any{"type": "string"},
+								"description": map[string]any{"type": "string"},
+								"status":      map[string]any{"type": "string", "enum": []string{"pending", "in_progress", "completed", "blocked"}},
+								"files": map[string]any{
+									"type":  "array",
+									"items": map[string]any{"type": "string"},
+								},
+								"verify": map[string]any{
+									"type":  "array",
+									"items": map[string]any{"type": "string"},
+								},
+								"risk": map[string]any{"type": "string", "enum": []string{"low", "medium", "high"}},
+							},
+							"required": []string{"status"},
+						},
+					},
+				},
+				"required": []string{"plan"},
+			},
+		},
+	}
+}
+
+func (UpdatePlanTool) Run(_ context.Context, raw json.RawMessage, execCtx *ExecutionContext) (string, error) {
+	if execCtx.Session == nil {
+		return "", errors.New("session is required for update_plan")
+	}
+
+	var args struct {
+		Goal                string   `json:"goal"`
+		Summary             string   `json:"summary"`
+		ImplementationBrief string   `json:"implementation_brief"`
+		Phase               string   `json:"phase"`
+		Risks               []string `json:"risks"`
+		Verification        []string `json:"verification"`
+		DecisionLog         []struct {
+			Decision string `json:"decision"`
+			Reason   string `json:"reason"`
+		} `json:"decision_log"`
+		DecisionGaps []string `json:"decision_gaps"`
+		ActiveChoice *struct {
+			ID       string `json:"id"`
+			Kind     string `json:"kind"`
+			Question string `json:"question"`
+			GapKey   string `json:"gap_key"`
+			Options  []struct {
+				ID          string `json:"id"`
+				Shortcut    string `json:"shortcut"`
+				Title       string `json:"title"`
+				Description string `json:"description"`
+				Recommended bool   `json:"recommended"`
+				Freeform    bool   `json:"freeform"`
+			} `json:"options"`
+		} `json:"active_choice"`
+		ScopeDefined           *bool  `json:"scope_defined"`
+		RiskAndRollbackDefined *bool  `json:"risk_and_rollback_defined"`
+		VerificationDefined    *bool  `json:"verification_defined"`
+		NextAction             string `json:"next_action"`
+		BlockReason            string `json:"block_reason"`
+		Explanation            string `json:"explanation"`
+		Plan                   []struct {
+			ID          string   `json:"id"`
+			Step        string   `json:"step"`
+			Title       string   `json:"title"`
+			Description string   `json:"description"`
+			Status      string   `json:"status"`
+			Files       []string `json:"files"`
+			Verify      []string `json:"verify"`
+			Risk        string   `json:"risk"`
+		} `json:"plan"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return "", err
+	}
+	if len(args.Plan) == 0 {
+		return "", errors.New("plan must contain at least one step")
+	}
+
+	steps := make([]planpkg.Step, 0, len(args.Plan))
+	inProgressCount := 0
+	for i, item := range args.Plan {
+		title := strings.TrimSpace(item.Title)
+		if title == "" {
+			title = strings.TrimSpace(item.Step)
+		}
+		status := planpkg.NormalizeStepStatus(item.Status)
+		if title == "" {
+			return "", errors.New("plan step title cannot be empty")
+		}
+		if status == planpkg.StepInProgress {
+			inProgressCount++
+		}
+		step := planpkg.Step{
+			ID:          strings.TrimSpace(item.ID),
+			Title:       title,
+			Description: strings.TrimSpace(item.Description),
+			Status:      status,
+			Files:       trimPlanStrings(item.Files),
+			Verify:      trimPlanStrings(item.Verify),
+			Risk:        normalizeRisk(item.Risk),
+		}
+		if step.ID == "" {
+			step.ID = fmt.Sprintf("s%d", i+1)
+		}
+		steps = append(steps, step)
+	}
+	if inProgressCount > 1 {
+		return "", errors.New("only one plan item can be in_progress")
+	}
+
+	state := execCtx.Session.Plan
+	state.Goal = chooseNonEmpty(strings.TrimSpace(args.Goal), state.Goal)
+	state.Summary = chooseNonEmpty(strings.TrimSpace(args.Summary), strings.TrimSpace(args.Explanation), state.Summary)
+	state.ImplementationBrief = chooseNonEmpty(strings.TrimSpace(args.ImplementationBrief), state.ImplementationBrief)
+	state.NextAction = chooseNonEmpty(strings.TrimSpace(args.NextAction), state.NextAction)
+	state.BlockReason = chooseNonEmpty(strings.TrimSpace(args.BlockReason), state.BlockReason)
+	state.Steps = steps
+	if args.Risks != nil {
+		state.Risks = trimPlanStrings(args.Risks)
+	}
+	if args.Verification != nil {
+		state.Verification = trimPlanStrings(args.Verification)
+	}
+	if args.DecisionLog != nil {
+		decisionLog := make([]planpkg.Decision, 0, len(args.DecisionLog))
+		for _, entry := range args.DecisionLog {
+			decisionLog = append(decisionLog, planpkg.Decision{
+				Decision: strings.TrimSpace(entry.Decision),
+				Reason:   strings.TrimSpace(entry.Reason),
+			})
+		}
+		state.DecisionLog = decisionLog
+	}
+	if args.DecisionGaps != nil {
+		state.DecisionGaps = trimPlanStrings(args.DecisionGaps)
+	}
+	if args.ActiveChoice != nil {
+		activeChoice := &planpkg.ActiveChoice{
+			ID:       strings.TrimSpace(args.ActiveChoice.ID),
+			Kind:     strings.TrimSpace(args.ActiveChoice.Kind),
+			Question: strings.TrimSpace(args.ActiveChoice.Question),
+			GapKey:   strings.TrimSpace(args.ActiveChoice.GapKey),
+			Options:  make([]planpkg.ChoiceOption, 0, len(args.ActiveChoice.Options)),
+		}
+		for _, option := range args.ActiveChoice.Options {
+			activeChoice.Options = append(activeChoice.Options, planpkg.ChoiceOption{
+				ID:          strings.TrimSpace(option.ID),
+				Shortcut:    strings.TrimSpace(option.Shortcut),
+				Title:       strings.TrimSpace(option.Title),
+				Description: strings.TrimSpace(option.Description),
+				Recommended: option.Recommended,
+				Freeform:    option.Freeform,
+			})
+		}
+		state.ActiveChoice = activeChoice
+	}
+	if args.ScopeDefined != nil {
+		state.ScopeDefined = *args.ScopeDefined
+	}
+	if args.RiskAndRollbackDefined != nil {
+		state.RiskRollbackDefined = *args.RiskAndRollbackDefined
+	}
+	if args.VerificationDefined != nil {
+		state.VerificationDefined = *args.VerificationDefined
+	}
+	state.Phase = planpkg.NormalizePhase(args.Phase)
+	if state.Phase == planpkg.PhaseNone {
+		state.Phase = planpkg.DerivePhase(execCtx.Mode, state)
+	}
+	state.UpdatedAt = time.Now().UTC()
+	state = planpkg.NormalizeState(state)
+	if state.NextAction == "" {
+		state.NextAction = planpkg.DefaultNextAction(state)
+	}
+
+	validation := planpkg.ValidateState(state)
+	if !validation.OK {
+		return "", errors.New(strings.Join(validation.Warnings, "; "))
+	}
+
+	execCtx.Session.Plan = state
+	return toJSON(map[string]any{
+		"ok":          true,
+		"explanation": strings.TrimSpace(args.Explanation),
+		"plan":        state,
+	})
+}
+
+func trimPlanStrings(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		trimmed := strings.TrimSpace(item)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizeRisk(raw string) planpkg.RiskLevel {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	return planpkg.NormalizeRisk(raw)
+}
+
+func chooseNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/tools/update_plan_test.go
+++ b/internal/tools/update_plan_test.go
@@ -1,0 +1,155 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
+	"github.com/1024XEngineer/bytemind/internal/session"
+)
+
+func TestUpdatePlanToolUpdatesSessionPlan(t *testing.T) {
+	workspace := t.TempDir()
+	sess := session.New(workspace)
+	tool := UpdatePlanTool{}
+	payload, _ := json.Marshal(map[string]any{
+		"explanation": "starting work",
+		"plan": []map[string]any{
+			{"step": "Inspect provider", "status": "completed"},
+			{"step": "Add tests", "status": "in_progress"},
+		},
+	})
+	result, err := tool.Run(context.Background(), payload, &ExecutionContext{Session: sess})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sess.Plan.Steps) != 2 || sess.Plan.Steps[1].Title != "Add tests" || sess.Plan.Steps[1].Status != planpkg.StepInProgress {
+		t.Fatalf("unexpected session plan %#v", sess.Plan)
+	}
+
+	var parsed struct {
+		Explanation string        `json:"explanation"`
+		Plan        planpkg.State `json:"plan"`
+	}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Explanation != "starting work" || len(parsed.Plan.Steps) != 2 {
+		t.Fatalf("unexpected result %#v", parsed)
+	}
+}
+
+func TestUpdatePlanToolRequiresSession(t *testing.T) {
+	tool := UpdatePlanTool{}
+	payload := []byte(`{"plan":[{"step":"x","status":"pending"}]}`)
+	_, err := tool.Run(context.Background(), payload, &ExecutionContext{})
+	if err == nil {
+		t.Fatal("expected missing session error")
+	}
+}
+
+func TestUpdatePlanToolRejectsInvalidPlanShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "empty plan",
+			payload: `{"plan":[]}`,
+		},
+		{
+			name:    "empty step",
+			payload: `{"plan":[{"step":" ","status":"pending"}]}`,
+		},
+		{
+			name:    "multiple in progress",
+			payload: `{"plan":[{"step":"x","status":"in_progress"},{"step":"y","status":"in_progress"}]}`,
+		},
+	}
+
+	tool := UpdatePlanTool{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess := session.New(t.TempDir())
+			_, err := tool.Run(context.Background(), []byte(tt.payload), &ExecutionContext{Session: sess})
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestUpdatePlanToolStoresConvergenceFields(t *testing.T) {
+	sess := session.New(t.TempDir())
+	tool := UpdatePlanTool{}
+	payload, _ := json.Marshal(map[string]any{
+		"phase":                     "converge_ready",
+		"scope_defined":             true,
+		"risk_and_rollback_defined": true,
+		"verification_defined":      true,
+		"decision_log":              []map[string]any{{"decision": "Keep plan state provider-agnostic", "reason": "Matches prompt architecture"}},
+		"risks":                     []string{"Mode switch regression"},
+		"verification":              []string{"go test ./internal/plan -v"},
+		"plan":                      []map[string]any{{"step": "Rewrite prompt", "status": "pending"}},
+	})
+
+	if _, err := tool.Run(context.Background(), payload, &ExecutionContext{Session: sess, Mode: planpkg.ModePlan}); err != nil {
+		t.Fatal(err)
+	}
+	if sess.Plan.Phase != planpkg.PhaseConvergeReady {
+		t.Fatalf("expected converge_ready phase, got %q", sess.Plan.Phase)
+	}
+	if len(sess.Plan.DecisionLog) != 1 || sess.Plan.DecisionLog[0].Decision == "" {
+		t.Fatalf("expected decision log to be stored, got %#v", sess.Plan.DecisionLog)
+	}
+	if !sess.Plan.ScopeDefined || !sess.Plan.RiskRollbackDefined || !sess.Plan.VerificationDefined {
+		t.Fatalf("expected readiness flags to be stored, got %#v", sess.Plan)
+	}
+}
+
+func TestUpdatePlanToolStoresActiveChoice(t *testing.T) {
+	sess := session.New(t.TempDir())
+	tool := UpdatePlanTool{}
+	payload, _ := json.Marshal(map[string]any{
+		"phase":         "clarify",
+		"decision_gaps": []string{"Choose the frontend stack"},
+		"active_choice": map[string]any{
+			"id":       "frontend_stack",
+			"kind":     "clarify",
+			"question": "前端希望走哪条路线？",
+			"options": []map[string]any{
+				{
+					"id":          "fastapi_jinja2",
+					"shortcut":    "A",
+					"title":       "FastAPI + Jinja2 HTML",
+					"description": "贴近现有 HTML GUI 方向",
+					"recommended": true,
+				},
+				{
+					"id":          "other",
+					"shortcut":    "B",
+					"title":       "Other",
+					"description": "输入自定义方案",
+					"freeform":    true,
+				},
+			},
+		},
+		"plan": []map[string]any{
+			{"step": "Define the stack", "status": "pending"},
+		},
+	})
+
+	if _, err := tool.Run(context.Background(), payload, &ExecutionContext{Session: sess, Mode: planpkg.ModePlan}); err != nil {
+		t.Fatal(err)
+	}
+	if sess.Plan.ActiveChoice == nil {
+		t.Fatal("expected active choice to be stored")
+	}
+	if got := sess.Plan.ActiveChoice.Question; got != "前端希望走哪条路线？" {
+		t.Fatalf("unexpected active choice question %q", got)
+	}
+	if len(sess.Plan.ActiveChoice.Options) != 2 || !sess.Plan.ActiveChoice.Options[1].Freeform {
+		t.Fatalf("unexpected active choice %#v", sess.Plan.ActiveChoice)
+	}
+}

--- a/tui/component_plan_actions.go
+++ b/tui/component_plan_actions.go
@@ -40,8 +40,8 @@ func (i planActionItem) Description() string { return i.DescriptionText }
 
 type planActionDelegate struct{}
 
-func (d planActionDelegate) Height() int  { return 4 }
-func (d planActionDelegate) Spacing() int { return 1 }
+func (d planActionDelegate) Height() int  { return 2 }
+func (d planActionDelegate) Spacing() int { return 0 }
 func (d planActionDelegate) Update(tea.Msg, *list.Model) tea.Cmd {
 	return nil
 }
@@ -56,32 +56,32 @@ func (d planActionDelegate) Render(w io.Writer, m list.Model, index int, item li
 	width := max(24, m.Width())
 	bodyWidth := max(16, width-4)
 
-	titleStyle := strongStyle.Copy().Foreground(colorAccent)
-	descStyle := mutedStyle.Copy()
-	cardStyle := lipgloss.NewStyle().
-		Width(width).
-		Padding(0, 1).
-		BorderStyle(lipgloss.RoundedBorder()).
-		BorderForeground(colorAccent)
-
-	badgeKind := "accent"
+	// Arrow + shortcut label
+	arrow := "  "
+	labelStyle := approvalOptionIdleStyle
 	if selected {
-		cardStyle = cardStyle.
-			BorderForeground(colorTool).
-			Background(semanticColors.WarningSoft)
-		titleStyle = titleStyle.Foreground(colorTool)
-		descStyle = descStyle.Foreground(lipgloss.Color("#F3E4C7"))
-		badgeKind = "warning"
+		arrow = approvalArrowStyle.Render("❯") + " "
+		labelStyle = approvalOptionSelectedStyle
 	}
 
-	titleParts := []string{renderPillBadge(action.Shortcut, badgeKind), " ", titleStyle.Render(action.TitleText)}
+	shortcut := strings.TrimSpace(action.Shortcut)
+	titleText := strings.TrimSpace(action.TitleText)
 	if action.Recommended {
-		titleParts = append(titleParts, " ", mutedStyle.Render("(推荐)"))
+		titleText += " (推荐)"
 	}
-	title := lipgloss.JoinHorizontal(lipgloss.Left, titleParts...)
-	desc := descStyle.Width(bodyWidth).Render(action.Description())
-	content := lipgloss.JoinVertical(lipgloss.Left, title, desc)
-	fmt.Fprint(w, cardStyle.Render(content)) //nolint:errcheck
+	titleLine := arrow + approvalNumberStyle.Render(shortcut+". ") + labelStyle.Render(titleText)
+
+	// Description line below, indented
+	desc := ""
+	if description := strings.TrimSpace(action.Description()); description != "" {
+		desc = approvalOptionDescriptionStyle.Width(bodyWidth).Render("     " + description)
+	}
+
+	content := titleLine
+	if desc != "" {
+		content += "\n" + desc
+	}
+	fmt.Fprint(w, content) //nolint:errcheck
 }
 
 type planActionPicker struct {
@@ -108,7 +108,7 @@ func newPlanActionPicker(width int, cfg planActionPickerConfig) *planActionPicke
 		items = append(items, item)
 	}
 
-	l := list.New(items, planActionDelegate{}, max(32, width), max(8, len(items)*5))
+	l := list.New(items, planActionDelegate{}, max(32, width), max(4, len(items)*3))
 	l.SetShowTitle(false)
 	l.SetShowFilter(false)
 	l.SetFilteringEnabled(false)
@@ -254,7 +254,7 @@ func (m *model) updatePlanActionPickerSize() {
 		return
 	}
 	width := min(72, max(36, m.chatPanelInnerWidth()))
-	m.planAction.list.SetSize(width, max(8, len(m.planAction.list.Items())*5))
+	m.planAction.list.SetSize(width, max(4, len(m.planAction.list.Items())*3))
 }
 
 func (m model) renderPlanActionPicker() string {
@@ -262,20 +262,39 @@ func (m model) renderPlanActionPicker() string {
 		return ""
 	}
 
-	picker := m.planAction.list
-	boxWidth := min(76, max(40, m.chatPanelInnerWidth()))
-	innerWidth := boxWidth - modalBoxStyle.GetHorizontalFrameSize() - 2
-	picker.SetSize(innerWidth, max(8, len(picker.Items())*5))
+	bannerWidth := max(24, m.chatPanelInnerWidth())
+	innerWidth := max(20, bannerWidth-approvalBannerStyle.GetHorizontalFrameSize())
 
-	lines := []string{modalTitleStyle.Render(m.planAction.title)}
+	picker := m.planAction.list
+	picker.SetSize(innerWidth, max(4, len(picker.Items())*3))
+
+	lines := make([]string, 0, 10)
+
+	// Title in accent bold
+	if title := strings.TrimSpace(m.planAction.title); title != "" {
+		lines = append(lines, approvalTitleStyle.Render(title))
+	}
+
+	// Prompt as subtitle
 	if prompt := strings.TrimSpace(m.planAction.prompt); prompt != "" {
-		lines = append(lines, strongStyle.Width(innerWidth).Render(prompt))
+		lines = append(lines, approvalReasonStyle.Render(trimToWidth(prompt, innerWidth)))
 	}
+
+	lines = append(lines, "") // blank separator
+
+	// List items
+	lines = append(lines, picker.View())
+
+	// Bottom hint
 	if hint := strings.TrimSpace(m.planAction.hint); hint != "" {
-		lines = append(lines, mutedStyle.Width(innerWidth).Render(hint))
+		hintText := approvalHintStyle.Render(hint)
+		lines = append(lines, "", hintText)
 	}
-	lines = append(lines, "", picker.View())
-	return modalBoxStyle.Width(boxWidth).Render(strings.Join(lines, "\n"))
+
+	body := lipgloss.NewStyle().
+		Width(innerWidth).
+		Render(strings.Join(lines, "\n"))
+	return approvalBannerStyle.Width(bannerWidth).Render(body)
 }
 
 func (m model) handlePlanActionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/tui/component_plan_panel.go
+++ b/tui/component_plan_panel.go
@@ -60,7 +60,7 @@ func (m model) planPanelContent(width int) string {
 
 	lines = append(lines, "", cardTitleStyle.Render("Steps"))
 	if len(m.plan.Steps) == 0 {
-		lines = append(lines, mutedStyle.Render("No structured plan yet."))
+		lines = append(lines, mutedStyle.Render("No structured plan yet. Use update_plan to create one."))
 	} else {
 		for _, step := range m.plan.Steps {
 			lines = append(lines, m.renderPlanStep(step, width), "")


### PR DESCRIPTION
## 问题

提交 `0a10c336` 移除了整个结构化 plan 协议（`update_plan` 工具、plan 阶段状态机、`active_choice` 机制、所有 repair heuristics），将 plan mode 简化为自由对话模式。这导致：

- plan 模式下不再弹出对话框，显式询问"切到 Build 模式开始执行"还是"继续微调计划"
- 用户回复"可以了"之后不会自动切换到 Build 模式开始执行
- TUI 端的卡片选择器组件（`component_plan_actions.go`）虽然还在，但因为 LLM 无法通过 `update_plan` 设置 `converge_ready` 阶段，`CanStartExecution()` 永远返回 false，对话框永远不会弹出

## 修复

Revert `0a10c336`，恢复结构化 plan 协议：

- 恢复 7 个被删除的文件：`update_plan.go`、`build_handoff_repair.go`、`plan_bootstrap_repair.go`、`plan_state_repair.go`、`plan_revision_response.go`、`plan_state_repair_regex_fix.go`、`plan_state_repair_test.go`
- 恢复 `plan.md` 详细 prompt（24 → 84 行），包含完整状态机、`active_choice` 用法、收敛标准
- 恢复 `turn_processing.go` 中的 6 个 repair heuristic
- 恢复 `tool_execution.go` 中的 `update_plan` 事件发射
- 恢复 `registry.go` 中的 `update_plan` 工具注册
- 移除 3 个与简化 plan mode 相关的不兼容测试

⚡ 生自 [Claude Code](https://claude.com/claude-code)