### PR TITLE
fix(tui): trim trailing newlines from pasted text to prevent cursor offset

### DIFF
--- a/tui/input_paste.go
+++ b/tui/input_paste.go
@@ -486,7 +486,7 @@ func (m *model) flushHiddenPasteProbeToInput() {
 	if strings.TrimSpace(probe.buffered) == "" {
 		return
 	}
-	m.setInputValue(probe.baseInput + probe.buffered)
+	m.setInputValue(probe.baseInput + strings.TrimRight(probe.buffered, "\n\r"))
 	now := time.Now()
 	m.lastInputAt = now
 	m.inputBurstBaseValue = probe.baseInput
@@ -575,7 +575,7 @@ func (m *model) finalizePasteSession(id int) {
 	source := m.pasteSession.sourceKind
 	m.clearPasteSession()
 
-	candidate := strings.ReplaceAll(content, ctrlVMarkerRune, "")
+	candidate := strings.TrimRight(strings.ReplaceAll(content, ctrlVMarkerRune, ""), "\n\r")
 	if candidate == "" {
 		m.setInputValue(base)
 		m.syncInputOverlays()

--- a/tui/model.go
+++ b/tui/model.go
@@ -2076,7 +2076,7 @@ func (m model) insertStartupGuideText(payload string) model {
 	if payload == "" {
 		return m
 	}
-	m.input.SetValue(m.input.Value() + normalizeNewlines(payload))
+	m.input.SetValue(m.input.Value() + strings.TrimRight(normalizeNewlines(payload), "\n\r"))
 	m.input.CursorEnd()
 	m.clearStartupGuidePasteState()
 	return m

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -3367,8 +3367,8 @@ func TestShortBracketedPastePayloadKeepsTrailingNewlineBoundary(t *testing.T) {
 	}
 	got, _ = updated.Update(pasteFinalizeMsg{ID: updated.pasteSession.finalizeID})
 	finalized := got.(model)
-	if !regexp.MustCompile(`^\[Paste #\d+ ~\d+ lines\]$`).MatchString(finalized.input.Value()) {
-		t.Fatalf("expected short multiline paste payload to finalize into marker, got %q", finalized.input.Value())
+	if finalized.input.Value() != "# title" {
+		t.Fatalf("expected short paste payload to trim trailing newline and keep literal text, got %q", finalized.input.Value())
 	}
 }
 func TestRapidBareEnterAfterRecentBurstIsTreatedAsPasteContinuation(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix pasted text causing cursor to jump to the next line due to trailing `\n` copy artifact from terminals
- Trim trailing `\n\r` at all paste insertion points: `finalizePasteSession`, `flushHiddenPasteProbeToInput`, `insertStartupGuideText`

## Root Cause
When copying text from terminals (especially Windows Terminal with mouse auto-copy), the clipboard includes trailing `\r\n`. After normalization this becomes `\n`, which causes `CursorEnd()` to land on an extra empty line below the pasted text.

## Fix
- `input_paste.go:578`: Trim trailing `\n\r` from candidate in `finalizePasteSession`
- `input_paste.go:489`: Trim trailing `\n\r` in `flushHiddenPasteProbeToInput`
- `model.go:2079`: Trim trailing `\n\r` in `insertStartupGuideText`
- `model_test.go`: Update test expectation for trimmed trailing newline

## Test plan
- [x] `go test ./tui/...` all pass
- [x] Manual test: mouse-select text → Ctrl+V paste → cursor stays on same line as pasted text