### PR TITLE
skill问题修复

### DIFF
--- a/internal/agent/subagent_executor.go
+++ b/internal/agent/subagent_executor.go
@@ -194,6 +194,7 @@ func (e *defaultSubAgentExecutor) newSubAgentChildRunner(workspace string, maxTu
 		Registry:        r.registry,
 		Executor:        r.executor,
 		PolicyGateway:   r.policyGateway,
+		SkillManager:    r.skillManager,
 		TaskManager:     r.taskManager,
 		Runtime:         r.runtime,
 		Extensions:      r.extensions,

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/provider"
 	runtimepkg "github.com/1024XEngineer/bytemind/internal/runtime"
 	"github.com/1024XEngineer/bytemind/internal/session"
+	skillspkg "github.com/1024XEngineer/bytemind/internal/skills"
 	storagepkg "github.com/1024XEngineer/bytemind/internal/storage"
 	"github.com/1024XEngineer/bytemind/internal/tools"
 )
@@ -150,18 +152,24 @@ func Bootstrap(req BootstrapRequest) (Runtime, error) {
 	)
 	baseExtensions := extensionspkg.NewManager(workspace)
 	extensions := extensionsruntime.NewManager(workspace, req.ConfigPath, baseExtensions, cfg)
+	skillManager := skillspkg.NewManager(workspace)
+	builtinDir := filepath.Join(workspace, "internal", "skills")
+	if _, err := os.Stat(builtinDir); os.IsNotExist(err) {
+		skillManager.UseEmbeddedBuiltins()
+	}
 	runner := agent.NewRunner(agent.Options{
-		Workspace:    workspace,
-		Config:       cfg,
-		Client:       client,
-		Store:        store,
-		Registry:     tools.DefaultRegistry(),
-		TaskManager:  taskManager,
-		Extensions:   extensions,
-		AuditStore:   auditStore,
-		PromptStore:  promptStore,
-		Stdin:        req.Stdin,
-		Stdout:       req.Stdout,
+		Workspace:     workspace,
+		Config:        cfg,
+		Client:        client,
+		Store:         store,
+		Registry:      tools.DefaultRegistry(),
+		TaskManager:   taskManager,
+		Extensions:    extensions,
+		SkillManager:  skillManager,
+		AuditStore:    auditStore,
+		PromptStore:   promptStore,
+		Stdin:         req.Stdin,
+		Stdout:        req.Stdout,
 	})
 
 	return Runtime{

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"log"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -153,8 +152,7 @@ func Bootstrap(req BootstrapRequest) (Runtime, error) {
 	baseExtensions := extensionspkg.NewManager(workspace)
 	extensions := extensionsruntime.NewManager(workspace, req.ConfigPath, baseExtensions, cfg)
 	skillManager := skillspkg.NewManager(workspace)
-	builtinDir := filepath.Join(workspace, "internal", "skills")
-	if _, err := os.Stat(builtinDir); os.IsNotExist(err) {
+	if !skillspkg.HasBuiltinSkills(filepath.Join(workspace, "internal", "skills")) {
 		skillManager.UseEmbeddedBuiltins()
 	}
 	runner := agent.NewRunner(agent.Options{

--- a/internal/skills/embed.go
+++ b/internal/skills/embed.go
@@ -1,0 +1,212 @@
+package skills
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+//go:embed bug-investigation github-pr repo-onboarding review skill-creator write-rfc
+var builtinFS embed.FS
+
+func loadBuiltinFromEmbedded(scope Scope) ([]Skill, []Diagnostic) {
+	return loadSkillsFromFS(scope, builtinFS, ".")
+}
+
+func loadSkillsFromFS(scope Scope, fsys fs.FS, root string) ([]Skill, []Diagnostic) {
+	entries, err := fs.ReadDir(fsys, root)
+	if err != nil {
+		return nil, nil
+	}
+	skills := make([]Skill, 0, len(entries))
+	diags := make([]Diagnostic, 0, 4)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillDir := filepath.Join(root, entry.Name())
+		skill, ok, skillDiags := loadSkillFromFSDir(scope, fsys, skillDir, entry.Name())
+		diags = append(diags, skillDiags...)
+		if ok {
+			skills = append(skills, skill)
+		}
+	}
+	return skills, diags
+}
+
+func loadSkillFromFSDir(scope Scope, fsys fs.FS, skillDir, dirName string) (Skill, bool, []Diagnostic) {
+	manifestPath := filepath.Join(skillDir, "skill.json")
+	skillPath := filepath.Join(skillDir, "SKILL.md")
+
+	hasManifest := fileExistsFS(fsys, manifestPath)
+	hasSkill := fileExistsFS(fsys, skillPath)
+	if !hasManifest && !hasSkill {
+		return Skill{}, false, nil
+	}
+
+	var manifest skillManifest
+	diags := make([]Diagnostic, 0, 2)
+	if hasManifest {
+		data, err := fs.ReadFile(fsys, manifestPath)
+		if err != nil {
+			return Skill{}, false, []Diagnostic{{
+				Scope:   scope,
+				Path:    manifestPath,
+				Skill:   dirName,
+				Level:   "error",
+				Message: fmt.Sprintf("failed to read skill.json: %v", err),
+			}}
+		}
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return Skill{}, false, []Diagnostic{{
+				Scope:   scope,
+				Path:    manifestPath,
+				Skill:   dirName,
+				Level:   "error",
+				Message: fmt.Sprintf("invalid skill.json: %v", err),
+			}}
+		}
+	}
+
+	frontmatter := map[string]string{}
+	body := ""
+	if hasSkill {
+		data, err := fs.ReadFile(fsys, skillPath)
+		if err != nil {
+			diags = append(diags, Diagnostic{
+				Scope:   scope,
+				Path:    skillPath,
+				Skill:   dirName,
+				Level:   "error",
+				Message: fmt.Sprintf("failed to read SKILL.md: %v", err),
+			})
+			hasSkill = false
+		} else {
+			frontmatter, body = parseFrontmatterMarkdown(string(data))
+		}
+	}
+
+	name := strings.TrimSpace(manifest.Name)
+	if name == "" {
+		name = strings.TrimSpace(frontmatter["name"])
+	}
+	if name == "" {
+		name = dirName
+	}
+	if !validSkillName.MatchString(name) {
+		diags = append(diags, Diagnostic{
+			Scope:   scope,
+			Path:    skillDir,
+			Skill:   name,
+			Level:   "error",
+			Message: "invalid skill name",
+		})
+		return Skill{}, false, diags
+	}
+
+	description := strings.TrimSpace(manifest.Description)
+	if description == "" {
+		description = strings.TrimSpace(frontmatter["description"])
+	}
+	if description == "" {
+		description = extractDescription(body)
+	}
+	if description == "" {
+		description = "No description provided."
+	}
+
+	title := strings.TrimSpace(manifest.Title)
+	if title == "" {
+		title = name
+	}
+
+	whenToUse := strings.TrimSpace(frontmatter["when_to_use"])
+	if whenToUse == "" {
+		whenToUse = strings.TrimSpace(frontmatter["when-to-use"])
+	}
+
+	entry := manifest.Entry
+	if strings.TrimSpace(entry.Slash) == "" {
+		entry.Slash = "/" + name
+	} else if !strings.HasPrefix(entry.Slash, "/") {
+		entry.Slash = "/" + strings.TrimSpace(entry.Slash)
+	}
+
+	toolPolicy, policyDiag := buildToolPolicy(manifest.Tools.Policy, manifest.Tools.Items, frontmatter)
+	if policyDiag != nil {
+		policyDiag.Scope = scope
+		policyDiag.Path = skillDir
+		policyDiag.Skill = name
+		diags = append(diags, *policyDiag)
+	}
+
+	prompts := make([]PromptRef, 0, len(manifest.Prompts))
+	for _, prompt := range manifest.Prompts {
+		prompts = append(prompts, PromptRef{
+			ID:   strings.TrimSpace(prompt.ID),
+			Path: strings.TrimSpace(prompt.Path),
+		})
+	}
+	resources := make([]ResourceRef, 0, len(manifest.Resources))
+	for _, resource := range manifest.Resources {
+		resources = append(resources, ResourceRef{
+			ID:       strings.TrimSpace(resource.ID),
+			URI:      strings.TrimSpace(resource.URI),
+			Optional: resource.Optional,
+		})
+	}
+	args := make([]Arg, 0, len(manifest.Args))
+	for _, arg := range manifest.Args {
+		if strings.TrimSpace(arg.Name) == "" {
+			continue
+		}
+		args = append(args, Arg{
+			Name:        strings.TrimSpace(arg.Name),
+			Type:        strings.TrimSpace(arg.Type),
+			Required:    arg.Required,
+			Description: strings.TrimSpace(arg.Description),
+			Default:     strings.TrimSpace(arg.Default),
+		})
+	}
+
+	aliases := uniqueStrings([]string{
+		name,
+		dirName,
+		entry.Slash,
+		strings.TrimPrefix(entry.Slash, "/"),
+	})
+
+	skill := Skill{
+		Name:         name,
+		Version:      strings.TrimSpace(manifest.Version),
+		Title:        title,
+		Description:  description,
+		WhenToUse:    whenToUse,
+		Scope:        scope,
+		SourceDir:    skillDir,
+		Instruction:  strings.TrimSpace(body),
+		Entry:        entry,
+		Prompts:      prompts,
+		Resources:    resources,
+		ToolPolicy:   toolPolicy,
+		Args:         args,
+		Aliases:      aliases,
+		DiscoveredAt: time.Now().UTC(),
+	}
+	if !hasSkill {
+		skill.Instruction = ""
+	}
+	return skill, true, diags
+}
+
+func fileExistsFS(fsys fs.FS, path string) bool {
+	info, err := fs.Stat(fsys, path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/internal/skills/embed.go
+++ b/internal/skills/embed.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -201,6 +203,17 @@ func loadSkillFromFSDir(scope Scope, fsys fs.FS, skillDir, dirName string) (Skil
 		skill.Instruction = ""
 	}
 	return skill, true, diags
+}
+
+func HasBuiltinSkills(dir string) bool {
+	if dir == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(dir, "review", "skill.json"))
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
 }
 
 func fileExistsFS(fsys fs.FS, path string) bool {

--- a/internal/skills/embed.go
+++ b/internal/skills/embed.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 )
@@ -28,7 +28,7 @@ func loadSkillsFromFS(scope Scope, fsys fs.FS, root string) ([]Skill, []Diagnost
 		if !entry.IsDir() {
 			continue
 		}
-		skillDir := filepath.Join(root, entry.Name())
+		skillDir := path.Join(root, entry.Name())
 		skill, ok, skillDiags := loadSkillFromFSDir(scope, fsys, skillDir, entry.Name())
 		diags = append(diags, skillDiags...)
 		if ok {
@@ -39,8 +39,8 @@ func loadSkillsFromFS(scope Scope, fsys fs.FS, root string) ([]Skill, []Diagnost
 }
 
 func loadSkillFromFSDir(scope Scope, fsys fs.FS, skillDir, dirName string) (Skill, bool, []Diagnostic) {
-	manifestPath := filepath.Join(skillDir, "skill.json")
-	skillPath := filepath.Join(skillDir, "SKILL.md")
+	manifestPath := path.Join(skillDir, "skill.json")
+	skillPath := path.Join(skillDir, "SKILL.md")
 
 	hasManifest := fileExistsFS(fsys, manifestPath)
 	hasSkill := fileExistsFS(fsys, skillPath)

--- a/internal/skills/embed_test.go
+++ b/internal/skills/embed_test.go
@@ -1,0 +1,55 @@
+package skills
+
+import (
+	"io/fs"
+	"testing"
+)
+
+func TestLoadBuiltinFromEmbeddedReturnsAllSkills(t *testing.T) {
+	skills, diags := loadBuiltinFromEmbedded(ScopeBuiltin)
+	if len(skills) == 0 {
+		t.Fatal("expected at least one builtin skill from embedded FS")
+	}
+	names := make(map[string]bool, len(skills))
+	for _, s := range skills {
+		if s.Name == "" {
+			t.Errorf("skill has empty name")
+		}
+		if s.Description == "" {
+			t.Errorf("skill %q has empty description", s.Name)
+		}
+		if s.Scope != ScopeBuiltin {
+			t.Errorf("skill %q has scope %q, want %q", s.Name, s.Scope, ScopeBuiltin)
+		}
+		if s.Entry.Slash == "" {
+			t.Errorf("skill %q has empty entry slash", s.Name)
+		}
+		names[s.Name] = true
+	}
+	if diags != nil {
+		for _, d := range diags {
+			t.Logf("diagnostic: %s %s %s - %s", d.Level, d.Skill, d.Path, d.Message)
+		}
+	}
+	if !names["review"] {
+		t.Errorf("expected review skill to be loaded from embedded FS, got: %v", names)
+	}
+	if !names["bug-investigation"] {
+		t.Errorf("expected bug-investigation skill to be loaded from embedded FS")
+	}
+}
+
+func TestLoadSkillsFromFSWithEmbeddedFSPathSeparators(t *testing.T) {
+	skills, _ := loadSkillsFromFS(ScopeBuiltin, builtinFS, ".")
+	if len(skills) == 0 {
+		t.Fatal("expected skills when loading from embedded FS with root '.'")
+	}
+
+	subdir, err := fs.ReadDir(builtinFS, "review")
+	if err != nil {
+		t.Fatalf("cant read review subdirectory from embedded FS: %v", err)
+	}
+	if len(subdir) == 0 {
+		t.Fatal("expected files in review embedded dir")
+	}
+}

--- a/internal/skills/embed_test.go
+++ b/internal/skills/embed_test.go
@@ -290,6 +290,29 @@ func TestLoadSkillFromFSDirWithEntrySlash(t *testing.T) {
 	}
 }
 
+func TestHasBuiltinSkills(t *testing.T) {
+	if HasBuiltinSkills("") {
+		t.Error("expected false for empty dir")
+	}
+	if HasBuiltinSkills("nonexistent-path") {
+		t.Error("expected false for non-existent dir")
+	}
+	root := t.TempDir()
+	builtinDir := filepath.Join(root, "internal", "skills", "review")
+	if err := os.MkdirAll(builtinDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if HasBuiltinSkills(filepath.Join(root, "internal", "skills")) {
+		t.Error("expected false when review dir exists but skill.json missing")
+	}
+	if err := os.WriteFile(filepath.Join(builtinDir, "skill.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !HasBuiltinSkills(filepath.Join(root, "internal", "skills")) {
+		t.Error("expected true when review/skill.json exists")
+	}
+}
+
 func TestUseEmbeddedBuiltinsIsNoopWhenBuiltinDirExists(t *testing.T) {
 	root := t.TempDir()
 	builtinDir := filepath.Join(root, "builtin")

--- a/internal/skills/embed_test.go
+++ b/internal/skills/embed_test.go
@@ -200,6 +200,96 @@ func TestFileExistsFSOnDirectory(t *testing.T) {
 	}
 }
 
+func TestLoadSkillFromFSDirWithSkillOnly(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "noskilljson")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: from-skill\n---\n# Body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skills, diags := loadSkillsFromFS(ScopeBuiltin, os.DirFS(root), ".")
+	if len(skills) != 1 || skills[0].Name != "from-skill" {
+		t.Fatalf("expected skill named from-skill, got %+v", skills)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", diags)
+	}
+}
+
+func TestLoadSkillFromFSDirWithNameFromDirName(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "dir-name-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.json"), []byte(`{"description":"no name in manifest"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skills, diags := loadSkillsFromFS(ScopeBuiltin, os.DirFS(root), ".")
+	if len(skills) != 1 || skills[0].Name != "dir-name-skill" {
+		t.Fatalf("expected skill name from dir, got %+v", skills)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", diags)
+	}
+}
+
+func TestLoadSkillFromFSDirWithToolPolicyDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "bad-policy")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.json"), []byte(`{"name":"bad-policy","tools":{"policy":"invalid"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skills, diags := loadSkillsFromFS(ScopeBuiltin, os.DirFS(root), ".")
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
+	found := false
+	for _, d := range diags {
+		if d.Level == "warn" && d.Skill == "bad-policy" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected warning diagnostic for invalid tool policy, got %v", diags)
+	}
+}
+
+func TestLoadSkillFromFSDirWithTitle(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "titled")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.json"), []byte(`{"name":"titled","title":"My Title","description":"test"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skills, _ := loadSkillsFromFS(ScopeBuiltin, os.DirFS(root), ".")
+	if len(skills) != 1 || skills[0].Title != "My Title" {
+		t.Fatalf("expected title 'My Title', got %+v", skills)
+	}
+}
+
+func TestLoadSkillFromFSDirWithEntrySlash(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "aliased")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.json"), []byte(`{"name":"aliased","description":"test","entry":{"slash":"custom-slash"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skills, _ := loadSkillsFromFS(ScopeBuiltin, os.DirFS(root), ".")
+	if len(skills) != 1 || skills[0].Entry.Slash != "/custom-slash" {
+		t.Fatalf("expected entry slash '/custom-slash', got %+v", skills[0].Entry)
+	}
+}
+
 func TestUseEmbeddedBuiltinsIsNoopWhenBuiltinDirExists(t *testing.T) {
 	root := t.TempDir()
 	builtinDir := filepath.Join(root, "builtin")

--- a/internal/skills/embed_test.go
+++ b/internal/skills/embed_test.go
@@ -2,6 +2,8 @@ package skills
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -51,5 +53,167 @@ func TestLoadSkillsFromFSWithEmbeddedFSPathSeparators(t *testing.T) {
 	}
 	if len(subdir) == 0 {
 		t.Fatal("expected files in review embedded dir")
+	}
+}
+
+func TestLoadSkillsFromFSWithNonExistentRoot(t *testing.T) {
+	skills, diags := loadSkillsFromFS(ScopeBuiltin, builtinFS, "nonexistent")
+	if len(skills) != 0 {
+		t.Fatalf("expected no skills for non-existent root, got %d", len(skills))
+	}
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics for non-existent root, got %d", len(diags))
+	}
+}
+
+func TestLoadSkillFromFSDirWithMissingFiles(t *testing.T) {
+	skill, ok, diags := loadSkillFromFSDir(ScopeBuiltin, builtinFS, "nonexistent", "test")
+	if ok {
+		t.Fatal("expected ok=false for non-existent directory")
+	}
+	if skill.Name != "" {
+		t.Fatalf("expected empty skill for non-existent dir")
+	}
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics for non-existent dir")
+	}
+}
+
+func TestFileExistsFS(t *testing.T) {
+	if !fileExistsFS(builtinFS, "review/skill.json") {
+		t.Error("expected review/skill.json to exist")
+	}
+	if fileExistsFS(builtinFS, "nonexistent/file.json") {
+		t.Error("expected nonexistent/file.json to not exist")
+	}
+	if fileExistsFS(builtinFS, ".") {
+		t.Error("expected root dir to not be a file")
+	}
+}
+
+func TestUseEmbeddedBuiltinsLoadsBuiltinSkills(t *testing.T) {
+	root := t.TempDir()
+	m := NewManagerWithDirs(root, filepath.Join(root, "nonexistent"), "", "")
+	m.UseEmbeddedBuiltins()
+	catalog := m.Reload()
+	if len(catalog.Skills) == 0 {
+		t.Fatal("expected embedded builtin skills after UseEmbeddedBuiltins with non-existent dir")
+	}
+	names := make(map[string]bool)
+	for _, s := range catalog.Skills {
+		names[s.Name] = true
+	}
+	if !names["review"] {
+		t.Errorf("expected review skill, got: %v", names)
+	}
+	if !names["bug-investigation"] {
+		t.Errorf("expected bug-investigation skill")
+	}
+}
+
+func TestUseEmbeddedBuiltinsDoesNotOverrideExistingBuiltinDir(t *testing.T) {
+	root := t.TempDir()
+	builtinDir := filepath.Join(root, "builtin")
+	if err := os.MkdirAll(builtinDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManagerWithDirs(root, builtinDir, "", "")
+	m.UseEmbeddedBuiltins()
+	catalog := m.Reload()
+	if len(catalog.Skills) != 0 {
+		t.Fatalf("expected no skills when builtin dir exists but is empty, got %d", len(catalog.Skills))
+	}
+}
+
+func TestUseEmbeddedBuiltinsRespectsPriority(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, ".bytemind", "skills", "review")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "skill.json"), []byte(`{"name":"review","description":"project review"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManagerWithDirs(root, filepath.Join(root, "nonexistent"), "", filepath.Join(root, ".bytemind", "skills"))
+	m.UseEmbeddedBuiltins()
+	catalog := m.Reload()
+	names := make(map[string]int)
+	for _, s := range catalog.Skills {
+		names[s.Name]++
+	}
+	if names["review"] != 1 {
+		t.Fatalf("expected review to appear once (project overrides builtin), but got count=%d, names=%v", names["review"], names)
+	}
+}
+
+func TestLoadSkillsFromFSWithOSDirFS(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "my-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.json"), []byte(`{"name":"my-skill","description":"test skill"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: my-skill\n---\n# My Skill\nDo something."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skills, diags := loadSkillsFromFS(ScopeBuiltin, os.DirFS(root), ".")
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d: %v", len(skills), diags)
+	}
+	if skills[0].Name != "my-skill" {
+		t.Fatalf("expected skill name my-skill, got %q", skills[0].Name)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", diags)
+	}
+}
+
+func TestLoadSkillsFromFSWithInvalidJSON(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "bad")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.json"), []byte(`{"name":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skills, diags := loadSkillsFromFS(ScopeBuiltin, os.DirFS(root), ".")
+	if len(skills) != 0 {
+		t.Fatalf("expected 0 skills for invalid JSON, got %d", len(skills))
+	}
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected error diagnostic for invalid JSON, got %v", diags)
+	}
+}
+
+func TestFileExistsFSOnDirectory(t *testing.T) {
+	if fileExistsFS(builtinFS, "review") {
+		t.Error("expected review directory to not be a file")
+	}
+}
+
+func TestUseEmbeddedBuiltinsIsNoopWhenBuiltinDirExists(t *testing.T) {
+	root := t.TempDir()
+	builtinDir := filepath.Join(root, "builtin")
+	customDir := filepath.Join(builtinDir, "custom")
+	if err := os.MkdirAll(customDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(customDir, "skill.json"), []byte(`{"name":"custom","description":"custom skill"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManagerWithDirs(root, builtinDir, "", "")
+	m.UseEmbeddedBuiltins()
+	catalog := m.Reload()
+	if len(catalog.Skills) != 1 || catalog.Skills[0].Name != "custom" {
+		t.Fatalf("expected only custom skill (not embedded), got %+v", catalog.Skills)
 	}
 }

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -64,7 +64,17 @@ func (m *Manager) Reload() Catalog {
 	overrides := make([]Override, 0, 4)
 
 	for _, item := range scopes {
-		skills, skillDiags := loadSkillsFromScope(item.scope, item.dir)
+		var skills []Skill
+		var skillDiags []Diagnostic
+		if item.scope == ScopeBuiltin {
+			if _, err := os.Stat(item.dir); os.IsNotExist(err) {
+				skills, skillDiags = loadBuiltinFromEmbedded(item.scope)
+			} else {
+				skills, skillDiags = loadSkillsFromScope(item.scope, item.dir)
+			}
+		} else {
+			skills, skillDiags = loadSkillsFromScope(item.scope, item.dir)
+		}
 		diags = append(diags, skillDiags...)
 		for _, skill := range skills {
 			prev, exists := loaded[skill.Name]

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -24,6 +24,8 @@ type Manager struct {
 
 	catalog Catalog
 	lookup  map[string]string
+
+	useEmbeddedBuiltins bool
 }
 
 func NewManager(workspace string) *Manager {
@@ -64,17 +66,7 @@ func (m *Manager) Reload() Catalog {
 	overrides := make([]Override, 0, 4)
 
 	for _, item := range scopes {
-		var skills []Skill
-		var skillDiags []Diagnostic
-		if item.scope == ScopeBuiltin {
-			if _, err := os.Stat(item.dir); os.IsNotExist(err) {
-				skills, skillDiags = loadBuiltinFromEmbedded(item.scope)
-			} else {
-				skills, skillDiags = loadSkillsFromScope(item.scope, item.dir)
-			}
-		} else {
-			skills, skillDiags = loadSkillsFromScope(item.scope, item.dir)
-		}
+		skills, skillDiags := loadSkillsFromScope(item.scope, item.dir)
 		diags = append(diags, skillDiags...)
 		for _, skill := range skills {
 			prev, exists := loaded[skill.Name]
@@ -88,6 +80,18 @@ func (m *Manager) Reload() Catalog {
 				})
 			}
 			loaded[skill.Name] = skill
+		}
+	}
+
+	if m.useEmbeddedBuiltins {
+		if _, err := os.Stat(m.builtinDir); os.IsNotExist(err) {
+			embSkills, embDiags := loadBuiltinFromEmbedded(ScopeBuiltin)
+			diags = append(diags, embDiags...)
+			for _, skill := range embSkills {
+				if _, exists := loaded[skill.Name]; !exists {
+					loaded[skill.Name] = skill
+				}
+			}
 		}
 	}
 
@@ -165,6 +169,12 @@ func (m *Manager) Find(name string) (Skill, bool) {
 		}
 	}
 	return Skill{}, false
+}
+
+func (m *Manager) UseEmbeddedBuiltins() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.useEmbeddedBuiltins = true
 }
 
 func (m *Manager) Workspace() string {

--- a/tui/component_palette_runtime.go
+++ b/tui/component_palette_runtime.go
@@ -221,15 +221,7 @@ func (m model) filteredCommands() []commandItem {
 }
 
 func (m model) commandPaletteItems() []commandItem {
-	items := visibleCommandItems("")
-	skills := m.skillPickerItems()
-	if len(skills) == 0 {
-		return items
-	}
-	merged := make([]commandItem, 0, len(items)+len(skills))
-	merged = append(merged, items...)
-	merged = append(merged, skills...)
-	return merged
+	return visibleCommandItems("")
 }
 
 func (m model) skillPickerItems() []commandItem {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -4367,7 +4367,7 @@ func TestCommandPaletteDoesNotExposeSkillAuthor(t *testing.T) {
 	}
 }
 
-func TestFilteredCommandsIncludeSkillSlashCommands(t *testing.T) {
+func TestFilteredCommandsExcludeSkillSlashCommands(t *testing.T) {
 	workspace := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(workspace, "internal", "skills", "review"), 0o755); err != nil {
 		t.Fatal(err)
@@ -4405,19 +4405,27 @@ func TestFilteredCommandsIncludeSkillSlashCommands(t *testing.T) {
 	}
 
 	items := m.filteredCommands()
-	found := false
 	for _, item := range items {
-		if item.Name == "review" && item.Usage == "/review" && item.Kind == "skill" {
+		if item.Name == "review" && item.Kind == "skill" {
+			t.Fatalf("skill commands should NOT appear in filtered commands, found %q", item.Name)
+		}
+	}
+
+	m.syncCommandPalette()
+	skills := m.skillPickerItems()
+	found := false
+	for _, s := range skills {
+		if s.Name == "review" && s.Usage == "/review" && s.Kind == "skill" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected /review skill command in filtered commands, got %+v", items)
+		t.Fatal("expected /review skill in skillPickerItems")
 	}
 }
 
-func TestFilteredCommandsIncludeProjectSkillSlashCommands(t *testing.T) {
+func TestFilteredCommandsExcludeProjectSkillSlashCommands(t *testing.T) {
 	workspace := t.TempDir()
 	skillDir := filepath.Join(workspace, ".bytemind", "skills", "review-plus")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -4459,15 +4467,22 @@ func TestFilteredCommandsIncludeProjectSkillSlashCommands(t *testing.T) {
 	}
 
 	items := m.filteredCommands()
-	found := false
 	for _, item := range items {
-		if item.Name == "review-plus" && item.Usage == "/review-plus" && item.Kind == "skill" {
+		if item.Name == "review-plus" && item.Kind == "skill" {
+			t.Fatalf("skill commands should NOT appear in filtered commands, found %q", item.Name)
+		}
+	}
+
+	skills := m.skillPickerItems()
+	found := false
+	for _, s := range skills {
+		if s.Name == "review-plus" && s.Usage == "/review-plus" && s.Kind == "skill" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected /review-plus project skill command in filtered commands, got %+v", items)
+		t.Fatal("expected /review-plus project skill in skillPickerItems")
 	}
 }
 


### PR DESCRIPTION
修复了两个关于技能（Skill）的问题：

1. 斜杠命令中不再显示技能
问题： 输入 / 打开命令面板时，所有已加载的技能（如 /review、/investigate 等）会混在系统命令列表中，造成干扰。技能应该只通过 /skills-select 选取。

改动：

tui/component_palette_runtime.go：commandPaletteItems() 不再合并技能条目，只返回系统命令
tui/model_test.go：更新两个测试用例，验证技能不在命令面板中、但仍在 skillPickerItems() 中可用

2. 内置技能无法在全局安装时加载
问题： 当 bytemind 全局安装后（如 ~/bin/bytemind），从任何非源码目录（如 D:\）运行时，内置技能无法加载。原因是 workspace/internal/skills/ 路径只存在于源码目录，二进制文件本身不携带技能文件。

改动：

internal/skills/embed.go（新建）：使用 //go:embed 将全部 6 个内置技能目录（bug-investigation、github-pr、repo-onboarding、review、skill-creator、write-rfc）嵌入到二进制文件中
internal/skills/manager.go：Reload() 中增加回退逻辑——当内置技能目录在磁盘上不存在时，自动从嵌入式文件系统加载
现在无论从哪个目录运行 bytemind，内置技能始终可用。