### PR TITLE
docs: write Windows config examples without BOM

### DIFF
--- a/www/api-key.md
+++ b/www/api-key.md
@@ -53,7 +53,7 @@ Replace `YOUR_DEEPSEEK_API_KEY` with the key you just copied.
 
 ```powershell
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.bytemind" | Out-Null
-@'
+$config = @'
 {
   "provider": {
     "type": "openai-compatible",
@@ -62,8 +62,13 @@ New-Item -ItemType Directory -Force "$env:USERPROFILE\.bytemind" | Out-Null
     "api_key": "YOUR_DEEPSEEK_API_KEY"
   }
 }
-'@ | Set-Content -Encoding utf8 "$env:USERPROFILE\.bytemind\config.json"
+'@
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText("$env:USERPROFILE\.bytemind\config.json", $config, $utf8NoBom)
 ```
+
+This writes `config.json` as UTF-8 without BOM, so it works consistently in both Windows PowerShell 5.1 and PowerShell 7+.
 
 </Tab>
 

--- a/www/quick-start.md
+++ b/www/quick-start.md
@@ -69,7 +69,7 @@ Start with a global config at `~/.bytemind/config.json`. You only need to config
 
 ```powershell
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.bytemind" | Out-Null
-@'
+$config = @'
 {
   "provider": {
     "type": "openai-compatible",
@@ -78,8 +78,13 @@ New-Item -ItemType Directory -Force "$env:USERPROFILE\.bytemind" | Out-Null
     "api_key": "YOUR_API_KEY"
   }
 }
-'@ | Set-Content -Encoding utf8 "$env:USERPROFILE\.bytemind\config.json"
+'@
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText("$env:USERPROFILE\.bytemind\config.json", $config, $utf8NoBom)
 ```
+
+This writes `config.json` as UTF-8 without BOM, so it works consistently in both Windows PowerShell 5.1 and PowerShell 7+.
 
 </Tab>
 

--- a/www/troubleshooting.md
+++ b/www/troubleshooting.md
@@ -117,6 +117,21 @@ Symptom: ByteMind behaves as if no config exists (uses defaults).
 
 New users should put common settings in the user config, not in `~/bin` or `%USERPROFILE%\bin`. Run `bytemind -v` to see which config file was loaded.
 
+## Config JSON Reports `invalid character 'ï'`
+
+Symptom: after creating `~/.bytemind/config.json` in Windows PowerShell, ByteMind exits with `invalid character 'ï' looking for beginning of value`.
+
+**Fix:** rewrite the file as UTF-8 without BOM:
+
+```powershell
+$path = "$env:USERPROFILE\.bytemind\config.json"
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+$text = [System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)
+[System.IO.File]::WriteAllText($path, $text, $utf8NoBom)
+```
+
+Windows PowerShell 5.1 writes UTF-8 with BOM when using `Set-Content -Encoding utf8`; PowerShell 7+ uses UTF-8 without BOM.
+
 ## Workspace Is Too Large or Too Broad
 
 Symptom: when started from your home directory, a drive root, Downloads, Desktop, or a very large folder, ByteMind reports that the current directory is too broad or feels slow.

--- a/www/zh/api-key.md
+++ b/www/zh/api-key.md
@@ -53,7 +53,7 @@
 
 ```powershell
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.bytemind" | Out-Null
-@'
+$config = @'
 {
   "provider": {
     "type": "openai-compatible",
@@ -62,8 +62,13 @@ New-Item -ItemType Directory -Force "$env:USERPROFILE\.bytemind" | Out-Null
     "api_key": "YOUR_DEEPSEEK_API_KEY"
   }
 }
-'@ | Set-Content -Encoding utf8 "$env:USERPROFILE\.bytemind\config.json"
+'@
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText("$env:USERPROFILE\.bytemind\config.json", $config, $utf8NoBom)
 ```
+
+这会把 `config.json` 写成不带 BOM 的 UTF-8，在 Windows PowerShell 5.1 和 PowerShell 7+ 中都能稳定工作。
 
 </Tab>
 

--- a/www/zh/quick-start.md
+++ b/www/zh/quick-start.md
@@ -69,7 +69,7 @@ bytemind --version
 
 ```powershell
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.bytemind" | Out-Null
-@'
+$config = @'
 {
   "provider": {
     "type": "openai-compatible",
@@ -78,8 +78,13 @@ New-Item -ItemType Directory -Force "$env:USERPROFILE\.bytemind" | Out-Null
     "api_key": "YOUR_API_KEY"
   }
 }
-'@ | Set-Content -Encoding utf8 "$env:USERPROFILE\.bytemind\config.json"
+'@
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText("$env:USERPROFILE\.bytemind\config.json", $config, $utf8NoBom)
 ```
+
+这会把 `config.json` 写成不带 BOM 的 UTF-8，在 Windows PowerShell 5.1 和 PowerShell 7+ 中都能稳定工作。
 
 </Tab>
 

--- a/www/zh/troubleshooting.md
+++ b/www/zh/troubleshooting.md
@@ -117,6 +117,21 @@ bytemind -max-iterations 64
 
 新用户建议先把通用配置放在用户目录，不要放到 `~/bin` 或 `%USERPROFILE%\bin`。运行 `bytemind -v` 可查看实际加载的配置文件路径。
 
+## 配置 JSON 报 `invalid character 'ï'`
+
+症状：在 Windows PowerShell 中创建 `~/.bytemind/config.json` 后，ByteMind 启动时报 `invalid character 'ï' looking for beginning of value`。
+
+**修复：** 将文件重写为不带 BOM 的 UTF-8：
+
+```powershell
+$path = "$env:USERPROFILE\.bytemind\config.json"
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+$text = [System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)
+[System.IO.File]::WriteAllText($path, $text, $utf8NoBom)
+```
+
+Windows PowerShell 5.1 使用 `Set-Content -Encoding utf8` 时会写入带 BOM 的 UTF-8；PowerShell 7+ 默认是不带 BOM 的 UTF-8。
+
 ## 工作区过大或目录不合适
 
 症状：在用户主目录、磁盘根目录、Downloads、Desktop 或很大的文件夹中启动时，ByteMind 提示当前目录过宽，或响应明显变慢。


### PR DESCRIPTION
## Summary
- update Windows PowerShell config examples to write UTF-8 without BOM across PowerShell versions
- document the invalid character 'ï' JSON parse error and recovery command in troubleshooting

## Verification
- npm run docs:build