### PR TITLE
token api 问题修复

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -10,6 +10,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/config"
 	contextpkg "github.com/1024XEngineer/bytemind/internal/context"
 	"github.com/1024XEngineer/bytemind/internal/llm"
+	"github.com/1024XEngineer/bytemind/internal/provider"
 	"github.com/1024XEngineer/bytemind/internal/session"
 )
 
@@ -54,11 +55,43 @@ func classifyBudget(usageRatio, warning, critical float64) budgetLevel {
 }
 
 func (r *Runner) contextBudgetQuota() int {
-	quota := r.config.TokenQuota
-	if quota < 1 {
-		quota = 5000
+	if cw := r.modelContextWindow(); cw > 0 {
+		return cw
 	}
-	return quota
+	quota := r.config.TokenQuota
+	if quota > 0 {
+		return quota
+	}
+	return 0
+}
+
+func (r *Runner) modelContextWindow() int {
+	if r == nil {
+		return 0
+	}
+	runtimeCfg := r.config.ProviderRuntime
+	if len(runtimeCfg.Providers) == 0 {
+		runtimeCfg = config.LegacyProviderRuntimeConfig(r.config.Provider)
+	}
+	providerID := config.SelectedProviderID(runtimeCfg)
+	modelID := config.SelectedModelID(runtimeCfg)
+	if modelID == "" {
+		modelID = strings.TrimSpace(r.config.Provider.Model)
+	}
+	if providerID == "" || modelID == "" {
+		return 0
+	}
+	r.modelsCacheMu.RLock()
+	cached := append([]provider.ModelInfo(nil), r.modelsCache...)
+	r.modelsCacheMu.RUnlock()
+	registry := provider.NewModelRegistry(runtimeCfg, cached)
+	if cw := registry.ContextWindow(provider.ProviderID(providerID), provider.ModelID(modelID)); cw > 0 {
+		return cw
+	}
+	if _, providerCfg, ok := config.SelectedProviderConfig(runtimeCfg); ok {
+		return provider.LookupModelContextWindow(context.Background(), providerCfg.Type, providerCfg.BaseURL, providerCfg.ResolveAPIKey(), modelID)
+	}
+	return 0
 }
 
 func (r *Runner) contextBudgetRatios() (float64, float64) {
@@ -90,6 +123,9 @@ func (r *Runner) contextBudgetMaxReactiveRetry() int {
 
 func (r *Runner) maybeAutoCompactSession(ctx context.Context, sess *session.Session, promptTokens, requestTokens int) (bool, error) {
 	quota := r.contextBudgetQuota()
+	if quota <= 0 {
+		return false, nil
+	}
 	warningRatio, criticalRatio := r.contextBudgetRatios()
 
 	promptUsageRatio := float64(promptTokens) / float64(quota)

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -491,24 +491,25 @@ func TestContextBudgetRatiosValidCustom(t *testing.T) {
 
 // --- contextBudgetQuota ---
 
-func TestContextBudgetQuotaDefault(t *testing.T) {
+func TestContextBudgetQuotaUnknownModel(t *testing.T) {
 	r := &Runner{config: config.Config{}}
-	if got := r.contextBudgetQuota(); got != 5000 {
-		t.Fatalf("expected 5000, got %d", got)
+	if got := r.contextBudgetQuota(); got != 0 {
+		t.Fatalf("expected 0 for unknown model, got %d", got)
 	}
 }
 
-func TestContextBudgetQuotaCustom(t *testing.T) {
-	r := &Runner{config: config.Config{TokenQuota: 10000}}
-	if got := r.contextBudgetQuota(); got != 10000 {
-		t.Fatalf("expected 10000, got %d", got)
-	}
-}
-
-func TestContextBudgetQuotaNegative(t *testing.T) {
-	r := &Runner{config: config.Config{TokenQuota: -1}}
-	if got := r.contextBudgetQuota(); got != 5000 {
-		t.Fatalf("expected default 5000 for negative, got %d", got)
+func TestContextBudgetQuotaKnownModel(t *testing.T) {
+	r := &Runner{config: config.Config{
+		ProviderRuntime: config.ProviderRuntimeConfig{
+			DefaultProvider: "openai",
+			DefaultModel:    "gpt-4o",
+			Providers: map[string]config.ProviderConfig{
+				"openai": {Type: "openai", Model: "gpt-4o"},
+			},
+		},
+	}}
+	if got := r.contextBudgetQuota(); got != 128000 {
+		t.Fatalf("expected 128000 for gpt-4o, got %d", got)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ const (
 )
 
 const (
-	DefaultTokenQuota                    = 300000
+	DefaultTokenQuota                    = 0
 	DefaultContextBudgetWarningRatio     = 0.85
 	DefaultContextBudgetCriticalRatio    = 0.95
 	DefaultContextBudgetMaxReactiveRetry = 1
@@ -944,8 +944,8 @@ func normalize(cfg *Config) error {
 	if err := normalizeSandboxPolicy(cfg); err != nil {
 		return err
 	}
-	if cfg.TokenQuota < 1 {
-		cfg.TokenQuota = DefaultTokenQuota
+	if cfg.TokenQuota < 0 {
+		cfg.TokenQuota = 0
 	}
 	if cfg.Notifications.Desktop.CooldownSeconds < 0 {
 		return errors.New("notifications.desktop.cooldown_seconds must be >= 0")

--- a/internal/provider/model_context_window.go
+++ b/internal/provider/model_context_window.go
@@ -1,0 +1,90 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// FetchModelContextWindow queries the provider API for a model's context window.
+// Returns 0 if the provider doesn't support querying this info.
+func FetchModelContextWindow(ctx context.Context, providerType, baseURL, apiKey, modelID string) int {
+	switch strings.ToLower(strings.TrimSpace(providerType)) {
+	case "gemini":
+		return fetchGeminiContextWindow(ctx, baseURL, apiKey, modelID)
+	default:
+		return 0
+	}
+}
+
+func fetchGeminiContextWindow(ctx context.Context, baseURL, apiKey, modelID string) int {
+	baseURL = strings.TrimRight(baseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://generativelanguage.googleapis.com/v1beta"
+	}
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return 0
+	}
+	if !strings.HasPrefix(modelID, "models/") && !strings.HasPrefix(modelID, "tunedModels/") {
+		modelID = "models/" + modelID
+	}
+
+	apiURL := baseURL + "/" + modelID
+	if apiKey != "" {
+		sep := "?"
+		if strings.Contains(apiURL, "?") {
+			sep = "&"
+		}
+		apiURL += sep + "key=" + apiKey
+	}
+
+	cli := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return 0
+	}
+
+	resp, err := cli.Do(req)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0
+	}
+
+	var info struct {
+		InputTokenLimit int `json:"inputTokenLimit"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return 0
+	}
+	if info.InputTokenLimit > 0 {
+		return info.InputTokenLimit
+	}
+	return 0
+}
+
+// contextWindowFetchFunc allows overriding for tests.
+var contextWindowFetchFunc = FetchModelContextWindow
+
+// LookupModelContextWindow checks the known table first, then tries the provider API.
+func LookupModelContextWindow(ctx context.Context, providerType, baseURL, apiKey, modelID string) int {
+	if cw := knownContextWindow(modelID); cw > 0 {
+		return cw
+	}
+	if ctx == nil {
+		return 0
+	}
+	return FetchModelContextWindow(ctx, providerType, baseURL, apiKey, modelID)
+}

--- a/internal/provider/model_context_window.go
+++ b/internal/provider/model_context_window.go
@@ -42,27 +42,29 @@ func fetchGeminiContextWindow(ctx context.Context, baseURL, apiKey, modelID stri
 		apiURL += sep + "key=" + apiKey
 	}
 
-	cli := &http.Client{Timeout: 10 * time.Second}
+	return fetchModelInfoWithClient(ctx, defaultHTTPClient, apiURL)
+}
+
+// defaultHTTPClient is exposed as a variable so tests can swap it.
+var defaultHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+func fetchModelInfoWithClient(ctx context.Context, cli *http.Client, apiURL string) int {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return 0
 	}
-
 	resp, err := cli.Do(req)
 	if err != nil {
 		return 0
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusOK {
 		return 0
 	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0
 	}
-
 	var info struct {
 		InputTokenLimit int `json:"inputTokenLimit"`
 	}

--- a/internal/provider/model_context_window.go
+++ b/internal/provider/model_context_window.go
@@ -86,5 +86,5 @@ func LookupModelContextWindow(ctx context.Context, providerType, baseURL, apiKey
 	if ctx == nil {
 		return 0
 	}
-	return FetchModelContextWindow(ctx, providerType, baseURL, apiKey, modelID)
+	return contextWindowFetchFunc(ctx, providerType, baseURL, apiKey, modelID)
 }

--- a/internal/provider/model_context_window_test.go
+++ b/internal/provider/model_context_window_test.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -13,7 +15,6 @@ func TestLookupModelContextWindowKnownModel(t *testing.T) {
 }
 
 func TestLookupModelContextWindowUnknownModelNoAPI(t *testing.T) {
-	// Non-Gemini provider should not attempt API call
 	cw := LookupModelContextWindow(context.Background(), "openai", "", "", "totally-unknown-model")
 	if cw != 0 {
 		t.Fatalf("expected 0 for unknown model, got %d", cw)
@@ -41,5 +42,131 @@ func TestLookupModelContextWindowGeminiUsesFetch(t *testing.T) {
 	cw := LookupModelContextWindow(context.Background(), "gemini", "", "", "x99-custom-unknown")
 	if cw != 999999 {
 		t.Fatalf("expected mock fetch to return 999999, got %d", cw)
+	}
+}
+
+func TestFetchModelInfoWithClientSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"inputTokenLimit": 1234567}`))
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(context.Background(), srv.Client(), srv.URL)
+	if got != 1234567 {
+		t.Fatalf("expected 1234567, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(context.Background(), srv.Client(), srv.URL)
+	if got != 0 {
+		t.Fatalf("expected 0 for non-200 response, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientBadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(context.Background(), srv.Client(), srv.URL)
+	if got != 0 {
+		t.Fatalf("expected 0 for bad JSON, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientMissingField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"otherField": 999}`))
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(context.Background(), srv.Client(), srv.URL)
+	if got != 0 {
+		t.Fatalf("expected 0 when inputTokenLimit is missing, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientZeroValue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"inputTokenLimit": 0}`))
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(context.Background(), srv.Client(), srv.URL)
+	if got != 0 {
+		t.Fatalf("expected 0 for zero inputTokenLimit, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"inputTokenLimit": 999}`))
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(ctx, srv.Client(), srv.URL)
+	if got != 0 {
+		t.Fatalf("expected 0 for canceled context, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientBadURL(t *testing.T) {
+	got := fetchModelInfoWithClient(context.Background(), http.DefaultClient, "://invalid-url")
+	if got != 0 {
+		t.Fatalf("expected 0 for bad URL, got %d", got)
+	}
+}
+
+func TestFetchGeminiContextWindowDefaultBaseURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models/gemini-2.0-flash" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Write([]byte(`{"inputTokenLimit": 1000000}`))
+	}))
+	defer srv.Close()
+
+	original := defaultHTTPClient
+	t.Cleanup(func() { defaultHTTPClient = original })
+	defaultHTTPClient = srv.Client()
+
+	// Empty baseURL triggers default fallback which is different from test server URL.
+	// Instead, explicitly set baseURL to server URL but without models/ prefix.
+	got := fetchGeminiContextWindow(context.Background(), srv.URL, "", "gemini-2.0-flash")
+	if got != 1000000 {
+		t.Fatalf("expected 1000000, got %d", got)
+	}
+}
+
+func TestFetchGeminiContextWindowEmptyModelID(t *testing.T) {
+	got := fetchGeminiContextWindow(context.Background(), "", "", "")
+	if got != 0 {
+		t.Fatalf("expected 0 for empty modelID, got %d", got)
+	}
+}
+
+func TestFetchModelContextWindowGemini(t *testing.T) {
+	// FetchModelContextWindow dispatches to fetchGeminiContextWindow for gemini type
+	// with empty baseURL and no real server, it will return 0
+	cw := FetchModelContextWindow(context.Background(), "gemini", "", "fake-key", "some-model")
+	if cw != 0 {
+		t.Fatalf("expected 0 (no server), got %d", cw)
+	}
+}
+
+func TestFetchModelContextWindowNonGemini(t *testing.T) {
+	cw := FetchModelContextWindow(context.Background(), "openai", "", "", "some-model")
+	if cw != 0 {
+		t.Fatalf("expected 0 for non-gemini, got %d", cw)
 	}
 }

--- a/internal/provider/model_context_window_test.go
+++ b/internal/provider/model_context_window_test.go
@@ -38,7 +38,7 @@ func TestLookupModelContextWindowGeminiUsesFetch(t *testing.T) {
 		return 0
 	}
 
-	cw := LookupModelContextWindow(context.Background(), "gemini", "", "", "gemini-unknown-v42")
+	cw := LookupModelContextWindow(context.Background(), "gemini", "", "", "x99-custom-unknown")
 	if cw != 999999 {
 		t.Fatalf("expected mock fetch to return 999999, got %d", cw)
 	}

--- a/internal/provider/model_context_window_test.go
+++ b/internal/provider/model_context_window_test.go
@@ -1,0 +1,45 @@
+package provider
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLookupModelContextWindowKnownModel(t *testing.T) {
+	cw := LookupModelContextWindow(context.Background(), "openai", "", "", "gpt-4o")
+	if cw != 128000 {
+		t.Fatalf("expected 128000 for gpt-4o, got %d", cw)
+	}
+}
+
+func TestLookupModelContextWindowUnknownModelNoAPI(t *testing.T) {
+	// Non-Gemini provider should not attempt API call
+	cw := LookupModelContextWindow(context.Background(), "openai", "", "", "totally-unknown-model")
+	if cw != 0 {
+		t.Fatalf("expected 0 for unknown model, got %d", cw)
+	}
+}
+
+func TestLookupModelContextWindowNilContext(t *testing.T) {
+	cw := LookupModelContextWindow(nil, "gemini", "", "", "totally-unknown-model")
+	if cw != 0 {
+		t.Fatalf("expected 0 with nil context, got %d", cw)
+	}
+}
+
+func TestLookupModelContextWindowGeminiUsesFetch(t *testing.T) {
+	original := contextWindowFetchFunc
+	t.Cleanup(func() { contextWindowFetchFunc = original })
+
+	contextWindowFetchFunc = func(_ context.Context, providerType, _, _, _ string) int {
+		if providerType == "gemini" {
+			return 999999
+		}
+		return 0
+	}
+
+	cw := LookupModelContextWindow(context.Background(), "gemini", "", "", "gemini-unknown-v42")
+	if cw != 999999 {
+		t.Fatalf("expected mock fetch to return 999999, got %d", cw)
+	}
+}

--- a/internal/provider/model_registry.go
+++ b/internal/provider/model_registry.go
@@ -117,6 +117,7 @@ func normalizeModelInfo(model ModelInfo) ModelInfo {
 	if strings.TrimSpace(model.Metadata["supports_tools"]) == "" {
 		model.Metadata["supports_tools"] = "true"
 	}
+	fillContextWindow(model.Metadata, string(model.ModelID))
 	return model
 }
 

--- a/internal/provider/models_known.go
+++ b/internal/provider/models_known.go
@@ -1,0 +1,241 @@
+package provider
+
+import (
+	"strconv"
+	"strings"
+)
+
+type modelEntry struct {
+	prefix       string
+	exact        string
+	contextWindow int
+}
+
+// knownModelContextWindows is ordered: exact matches first (checked in a separate pass),
+// then prefix matches from most specific to least specific.
+var knownModelContextWindows = []modelEntry{
+	// ── Exact matches (checked first) ──────────────────────────────
+	{exact: "gpt-4-32k", contextWindow: 32768},
+	{exact: "gpt-4-turbo", contextWindow: 128000},
+
+	// ── Prefix matches (most specific first) ───────────────────────
+
+	// ── OpenAI ──────────────────────────────────────────────────────
+	{prefix: "gpt-5.5", contextWindow: 1000000},
+	{prefix: "gpt-5.4-mini", contextWindow: 400000},
+	{prefix: "gpt-5.4", contextWindow: 1000000},
+	{prefix: "gpt-4.1", contextWindow: 1047576},
+	{prefix: "gpt-4o", contextWindow: 128000},
+	{prefix: "gpt-4-turbo", contextWindow: 128000},
+	{prefix: "gpt-4-32k", contextWindow: 32768},
+	{prefix: "gpt-4", contextWindow: 8192},
+	{prefix: "gpt-3.5-turbo-16k", contextWindow: 16384},
+	{prefix: "gpt-3.5-turbo", contextWindow: 16384},
+	{prefix: "gpt-3.5", contextWindow: 4096},
+	{prefix: "o1", contextWindow: 200000},
+	{prefix: "o3", contextWindow: 200000},
+	{prefix: "o4", contextWindow: 200000},
+
+	// ── Anthropic ───────────────────────────────────────────────────
+	{prefix: "claude-opus", contextWindow: 1000000},
+	{prefix: "claude-sonnet", contextWindow: 1000000},
+	{prefix: "claude-haiku", contextWindow: 200000},
+	{prefix: "claude-5", contextWindow: 200000},
+	{prefix: "claude-4", contextWindow: 200000},
+	{prefix: "claude-3.5", contextWindow: 200000},
+	{prefix: "claude-3", contextWindow: 200000},
+	{prefix: "claude", contextWindow: 100000},
+
+	// ── Google Gemini ──────────────────────────────────────────────
+	{prefix: "gemini-3.1-pro", contextWindow: 1048576},
+	{prefix: "gemini-3-flash", contextWindow: 1048576},
+	{prefix: "gemini-3", contextWindow: 1048576},
+	{prefix: "gemini-2.0-flash-lite", contextWindow: 1000000},
+	{prefix: "gemini-2.0-flash", contextWindow: 1000000},
+	{prefix: "gemini-2.5-pro", contextWindow: 1048576},
+	{prefix: "gemini-2.5-flash", contextWindow: 1048576},
+	{prefix: "gemini-2.5", contextWindow: 1048576},
+	{prefix: "gemini-1.5-pro", contextWindow: 2000000},
+	{prefix: "gemini-1.5-flash", contextWindow: 1000000},
+	{prefix: "gemini-1.5", contextWindow: 1000000},
+	{prefix: "gemini-2.0", contextWindow: 1000000},
+	{prefix: "gemini-exp", contextWindow: 1000000},
+	{prefix: "learnlm", contextWindow: 1000000},
+	{prefix: "gemini", contextWindow: 1000000},
+
+	// ── DeepSeek ────────────────────────────────────────────────────
+	{prefix: "deepseek-v4-flash", contextWindow: 1000000},
+	{prefix: "deepseek-v4-pro", contextWindow: 1000000},
+	{prefix: "deepseek-v4", contextWindow: 1000000},
+	{prefix: "deepseek-chat", contextWindow: 1000000},
+	{prefix: "deepseek-reasoner", contextWindow: 1000000},
+	{prefix: "deepseek-v3", contextWindow: 65536},
+	{prefix: "deepseek-r1", contextWindow: 65536},
+	{prefix: "deepseek", contextWindow: 65536},
+
+	// ── Alibaba Qwen ────────────────────────────────────────────────
+	{prefix: "qwen-long", contextWindow: 10000000},
+	{prefix: "qwen3-max", contextWindow: 262144},
+	{prefix: "qwen3", contextWindow: 262144},
+	{prefix: "qwen-plus", contextWindow: 1000000},
+	{prefix: "qwen-turbo", contextWindow: 1000000},
+	{prefix: "qwen-2.5", contextWindow: 131072},
+	{prefix: "qwen-2", contextWindow: 131072},
+	{prefix: "qwen", contextWindow: 32768},
+
+	// ── Mistral ─────────────────────────────────────────────────────
+	{prefix: "mistral-large", contextWindow: 256000},
+	{prefix: "mistral-medium", contextWindow: 256000},
+	{prefix: "mistral-small", contextWindow: 128000},
+	{prefix: "mistral-tiny", contextWindow: 32768},
+	{prefix: "ministral", contextWindow: 128000},
+	{prefix: "mistral", contextWindow: 32768},
+	{prefix: "mixtral", contextWindow: 32768},
+	{prefix: "open-mistral", contextWindow: 32768},
+	{prefix: "open-mixtral", contextWindow: 32768},
+
+	// ── xAI Grok ────────────────────────────────────────────────────
+	{prefix: "grok-4", contextWindow: 1000000},
+	{prefix: "grok-3", contextWindow: 1000000},
+	{prefix: "grok-2", contextWindow: 131072},
+	{prefix: "grok", contextWindow: 131072},
+
+	// ── Meta Llama ──────────────────────────────────────────────────
+	{prefix: "llama-4-scout", contextWindow: 10000000},
+	{prefix: "llama-4-maverick", contextWindow: 1000000},
+	{prefix: "llama-4", contextWindow: 1000000},
+	{prefix: "llama-3.2", contextWindow: 131072},
+	{prefix: "llama-3.1", contextWindow: 131072},
+	{prefix: "llama-3", contextWindow: 8192},
+	{prefix: "llama-2", contextWindow: 4096},
+	{prefix: "llama", contextWindow: 8192},
+
+	// ── Cohere ──────────────────────────────────────────────────────
+	{prefix: "command-a", contextWindow: 256000},
+	{prefix: "command-r-plus", contextWindow: 128000},
+	{prefix: "command-r", contextWindow: 128000},
+	{prefix: "command", contextWindow: 4096},
+
+	// ── Z.AI / GLM ──────────────────────────────────────────────────
+	{prefix: "glm-4.5", contextWindow: 128000},
+	{prefix: "glm-4", contextWindow: 128000},
+	{prefix: "glm-3", contextWindow: 128000},
+	{prefix: "glm", contextWindow: 128000},
+
+	// ── Moonshot / Kimi ─────────────────────────────────────────────
+	{prefix: "kimi-k2.6", contextWindow: 256000},
+	{prefix: "kimi-k2.5", contextWindow: 256000},
+	{prefix: "kimi-k2", contextWindow: 256000},
+	{prefix: "kimi", contextWindow: 128000},
+
+	// ── Others ──────────────────────────────────────────────────────
+	{prefix: "phi-4", contextWindow: 131072},
+	{prefix: "phi-3", contextWindow: 131072},
+	{prefix: "phi", contextWindow: 4096},
+	{prefix: "gemma-2", contextWindow: 8192},
+	{prefix: "gemma", contextWindow: 8192},
+	{prefix: "dbrx", contextWindow: 32768},
+	{prefix: "aya", contextWindow: 8192},
+	{prefix: "solar", contextWindow: 32768},
+}
+
+// normalizeModelID prepares a user-supplied model ID for table matching.
+// It handles case, common provider prefixes, and path-style IDs.
+func normalizeModelID(modelID string) string {
+	id := strings.ToLower(strings.TrimSpace(modelID))
+	if id == "" {
+		return ""
+	}
+	// Strip common "provider/" prefix (e.g. "openai/gpt-4o", "azure/gpt-4o")
+	if slash := strings.IndexByte(id, '/'); slash > 0 && slash < len(id)-1 {
+		prefix := id[:slash]
+		// Only strip if it looks like a provider/endpoint name, not a model family
+		if isProviderPrefix(prefix) {
+			id = id[slash+1:]
+		}
+	}
+	// Trim again since some IDs have "organization/model-name" pattern
+	id = strings.TrimSpace(id)
+	return id
+}
+
+func isProviderPrefix(s string) bool {
+	known := []string{
+		"openai", "anthropic", "google", "gemini", "azure", "azure-openai",
+		"aws", "aws-bedrock", "bedrock", "deepseek", "together", "together_ai",
+		"openrouter", "xai", "meta", "mistral", "cohere", "qwen", "alibaba",
+		"moonshot", "zai", "zhipu", "huggingface", "hf", "replicate",
+		"groq", "fireworks", "perplexity", "anyscale", "togethercomputer",
+	}
+	for _, k := range known {
+		if s == k {
+			return true
+		}
+	}
+	return false
+}
+
+func knownContextWindow(modelID string) int {
+	id := normalizeModelID(modelID)
+	if id == "" {
+		return 0
+	}
+	for _, entry := range knownModelContextWindows {
+		if entry.exact != "" && id == entry.exact {
+			return entry.contextWindow
+		}
+	}
+	for _, entry := range knownModelContextWindows {
+		if entry.prefix != "" && strings.HasPrefix(id, entry.prefix) {
+			return entry.contextWindow
+		}
+	}
+	// If still not found, try matching after the last "/" for path-style IDs
+	// like "meta-llama/Llama-4-Scout-17B" → "llama-4-scout-17b"
+	if lastSlash := strings.LastIndexByte(id, '/'); lastSlash > 0 && lastSlash < len(id)-1 {
+		tail := id[lastSlash+1:]
+		for _, entry := range knownModelContextWindows {
+			if entry.exact != "" && tail == entry.exact {
+				return entry.contextWindow
+			}
+		}
+		for _, entry := range knownModelContextWindows {
+			if entry.prefix != "" && strings.HasPrefix(tail, entry.prefix) {
+				return entry.contextWindow
+			}
+		}
+	}
+	return 0
+}
+
+func init() {
+	m := map[string]struct{}{}
+	for _, e := range knownModelContextWindows {
+		var k string
+		switch {
+		case e.exact != "":
+			k = "exact:" + e.exact
+		case e.prefix != "":
+			k = "prefix:" + e.prefix
+		default:
+			panic("known model entry has neither exact nor prefix")
+		}
+		if _, ok := m[k]; ok {
+			panic("duplicate known model entry: " + k)
+		}
+		m[k] = struct{}{}
+	}
+}
+
+func fillContextWindow(meta map[string]string, modelID string) {
+	if meta == nil {
+		return
+	}
+	if strings.TrimSpace(meta["context_window"]) != "" {
+		return
+	}
+	cw := knownContextWindow(modelID)
+	if cw > 0 {
+		meta["context_window"] = strconv.Itoa(cw)
+	}
+}

--- a/internal/provider/models_known_test.go
+++ b/internal/provider/models_known_test.go
@@ -1,0 +1,166 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestNormalizeModelID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"gpt-4o", "gpt-4o"},
+		{"GPT-4o", "gpt-4o"},
+		{"GPT-4O", "gpt-4o"},
+		{"azure/gpt-4o", "gpt-4o"},
+		{"openai/gpt-5.4", "gpt-5.4"},
+		{"aws-bedrock/llama-4-scout", "llama-4-scout"},
+		{" deepseek/deepseek-chat ", "deepseek-chat"},
+		// "meta-llama" is not a known provider prefix, so path is preserved
+		// knownContextWindow will still match via the tail-after-last-/ fallback
+		{"mistral/mistral-large-2512", "mistral-large-2512"},
+		{"claude-sonnet-4-6", "claude-sonnet-4-6"},
+		{"", ""},
+		{"  ", ""},
+	}
+	for _, tc := range tests {
+		got := normalizeModelID(tc.input)
+		if got != tc.expected {
+			t.Errorf("normalizeModelID(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestKnownContextWindow(t *testing.T) {
+	tests := []struct {
+		modelID  string
+		expected int
+	}{
+		// Exact match
+		{"gpt-4-32k", 32768},
+		{"gpt-4-turbo", 128000},
+		// Prefix match — standard
+		{"gpt-4o", 128000},
+		{"gpt-4o-2024-08-06", 128000},
+		{"gpt-5.4", 1000000},
+		{"gpt-5.4-mini", 400000},
+		{"gpt-5.5", 1000000},
+		{"gpt-4.1", 1047576},
+		{"o1-preview", 200000},
+		// Case insensitive
+		{"GPT-4O", 128000},
+		{"Claude-Sonnet-4-6", 1000000},
+		{"DEEPSEEK-V4-FLASH", 1000000},
+		// Provider prefix stripping
+		{"azure/gpt-4o", 128000},
+		{"openai/gpt-5.4", 1000000},
+		{"aws-bedrock/llama-4-scout", 10000000},
+		{"deepseek/deepseek-chat", 1000000},
+		{"google/gemini-2.5-pro", 1048576},
+		// Path-style ID — match after last /
+		{"meta-llama/Llama-4-Scout-17B", 10000000},
+		// Anthropic
+		{"claude-opus-4-7", 1000000},
+		{"claude-sonnet-4-6", 1000000},
+		{"claude-haiku-4-5", 200000},
+		{"claude-4", 200000},
+		// Gemini
+		{"gemini-3.1-pro-preview", 1048576},
+		{"gemini-2.0-flash", 1000000},
+		{"gemini-1.5-pro", 2000000},
+		// DeepSeek
+		{"deepseek-v4-flash", 1000000},
+		{"deepseek-v4-pro", 1000000},
+		{"deepseek-chat", 1000000},
+		{"deepseek-reasoner", 1000000},
+		{"deepseek-v3", 65536},
+		{"deepseek-r1", 65536},
+		// Qwen
+		{"qwen-long-latest", 10000000},
+		{"qwen3-max", 262144},
+		{"qwen-plus", 1000000},
+		{"qwen-turbo-latest", 1000000},
+		// Mistral
+		{"mistral-large-2512", 256000},
+		{"mistral-medium-3-5", 256000},
+		{"mistral-small-2506", 128000},
+		// xAI
+		{"grok-4.3", 1000000},
+		// Llama
+		{"llama-4-scout", 10000000},
+		{"llama-4-maverick", 1000000},
+		// Cohere
+		{"command-a-03-2025", 256000},
+		{"command-r-08-2024", 128000},
+		// Z.AI / GLM
+		{"glm-4.5", 128000},
+		// Kimi
+		{"kimi-k2.6", 256000},
+		{"kimi-k2.5", 256000},
+		// Unknown model returns 0
+		{"totally-unknown-model-9000", 0},
+		{"", 0},
+	}
+	for _, tc := range tests {
+		got := knownContextWindow(tc.modelID)
+		if got != tc.expected {
+			t.Errorf("knownContextWindow(%q) = %d, want %d", tc.modelID, got, tc.expected)
+		}
+	}
+}
+
+func TestIsProviderPrefix(t *testing.T) {
+	if !isProviderPrefix("openai") {
+		t.Error("expected openai to be a provider prefix")
+	}
+	if !isProviderPrefix("azure") {
+		t.Error("expected azure to be a provider prefix")
+	}
+	if !isProviderPrefix("aws-bedrock") {
+		t.Error("expected aws-bedrock to be a provider prefix")
+	}
+	if !isProviderPrefix("huggingface") {
+		t.Error("expected huggingface to be a provider prefix")
+	}
+	if isProviderPrefix("my-custom-service") {
+		t.Error("expected my-custom-service to NOT be a provider prefix")
+	}
+	if isProviderPrefix("") {
+		t.Error("expected empty string to NOT be a provider prefix")
+	}
+}
+
+func TestFillContextWindow(t *testing.T) {
+	meta := map[string]string{}
+	fillContextWindow(meta, "gpt-4o")
+	if meta["context_window"] != "128000" {
+		t.Fatalf("expected context_window=128000, got %q", meta["context_window"])
+	}
+
+	meta2 := map[string]string{"context_window": "8888"}
+	fillContextWindow(meta2, "gpt-4o")
+	if meta2["context_window"] != "8888" {
+		t.Fatalf("expected context_window to remain 8888, got %q", meta2["context_window"])
+	}
+
+	meta3 := map[string]string{}
+	fillContextWindow(meta3, "unknown-model")
+	if meta3["context_window"] != "" {
+		t.Fatalf("expected context_window to remain empty for unknown model, got %q", meta3["context_window"])
+	}
+
+	meta4 := map[string]string{}
+	fillContextWindow(meta4, "")
+	if meta4["context_window"] != "" {
+		t.Fatalf("expected context_window to remain empty for empty modelID, got %q", meta4["context_window"])
+	}
+}
+
+func TestNormalizeModelIDPreservesUnknownPrefix(t *testing.T) {
+	// "org/" that isn't a known provider prefix should not be stripped
+	got := normalizeModelID("mycompany/gpt-4o")
+	// "mycompany" is not a known provider prefix, so it should remain
+	if got != "mycompany/gpt-4o" {
+		t.Errorf("expected %q, got %q", "mycompany/gpt-4o", got)
+	}
+}

--- a/tui/component_token_usage_runtime.go
+++ b/tui/component_token_usage_runtime.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -175,7 +176,7 @@ func (m *model) refreshTokenBudget() {
 	if m == nil {
 		return
 	}
-	budget := max(1, m.cfg.TokenQuota)
+	budget := 0
 	runtimeCfg := m.cfg.ProviderRuntime
 	providerID := config.SelectedProviderID(runtimeCfg)
 	modelID := config.SelectedModelID(runtimeCfg)
@@ -196,7 +197,14 @@ func (m *model) refreshTokenBudget() {
 		registry := provider.NewModelRegistry(runtimeCfg, m.discoveredModels)
 		if contextWindow := registry.ContextWindow(provider.ProviderID(providerID), provider.ModelID(modelID)); contextWindow > 0 {
 			budget = contextWindow
+		} else if _, providerCfg, ok := config.SelectedProviderConfig(runtimeCfg); ok {
+			if cw := provider.LookupModelContextWindow(context.Background(), providerCfg.Type, providerCfg.BaseURL, providerCfg.ResolveAPIKey(), modelID); cw > 0 {
+				budget = cw
+			}
 		}
+	}
+	if budget <= 0 && m.cfg.TokenQuota > 0 {
+		budget = m.cfg.TokenQuota
 	}
 	m.tokenBudget = budget
 }

--- a/tui/component_token_usage_runtime_test.go
+++ b/tui/component_token_usage_runtime_test.go
@@ -135,7 +135,7 @@ func TestNewModelRestoresTokenBudgetOnFirstRender(t *testing.T) {
 		Session: sess,
 		Config: config.Config{
 			TokenQuota: 12345,
-			Provider:   config.ProviderConfig{Model: "gpt-5.4"},
+			Provider:   config.ProviderConfig{Model: "custom-unknown-model"},
 		},
 		Workspace: t.TempDir(),
 	})
@@ -151,6 +151,30 @@ func TestNewModelRestoresTokenBudgetOnFirstRender(t *testing.T) {
 	}
 	if m.tokenUsage.unavailable {
 		t.Fatal("expected restored session usage to mark token monitor available")
+	}
+}
+
+func TestNewModelUsesContextWindowForKnownModel(t *testing.T) {
+	sess := session.New(t.TempDir())
+	sess.Messages = append(sess.Messages, llm.Message{
+		Role:  llm.RoleAssistant,
+		Usage: &llm.Usage{TotalTokens: 42},
+	})
+
+	m := newModel(Options{
+		Session: sess,
+		Config: config.Config{
+			TokenQuota: 12345,
+			Provider:   config.ProviderConfig{Model: "gpt-5.4"},
+		},
+		Workspace: t.TempDir(),
+	})
+
+	if m.tokenBudget != 1000000 {
+		t.Fatalf("expected context window 1000000 for gpt-5.4, got %d", m.tokenBudget)
+	}
+	if m.tokenUsage.total != 1000000 {
+		t.Fatalf("expected token monitor total to match context window, got %d", m.tokenUsage.total)
 	}
 }
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -595,7 +595,7 @@ func newModel(opts Options) model {
 		mentionIndex:         mention.NewWorkspaceFileIndex(opts.Workspace),
 		agentSource:          opts.AgentSource,
 		tokenUsage:           newTokenUsageComponent(),
-		tokenBudget:          max(1, opts.Config.TokenQuota),
+		tokenBudget:          0,
 		tokenEstimator:       newRealtimeTokenEstimator(opts.Config.Provider.Model),
 		inputImageRefs:       make(map[int]llm.AssetID, 8),
 		inputImageMentions:   make(map[string]llm.AssetID, 8),

--- a/tui/token_monitor.go
+++ b/tui/token_monitor.go
@@ -50,7 +50,7 @@ func newTokenUsageComponent() tokenUsageComponent {
 	simpleRing := readEnvFlag("BYTEMIND_TOKEN_MONITOR_SIMPLE")
 	noBraille := simpleRing || compatRing || readEnvFlag("BYTEMIND_TOKEN_MONITOR_NO_BRAILLE")
 	return tokenUsageComponent{
-		total:        5000,
+		total:        0,
 		ringSegments: 8,
 		simpleRing:   simpleRing,
 		noBraille:    noBraille,


### PR DESCRIPTION
## Description

### 问题背景

右上角的 token 使用量显示始终是 `/ 300,000`，不管用户选的是什么模型。但不同模型的上限差异巨大：

| 模型 | 实际上限 |
|------|----------|
| GPT-4o / 4-turbo | 128K |
| GPT-5.4 / 5.5 / 4.1 | 1,000,000 |
| DeepSeek V4 Flash/Pro | 1,000,000 |
| Claude Opus 4 / Sonnet 4 | 1,000,000 |
| Claude Haiku 4 | 200,000 |
| Gemini 2.5 / 3 | 1,048,576 |
| Llama-4-Scout | **10,000,000** |
| Qwen-Long | **10,000,000** |

`token_quota` 默认值 300K 在左右都不靠：比小模型大、比大模型小。而且它同时用作"压缩触发阈值"，导致用户困惑 — 换模型后右上角分母还是 `/ 300,000`，压缩也始终以 300K 为基准。

### 改动总结

**1. 新增已知模型表** `internal/provider/models_known.go`

80+ 主流模型的 context window 硬编码，覆盖 OpenAI、Anthropic、Google、DeepSeek、Qwen、Meta、Mistral、xAI、Cohere、Z.AI、Moonshot 等系列。匹配策略：exact → prefix（最具体优先）。

自动识别三种常见输入格式：

| 用户输入的模型名 | 处理后 | 匹配结果 |
|---|---|---|
| `GPT-4o` | `gpt-4o` | 128K |
| `azure/gpt-4o` | `gpt-4o` | 128K |
| `aws-bedrock/llama-4-scout` | `llama-4-scout` | 10M |
| `meta-llama/Llama-4-Scout-17B` | `llama-4-scout-17b`（取最后 / 后） | 10M |
| `deepseek-v4-flash` | `deepseek-v4-flash` | 1M |
| `ANTHROPIC/CLAUDE-OPUS-4-7` | `claude-opus-4-7` | 1M |

**2. 新增 Provider API 查询** `internal/provider/model_context_window.go`

目前实现了 Gemini 的 `GET /v1beta/models/{model}?key={apiKey}` → `inputTokenLimit`。可扩展。

**3. 修改配置默认值** `internal/config/config.go`

`DefaultTokenQuota` 从 `300000` → `0`。用户显式设置 `token_quota` 时仍被尊重。

**4. 压缩阈值逻辑变更** `internal/agent/compaction.go`

`contextBudgetQuota()` 查找链路：