### PR TITLE
fix: 解决#437未解决完的问题

### DIFF
--- a/tui/component_chat_stream.go
+++ b/tui/component_chat_stream.go
@@ -106,20 +106,13 @@ func (m *model) finishAssistantMessage(content string) {
 		current := &m.chatItems[m.streamingIndex]
 		if current.Kind == "assistant" && (current.Status == "thinking" || current.Status == "pending") {
 			m.removeStreamingAssistantPlaceholder()
-			m.chatItems = append(m.chatItems, chatEntry{
-				Kind:   "assistant",
-				Title:  assistantLabel,
-				Body:   finalContent,
-				Status: "final",
-			})
+		} else {
+			current.Title = assistantLabel
+			current.Body = finalContent
+			current.Status = "final"
+			m.streamingIndex = -1
 			return
 		}
-
-		current.Title = assistantLabel
-		current.Body = finalContent
-		current.Status = "final"
-		m.streamingIndex = -1
-		return
 	}
 
 	if idx := m.latestTailOpenAssistantIndex(); idx >= 0 {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -7805,6 +7805,30 @@ func TestFinishAssistantMessageFinalizesTailStreamingCardWhenIndexLost(t *testin
 	}
 }
 
+func TestFinishAssistantMessageFinalizesStreamingCardAfterPendingPlaceholder(t *testing.T) {
+	m := model{
+		chatItems: []chatEntry{
+			{Kind: "user", Title: "You", Body: "hello", Status: "final"},
+			{Kind: "assistant", Title: assistantLabel, Body: "Hello! How can I help?", Status: "streaming"},
+			{Kind: "assistant", Title: thinkingLabel, Body: "receiving hidden reasoning...", Status: "pending"},
+		},
+		streamingIndex: 2,
+	}
+
+	m.finishAssistantMessage("Hello! How can I help?")
+
+	if len(m.chatItems) != 2 {
+		t.Fatalf("expected pending placeholder to be removed without appending a duplicate answer, got %d items", len(m.chatItems))
+	}
+	last := m.chatItems[1]
+	if last.Title != assistantLabel || last.Status != "final" || last.Body != "Hello! How can I help?" {
+		t.Fatalf("expected streamed assistant card to be finalized in place, got %+v", last)
+	}
+	if m.streamingIndex != -1 {
+		t.Fatalf("expected streaming index to be cleared, got %d", m.streamingIndex)
+	}
+}
+
 func TestFinishAssistantMessageDoesNotMoveFinalAnswerBeforeToolTail(t *testing.T) {
 	m := model{
 		chatItems: []chatEntry{


### PR DESCRIPTION
PR #437 漏了一个事件顺序：streaming 的 Generating 卡片已经有内容后，后续 hidden reasoning 又创建了一个 pending 占位并抢走 streamingIndex，最终消息就只删了占位、再追加 Answer，旧的 Generating 留下来了。
已修掉：在 component_chat_stream.go (line 106) 里，pending/thinking 占位删除后不再立刻追加最终答案，而是继续走已有的尾部开放 assistant 收尾逻辑，这样会把前一个 Generating 原地改成 Answer。还在 model_test.go (line 7808) 加了复现测试。