### PR TITLE
fix: dedupe final assistant stream

### DIFF
--- a/tui/component_chat_stream.go
+++ b/tui/component_chat_stream.go
@@ -115,6 +115,10 @@ func (m *model) finishAssistantMessage(content string) {
 		}
 	}
 
+	if m.finalizeTailStreamingAssistantBeforePlaceholders(finalContent) {
+		return
+	}
+
 	if idx := m.latestTailOpenAssistantIndex(); idx >= 0 {
 		m.chatItems[idx].Title = assistantLabel
 		m.chatItems[idx].Body = finalContent
@@ -138,6 +142,46 @@ func (m *model) finishAssistantMessage(content string) {
 		Body:   finalContent,
 		Status: "final",
 	})
+}
+
+func (m *model) finalizeTailStreamingAssistantBeforePlaceholders(finalContent string) bool {
+	idx := len(m.chatItems) - 1
+	for idx >= 0 && isAssistantTransientPlaceholder(m.chatItems[idx]) {
+		idx--
+	}
+	if idx < 0 || idx == len(m.chatItems)-1 || !isAssistantStreamingAnswer(m.chatItems[idx]) {
+		return false
+	}
+	m.chatItems = m.chatItems[:idx+1]
+	m.chatItems[idx].Title = assistantLabel
+	m.chatItems[idx].Body = finalContent
+	m.chatItems[idx].Status = "final"
+	m.streamingIndex = -1
+	return true
+}
+
+func isAssistantStreamingAnswer(item chatEntry) bool {
+	if item.Kind != "assistant" {
+		return false
+	}
+	switch strings.TrimSpace(strings.ToLower(item.Status)) {
+	case "streaming", "settling":
+		return true
+	default:
+		return false
+	}
+}
+
+func isAssistantTransientPlaceholder(item chatEntry) bool {
+	if item.Kind != "assistant" {
+		return false
+	}
+	switch strings.TrimSpace(strings.ToLower(item.Status)) {
+	case "thinking", "pending":
+		return true
+	default:
+		return false
+	}
 }
 
 func (m model) latestTailOpenAssistantIndex() int {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -7950,6 +7950,30 @@ func TestFinishAssistantMessageFinalizesStreamingCardAfterPendingPlaceholder(t *
 	}
 }
 
+func TestFinishAssistantMessageFinalizesStreamingCardWhenPlaceholderIndexLost(t *testing.T) {
+	m := model{
+		chatItems: []chatEntry{
+			{Kind: "user", Title: "You", Body: "hello", Status: "final"},
+			{Kind: "assistant", Title: assistantLabel, Body: "Hello! How can I help?", Status: "streaming"},
+			{Kind: "assistant", Title: thinkingLabel, Body: "receiving hidden reasoning...", Status: "pending"},
+		},
+		streamingIndex: -1,
+	}
+
+	m.finishAssistantMessage("Hello! How can I help?")
+
+	if len(m.chatItems) != 2 {
+		t.Fatalf("expected stale pending placeholder to be removed without duplicate answer, got %d items", len(m.chatItems))
+	}
+	last := m.chatItems[1]
+	if last.Title != assistantLabel || last.Status != "final" || last.Body != "Hello! How can I help?" {
+		t.Fatalf("expected streamed assistant card to be finalized in place, got %+v", last)
+	}
+	if m.streamingIndex != -1 {
+		t.Fatalf("expected streaming index to stay cleared, got %d", m.streamingIndex)
+	}
+}
+
 func TestFinishAssistantMessageDoesNotMoveFinalAnswerBeforeToolTail(t *testing.T) {
 	m := model{
 		chatItems: []chatEntry{


### PR DESCRIPTION
## Summary
- finalize a stale streaming assistant card when trailing pending/thinking placeholders remain
- add regression coverage for lost streamingIndex placeholder cleanup

## Tests
- go test ./tui
- go test ./...