### PR TITLE
fix(tui): consume delayed paste echoes

### DIFF
--- a/tui/input_paste_transaction.go
+++ b/tui/input_paste_transaction.go
@@ -68,12 +68,6 @@ func (m *model) consumePasteEchoKey(msg tea.KeyMsg) bool {
 	if m == nil || !m.pasteTransaction.Active || msg.Paste {
 		return false
 	}
-	if msg.Type == tea.KeyRunes && m.shouldExpireStalePasteTransactionBeforeRunes() {
-		// No echoed payload arrived for a while; treat upcoming runes as fresh
-		// user input (for example a second paste operation), not stale echo.
-		m.clearPasteTransaction()
-		return false
-	}
 	if isCtrlVControlKey(msg) {
 		// Some terminals emit Ctrl+V key markers before/within the echoed
 		// key stream. Ignore them so they do not tear down the active
@@ -102,6 +96,12 @@ func (m *model) consumePasteEchoKey(msg tea.KeyMsg) bool {
 			m.releasePasteSubmitSuppression()
 			return true
 		}
+		m.clearPasteTransaction()
+		return false
+	}
+	if msg.Type == tea.KeyRunes && m.shouldExpireStalePasteTransactionBeforeRunes() && !strings.HasPrefix(remaining, fragment) {
+		// No matching echoed payload arrived for a while; treat upcoming
+		// runes as fresh user input, not stale echo.
 		m.clearPasteTransaction()
 		return false
 	}

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -3519,6 +3519,49 @@ func TestPasteMsgTransactionConsumesEchoedPlainKeyStream(t *testing.T) {
 	}
 }
 
+func TestPasteMsgTransactionConsumesDelayedMatchingEcho(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	longPaste := strings.Join([]string{"echo line 1", "echo line 2", "echo line 3"}, "\n")
+
+	got, _ := m.handlePastePayload(longPaste + "\n")
+	updated := got.(model)
+	afterPaste := updated.input.Value()
+	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(afterPaste) {
+		t.Fatalf("expected paste payload to compress into marker, got %q", afterPaste)
+	}
+
+	updated.pasteTransaction.StartedAt = time.Now().Add(-2 * pasteTransactionAppendWindow)
+	got, _ = updated.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("echo line 1")})
+	updated = got.(model)
+
+	if updated.input.Value() != afterPaste {
+		t.Fatalf("expected delayed matching echo to be consumed, got %q", updated.input.Value())
+	}
+	if updated.pasteTransaction.Consumed != len([]rune("echo line 1")) {
+		t.Fatalf("expected delayed echo to advance consumed offset, got %d", updated.pasteTransaction.Consumed)
+	}
+}
+
+func TestPasteMsgTransactionReleasesDelayedNonMatchingInput(t *testing.T) {
+	m := newImagePipelineModel(t)
+	m.screen = screenChat
+	longPaste := strings.Join([]string{"echo line 1", "echo line 2", "echo line 3"}, "\n")
+
+	got, _ := m.handlePastePayload(longPaste + "\n")
+	updated := got.(model)
+	updated.pasteTransaction.StartedAt = time.Now().Add(-2 * pasteTransactionAppendWindow)
+
+	consumed := updated.consumePasteEchoKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("manual")})
+
+	if consumed {
+		t.Fatalf("expected stale non-matching input not to be consumed")
+	}
+	if updated.pasteTransaction.Active {
+		t.Fatalf("expected stale non-matching transaction to clear")
+	}
+}
+
 func TestPasteKeyTransactionConsumesEchoedPlainKeyStream(t *testing.T) {
 	m := newImagePipelineModel(t)
 	m.screen = screenChat


### PR DESCRIPTION
## 概要
- 修复长文本粘贴被终端拆成延迟回显时，前半段压缩成 `[Paste #...]`、后半段裸露在输入框里的问题。
- `pasteTransaction` 现在会先检查延迟 key fragment 是否仍匹配剩余粘贴内容；匹配则继续吞掉，不再仅因超过 120ms 就过期。
- 对于超时且不匹配的输入，仍会释放事务并保留为普通输入，避免误吞用户手打内容。
- 补充延迟匹配和延迟不匹配两个回归测试，覆盖 Codecov 标出的 `input_paste_transaction.go` 新增分支。

## 验证
- `go test ./tui -run 'TestPasteMsgTransactionConsumesDelayedMatchingEcho|TestPasteMsgTransactionReleasesDelayedNonMatchingInput' -count=1 -coverprofile $env:TEMP\paste-cover.out`
- `go test ./tui -count=1`