### PR TITLE
Workspace session

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -10,6 +10,7 @@ import (
 	"github.com/1024XEngineer/bytemind/internal/config"
 	contextpkg "github.com/1024XEngineer/bytemind/internal/context"
 	"github.com/1024XEngineer/bytemind/internal/llm"
+	"github.com/1024XEngineer/bytemind/internal/provider"
 	"github.com/1024XEngineer/bytemind/internal/session"
 )
 
@@ -54,11 +55,43 @@ func classifyBudget(usageRatio, warning, critical float64) budgetLevel {
 }
 
 func (r *Runner) contextBudgetQuota() int {
-	quota := r.config.TokenQuota
-	if quota < 1 {
-		quota = 5000
+	if cw := r.modelContextWindow(); cw > 0 {
+		return cw
 	}
-	return quota
+	quota := r.config.TokenQuota
+	if quota > 0 {
+		return quota
+	}
+	return 0
+}
+
+func (r *Runner) modelContextWindow() int {
+	if r == nil {
+		return 0
+	}
+	runtimeCfg := r.config.ProviderRuntime
+	if len(runtimeCfg.Providers) == 0 {
+		runtimeCfg = config.LegacyProviderRuntimeConfig(r.config.Provider)
+	}
+	providerID := config.SelectedProviderID(runtimeCfg)
+	modelID := config.SelectedModelID(runtimeCfg)
+	if modelID == "" {
+		modelID = strings.TrimSpace(r.config.Provider.Model)
+	}
+	if providerID == "" || modelID == "" {
+		return 0
+	}
+	r.modelsCacheMu.RLock()
+	cached := append([]provider.ModelInfo(nil), r.modelsCache...)
+	r.modelsCacheMu.RUnlock()
+	registry := provider.NewModelRegistry(runtimeCfg, cached)
+	if cw := registry.ContextWindow(provider.ProviderID(providerID), provider.ModelID(modelID)); cw > 0 {
+		return cw
+	}
+	if _, providerCfg, ok := config.SelectedProviderConfig(runtimeCfg); ok {
+		return provider.LookupModelContextWindow(context.Background(), providerCfg.Type, providerCfg.BaseURL, providerCfg.ResolveAPIKey(), modelID)
+	}
+	return 0
 }
 
 func (r *Runner) contextBudgetRatios() (float64, float64) {
@@ -90,6 +123,9 @@ func (r *Runner) contextBudgetMaxReactiveRetry() int {
 
 func (r *Runner) maybeAutoCompactSession(ctx context.Context, sess *session.Session, promptTokens, requestTokens int) (bool, error) {
 	quota := r.contextBudgetQuota()
+	if quota <= 0 {
+		return false, nil
+	}
 	warningRatio, criticalRatio := r.contextBudgetRatios()
 
 	promptUsageRatio := float64(promptTokens) / float64(quota)

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -62,7 +62,7 @@ func (r *Runner) contextBudgetQuota() int {
 	if quota > 0 {
 		return quota
 	}
-	return 0
+	return config.DefaultContextBudgetFallback
 }
 
 func (r *Runner) modelContextWindow() int {

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -491,24 +491,25 @@ func TestContextBudgetRatiosValidCustom(t *testing.T) {
 
 // --- contextBudgetQuota ---
 
-func TestContextBudgetQuotaDefault(t *testing.T) {
+func TestContextBudgetQuotaUnknownModel(t *testing.T) {
 	r := &Runner{config: config.Config{}}
-	if got := r.contextBudgetQuota(); got != 5000 {
-		t.Fatalf("expected 5000, got %d", got)
+	if got := r.contextBudgetQuota(); got != 0 {
+		t.Fatalf("expected 0 for unknown model, got %d", got)
 	}
 }
 
-func TestContextBudgetQuotaCustom(t *testing.T) {
-	r := &Runner{config: config.Config{TokenQuota: 10000}}
-	if got := r.contextBudgetQuota(); got != 10000 {
-		t.Fatalf("expected 10000, got %d", got)
-	}
-}
-
-func TestContextBudgetQuotaNegative(t *testing.T) {
-	r := &Runner{config: config.Config{TokenQuota: -1}}
-	if got := r.contextBudgetQuota(); got != 5000 {
-		t.Fatalf("expected default 5000 for negative, got %d", got)
+func TestContextBudgetQuotaKnownModel(t *testing.T) {
+	r := &Runner{config: config.Config{
+		ProviderRuntime: config.ProviderRuntimeConfig{
+			DefaultProvider: "openai",
+			DefaultModel:    "gpt-4o",
+			Providers: map[string]config.ProviderConfig{
+				"openai": {Type: "openai", Model: "gpt-4o"},
+			},
+		},
+	}}
+	if got := r.contextBudgetQuota(); got != 128000 {
+		t.Fatalf("expected 128000 for gpt-4o, got %d", got)
 	}
 }
 

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -491,10 +491,10 @@ func TestContextBudgetRatiosValidCustom(t *testing.T) {
 
 // --- contextBudgetQuota ---
 
-func TestContextBudgetQuotaUnknownModel(t *testing.T) {
+func TestContextBudgetQuotaUnknownModelFallsBack(t *testing.T) {
 	r := &Runner{config: config.Config{}}
-	if got := r.contextBudgetQuota(); got != 0 {
-		t.Fatalf("expected 0 for unknown model, got %d", got)
+	if got := r.contextBudgetQuota(); got != config.DefaultContextBudgetFallback {
+		t.Fatalf("expected %d fallback for unknown model, got %d", config.DefaultContextBudgetFallback, got)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ const (
 	DefaultContextBudgetWarningRatio     = 0.85
 	DefaultContextBudgetCriticalRatio    = 0.95
 	DefaultContextBudgetMaxReactiveRetry = 1
+	DefaultContextBudgetFallback         = 128000
 	DefaultMCPSyncTTLSeconds             = 30
 	DefaultMCPStartupTimeoutSeconds      = 20
 	DefaultMCPCallTimeoutSeconds         = 60

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ const (
 )
 
 const (
-	DefaultTokenQuota                    = 300000
+	DefaultTokenQuota                    = 0
 	DefaultContextBudgetWarningRatio     = 0.85
 	DefaultContextBudgetCriticalRatio    = 0.95
 	DefaultContextBudgetMaxReactiveRetry = 1
@@ -944,8 +944,8 @@ func normalize(cfg *Config) error {
 	if err := normalizeSandboxPolicy(cfg); err != nil {
 		return err
 	}
-	if cfg.TokenQuota < 1 {
-		cfg.TokenQuota = DefaultTokenQuota
+	if cfg.TokenQuota < 0 {
+		cfg.TokenQuota = 0
 	}
 	if cfg.Notifications.Desktop.CooldownSeconds < 0 {
 		return errors.New("notifications.desktop.cooldown_seconds must be >= 0")

--- a/internal/provider/model_context_window.go
+++ b/internal/provider/model_context_window.go
@@ -1,0 +1,90 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// FetchModelContextWindow queries the provider API for a model's context window.
+// Returns 0 if the provider doesn't support querying this info.
+func FetchModelContextWindow(ctx context.Context, providerType, baseURL, apiKey, modelID string) int {
+	switch strings.ToLower(strings.TrimSpace(providerType)) {
+	case "gemini":
+		return fetchGeminiContextWindow(ctx, baseURL, apiKey, modelID)
+	default:
+		return 0
+	}
+}
+
+func fetchGeminiContextWindow(ctx context.Context, baseURL, apiKey, modelID string) int {
+	baseURL = strings.TrimRight(baseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://generativelanguage.googleapis.com/v1beta"
+	}
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return 0
+	}
+	if !strings.HasPrefix(modelID, "models/") && !strings.HasPrefix(modelID, "tunedModels/") {
+		modelID = "models/" + modelID
+	}
+
+	apiURL := baseURL + "/" + modelID
+	if apiKey != "" {
+		sep := "?"
+		if strings.Contains(apiURL, "?") {
+			sep = "&"
+		}
+		apiURL += sep + "key=" + apiKey
+	}
+
+	cli := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return 0
+	}
+
+	resp, err := cli.Do(req)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0
+	}
+
+	var info struct {
+		InputTokenLimit int `json:"inputTokenLimit"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return 0
+	}
+	if info.InputTokenLimit > 0 {
+		return info.InputTokenLimit
+	}
+	return 0
+}
+
+// contextWindowFetchFunc allows overriding for tests.
+var contextWindowFetchFunc = FetchModelContextWindow
+
+// LookupModelContextWindow checks the known table first, then tries the provider API.
+func LookupModelContextWindow(ctx context.Context, providerType, baseURL, apiKey, modelID string) int {
+	if cw := knownContextWindow(modelID); cw > 0 {
+		return cw
+	}
+	if ctx == nil {
+		return 0
+	}
+	return FetchModelContextWindow(ctx, providerType, baseURL, apiKey, modelID)
+}

--- a/internal/provider/model_context_window.go
+++ b/internal/provider/model_context_window.go
@@ -42,27 +42,29 @@ func fetchGeminiContextWindow(ctx context.Context, baseURL, apiKey, modelID stri
 		apiURL += sep + "key=" + apiKey
 	}
 
-	cli := &http.Client{Timeout: 10 * time.Second}
+	return fetchModelInfoWithClient(ctx, defaultHTTPClient, apiURL)
+}
+
+// defaultHTTPClient is exposed as a variable so tests can swap it.
+var defaultHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+func fetchModelInfoWithClient(ctx context.Context, cli *http.Client, apiURL string) int {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return 0
 	}
-
 	resp, err := cli.Do(req)
 	if err != nil {
 		return 0
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusOK {
 		return 0
 	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0
 	}
-
 	var info struct {
 		InputTokenLimit int `json:"inputTokenLimit"`
 	}

--- a/internal/provider/model_context_window.go
+++ b/internal/provider/model_context_window.go
@@ -86,5 +86,5 @@ func LookupModelContextWindow(ctx context.Context, providerType, baseURL, apiKey
 	if ctx == nil {
 		return 0
 	}
-	return FetchModelContextWindow(ctx, providerType, baseURL, apiKey, modelID)
+	return contextWindowFetchFunc(ctx, providerType, baseURL, apiKey, modelID)
 }

--- a/internal/provider/model_context_window_test.go
+++ b/internal/provider/model_context_window_test.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -13,7 +15,6 @@ func TestLookupModelContextWindowKnownModel(t *testing.T) {
 }
 
 func TestLookupModelContextWindowUnknownModelNoAPI(t *testing.T) {
-	// Non-Gemini provider should not attempt API call
 	cw := LookupModelContextWindow(context.Background(), "openai", "", "", "totally-unknown-model")
 	if cw != 0 {
 		t.Fatalf("expected 0 for unknown model, got %d", cw)
@@ -41,5 +42,131 @@ func TestLookupModelContextWindowGeminiUsesFetch(t *testing.T) {
 	cw := LookupModelContextWindow(context.Background(), "gemini", "", "", "x99-custom-unknown")
 	if cw != 999999 {
 		t.Fatalf("expected mock fetch to return 999999, got %d", cw)
+	}
+}
+
+func TestFetchModelInfoWithClientSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"inputTokenLimit": 1234567}`))
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(context.Background(), srv.Client(), srv.URL)
+	if got != 1234567 {
+		t.Fatalf("expected 1234567, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(context.Background(), srv.Client(), srv.URL)
+	if got != 0 {
+		t.Fatalf("expected 0 for non-200 response, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientBadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(context.Background(), srv.Client(), srv.URL)
+	if got != 0 {
+		t.Fatalf("expected 0 for bad JSON, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientMissingField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"otherField": 999}`))
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(context.Background(), srv.Client(), srv.URL)
+	if got != 0 {
+		t.Fatalf("expected 0 when inputTokenLimit is missing, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientZeroValue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"inputTokenLimit": 0}`))
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(context.Background(), srv.Client(), srv.URL)
+	if got != 0 {
+		t.Fatalf("expected 0 for zero inputTokenLimit, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"inputTokenLimit": 999}`))
+	}))
+	defer srv.Close()
+
+	got := fetchModelInfoWithClient(ctx, srv.Client(), srv.URL)
+	if got != 0 {
+		t.Fatalf("expected 0 for canceled context, got %d", got)
+	}
+}
+
+func TestFetchModelInfoWithClientBadURL(t *testing.T) {
+	got := fetchModelInfoWithClient(context.Background(), http.DefaultClient, "://invalid-url")
+	if got != 0 {
+		t.Fatalf("expected 0 for bad URL, got %d", got)
+	}
+}
+
+func TestFetchGeminiContextWindowDefaultBaseURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models/gemini-2.0-flash" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Write([]byte(`{"inputTokenLimit": 1000000}`))
+	}))
+	defer srv.Close()
+
+	original := defaultHTTPClient
+	t.Cleanup(func() { defaultHTTPClient = original })
+	defaultHTTPClient = srv.Client()
+
+	// Empty baseURL triggers default fallback which is different from test server URL.
+	// Instead, explicitly set baseURL to server URL but without models/ prefix.
+	got := fetchGeminiContextWindow(context.Background(), srv.URL, "", "gemini-2.0-flash")
+	if got != 1000000 {
+		t.Fatalf("expected 1000000, got %d", got)
+	}
+}
+
+func TestFetchGeminiContextWindowEmptyModelID(t *testing.T) {
+	got := fetchGeminiContextWindow(context.Background(), "", "", "")
+	if got != 0 {
+		t.Fatalf("expected 0 for empty modelID, got %d", got)
+	}
+}
+
+func TestFetchModelContextWindowGemini(t *testing.T) {
+	// FetchModelContextWindow dispatches to fetchGeminiContextWindow for gemini type
+	// with empty baseURL and no real server, it will return 0
+	cw := FetchModelContextWindow(context.Background(), "gemini", "", "fake-key", "some-model")
+	if cw != 0 {
+		t.Fatalf("expected 0 (no server), got %d", cw)
+	}
+}
+
+func TestFetchModelContextWindowNonGemini(t *testing.T) {
+	cw := FetchModelContextWindow(context.Background(), "openai", "", "", "some-model")
+	if cw != 0 {
+		t.Fatalf("expected 0 for non-gemini, got %d", cw)
 	}
 }

--- a/internal/provider/model_context_window_test.go
+++ b/internal/provider/model_context_window_test.go
@@ -38,7 +38,7 @@ func TestLookupModelContextWindowGeminiUsesFetch(t *testing.T) {
 		return 0
 	}
 
-	cw := LookupModelContextWindow(context.Background(), "gemini", "", "", "gemini-unknown-v42")
+	cw := LookupModelContextWindow(context.Background(), "gemini", "", "", "x99-custom-unknown")
 	if cw != 999999 {
 		t.Fatalf("expected mock fetch to return 999999, got %d", cw)
 	}

--- a/internal/provider/model_context_window_test.go
+++ b/internal/provider/model_context_window_test.go
@@ -1,0 +1,45 @@
+package provider
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLookupModelContextWindowKnownModel(t *testing.T) {
+	cw := LookupModelContextWindow(context.Background(), "openai", "", "", "gpt-4o")
+	if cw != 128000 {
+		t.Fatalf("expected 128000 for gpt-4o, got %d", cw)
+	}
+}
+
+func TestLookupModelContextWindowUnknownModelNoAPI(t *testing.T) {
+	// Non-Gemini provider should not attempt API call
+	cw := LookupModelContextWindow(context.Background(), "openai", "", "", "totally-unknown-model")
+	if cw != 0 {
+		t.Fatalf("expected 0 for unknown model, got %d", cw)
+	}
+}
+
+func TestLookupModelContextWindowNilContext(t *testing.T) {
+	cw := LookupModelContextWindow(nil, "gemini", "", "", "totally-unknown-model")
+	if cw != 0 {
+		t.Fatalf("expected 0 with nil context, got %d", cw)
+	}
+}
+
+func TestLookupModelContextWindowGeminiUsesFetch(t *testing.T) {
+	original := contextWindowFetchFunc
+	t.Cleanup(func() { contextWindowFetchFunc = original })
+
+	contextWindowFetchFunc = func(_ context.Context, providerType, _, _, _ string) int {
+		if providerType == "gemini" {
+			return 999999
+		}
+		return 0
+	}
+
+	cw := LookupModelContextWindow(context.Background(), "gemini", "", "", "gemini-unknown-v42")
+	if cw != 999999 {
+		t.Fatalf("expected mock fetch to return 999999, got %d", cw)
+	}
+}

--- a/internal/provider/model_registry.go
+++ b/internal/provider/model_registry.go
@@ -117,6 +117,7 @@ func normalizeModelInfo(model ModelInfo) ModelInfo {
 	if strings.TrimSpace(model.Metadata["supports_tools"]) == "" {
 		model.Metadata["supports_tools"] = "true"
 	}
+	fillContextWindow(model.Metadata, string(model.ModelID))
 	return model
 }
 

--- a/internal/provider/models_known.go
+++ b/internal/provider/models_known.go
@@ -1,0 +1,241 @@
+package provider
+
+import (
+	"strconv"
+	"strings"
+)
+
+type modelEntry struct {
+	prefix       string
+	exact        string
+	contextWindow int
+}
+
+// knownModelContextWindows is ordered: exact matches first (checked in a separate pass),
+// then prefix matches from most specific to least specific.
+var knownModelContextWindows = []modelEntry{
+	// ── Exact matches (checked first) ──────────────────────────────
+	{exact: "gpt-4-32k", contextWindow: 32768},
+	{exact: "gpt-4-turbo", contextWindow: 128000},
+
+	// ── Prefix matches (most specific first) ───────────────────────
+
+	// ── OpenAI ──────────────────────────────────────────────────────
+	{prefix: "gpt-5.5", contextWindow: 1000000},
+	{prefix: "gpt-5.4-mini", contextWindow: 400000},
+	{prefix: "gpt-5.4", contextWindow: 1000000},
+	{prefix: "gpt-4.1", contextWindow: 1047576},
+	{prefix: "gpt-4o", contextWindow: 128000},
+	{prefix: "gpt-4-turbo", contextWindow: 128000},
+	{prefix: "gpt-4-32k", contextWindow: 32768},
+	{prefix: "gpt-4", contextWindow: 8192},
+	{prefix: "gpt-3.5-turbo-16k", contextWindow: 16384},
+	{prefix: "gpt-3.5-turbo", contextWindow: 16384},
+	{prefix: "gpt-3.5", contextWindow: 4096},
+	{prefix: "o1", contextWindow: 200000},
+	{prefix: "o3", contextWindow: 200000},
+	{prefix: "o4", contextWindow: 200000},
+
+	// ── Anthropic ───────────────────────────────────────────────────
+	{prefix: "claude-opus", contextWindow: 1000000},
+	{prefix: "claude-sonnet", contextWindow: 1000000},
+	{prefix: "claude-haiku", contextWindow: 200000},
+	{prefix: "claude-5", contextWindow: 200000},
+	{prefix: "claude-4", contextWindow: 200000},
+	{prefix: "claude-3.5", contextWindow: 200000},
+	{prefix: "claude-3", contextWindow: 200000},
+	{prefix: "claude", contextWindow: 100000},
+
+	// ── Google Gemini ──────────────────────────────────────────────
+	{prefix: "gemini-3.1-pro", contextWindow: 1048576},
+	{prefix: "gemini-3-flash", contextWindow: 1048576},
+	{prefix: "gemini-3", contextWindow: 1048576},
+	{prefix: "gemini-2.0-flash-lite", contextWindow: 1000000},
+	{prefix: "gemini-2.0-flash", contextWindow: 1000000},
+	{prefix: "gemini-2.5-pro", contextWindow: 1048576},
+	{prefix: "gemini-2.5-flash", contextWindow: 1048576},
+	{prefix: "gemini-2.5", contextWindow: 1048576},
+	{prefix: "gemini-1.5-pro", contextWindow: 2000000},
+	{prefix: "gemini-1.5-flash", contextWindow: 1000000},
+	{prefix: "gemini-1.5", contextWindow: 1000000},
+	{prefix: "gemini-2.0", contextWindow: 1000000},
+	{prefix: "gemini-exp", contextWindow: 1000000},
+	{prefix: "learnlm", contextWindow: 1000000},
+	{prefix: "gemini", contextWindow: 1000000},
+
+	// ── DeepSeek ────────────────────────────────────────────────────
+	{prefix: "deepseek-v4-flash", contextWindow: 1000000},
+	{prefix: "deepseek-v4-pro", contextWindow: 1000000},
+	{prefix: "deepseek-v4", contextWindow: 1000000},
+	{prefix: "deepseek-chat", contextWindow: 1000000},
+	{prefix: "deepseek-reasoner", contextWindow: 1000000},
+	{prefix: "deepseek-v3", contextWindow: 65536},
+	{prefix: "deepseek-r1", contextWindow: 65536},
+	{prefix: "deepseek", contextWindow: 65536},
+
+	// ── Alibaba Qwen ────────────────────────────────────────────────
+	{prefix: "qwen-long", contextWindow: 10000000},
+	{prefix: "qwen3-max", contextWindow: 262144},
+	{prefix: "qwen3", contextWindow: 262144},
+	{prefix: "qwen-plus", contextWindow: 1000000},
+	{prefix: "qwen-turbo", contextWindow: 1000000},
+	{prefix: "qwen-2.5", contextWindow: 131072},
+	{prefix: "qwen-2", contextWindow: 131072},
+	{prefix: "qwen", contextWindow: 32768},
+
+	// ── Mistral ─────────────────────────────────────────────────────
+	{prefix: "mistral-large", contextWindow: 256000},
+	{prefix: "mistral-medium", contextWindow: 256000},
+	{prefix: "mistral-small", contextWindow: 128000},
+	{prefix: "mistral-tiny", contextWindow: 32768},
+	{prefix: "ministral", contextWindow: 128000},
+	{prefix: "mistral", contextWindow: 32768},
+	{prefix: "mixtral", contextWindow: 32768},
+	{prefix: "open-mistral", contextWindow: 32768},
+	{prefix: "open-mixtral", contextWindow: 32768},
+
+	// ── xAI Grok ────────────────────────────────────────────────────
+	{prefix: "grok-4", contextWindow: 1000000},
+	{prefix: "grok-3", contextWindow: 1000000},
+	{prefix: "grok-2", contextWindow: 131072},
+	{prefix: "grok", contextWindow: 131072},
+
+	// ── Meta Llama ──────────────────────────────────────────────────
+	{prefix: "llama-4-scout", contextWindow: 10000000},
+	{prefix: "llama-4-maverick", contextWindow: 1000000},
+	{prefix: "llama-4", contextWindow: 1000000},
+	{prefix: "llama-3.2", contextWindow: 131072},
+	{prefix: "llama-3.1", contextWindow: 131072},
+	{prefix: "llama-3", contextWindow: 8192},
+	{prefix: "llama-2", contextWindow: 4096},
+	{prefix: "llama", contextWindow: 8192},
+
+	// ── Cohere ──────────────────────────────────────────────────────
+	{prefix: "command-a", contextWindow: 256000},
+	{prefix: "command-r-plus", contextWindow: 128000},
+	{prefix: "command-r", contextWindow: 128000},
+	{prefix: "command", contextWindow: 4096},
+
+	// ── Z.AI / GLM ──────────────────────────────────────────────────
+	{prefix: "glm-4.5", contextWindow: 128000},
+	{prefix: "glm-4", contextWindow: 128000},
+	{prefix: "glm-3", contextWindow: 128000},
+	{prefix: "glm", contextWindow: 128000},
+
+	// ── Moonshot / Kimi ─────────────────────────────────────────────
+	{prefix: "kimi-k2.6", contextWindow: 256000},
+	{prefix: "kimi-k2.5", contextWindow: 256000},
+	{prefix: "kimi-k2", contextWindow: 256000},
+	{prefix: "kimi", contextWindow: 128000},
+
+	// ── Others ──────────────────────────────────────────────────────
+	{prefix: "phi-4", contextWindow: 131072},
+	{prefix: "phi-3", contextWindow: 131072},
+	{prefix: "phi", contextWindow: 4096},
+	{prefix: "gemma-2", contextWindow: 8192},
+	{prefix: "gemma", contextWindow: 8192},
+	{prefix: "dbrx", contextWindow: 32768},
+	{prefix: "aya", contextWindow: 8192},
+	{prefix: "solar", contextWindow: 32768},
+}
+
+// normalizeModelID prepares a user-supplied model ID for table matching.
+// It handles case, common provider prefixes, and path-style IDs.
+func normalizeModelID(modelID string) string {
+	id := strings.ToLower(strings.TrimSpace(modelID))
+	if id == "" {
+		return ""
+	}
+	// Strip common "provider/" prefix (e.g. "openai/gpt-4o", "azure/gpt-4o")
+	if slash := strings.IndexByte(id, '/'); slash > 0 && slash < len(id)-1 {
+		prefix := id[:slash]
+		// Only strip if it looks like a provider/endpoint name, not a model family
+		if isProviderPrefix(prefix) {
+			id = id[slash+1:]
+		}
+	}
+	// Trim again since some IDs have "organization/model-name" pattern
+	id = strings.TrimSpace(id)
+	return id
+}
+
+func isProviderPrefix(s string) bool {
+	known := []string{
+		"openai", "anthropic", "google", "gemini", "azure", "azure-openai",
+		"aws", "aws-bedrock", "bedrock", "deepseek", "together", "together_ai",
+		"openrouter", "xai", "meta", "mistral", "cohere", "qwen", "alibaba",
+		"moonshot", "zai", "zhipu", "huggingface", "hf", "replicate",
+		"groq", "fireworks", "perplexity", "anyscale", "togethercomputer",
+	}
+	for _, k := range known {
+		if s == k {
+			return true
+		}
+	}
+	return false
+}
+
+func knownContextWindow(modelID string) int {
+	id := normalizeModelID(modelID)
+	if id == "" {
+		return 0
+	}
+	for _, entry := range knownModelContextWindows {
+		if entry.exact != "" && id == entry.exact {
+			return entry.contextWindow
+		}
+	}
+	for _, entry := range knownModelContextWindows {
+		if entry.prefix != "" && strings.HasPrefix(id, entry.prefix) {
+			return entry.contextWindow
+		}
+	}
+	// If still not found, try matching after the last "/" for path-style IDs
+	// like "meta-llama/Llama-4-Scout-17B" → "llama-4-scout-17b"
+	if lastSlash := strings.LastIndexByte(id, '/'); lastSlash > 0 && lastSlash < len(id)-1 {
+		tail := id[lastSlash+1:]
+		for _, entry := range knownModelContextWindows {
+			if entry.exact != "" && tail == entry.exact {
+				return entry.contextWindow
+			}
+		}
+		for _, entry := range knownModelContextWindows {
+			if entry.prefix != "" && strings.HasPrefix(tail, entry.prefix) {
+				return entry.contextWindow
+			}
+		}
+	}
+	return 0
+}
+
+func init() {
+	m := map[string]struct{}{}
+	for _, e := range knownModelContextWindows {
+		var k string
+		switch {
+		case e.exact != "":
+			k = "exact:" + e.exact
+		case e.prefix != "":
+			k = "prefix:" + e.prefix
+		default:
+			panic("known model entry has neither exact nor prefix")
+		}
+		if _, ok := m[k]; ok {
+			panic("duplicate known model entry: " + k)
+		}
+		m[k] = struct{}{}
+	}
+}
+
+func fillContextWindow(meta map[string]string, modelID string) {
+	if meta == nil {
+		return
+	}
+	if strings.TrimSpace(meta["context_window"]) != "" {
+		return
+	}
+	cw := knownContextWindow(modelID)
+	if cw > 0 {
+		meta["context_window"] = strconv.Itoa(cw)
+	}
+}

--- a/internal/provider/models_known_test.go
+++ b/internal/provider/models_known_test.go
@@ -1,0 +1,166 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestNormalizeModelID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"gpt-4o", "gpt-4o"},
+		{"GPT-4o", "gpt-4o"},
+		{"GPT-4O", "gpt-4o"},
+		{"azure/gpt-4o", "gpt-4o"},
+		{"openai/gpt-5.4", "gpt-5.4"},
+		{"aws-bedrock/llama-4-scout", "llama-4-scout"},
+		{" deepseek/deepseek-chat ", "deepseek-chat"},
+		// "meta-llama" is not a known provider prefix, so path is preserved
+		// knownContextWindow will still match via the tail-after-last-/ fallback
+		{"mistral/mistral-large-2512", "mistral-large-2512"},
+		{"claude-sonnet-4-6", "claude-sonnet-4-6"},
+		{"", ""},
+		{"  ", ""},
+	}
+	for _, tc := range tests {
+		got := normalizeModelID(tc.input)
+		if got != tc.expected {
+			t.Errorf("normalizeModelID(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestKnownContextWindow(t *testing.T) {
+	tests := []struct {
+		modelID  string
+		expected int
+	}{
+		// Exact match
+		{"gpt-4-32k", 32768},
+		{"gpt-4-turbo", 128000},
+		// Prefix match — standard
+		{"gpt-4o", 128000},
+		{"gpt-4o-2024-08-06", 128000},
+		{"gpt-5.4", 1000000},
+		{"gpt-5.4-mini", 400000},
+		{"gpt-5.5", 1000000},
+		{"gpt-4.1", 1047576},
+		{"o1-preview", 200000},
+		// Case insensitive
+		{"GPT-4O", 128000},
+		{"Claude-Sonnet-4-6", 1000000},
+		{"DEEPSEEK-V4-FLASH", 1000000},
+		// Provider prefix stripping
+		{"azure/gpt-4o", 128000},
+		{"openai/gpt-5.4", 1000000},
+		{"aws-bedrock/llama-4-scout", 10000000},
+		{"deepseek/deepseek-chat", 1000000},
+		{"google/gemini-2.5-pro", 1048576},
+		// Path-style ID — match after last /
+		{"meta-llama/Llama-4-Scout-17B", 10000000},
+		// Anthropic
+		{"claude-opus-4-7", 1000000},
+		{"claude-sonnet-4-6", 1000000},
+		{"claude-haiku-4-5", 200000},
+		{"claude-4", 200000},
+		// Gemini
+		{"gemini-3.1-pro-preview", 1048576},
+		{"gemini-2.0-flash", 1000000},
+		{"gemini-1.5-pro", 2000000},
+		// DeepSeek
+		{"deepseek-v4-flash", 1000000},
+		{"deepseek-v4-pro", 1000000},
+		{"deepseek-chat", 1000000},
+		{"deepseek-reasoner", 1000000},
+		{"deepseek-v3", 65536},
+		{"deepseek-r1", 65536},
+		// Qwen
+		{"qwen-long-latest", 10000000},
+		{"qwen3-max", 262144},
+		{"qwen-plus", 1000000},
+		{"qwen-turbo-latest", 1000000},
+		// Mistral
+		{"mistral-large-2512", 256000},
+		{"mistral-medium-3-5", 256000},
+		{"mistral-small-2506", 128000},
+		// xAI
+		{"grok-4.3", 1000000},
+		// Llama
+		{"llama-4-scout", 10000000},
+		{"llama-4-maverick", 1000000},
+		// Cohere
+		{"command-a-03-2025", 256000},
+		{"command-r-08-2024", 128000},
+		// Z.AI / GLM
+		{"glm-4.5", 128000},
+		// Kimi
+		{"kimi-k2.6", 256000},
+		{"kimi-k2.5", 256000},
+		// Unknown model returns 0
+		{"totally-unknown-model-9000", 0},
+		{"", 0},
+	}
+	for _, tc := range tests {
+		got := knownContextWindow(tc.modelID)
+		if got != tc.expected {
+			t.Errorf("knownContextWindow(%q) = %d, want %d", tc.modelID, got, tc.expected)
+		}
+	}
+}
+
+func TestIsProviderPrefix(t *testing.T) {
+	if !isProviderPrefix("openai") {
+		t.Error("expected openai to be a provider prefix")
+	}
+	if !isProviderPrefix("azure") {
+		t.Error("expected azure to be a provider prefix")
+	}
+	if !isProviderPrefix("aws-bedrock") {
+		t.Error("expected aws-bedrock to be a provider prefix")
+	}
+	if !isProviderPrefix("huggingface") {
+		t.Error("expected huggingface to be a provider prefix")
+	}
+	if isProviderPrefix("my-custom-service") {
+		t.Error("expected my-custom-service to NOT be a provider prefix")
+	}
+	if isProviderPrefix("") {
+		t.Error("expected empty string to NOT be a provider prefix")
+	}
+}
+
+func TestFillContextWindow(t *testing.T) {
+	meta := map[string]string{}
+	fillContextWindow(meta, "gpt-4o")
+	if meta["context_window"] != "128000" {
+		t.Fatalf("expected context_window=128000, got %q", meta["context_window"])
+	}
+
+	meta2 := map[string]string{"context_window": "8888"}
+	fillContextWindow(meta2, "gpt-4o")
+	if meta2["context_window"] != "8888" {
+		t.Fatalf("expected context_window to remain 8888, got %q", meta2["context_window"])
+	}
+
+	meta3 := map[string]string{}
+	fillContextWindow(meta3, "unknown-model")
+	if meta3["context_window"] != "" {
+		t.Fatalf("expected context_window to remain empty for unknown model, got %q", meta3["context_window"])
+	}
+
+	meta4 := map[string]string{}
+	fillContextWindow(meta4, "")
+	if meta4["context_window"] != "" {
+		t.Fatalf("expected context_window to remain empty for empty modelID, got %q", meta4["context_window"])
+	}
+}
+
+func TestNormalizeModelIDPreservesUnknownPrefix(t *testing.T) {
+	// "org/" that isn't a known provider prefix should not be stripped
+	got := normalizeModelID("mycompany/gpt-4o")
+	// "mycompany" is not a known provider prefix, so it should remain
+	if got != "mycompany/gpt-4o" {
+		t.Errorf("expected %q, got %q", "mycompany/gpt-4o", got)
+	}
+}

--- a/internal/session/store_delete.go
+++ b/internal/session/store_delete.go
@@ -64,7 +64,7 @@ func (s *Store) CleanupZeroMessageSessions(workspace, activeSessionID string) (C
 	workspace = strings.TrimSpace(workspace)
 	activeSessionID = strings.TrimSpace(activeSessionID)
 
-	summaries, _, err := s.ListInWorkspace(workspace, 0)
+	summaries, _, err := s.ListInWorkspace(workspace, 500)
 	if err != nil {
 		return result, err
 	}

--- a/internal/session/store_list.go
+++ b/internal/session/store_list.go
@@ -60,17 +60,17 @@ func (s *Store) summariesFromSources(sources []sessionSource, limit int) ([]Summ
 		})
 	}
 
-	// Sort by session UpdatedAt descending (snapshot value or fallback to source file mtime)
+	// Use the max of snapshot UpdatedAt and source file mtime.
+	// snapshot UpdatedAt can lag behind if events were appended after the last snapshot refresh.
+	for i := range metas {
+		snapAt := metas[i].updatedAt
+		mt := metas[i].source.updatedAt
+		if !snapAt.IsZero() && mt.After(snapAt) {
+			metas[i].updatedAt = mt
+		}
+	}
 	sort.Slice(metas, func(i, j int) bool {
-		left := metas[i].updatedAt
-		if left.IsZero() {
-			left = metas[i].source.updatedAt
-		}
-		right := metas[j].updatedAt
-		if right.IsZero() {
-			right = metas[j].source.updatedAt
-		}
-		return left.After(right)
+		return metas[i].updatedAt.After(metas[j].updatedAt)
 	})
 
 	// Phase 2: determine how many to fully replay.

--- a/internal/session/store_list.go
+++ b/internal/session/store_list.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 func (s *Store) List(limit int) ([]Summary, []string, error) {
@@ -27,13 +28,74 @@ func (s *Store) ListInWorkspace(workspace string, limit int) ([]Summary, []strin
 }
 
 func (s *Store) summariesFromSources(sources []sessionSource, limit int) ([]Summary, []string, error) {
-	summaries := make([]Summary, 0, len(sources))
 	warnings := make([]string, 0)
 	seenIDs := make(map[string]struct{}, len(sources))
+
+	// Phase 1: lightweight metadata scan to get UpdatedAt without full event replay.
+	// This lets us skip expensive replay for sessions that won't make the limit cutoff.
+	type sourceMeta struct {
+		source    sessionSource
+		updatedAt time.Time
+		hasSnap   bool
+	}
+	metas := make([]sourceMeta, 0, len(sources))
 	for _, source := range sources {
 		if _, ok := seenIDs[source.paths.SessionID]; ok {
 			continue
 		}
+		seenIDs[source.paths.SessionID] = struct{}{}
+
+		var updatedAt time.Time
+		hasSnap := false
+		if source.kind == sourceKindEvents && source.paths.Snapshot != "" {
+			if snap, err := readSnapshotFile(source.paths.Snapshot); err == nil {
+				updatedAt = snap.Session.UpdatedAt
+				hasSnap = true
+			}
+		}
+		metas = append(metas, sourceMeta{
+			source:    source,
+			updatedAt: updatedAt,
+			hasSnap:   hasSnap,
+		})
+	}
+
+	// Sort by session UpdatedAt descending (snapshot value or fallback to source file mtime)
+	sort.Slice(metas, func(i, j int) bool {
+		left := metas[i].updatedAt
+		if left.IsZero() {
+			left = metas[i].source.updatedAt
+		}
+		right := metas[j].updatedAt
+		if right.IsZero() {
+			right = metas[j].source.updatedAt
+		}
+		return left.After(right)
+	})
+
+	// Phase 2: determine how many to fully replay.
+	// Process top sessions with enough buffer for sort stability.
+	replayCount := limit
+	if replayCount <= 0 {
+		replayCount = len(metas)
+	}
+	buffer := replayCount / 2
+	if buffer < 10 {
+		buffer = 10
+	}
+	target := replayCount + buffer
+	if target > len(metas) {
+		target = len(metas)
+	}
+
+	seenIDs = make(map[string]struct{}, target)
+	summaries := make([]Summary, 0, limit)
+	for _, meta := range metas[:target] {
+		source := meta.source
+		if _, ok := seenIDs[source.paths.SessionID]; ok {
+			continue
+		}
+		seenIDs[source.paths.SessionID] = struct{}{}
 
 		var (
 			sess *Session

--- a/tui/component_sessions.go
+++ b/tui/component_sessions.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/1024XEngineer/bytemind/internal/llm"
+	"github.com/1024XEngineer/bytemind/internal/mention"
 	planpkg "github.com/1024XEngineer/bytemind/internal/plan"
 	"github.com/1024XEngineer/bytemind/internal/session"
 
@@ -44,9 +45,11 @@ func (m model) renderSessionsModal() string {
 		summary := m.sessions[i]
 		prefix := "  "
 		style := lipgloss.NewStyle()
+		wsStyle := mutedStyle
 		if i == m.sessionCursor {
 			prefix = "> "
 			style = style.Foreground(colorAccent).Bold(true)
+			wsStyle = wsStyle.Foreground(colorAccent)
 		}
 		rawCount := summary.RawMessageCount
 		if rawCount == 0 {
@@ -54,7 +57,7 @@ func (m model) renderSessionsModal() string {
 		}
 		line := fmt.Sprintf("%s%s  %s  raw:%d", prefix, summary.ID, summary.UpdatedAt.Local().Format("2006-01-02 15:04"), rawCount)
 		lines = append(lines, style.Render(line))
-		lines = append(lines, mutedStyle.Render("   "+summary.Workspace))
+		lines = append(lines, wsStyle.Render("   "+compact(summary.Workspace, 56)))
 		lines = append(lines, mutedStyle.Render("   "+displaySessionTitle(summary)))
 		lines = append(lines, "")
 	}
@@ -107,6 +110,7 @@ func (m model) handleSessionsModalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.statusNote = err.Error()
 		} else {
 			m.sessionsOpen = false
+			return m, m.loadSessionsCmd()
 		}
 	}
 	return m, nil
@@ -174,13 +178,12 @@ func (m *model) resumeSession(prefix string) error {
 	if err != nil {
 		return err
 	}
-	next, err := loadSessionForWorkspace(m.store, m.workspace, id)
+	next, err := m.store.Load(id)
 	if err != nil {
 		return err
 	}
-	if !sameWorkspace(m.workspace, next.Workspace) {
-		return fmt.Errorf("session %s belongs to workspace %s", next.ID, next.Workspace)
-	}
+	m.workspace = next.Workspace
+	m.mentionIndex = mention.NewWorkspaceFileIndex(m.workspace)
 	m.sess = next
 	m.resetSessionApprovalState()
 	m.screen = screenChat
@@ -191,7 +194,7 @@ func (m *model) resumeSession(prefix string) error {
 	m.runIndicatorState = runIndicatorReady
 	m.lastRunDuration = 0
 	m.phase = "idle"
-	m.statusNote = "Resumed session " + shortID(next.ID)
+	m.statusNote = "Resumed session " + shortID(next.ID) + " (" + m.workspace + ")"
 	m.chatAutoFollow = true
 	m.restoreTokenUsageFromSession(next)
 	m.syncTokenUsageComponent()
@@ -251,7 +254,8 @@ func (m *model) reloadSessions() error {
 		m.sessionCursor = 0
 		return nil
 	}
-	summaries, _, err := listSessionsForWorkspace(m.store, m.workspace, sessionListFetchLimit())
+	// List sessions across all workspaces for cross-workspace resume.
+	summaries, _, err := m.store.List(sessionListFetchLimit())
 	if err != nil {
 		return err
 	}

--- a/tui/component_sessions_test.go
+++ b/tui/component_sessions_test.go
@@ -561,7 +561,7 @@ func TestLoadSessionsCmdBranches(t *testing.T) {
 	})
 }
 
-func TestLoadSessionsCmdScopesToWorkspace(t *testing.T) {
+func TestLoadSessionsCmdCrossWorkspace(t *testing.T) {
 	store, err := session.NewStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -585,8 +585,8 @@ func TestLoadSessionsCmdScopesToWorkspace(t *testing.T) {
 	if msg.Err != nil {
 		t.Fatalf("expected loadSessionsCmd success, got err=%v", msg.Err)
 	}
-	if len(msg.Summaries) != 1 || msg.Summaries[0].ID != current.ID {
-		t.Fatalf("expected only current workspace session, got %+v", msg.Summaries)
+	if len(msg.Summaries) != 2 {
+		t.Fatalf("expected both workspace sessions, got %+v", msg.Summaries)
 	}
 }
 
@@ -784,7 +784,7 @@ func TestHandleSessionsModalEnterSuccessClosesModal(t *testing.T) {
 	}
 }
 
-func TestResumeSessionScopesPrefixToWorkspace(t *testing.T) {
+func TestResumeSessionWorkspaceAutoSwitch(t *testing.T) {
 	store, err := session.NewStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -796,15 +796,9 @@ func TestResumeSessionScopesPrefixToWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 	target := session.New(workspace)
-	target.ID = "resume-current"
+	target.ID = "resume-target"
 	target.Messages = []llm.Message{llm.NewUserTextMessage("current target")}
 	if err := store.Save(target); err != nil {
-		t.Fatal(err)
-	}
-	other := session.New(t.TempDir())
-	other.ID = "resume-other"
-	other.Messages = []llm.Message{llm.NewUserTextMessage("other target")}
-	if err := store.Save(other); err != nil {
 		t.Fatal(err)
 	}
 
@@ -814,11 +808,14 @@ func TestResumeSessionScopesPrefixToWorkspace(t *testing.T) {
 		sess:      current,
 		input:     textarea.New(),
 	}
-	if err := m.resumeSession("resume"); err != nil {
-		t.Fatalf("expected workspace-scoped prefix to resolve, got %v", err)
+	if err := m.resumeSession("resume-target"); err != nil {
+		t.Fatalf("expected prefix to resolve, got %v", err)
 	}
 	if m.sess == nil || m.sess.ID != target.ID {
-		t.Fatalf("expected current workspace target to resume, got %#v", m.sess)
+		t.Fatalf("expected target to resume, got %#v", m.sess)
+	}
+	if m.workspace != target.Workspace {
+		t.Fatalf("expected workspace to switch to session workspace %q, got %q", target.Workspace, m.workspace)
 	}
 }
 

--- a/tui/component_status_scroll.go
+++ b/tui/component_status_scroll.go
@@ -10,9 +10,13 @@ import (
 )
 
 func (m model) renderTopRightCluster(width int) string {
-	parts := make([]string, 0, 2)
+	parts := make([]string, 0, 3)
 	if toast := strings.TrimSpace(m.selectionToast); toast != "" {
 		parts = append(parts, selectionToastStyle.Render(toast))
+	}
+	ws := compact(m.workspace, 28)
+	if ws != "" {
+		parts = append(parts, workspaceBadgeStyle.Render(ws))
 	}
 	if badge := strings.TrimSpace(m.renderTokenBadge(width)); badge != "" {
 		parts = append(parts, badge)

--- a/tui/component_token_usage_runtime.go
+++ b/tui/component_token_usage_runtime.go
@@ -121,7 +121,8 @@ func (m model) loadSessionsCmd() tea.Cmd {
 		if m.store == nil {
 			return sessionsLoadedMsg{}
 		}
-		summaries, _, err := listSessionsForWorkspace(m.store, m.workspace, sessionListFetchLimit())
+		// List sessions across all workspaces so the user can browse and switch.
+		summaries, _, err := m.store.List(sessionListFetchLimit())
 		return sessionsLoadedMsg{Summaries: summaries, Err: err}
 	}
 }

--- a/tui/component_token_usage_runtime.go
+++ b/tui/component_token_usage_runtime.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -175,7 +176,7 @@ func (m *model) refreshTokenBudget() {
 	if m == nil {
 		return
 	}
-	budget := max(1, m.cfg.TokenQuota)
+	budget := 0
 	runtimeCfg := m.cfg.ProviderRuntime
 	providerID := config.SelectedProviderID(runtimeCfg)
 	modelID := config.SelectedModelID(runtimeCfg)
@@ -196,7 +197,14 @@ func (m *model) refreshTokenBudget() {
 		registry := provider.NewModelRegistry(runtimeCfg, m.discoveredModels)
 		if contextWindow := registry.ContextWindow(provider.ProviderID(providerID), provider.ModelID(modelID)); contextWindow > 0 {
 			budget = contextWindow
+		} else if _, providerCfg, ok := config.SelectedProviderConfig(runtimeCfg); ok {
+			if cw := provider.LookupModelContextWindow(context.Background(), providerCfg.Type, providerCfg.BaseURL, providerCfg.ResolveAPIKey(), modelID); cw > 0 {
+				budget = cw
+			}
 		}
+	}
+	if budget <= 0 && m.cfg.TokenQuota > 0 {
+		budget = m.cfg.TokenQuota
 	}
 	m.tokenBudget = budget
 }

--- a/tui/component_token_usage_runtime.go
+++ b/tui/component_token_usage_runtime.go
@@ -199,8 +199,17 @@ func (m *model) refreshTokenBudget() {
 		if contextWindow := registry.ContextWindow(provider.ProviderID(providerID), provider.ModelID(modelID)); contextWindow > 0 {
 			budget = contextWindow
 		} else if _, providerCfg, ok := config.SelectedProviderConfig(runtimeCfg); ok {
-			if cw := provider.LookupModelContextWindow(context.Background(), providerCfg.Type, providerCfg.BaseURL, providerCfg.ResolveAPIKey(), modelID); cw > 0 {
-				budget = cw
+			cacheKey := providerID + ":" + modelID
+			if cached, ok := m.contextWindowCache[cacheKey]; ok {
+				budget = cached
+			} else {
+				if cw := provider.LookupModelContextWindow(context.Background(), providerCfg.Type, providerCfg.BaseURL, providerCfg.ResolveAPIKey(), modelID); cw > 0 {
+					budget = cw
+				}
+				if m.contextWindowCache == nil {
+					m.contextWindowCache = make(map[string]int)
+				}
+				m.contextWindowCache[cacheKey] = budget
 			}
 		}
 	}

--- a/tui/component_token_usage_runtime_test.go
+++ b/tui/component_token_usage_runtime_test.go
@@ -135,7 +135,7 @@ func TestNewModelRestoresTokenBudgetOnFirstRender(t *testing.T) {
 		Session: sess,
 		Config: config.Config{
 			TokenQuota: 12345,
-			Provider:   config.ProviderConfig{Model: "gpt-5.4"},
+			Provider:   config.ProviderConfig{Model: "custom-unknown-model"},
 		},
 		Workspace: t.TempDir(),
 	})
@@ -151,6 +151,30 @@ func TestNewModelRestoresTokenBudgetOnFirstRender(t *testing.T) {
 	}
 	if m.tokenUsage.unavailable {
 		t.Fatal("expected restored session usage to mark token monitor available")
+	}
+}
+
+func TestNewModelUsesContextWindowForKnownModel(t *testing.T) {
+	sess := session.New(t.TempDir())
+	sess.Messages = append(sess.Messages, llm.Message{
+		Role:  llm.RoleAssistant,
+		Usage: &llm.Usage{TotalTokens: 42},
+	})
+
+	m := newModel(Options{
+		Session: sess,
+		Config: config.Config{
+			TokenQuota: 12345,
+			Provider:   config.ProviderConfig{Model: "gpt-5.4"},
+		},
+		Workspace: t.TempDir(),
+	})
+
+	if m.tokenBudget != 1000000 {
+		t.Fatalf("expected context window 1000000 for gpt-5.4, got %d", m.tokenBudget)
+	}
+	if m.tokenUsage.total != 1000000 {
+		t.Fatalf("expected token monitor total to match context window, got %d", m.tokenUsage.total)
 	}
 }
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -515,6 +515,10 @@ type model struct {
 	stagnationStart  time.Time
 	stagnationActive bool
 	reducedMotion    bool
+
+	// contextWindowCache caches API model context window lookups to avoid
+	// repeat HTTP requests during streaming.
+	contextWindowCache map[string]int
 }
 
 func newModel(opts Options) model {

--- a/tui/model.go
+++ b/tui/model.go
@@ -595,7 +595,7 @@ func newModel(opts Options) model {
 		mentionIndex:         mention.NewWorkspaceFileIndex(opts.Workspace),
 		agentSource:          opts.AgentSource,
 		tokenUsage:           newTokenUsageComponent(),
-		tokenBudget:          max(1, opts.Config.TokenQuota),
+		tokenBudget:          0,
 		tokenEstimator:       newRealtimeTokenEstimator(opts.Config.Provider.Model),
 		inputImageRefs:       make(map[int]llm.AssetID, 8),
 		inputImageMentions:   make(map[string]llm.AssetID, 8),

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -655,6 +655,11 @@ var (
 				Bold(true).
 				Padding(0, 1)
 
+	workspaceBadgeStyle = lipgloss.NewStyle().
+				Foreground(semanticColors.TextMuted).
+				Background(lipgloss.Color("#252830")).
+				Padding(0, 1)
+
 	mutedStyle  = lipgloss.NewStyle().Foreground(semanticColors.TextMuted)
 	accentStyle = lipgloss.NewStyle().Foreground(semanticColors.Accent)
 	infoStyle   = lipgloss.NewStyle().Foreground(semanticColors.ToolSoft)

--- a/tui/token_monitor.go
+++ b/tui/token_monitor.go
@@ -50,7 +50,7 @@ func newTokenUsageComponent() tokenUsageComponent {
 	simpleRing := readEnvFlag("BYTEMIND_TOKEN_MONITOR_SIMPLE")
 	noBraille := simpleRing || compatRing || readEnvFlag("BYTEMIND_TOKEN_MONITOR_NO_BRAILLE")
 	return tokenUsageComponent{
-		total:        5000,
+		total:        0,
 		ringSegments: 8,
 		simpleRing:   simpleRing,
 		noBraille:    noBraille,


### PR DESCRIPTION
## 概述
对 session 管理的三项改进：

### 1. 跨工作区 session 浏览与自动切换
- Session 列表现在展示**所有工作区**的 session，每条都标明所属工作区路径
- 选择其他工作区的 session 时，TUI 工作区**自动切换**到该 session 所在目录
- 当前工作区路径展示在右上角区域（token 用量标签的左边）

### 2. Session 列表卡死修复
- **`summariesFromSources`** — 改为两阶段扫描：先只读 snapshot 元数据获取 `UpdatedAt` 排序，再只完整回放 top N 个 session（limit + buffer），避免全量回放
- **`CleanupZeroMessageSessions`** — 限制从 `0`（无限制）改为 `500`，防止无上限的事件回放

### 3. TUI 工作区可见性
- 新增 `workspaceBadgeStyle` 在右上角显示当前工作区路径
- Session 弹窗中工作区行在光标选中时高亮
- 恢复 session 时状态提示包含路径（如 `"Resumed session abc (/home/project)"`）