### PR TITLE
修复拖拽图片路径逐字符输入问题

### DIFF
--- a/tui/input_images.go
+++ b/tui/input_images.go
@@ -24,7 +24,7 @@ import (
 
 var imagePlaceholderPattern = regexp.MustCompile(`\[Image ?#(\d+)\]`)
 var imageMentionPattern = regexp.MustCompile(`(?i)@([^\s@]+?\.(?:png|jpe?g|webp|gif))`)
-var inlineWindowsImagePathPattern = regexp.MustCompile(`(?i)[a-z]:\\[^\r\n\t"'<>|]*?\.(?:png|jpe?g|webp|gif)`)
+var inlineWindowsImagePathPattern = regexp.MustCompile(`(?i)[a-z]:[\\/][^\r\n\t"'<>|]*?\.(?:png|jpe?g|webp|gif)`)
 var inlineUnixImagePathPattern = regexp.MustCompile(`(?i)/(?:[^\r\n\t"'<>|/]+/)*[^\r\n\t"'<>|/]+\.(?:png|jpe?g|webp|gif)`)
 
 type inputMutationClass string
@@ -400,6 +400,30 @@ func (m *model) applyWholeInputImagePathFallback(text, source string) (string, s
 			!(m.inputBurstSize >= 4 && isLikelyPathInput(strings.TrimSpace(text))) {
 			return text, ""
 		}
+	}
+
+	if paths := extractImagePathsFromChunk(text, m.workspace); len(paths) > 0 {
+		placeholders := make([]string, 0, len(paths))
+		notes := make([]string, 0, len(paths))
+		for _, path := range paths {
+			placeholder, note, ok := m.ingestImageFromPath(path)
+			if !ok {
+				notes = append(notes, note)
+				continue
+			}
+			placeholders = append(placeholders, placeholder)
+		}
+		if len(placeholders) == 0 {
+			return text, strings.Join(notes, "; ")
+		}
+
+		updated := strings.Join(placeholders, " ")
+		m.syncInputImageRefs(updated)
+		note := fmt.Sprintf("Attached %d image(s): %s", len(placeholders), strings.Join(placeholders, ", "))
+		if len(notes) > 0 {
+			note += "; " + notes[0]
+		}
+		return updated, note
 	}
 
 	spans := extractInlineImagePathSpans(text)
@@ -1124,9 +1148,17 @@ func extractInlineImagePathSpans(chunk string) []imagePathSpan {
 			if _, ok := mediaTypeFromPath(resolved); !ok {
 				continue
 			}
+			start, end := loc[0], loc[1]
+			if start > 0 && end < len(chunk) {
+				openQuote := chunk[start-1]
+				if (openQuote == '"' || openQuote == '\'') && chunk[end] == openQuote {
+					start--
+					end++
+				}
+			}
 			matches = append(matches, imagePathSpan{
-				Start: loc[0],
-				End:   loc[1],
+				Start: start,
+				End:   end,
 				Path:  resolved,
 			})
 		}

--- a/tui/input_images_test.go
+++ b/tui/input_images_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -41,6 +42,35 @@ func (f fakeClipboardTextReader) ReadText(context.Context) (string, error) {
 		*f.calls++
 	}
 	return f.text, f.err
+}
+
+type flakyImageStore struct {
+	failFile string
+}
+
+func (s flakyImageStore) PutImage(_ context.Context, in assets.PutImageInput) (assets.ImageMeta, error) {
+	if in.FileName == s.failFile {
+		return assets.ImageMeta{}, errors.New("simulated image store failure")
+	}
+	return assets.ImageMeta{
+		AssetID:   llm.AssetID("asset-" + in.FileName),
+		ImageID:   in.ImageID,
+		MediaType: in.MediaType,
+		FileName:  in.FileName,
+		ByteSize:  int64(len(in.Data)),
+	}, nil
+}
+
+func (s flakyImageStore) GetImageByAssetID(context.Context, corepkg.SessionID, llm.AssetID) (assets.ImageBlob, error) {
+	return assets.ImageBlob{}, errors.New("not implemented")
+}
+
+func (s flakyImageStore) DeleteSessionImages(context.Context, corepkg.SessionID) error {
+	return nil
+}
+
+func (s flakyImageStore) GC(context.Context, []corepkg.SessionID, time.Time) error {
+	return nil
 }
 
 func newImagePipelineModel(t *testing.T) *model {
@@ -483,6 +513,84 @@ func TestApplyWholeInputImagePathFallbackRequiresPasteSignalOrRecentPaste(t *tes
 	}
 	if !strings.Contains(note, "Attached 1 image") {
 		t.Fatalf("expected attach note, got %q", note)
+	}
+}
+
+func TestApplyWholeInputImagePathFallbackConvertsQuotedSlashPath(t *testing.T) {
+	m := newImagePipelineModel(t)
+	imagePath := filepath.ToSlash(filepath.Join(m.workspace, "dragged image.png"))
+	if err := os.WriteFile(imagePath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write image fixture: %v", err)
+	}
+
+	updated, note := m.applyWholeInputImagePathFallback(`"`+imagePath+`"`, "paste")
+	if updated != "[Image#1]" {
+		t.Fatalf("expected quoted slash path to become image placeholder, got %q", updated)
+	}
+	if strings.Contains(updated, `"`) {
+		t.Fatalf("expected quotes to be removed with path, got %q", updated)
+	}
+	if !strings.Contains(note, "Attached 1 image") {
+		t.Fatalf("expected attach note, got %q", note)
+	}
+}
+
+func TestApplyWholeInputImagePathFallbackReportsPartialIngestFailure(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.imageStore = flakyImageStore{failFile: "bad.png"}
+
+	okPath := filepath.Join(m.workspace, "ok.png")
+	badPath := filepath.Join(m.workspace, "bad.png")
+	for _, path := range []string{okPath, badPath} {
+		if err := os.WriteFile(path, []byte("png"), 0o644); err != nil {
+			t.Fatalf("write image fixture: %v", err)
+		}
+	}
+
+	updated, note := m.applyWholeInputImagePathFallback(okPath+" "+badPath, "paste")
+	if updated != "[Image#1]" {
+		t.Fatalf("expected successful path to remain as placeholder, got %q", updated)
+	}
+	if !strings.Contains(note, "Attached 1 image") || !strings.Contains(note, "simulated image store failure") {
+		t.Fatalf("expected attach note with partial failure, got %q", note)
+	}
+}
+
+func TestApplyWholeInputImagePathFallbackReportsFailureWhenNoImagesAttach(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.imageStore = nil
+
+	imagePath := filepath.Join(m.workspace, "missing-store.png")
+	if err := os.WriteFile(imagePath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write image fixture: %v", err)
+	}
+
+	updated, note := m.applyWholeInputImagePathFallback(imagePath, "paste")
+	if updated != imagePath {
+		t.Fatalf("expected failed attach to leave input unchanged, got %q", updated)
+	}
+	if !strings.Contains(note, "image store unavailable") {
+		t.Fatalf("expected image store failure note, got %q", note)
+	}
+}
+
+func TestExtractInlineImagePathSpansIncludesMatchingQuotes(t *testing.T) {
+	workspace := t.TempDir()
+	imagePath := filepath.ToSlash(filepath.Join(workspace, "inline.png"))
+	if err := os.WriteFile(imagePath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write image fixture: %v", err)
+	}
+
+	chunk := `look at "` + imagePath + `" please`
+	spans := extractInlineImagePathSpans(chunk)
+	if len(spans) != 1 {
+		t.Fatalf("expected one image path span, got %d", len(spans))
+	}
+	if got := chunk[spans[0].Start:spans[0].End]; got != `"`+imagePath+`"` {
+		t.Fatalf("expected span to include matching quotes, got %q", got)
+	}
+	if spans[0].Path != filepath.Clean(imagePath) {
+		t.Fatalf("expected cleaned path %q, got %q", filepath.Clean(imagePath), spans[0].Path)
 	}
 }
 

--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -220,13 +220,16 @@ func (m *model) shouldPromoteImplicitPasteCandidate(msg tea.KeyMsg) bool {
 	if trimmed == "" || strings.Contains(trimmed, "[Paste #") || strings.Contains(trimmed, "[Pasted #") {
 		return false
 	}
-	if isLikelyPathInput(trimmed) || len(extractImagePathsFromChunk(projected, m.workspace)) > 0 || len(extractInlineImagePathSpans(projected)) > 0 {
-		return false
-	}
 	projectedChars := m.pasteBurstCandidate.charCount + len([]rune(strings.TrimSpace(fragment)))
 	projectedEvents := m.pasteBurstCandidate.eventCount
 	if strings.TrimSpace(fragment) != "" {
 		projectedEvents++
+	}
+	if m.shouldPromoteImplicitImagePathPaste(projected, projectedChars, projectedEvents) {
+		return true
+	}
+	if isLikelyPathInput(trimmed) || len(extractImagePathsFromChunk(projected, m.workspace)) > 0 || len(extractInlineImagePathSpans(projected)) > 0 {
+		return false
 	}
 	if strings.Contains(projected, "\n") && projectedChars >= pasteBurstImmediateMinChars {
 		return true
@@ -605,6 +608,18 @@ func (m *model) finalizePasteSession(id int) {
 			return
 		}
 	}
+	if updated, note := m.applyWholeInputImagePathFallback(candidate, source); updated != candidate {
+		m.setInputValue(base + updated)
+		m.lastPasteAt = now
+		m.armPasteSubmitGuard(now)
+		m.lastInputAt = now
+		m.inputBurstSize = max(1, len([]rune(candidate)))
+		if strings.TrimSpace(note) != "" {
+			m.statusNote = note
+		}
+		m.syncInputOverlays()
+		return
+	}
 	if (source != "paste-key" && strings.Contains(candidate, "\n")) || m.shouldCompressPastedText(candidate, source) || (isPasteLikeSource(source) && m.isLongPastedText(candidate)) {
 		marker, stored, err := m.compressPastedText(candidate)
 		if err != nil {
@@ -649,7 +664,7 @@ func (m *model) ingestPasteFragment(fragment, source string) tea.Cmd {
 		m.finalizePasteSession(id)
 		return schedulePasteBurstSettle(generation)
 	}
-	if shouldPreviewPasteSession(source) {
+	if shouldPreviewPasteSession(source) && !m.shouldHoldImagePathPastePreview() {
 		m.syncPasteSessionPreview()
 	}
 	return tea.Batch(schedulePasteFinalize(id), schedulePasteBurstSettle(generation))
@@ -1050,6 +1065,28 @@ func isCtrlVSource(source string) bool {
 func isPasteLikeSource(source string) bool {
 	source = strings.ToLower(strings.TrimSpace(source))
 	return isCtrlVSource(source) || strings.Contains(source, "paste")
+}
+
+func (m *model) shouldPromoteImplicitImagePathPaste(projected string, projectedChars, projectedEvents int) bool {
+	if m == nil || projectedEvents < 4 || projectedChars < pasteBurstImmediateMinChars {
+		return false
+	}
+	trimmed := strings.TrimSpace(projected)
+	if trimmed == "" || strings.ContainsAny(trimmed, "\r\n\t") {
+		return false
+	}
+	return isLikelyPathInput(strings.Trim(trimmed, `"'`))
+}
+
+func (m *model) shouldHoldImagePathPastePreview() bool {
+	if m == nil || !m.pasteSession.active {
+		return false
+	}
+	trimmed := strings.TrimSpace(m.pasteSession.bufferedText)
+	if trimmed == "" || strings.ContainsAny(trimmed, "\r\n\t") {
+		return false
+	}
+	return isLikelyPathInput(strings.Trim(trimmed, `"'`))
 }
 
 func (m *model) shouldCompressPastedText(input, source string) bool {

--- a/tui/input_paste_test.go
+++ b/tui/input_paste_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -1235,6 +1237,118 @@ func TestIsSplitPasteContinuationEmptyInput(t *testing.T) {
 func TestIsSplitPasteContinuationPathInput(t *testing.T) {
 	if isSplitPasteContinuation(`C:\Users\test\file`, "paste-key", time.Now()) {
 		t.Fatalf("expected path-like input to not be a split continuation")
+	}
+}
+
+func TestShouldPromoteImplicitImagePathPasteGuards(t *testing.T) {
+	var nilModel *model
+	if nilModel.shouldPromoteImplicitImagePathPaste(`C:/tmp/image.png`, pasteBurstImmediateMinChars, 4) {
+		t.Fatalf("expected nil model to not promote image path paste")
+	}
+
+	m := newImagePipelineModel(t)
+	if m.shouldPromoteImplicitImagePathPaste(`C:/tmp/image.png`, pasteBurstImmediateMinChars-1, 4) {
+		t.Fatalf("expected short path burst to not promote")
+	}
+	if m.shouldPromoteImplicitImagePathPaste("C:/tmp/\nimage.png", pasteBurstImmediateMinChars, 4) {
+		t.Fatalf("expected newline-containing path burst to not promote")
+	}
+	if !m.shouldPromoteImplicitImagePathPaste(`"C:/tmp/image.png"`, pasteBurstImmediateMinChars, 4) {
+		t.Fatalf("expected quoted path burst to promote")
+	}
+}
+
+func TestShouldPromoteImplicitPasteCandidatePromotesImagePathBurst(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.input.SetValue(`C:/tmp/image.pn`)
+	m.pasteBurstCandidate = pasteBurstCandidateState{
+		active:      true,
+		baseInput:   "",
+		lastEventAt: time.Now(),
+		charCount:   len(`C:/tmp/image.pn`),
+		eventCount:  4,
+	}
+
+	if !m.shouldPromoteImplicitPasteCandidate(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}) {
+		t.Fatalf("expected image path burst to promote into paste session")
+	}
+}
+
+func TestShouldPromoteImplicitPasteCandidateRejectsSmallPathBurst(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.input.SetValue(`C:/tmp`)
+	m.pasteBurstCandidate = pasteBurstCandidateState{
+		active:      true,
+		baseInput:   "",
+		lastEventAt: time.Now(),
+		charCount:   len(`C:/tmp`),
+		eventCount:  1,
+	}
+
+	if m.shouldPromoteImplicitPasteCandidate(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}}) {
+		t.Fatalf("expected small path burst to remain ordinary path input")
+	}
+}
+
+func TestShouldHoldImagePathPastePreviewGuards(t *testing.T) {
+	var nilModel *model
+	if nilModel.shouldHoldImagePathPastePreview() {
+		t.Fatalf("expected nil model to not hold image path preview")
+	}
+
+	m := newImagePipelineModel(t)
+	if m.shouldHoldImagePathPastePreview() {
+		t.Fatalf("expected inactive paste session to not hold preview")
+	}
+
+	m.pasteSession.active = true
+	m.pasteSession.bufferedText = "C:/tmp/\nimage.png"
+	if m.shouldHoldImagePathPastePreview() {
+		t.Fatalf("expected newline-containing buffered text to not hold preview")
+	}
+
+	m.pasteSession.bufferedText = `"C:/tmp/image.png"`
+	if !m.shouldHoldImagePathPastePreview() {
+		t.Fatalf("expected quoted path-like buffered text to hold preview")
+	}
+}
+
+func TestIngestPasteFragmentHoldsImagePathPreview(t *testing.T) {
+	m := newImagePipelineModel(t)
+
+	cmd := m.ingestPasteFragment(`C:/tmp/image.pn`, "paste-burst")
+	if cmd == nil {
+		t.Fatalf("expected paste fragment to schedule finalize")
+	}
+	if m.input.Value() != "" {
+		t.Fatalf("expected image path paste preview to stay buffered, got %q", m.input.Value())
+	}
+	if !m.hasActivePasteSession() {
+		t.Fatalf("expected active paste session")
+	}
+}
+
+func TestFinalizePasteSessionConvertsImagePathFallback(t *testing.T) {
+	m := newImagePipelineModel(t)
+	imagePath := filepath.ToSlash(filepath.Join(m.workspace, "finalize.png"))
+	if err := os.WriteFile(imagePath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write image fixture: %v", err)
+	}
+
+	m.pasteSession = pasteSessionState{
+		active:       true,
+		baseInput:    "look ",
+		bufferedText: imagePath,
+		sourceKind:   "paste-burst",
+		finalizeID:   1,
+	}
+	m.finalizePasteSession(1)
+
+	if m.input.Value() != "look [Image#1]" {
+		t.Fatalf("expected paste session to attach image path, got %q", m.input.Value())
+	}
+	if !strings.Contains(m.statusNote, "Attached 1 image") {
+		t.Fatalf("expected attach status note, got %q", m.statusNote)
 	}
 }
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -1576,7 +1576,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if fragment, source, ok := m.pasteFragmentFromKey(msg); ok {
-		if source == "paste-key" || source == "paste-burst" || source == "rune-burst-paste" {
+		if source == "paste-key" || source == "rune-burst-paste" || (source == "paste-burst" && !m.shouldHoldImagePathPastePreview()) {
 			m.beginOrAppendPasteTransaction(fragment, source)
 		}
 		return m, m.ingestPasteFragment(fragment, source)

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -3256,8 +3256,43 @@ func TestRapidRuneInputForImagePathTriggersFallbackPlaceholder(t *testing.T) {
 		next := got.(model)
 		m = &next
 	}
+	if m.input.Value() == imagePath {
+		t.Fatalf("expected rapid path input to be handled through paste buffering, got raw path")
+	}
+	if m.hasActivePasteSession() {
+		got, _ := m.Update(pasteFinalizeMsg{ID: m.pasteSession.finalizeID})
+		next := got.(model)
+		m = &next
+	}
 	if m.input.Value() != "[Image#1]" {
 		t.Fatalf("expected rapid path input to convert to placeholder, got %q", m.input.Value())
+	}
+}
+
+func TestRapidRuneInputForSlashImagePathTriggersFallbackPlaceholder(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+
+	imagePath := filepath.ToSlash(filepath.Join(m.workspace, "drag-slash.png"))
+	if err := os.WriteFile(imagePath, []byte("png-bytes"), 0o644); err != nil {
+		t.Fatalf("write image fixture: %v", err)
+	}
+
+	for _, r := range imagePath {
+		got, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		next := got.(model)
+		m = &next
+	}
+	if m.input.Value() == imagePath {
+		t.Fatalf("expected rapid slash path input to be handled through paste buffering, got raw path")
+	}
+	if m.hasActivePasteSession() {
+		got, _ := m.Update(pasteFinalizeMsg{ID: m.pasteSession.finalizeID})
+		next := got.(model)
+		m = &next
+	}
+	if m.input.Value() != "[Image#1]" {
+		t.Fatalf("expected slash path input to convert to placeholder, got %q", m.input.Value())
 	}
 }
 


### PR DESCRIPTION
## 背景

拖拽图片到输入框时，部分终端会把文件路径逐字符注入。原逻辑对这类 path-like rune burst 只是当普通输入处理，而且 Windows 正斜杠路径（例如 `D:/.../image.png`）不会被识别，导致路径最终可能原样留在输入框里。

## 修改

- 复用现有 pasteSession：快速路径输入会被提升为隐式粘贴处理，等待现有 120ms finalize，而不是新增独立的图片拖拽状态机。
- pasteSession finalize 时复用 `applyWholeInputImagePathFallback`，让拖拽路径和粘贴路径走同一套图片 ingest / `[Image#N]` 替换逻辑。
- 支持识别 Windows 盘符 + 正斜杠图片路径，例如 `D:/foo/bar.png`。
- whole-input 图片路径 fallback 先按完整路径 token 处理，避免带引号或带空格路径无法替换。
- 图片路径 burst 不启用 paste echo transaction，避免连续重复字符（例如 `AppData`）被误当作回显吞掉。
- 补充回归测试覆盖反斜杠路径、正斜杠路径、带引号路径。

## 测试

- `go test ./tui -run TestApplyWholeInputImagePathFallbackConvertsQuotedSlashPath|TestRapidRuneInputForSlashImagePathTriggersFallbackPlaceholder|TestRapidRuneInputForImagePathTriggersFallbackPlaceholder -count=1`
- `go test ./...`