### PR TITLE
fix(tui): prevent duplicate assistant answer cards

### DIFF
--- a/tui/component_chat_stream.go
+++ b/tui/component_chat_stream.go
@@ -10,6 +10,7 @@ import (
 )
 
 var streamTurnIntentTagPattern = regexp.MustCompile(`(?is)<turn_intent>\s*[a-z_]*\s*</turn_intent>|</?turn_intent>\s*`)
+var finalAnswerElapsedPattern = regexp.MustCompile(`(?is)\n+\s*(Processed for|Completed in)\s+[0-9]+[hms](?:\s+[0-9]+[hms])*\s*$`)
 
 func stripStreamControlTags(delta string) string {
 	if strings.TrimSpace(delta) == "" {
@@ -121,9 +122,18 @@ func (m *model) finishAssistantMessage(content string) {
 		return
 	}
 
+	if idx := m.latestTailOpenAssistantIndex(); idx >= 0 {
+		m.chatItems[idx].Title = assistantLabel
+		m.chatItems[idx].Body = finalContent
+		m.chatItems[idx].Status = "final"
+		m.streamingIndex = -1
+		return
+	}
+
 	if len(m.chatItems) > 0 {
 		last := &m.chatItems[len(m.chatItems)-1]
-		if last.Kind == "assistant" && last.Title == assistantLabel && strings.TrimSpace(last.Body) == finalContent {
+		if last.Kind == "assistant" && last.Title == assistantLabel && sameAssistantFinalBody(last.Body, finalContent) {
+			last.Body = finalContent
 			last.Status = "final"
 			return
 		}
@@ -135,6 +145,35 @@ func (m *model) finishAssistantMessage(content string) {
 		Body:   finalContent,
 		Status: "final",
 	})
+}
+
+func (m model) latestTailOpenAssistantIndex() int {
+	if len(m.chatItems) == 0 {
+		return -1
+	}
+	index := len(m.chatItems) - 1
+	item := m.chatItems[index]
+	if item.Kind != "assistant" {
+		return -1
+	}
+	switch strings.TrimSpace(strings.ToLower(item.Status)) {
+	case "pending", "thinking", "streaming", "settling":
+		return index
+	default:
+		return -1
+	}
+}
+
+func sameAssistantFinalBody(a, b string) bool {
+	return normalizeAssistantFinalBody(a) == normalizeAssistantFinalBody(b)
+}
+
+func normalizeAssistantFinalBody(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+	return strings.TrimSpace(finalAnswerElapsedPattern.ReplaceAllString(content, ""))
 }
 
 func (m *model) appendChat(item chatEntry) {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -7779,6 +7779,76 @@ func TestFinishAssistantMessageDoesNotAppendDuplicateCard(t *testing.T) {
 	}
 }
 
+func TestFinishAssistantMessageFinalizesTailStreamingCardWhenIndexLost(t *testing.T) {
+	m := model{
+		chatItems: []chatEntry{
+			{
+				Kind:   "assistant",
+				Title:  assistantLabel,
+				Body:   "garbled streamed preview",
+				Status: "streaming",
+			},
+		},
+		streamingIndex: -1,
+	}
+
+	m.finishAssistantMessage("clean final answer")
+
+	if len(m.chatItems) != 1 {
+		t.Fatalf("expected final message to update tail streaming card, got %d items", len(m.chatItems))
+	}
+	if m.chatItems[0].Status != "final" || m.chatItems[0].Body != "clean final answer" {
+		t.Fatalf("expected tail streaming card to be finalized in place, got %+v", m.chatItems[0])
+	}
+	if m.streamingIndex != -1 {
+		t.Fatalf("expected streaming index to stay cleared, got %d", m.streamingIndex)
+	}
+}
+
+func TestFinishAssistantMessageDoesNotMoveFinalAnswerBeforeToolTail(t *testing.T) {
+	m := model{
+		chatItems: []chatEntry{
+			{Kind: "assistant", Title: assistantLabel, Body: "old streamed text", Status: "streaming"},
+			{Kind: "tool", Title: toolEntryTitle("read_file"), Body: "Read main.go", Status: "done"},
+		},
+		streamingIndex: -1,
+	}
+
+	m.finishAssistantMessage("final answer after tool")
+
+	if len(m.chatItems) != 3 {
+		t.Fatalf("expected final message after tool tail, got %d items", len(m.chatItems))
+	}
+	last := m.chatItems[len(m.chatItems)-1]
+	if last.Kind != "assistant" || last.Status != "final" || last.Body != "final answer after tool" {
+		t.Fatalf("expected final assistant answer at tail, got %+v", last)
+	}
+}
+
+func TestFinishAssistantMessageDedupesRepeatedFinalWithElapsedDecoration(t *testing.T) {
+	m := model{
+		runStartedAt: time.Now().Add(-2 * time.Second),
+		chatItems: []chatEntry{
+			{
+				Kind:   "assistant",
+				Title:  assistantLabel,
+				Body:   "same answer\n\nProcessed for 1s",
+				Status: "final",
+			},
+		},
+		streamingIndex: -1,
+	}
+
+	m.finishAssistantMessage("same answer")
+
+	if len(m.chatItems) != 1 {
+		t.Fatalf("expected repeated final message to update existing card, got %d items", len(m.chatItems))
+	}
+	if !strings.Contains(m.chatItems[0].Body, "same answer") || !strings.Contains(m.chatItems[0].Body, "Processed for") {
+		t.Fatalf("expected final body with elapsed decoration, got %q", m.chatItems[0].Body)
+	}
+}
+
 func TestShouldKeepStreamingIndexOnRunFinishedBranches(t *testing.T) {
 	m := model{
 		chatItems: []chatEntry{


### PR DESCRIPTION
## 概要
- 当最终 assistant 消息到达、但流式输出索引已经丢失时，直接把尾部的流式 assistant 卡片原地收尾，避免再追加一张重复回答卡片。
- 重复最终回答判断会忽略 `Processed for ...` / `Completed in ...` 这类耗时尾注，避免同一答案因为尾注不同被误判为新回答。
- 增加回归测试，覆盖流式索引丢失、工具结果位于尾部、耗时尾注去重这几个场景。

## 测试
- `go test ./...`